### PR TITLE
fix: Avoid errors when missing subscription information cache id

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -267,6 +267,9 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
         if not getattr(self.organisation, "subscription_information_cache", None):
             return
 
+        if not self.organisation.subscription_information_cache.id:
+            return
+
         self.organisation.subscription_information_cache.delete()
 
     def prepare_for_cancel(

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -267,6 +267,8 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
         if not getattr(self.organisation, "subscription_information_cache", None):
             return
 
+        # There is a weird bug where the cache is present, but the id is unset.
+        # See here for more: https://flagsmith.sentry.io/issues/4945988284/
         if not self.organisation.subscription_information_cache.id:
             return
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

A [Sentry issue](https://flagsmith.sentry.io/issues/4945988284/?alert_rule_id=14542360&alert_type=issue&environment=production&notification_uuid=807455be-47d6-417f-ade1-b075a549842d&project=5544478&referrer=slack) alerted the ability of an unset subscription information cache id during an organisational delete. This code simply checks the presence of the model in question and does not delete it if the id is not present. 

Though only three occurrences at the time of this writing have happened, it's not clear as to how the application got into the state where an model is set without an id. 

## How did you test this code?

I am going to rely on CI since the change is very simple.