### PR TITLE
fix: Invalid Segment base URLs

### DIFF
--- a/api/integrations/segment/constants.py
+++ b/api/integrations/segment/constants.py
@@ -1,2 +1,2 @@
-DEFAULT_BASE_URL = "api.segment.io/"
-DUBLIN_BASE_URL = "events.eu1.segmentapis.com/"
+DEFAULT_BASE_URL = "https://api.segment.io/"
+DUBLIN_BASE_URL = "https://events.eu1.segmentapis.com/"

--- a/api/integrations/segment/migrations/0006_set_base_url_to_default_again.py
+++ b/api/integrations/segment/migrations/0006_set_base_url_to_default_again.py
@@ -1,0 +1,28 @@
+# TODO: squash 0005 and this migration together
+
+from django.apps.registry import Apps
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+from integrations.segment import constants
+
+
+_INVALID_DEFAULT_BASE_URL = "api.segment.io/"
+
+
+def set_base_url(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    SegmentConfiguration = apps.get_model("segment", "SegmentConfiguration")
+    SegmentConfiguration.objects.filter(base_url=_INVALID_DEFAULT_BASE_URL).update(
+        base_url=constants.DEFAULT_BASE_URL,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("segment", "0005_set_base_url_to_default"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_base_url, reverse_code=migrations.RunPython.noop),
+    ]

--- a/api/integrations/segment/serializers.py
+++ b/api/integrations/segment/serializers.py
@@ -15,7 +15,7 @@ class SegmentConfigurationSerializer(BaseEnvironmentIntegrationModelSerializer):
             constants.DUBLIN_BASE_URL,
         ],
         required=False,
-        default="api.segment.io/",
+        default=constants.DEFAULT_BASE_URL,
     )
 
     class Meta:

--- a/api/tests/unit/integrations/segment/test_unit_segment.py
+++ b/api/tests/unit/integrations/segment/test_unit_segment.py
@@ -10,7 +10,7 @@ from integrations.segment.segment import SegmentWrapper
 def test_segment_initialized_correctly():
     # Given
     api_key = "123key"
-    base_url = "api.segment.io/"
+    base_url = "https://api.segment.io/"
     config = SegmentConfiguration(api_key=api_key, base_url=base_url)
 
     # When


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes

```
MissingSchema
Invalid URL 'api.segment.io/v1/batch': No scheme supplied. Perhaps you meant https://api.segment.io/v1/batch?
```

and adds a new migration to fix the invalid base URLs written by the previous migration.

## How did you test this code?

We're going to test in staging, then in production.