### PR TITLE
fix(usage notifications): handle plans with billing terms longer than 12 months

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -128,7 +128,7 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
             return
 
         # Truncate to the closest active month to get start of current period.
-        month_delta = relativedelta(now, billing_starts_at).months
+        month_delta = _get_total_months(relativedelta(now, billing_starts_at))
         period_starts_at = relativedelta(months=month_delta) + billing_starts_at
 
         allowed_api_calls = subscription_cache.allowed_30d_api_calls
@@ -160,3 +160,7 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
         return
 
     _send_api_usage_notification(organisation, matched_threshold)
+
+
+def _get_total_months(rd: relativedelta) -> int:
+    return rd.months + rd.years * 12


### PR DESCRIPTION
## Changes

This PR fixes an issue raised by a customer where they were sent a notification saying that they had used more than 500% of their allowance because the query to influx was returning all of their usage since the start of the billing period.

The bug was that `relativedelta.months` is not the same as `relativedelta.total_months` so actually the result from `relativedelta.months` was 0 rather than 12, because the relative delta looked something like `relativedelta(years=1, months=0, ...)`. 

I'm still unsure how we have billing terms that last for longer than 12 months, but this change should be robust to handle billing terms <12 months, or >12 months.  

External (private) references for context:

[Crisp chat with customer](https://app.crisp.chat/website/8857f89e-0eb5-4263-ab49-a293872b6c19/inbox/session_49fc2f0d-b9df-44c6-a9cd-8a9accc7da25/)
[Slack conversation](https://flagsmith.slack.com/archives/C06P8KV2CC8/p1746174774108729)

## How did you test this code?

Added a new unit test. 
