### PR TITLE
feat: Enhance feature segment permissions with tag validation

### DIFF
--- a/api/features/feature_segments/permissions.py
+++ b/api/features/feature_segments/permissions.py
@@ -27,14 +27,18 @@ class FeatureSegmentPermissions(IsAuthenticated):
                 environment = request.data.get("environment")
                 environment = Environment.objects.get(id=int(environment))
 
-                feature_id = request.data.get("feature") or view.kwargs.get("feature_pk")
+                feature_id = request.data.get("feature") or view.kwargs.get(
+                    "feature_pk"
+                )
                 feature = Feature.objects.get(
                     id=feature_id, project=environment.project
                 )
                 tag_ids = list(feature.tags.values_list("id", flat=True))
 
                 return request.user.has_environment_permission(
-                    permission=MANAGE_SEGMENT_OVERRIDES, environment=environment, tag_ids=tag_ids
+                    permission=MANAGE_SEGMENT_OVERRIDES,
+                    environment=environment,
+                    tag_ids=tag_ids,
                 )
 
         return False

--- a/api/features/feature_segments/permissions.py
+++ b/api/features/feature_segments/permissions.py
@@ -6,6 +6,7 @@ from common.environments.permissions import (  # type: ignore[import-untyped]
 from rest_framework.permissions import IsAuthenticated
 
 from environments.models import Environment
+from features.models import Feature
 
 
 class FeatureSegmentPermissions(IsAuthenticated):
@@ -17,7 +18,7 @@ class FeatureSegmentPermissions(IsAuthenticated):
         if view.detail:
             return True
 
-        # handle by the view
+        # handled by the view
         if view.action in ["list", "get_by_uuid", "update_priorities"]:
             return True
 
@@ -26,13 +27,23 @@ class FeatureSegmentPermissions(IsAuthenticated):
                 environment = request.data.get("environment")
                 environment = Environment.objects.get(id=int(environment))
 
+                feature_id = request.data.get("feature") or view.kwargs.get("feature_pk")
+                feature = Feature.objects.get(
+                    id=feature_id, project=environment.project
+                )
+                tag_ids = list(feature.tags.values_list("id", flat=True))
+
                 return request.user.has_environment_permission(
-                    MANAGE_SEGMENT_OVERRIDES, environment
+                    permission=MANAGE_SEGMENT_OVERRIDES, environment=environment, tag_ids=tag_ids
                 )
 
         return False
 
     def has_object_permission(self, request, view, obj):  # type: ignore[no-untyped-def]
+        tag_ids = list(obj.feature.tags.values_list("id", flat=True))
+
         return request.user.has_environment_permission(
-            MANAGE_SEGMENT_OVERRIDES, environment=obj.environment
+            permission=MANAGE_SEGMENT_OVERRIDES,
+            environment=obj.environment,
+            tag_ids=tag_ids,
         )

--- a/api/features/feature_segments/permissions.py
+++ b/api/features/feature_segments/permissions.py
@@ -27,13 +27,13 @@ class FeatureSegmentPermissions(IsAuthenticated):
                 environment = request.data.get("environment")
                 environment = Environment.objects.get(id=int(environment))
 
-                feature_id = request.data.get("feature") or view.kwargs.get(
-                    "feature_pk"
-                )
-                feature = Feature.objects.get(
-                    id=feature_id, project=environment.project
-                )
-                tag_ids = list(feature.tags.values_list("id", flat=True))
+                if feature_id := request.data.get("feature"):
+                    feature = Feature.objects.get(
+                        id=feature_id, project=environment.project
+                    )
+                    tag_ids = list(feature.tags.values_list("id", flat=True))
+                else:
+                    tag_ids = []
 
                 return request.user.has_environment_permission(
                     permission=MANAGE_SEGMENT_OVERRIDES,

--- a/api/features/permissions.py
+++ b/api/features/permissions.py
@@ -213,15 +213,13 @@ class CreateSegmentOverridePermissions(IsAuthenticated):
 
         feature_id = request.data.get("feature") or view.kwargs.get("feature_pk")
 
-        feature = Feature.objects.get(
-            id=feature_id, project=environment.project
-        )
+        feature = Feature.objects.get(id=feature_id, project=environment.project)
         tag_ids = list(feature.tags.values_list("id", flat=True))
 
         return request.user.has_environment_permission(
             permission=MANAGE_SEGMENT_OVERRIDES,
             environment=environment,
-            tag_ids=tag_ids
+            tag_ids=tag_ids,
         )
 
 

--- a/api/features/permissions.py
+++ b/api/features/permissions.py
@@ -211,10 +211,11 @@ class CreateSegmentOverridePermissions(IsAuthenticated):
             Environment, api_key=view.kwargs["environment_api_key"]
         )
 
-        feature_id = request.data.get("feature") or view.kwargs.get("feature_pk")
-
-        feature = Feature.objects.get(id=feature_id, project=environment.project)
-        tag_ids = list(feature.tags.values_list("id", flat=True))
+        if feature_id := view.kwargs.get("feature_pk"):
+            feature = Feature.objects.get(id=feature_id, project=environment.project)
+            tag_ids = list(feature.tags.values_list("id", flat=True))
+        else:
+            tag_ids = []
 
         return request.user.has_environment_permission(
             permission=MANAGE_SEGMENT_OVERRIDES,

--- a/api/features/permissions.py
+++ b/api/features/permissions.py
@@ -211,9 +211,17 @@ class CreateSegmentOverridePermissions(IsAuthenticated):
             Environment, api_key=view.kwargs["environment_api_key"]
         )
 
+        feature_id = request.data.get("feature") or view.kwargs.get("feature_pk")
+
+        feature = Feature.objects.get(
+            id=feature_id, project=environment.project
+        )
+        tag_ids = list(feature.tags.values_list("id", flat=True))
+
         return request.user.has_environment_permission(
             permission=MANAGE_SEGMENT_OVERRIDES,
             environment=environment,
+            tag_ids=tag_ids
         )
 
 

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_permissions.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_permissions.py
@@ -1,0 +1,149 @@
+from unittest.mock import MagicMock, patch
+
+from rest_framework.permissions import IsAuthenticated
+
+from features.feature_segments.permissions import FeatureSegmentPermissions
+
+
+def test_has_permission_when_super_returns_false():  # type: ignore[no-untyped-def]  # noqa: E501
+    permission = FeatureSegmentPermissions()
+    request = MagicMock()
+    view = MagicMock()
+    with patch.object(IsAuthenticated, "has_permission", return_value=False):
+        result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+        assert result is False
+
+
+def test_feature_permission_return_true_if_view_action_is_list():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+
+    request = MagicMock()
+    view = MagicMock()
+    view.action = "list"
+    view.detail = None
+
+    # WHEN
+    result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+    # THEN
+    assert result is True
+
+
+def test_feature_permission_return_true_if_view_action_is_get_by_uuid():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+
+    request = MagicMock()
+    view = MagicMock()
+    view.action = "get_by_uuid"
+    view.detail = None
+
+    # WHEN
+    result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+    # THEN
+    assert result is True
+
+
+def test_feature_permission_return_true_if_view_action_is_update_priorities():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+
+    request = MagicMock()
+    view = MagicMock()
+    view.action = "update_priorities"
+    view.detail = None
+
+    # WHEN
+    result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+    # THEN
+    assert result is True
+
+
+def test_feature_permission_return_true_if_view_details_is_not_falsy():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+
+    request = MagicMock()
+    view = MagicMock()
+    view.action = "anything"
+    view.detail = "anything"
+
+    # WHEN
+    result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+    # THEN
+    assert result is True
+
+
+def test_feature_permission_return_false_if_view_action_is_unsupported():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+
+    request = MagicMock()
+    view = MagicMock()
+    view.action = "anything"
+    view.detail = None
+
+    # WHEN
+    result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+    # THEN
+    assert result is False
+
+
+def test_feature_permission_pass_empty_list_of_tags_if_feature_id_is_not_provided():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+    fake_env = MagicMock()
+
+    request = MagicMock()
+    request.data = {"environment": "1", "feature": None}
+    request.user.has_environment_permission.return_value = True
+
+    view = MagicMock()
+    view.action = "create"
+    view.detail = None
+
+    # WHEN
+    with patch("environments.models.Environment.objects.get", return_value=fake_env):
+        result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+        # THEN
+        assert result is True
+        request.user.has_environment_permission.assert_called_once_with(
+            permission="MANAGE_SEGMENT_OVERRIDES",
+            environment=fake_env,
+            tag_ids=[],
+        )
+
+
+def test_feature_permission_pass_list_of_tags_if_feature_id_is_provided():  # type: ignore[no-untyped-def]  # noqa: E501
+    # GIVEN
+    permission = FeatureSegmentPermissions()
+    fake_env = MagicMock()
+    fake_feature = MagicMock()
+    fake_feature.tags.values_list.return_value = [1, 2, 3]
+
+    request = MagicMock()
+    request.data = {"environment": "1", "feature": "1"}
+    request.user.has_environment_permission.return_value = True
+
+    view = MagicMock()
+    view.action = "create"
+    view.detail = None
+
+    # WHEN
+    with patch("environments.models.Environment.objects.get", return_value=fake_env):
+        with patch("features.models.Feature.objects.get", return_value=fake_feature):
+            result = permission.has_permission(request, view)  # type: ignore[no-untyped-call]
+
+            # THEN
+            assert result is True
+            request.user.has_environment_permission.assert_called_once_with(
+                permission="MANAGE_SEGMENT_OVERRIDES",
+                environment=fake_env,
+                tag_ids=[1, 2, 3],
+            )

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -29,8 +29,6 @@ from tests.types import (
 from users.models import FFAdminUser
 
 
-from common.environments.permissions import MANAGE_SEGMENT_OVERRIDES
-
 @pytest.mark.skipif(
     settings.IS_RBAC_INSTALLED is True,
     reason="Skip this test if RBAC is installed",
@@ -273,62 +271,69 @@ def test_create_feature_segment_staff_wrong_permission(  # type: ignore[no-untyp
 
 
 def test_create_segment_override_permissions_granted(
-        staff_user: FFAdminUser,
-        project: Project,
-        environment: Environment,
-        feature: Feature,
-        segment: Segment,
-        staff_client: APIClient,
-        with_environment_permissions: WithEnvironmentPermissionsCallable,
+    staff_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    segment: Segment,
+    staff_client: APIClient,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Give user permission to manage segment overrides
     with_environment_permissions([MANAGE_SEGMENT_OVERRIDES])  # type: ignore[call-arg]
 
-    url = reverse("api-v1:environments:create-segment-override", args=[environment.api_key, feature.id])
+    url = reverse(
+        "api-v1:environments:create-segment-override",
+        args=[environment.api_key, feature.id],
+    )
     data = {
-        "feature_segment": {
-            "segment": segment.id
-        },
+        "feature_segment": {"segment": segment.id},
         "enabled": True,
         "feature_state_value": {
             "type": "unicode",
             "string_value": "new_state",
-        }
+        },
     }
 
     # When
-    response = staff_client.post(url, data=json.dumps(data), content_type="application/json")
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
 
     # Then
     assert response.status_code == status.HTTP_201_CREATED
 
 
 def test_create_segment_override_permissions_denied(
-        staff_user: FFAdminUser,
-        project: Project,
-        environment: Environment,
-        feature: Feature,
-        segment: Segment,
-        staff_client: APIClient,
+    staff_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    segment: Segment,
+    staff_client: APIClient,
 ) -> None:
     # No permissions given explicitly for MANAGE_SEGMENT_OVERRIDES
-    url = reverse("api-v1:environments:create-segment-override", args=[environment.api_key, feature.id])
+    url = reverse(
+        "api-v1:environments:create-segment-override",
+        args=[environment.api_key, feature.id],
+    )
     data = {
-        "feature_segment": {
-            "segment": segment.id
-        },
+        "feature_segment": {"segment": segment.id},
         "enabled": True,
         "feature_state_value": {
             "type": "unicode",
             "string_value": "new_state",
-        }
+        },
     }
 
     # When
-    response = staff_client.post(url, data=json.dumps(data), content_type="application/json")
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
 
 @pytest.mark.parametrize(
     "client",

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -29,6 +29,8 @@ from tests.types import (
 from users.models import FFAdminUser
 
 
+from common.environments.permissions import MANAGE_SEGMENT_OVERRIDES
+
 @pytest.mark.skipif(
     settings.IS_RBAC_INSTALLED is True,
     reason="Skip this test if RBAC is installed",
@@ -269,6 +271,64 @@ def test_create_feature_segment_staff_wrong_permission(  # type: ignore[no-untyp
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
+
+def test_create_segment_override_permissions_granted(
+        staff_user: FFAdminUser,
+        project: Project,
+        environment: Environment,
+        feature: Feature,
+        segment: Segment,
+        staff_client: APIClient,
+        with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Give user permission to manage segment overrides
+    with_environment_permissions([MANAGE_SEGMENT_OVERRIDES])  # type: ignore[call-arg]
+
+    url = reverse("api-v1:environments:create-segment-override", args=[environment.api_key, feature.id])
+    data = {
+        "feature_segment": {
+            "segment": segment.id
+        },
+        "enabled": True,
+        "feature_state_value": {
+            "type": "unicode",
+            "string_value": "new_state",
+        }
+    }
+
+    # When
+    response = staff_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_create_segment_override_permissions_denied(
+        staff_user: FFAdminUser,
+        project: Project,
+        environment: Environment,
+        feature: Feature,
+        segment: Segment,
+        staff_client: APIClient,
+) -> None:
+    # No permissions given explicitly for MANAGE_SEGMENT_OVERRIDES
+    url = reverse("api-v1:environments:create-segment-override", args=[environment.api_key, feature.id])
+    data = {
+        "feature_segment": {
+            "segment": segment.id
+        },
+        "enabled": True,
+        "feature_state_value": {
+            "type": "unicode",
+            "string_value": "new_state",
+        }
+    }
+
+    # When
+    response = staff_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 @pytest.mark.parametrize(
     "client",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR partially enables a check against tags for the management of segments overrides. Testing is limited as this would require the settings.IS_RBAC_INSTALLED to be true, forcing it in tests causes an obvious error.

What remains to do is some additional testing, I think.

## How did you test this code?

Added a couple of automated tests, which are not really checking much of the logic, since rbac repo is needed for this.


## More info

I'm afraid this PR is only partial as to fully complete this work I would need access to the private rbac repo. This PR also requires the addition of the MANAGE_SEGMENT_OVERRIDES permission to the TAG_SUPPORTED_PERMISSIONS in the common repo. PR -> https://github.com/Flagsmith/flagsmith-common/pull/14