### PR TITLE
style: Fix text body dark util

### DIFF
--- a/frontend/web/styles/project/_utils.scss
+++ b/frontend/web/styles/project/_utils.scss
@@ -162,15 +162,14 @@
 }
 .dark {
     .text-body {
-        color: white;
+        color: white !important;
         >path{
-            fill: white;
+            fill: white !important;
         }
     }
     .bg-primary {
         background: $bt-brand-primary-dark !important;
     }
-
 }
 
 .link-unstyled {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Bootstrap was overriding the body-text color in dark mode

Before: 

<img width="230" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/10aa04c1-30df-4c96-bcff-f5e0a9e3c9a0">


After: 

<img width="242" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/ea289940-d2f1-4149-8e64-6c422db12fd2">


## How did you test this code?

As above