### PR TITLE
fix(signup/serializer): Add validate_email to do case insenstive lookup at signup

### DIFF
--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import PermissionDenied
 
 from organisations.invites.models import Invite
+from users.models import FFAdminUser
 
 from .constants import USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
 
@@ -23,6 +24,14 @@ class CustomUserCreateSerializer(UserCreateSerializer):
     class Meta(UserCreateSerializer.Meta):
         fields = UserCreateSerializer.Meta.fields + ("is_active",)
         read_only_fields = ("is_active",)
+
+    def validate_email(self, value):
+        if FFAdminUser.objects.filter(email__iexact=value).count() != 0:
+            raise serializers.ValidationError(
+                "Feature flag admin user with this email already exists."
+            )
+
+        return value.lower()
 
     @staticmethod
     def get_key(instance):

--- a/api/custom_auth/tests/test_serializer.py
+++ b/api/custom_auth/tests/test_serializer.py
@@ -25,7 +25,7 @@ def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(db):
     serializer = CustomUserCreateSerializer(data=user_dict)
 
     # When
-    assert serializer.is_valid() == False
+    assert serializer.is_valid() is False
     assert (
         serializer.errors["email"][0].title()
         == "Feature Flag Admin User With This Email Already Exists."

--- a/api/custom_auth/tests/test_serializer.py
+++ b/api/custom_auth/tests/test_serializer.py
@@ -1,0 +1,32 @@
+from custom_auth.serializers import CustomUserCreateSerializer
+from users.models import FFAdminUser
+
+user_dict = {
+    "email": "TestUser@mail.com",
+    "password": "pass@word123",
+    "first_name": "test",
+    "last_name": "user",
+}
+
+
+def test_CustomUserCreateSerializer_converts_email_to_lower_case(db):
+    # Given
+    serializer = CustomUserCreateSerializer(data=user_dict)
+    # When
+    serializer.is_valid(raise_exception=True)
+    # Then
+    assert serializer.validated_data["email"] == "testuser@mail.com"
+
+
+def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(db):
+
+    # Given
+    FFAdminUser.objects.create(email="testuser@mail.com")
+    serializer = CustomUserCreateSerializer(data=user_dict)
+
+    # When
+    assert serializer.is_valid() == False
+    assert (
+        serializer.errors["email"][0].title()
+        == "Feature Flag Admin User With This Email Already Exists."
+    )

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -64,8 +64,9 @@ class UserManager(BaseUserManager):
 
         return self._create_user(email, password, **extra_fields)
 
-    def get_by_natural_key(self, username):
-        return self.get(email__iexact=username)
+    def get_by_natural_key(self, email):
+        # Used to allow case insensitive login
+        return self.get(email__iexact=email)
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Add validate_email that does a case insensitive  lookup
using the email to see a user exists with that email, and returns
the email with all lower case letters

closes #415 

