### PR TITLE
improvement/aws-http-protocol-header

### DIFF
--- a/api/app/settings/production.py
+++ b/api/app/settings/production.py
@@ -1,3 +1,7 @@
 from app.settings.common import *
 
 REST_FRAMEWORK["PAGE_SIZE"] = 999
+
+# Needed by Elastic Beanstalk to correctly identify incoming protocol
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html#x-forwarded-proto
+SECURE_PROXY_SSL_HEADER = ("X-Forwarded-Proto", "https")


### PR DESCRIPTION
Fixes `build_absolute_uri()` returning `http` when the incoming request is over `https`