### PR TITLE
feat: add ability to duplicate a segment with user-defined name (#5259)

### DIFF
--- a/frontend/web/components/modals/CreateDuplicateSegmentModal.tsx
+++ b/frontend/web/components/modals/CreateDuplicateSegmentModal.tsx
@@ -2,7 +2,7 @@ import React, { FC, FormEvent, useState } from 'react'
 import { Segment, SegmentRule } from 'common/types/responses'
 import ProjectProvider from 'common/providers/ProjectProvider'
 import InputGroup from 'components/base/forms/InputGroup'
-import Utils from 'common/utils/utils' // we need this to make JSX compile
+import Utils from 'common/utils/utils'
 import Button from 'components/base/forms/Button'
 import ModalHR from './ModalHR'
 

--- a/frontend/web/components/modals/CreateDuplicateSegmentModal.tsx
+++ b/frontend/web/components/modals/CreateDuplicateSegmentModal.tsx
@@ -1,0 +1,94 @@
+import React, { FC, FormEvent, useState } from 'react'
+import { Segment, SegmentRule } from 'common/types/responses'
+import ProjectProvider from 'common/providers/ProjectProvider'
+import InputGroup from 'components/base/forms/InputGroup'
+import Utils from 'common/utils/utils' // we need this to make JSX compile
+import Button from 'components/base/forms/Button'
+import ModalHR from './ModalHR'
+
+type CreateDuplicateSegmentType = {
+  segment: Segment
+  cb: (segment: Omit<Segment, 'id' | 'uuid'>) => void
+}
+
+const CreateDuplicateSegmentModal: FC<CreateDuplicateSegmentType> = ({
+  cb,
+  segment,
+}) => {
+  const [challenge, setChallenge] = useState()
+
+  function removeIds(rules: SegmentRule[]): SegmentRule[] {
+    return rules.map(rule => ({
+      conditions: rule.conditions.map(({ delete: del, description, operator, property, value }) => ({
+        delete: del,
+        description,
+        operator,
+        property,
+        value,
+      })),
+      delete: rule.delete,
+      rules: removeIds(rule.rules),
+      type: rule.type,
+    }));
+  }
+  
+  const submit = (e: FormEvent) => {
+    e.preventDefault()
+    if (challenge) {
+      const newSegment: Omit<Segment, 'id' | 'uuid'> = {
+        description: segment.description,
+        metadata: segment.metadata,
+        name: challenge,
+        project: segment.project,
+        rules: removeIds(segment.rules),
+        ...(segment.feature && { feature: segment.feature }),
+      }
+      closeModal()
+      console.log(newSegment)
+      cb(newSegment)
+    }
+  }
+
+  return (
+    <ProjectProvider>
+      {() => (
+        <form id='confirm-duplicate-segment-modal' onSubmit={submit}>
+            <div className='modal-body'>
+                <p>
+                This will create a copy of <strong>{segment.name}</strong>, including all its rules and configuration.
+                You can modify the duplicate without affecting the original segment.
+                </p>
+                <InputGroup
+                className='mb-0'
+                inputProps={{
+                    className: 'full-width',
+                    name: 'new-segment-name',
+                }}
+                title='Please enter a name for the new segment'
+                placeholder='new_segment_name'
+                onChange={(e: InputEvent) => {
+                    setChallenge(Utils.safeParseEventValue(e))
+                }}
+                />
+            </div>
+            <ModalHR />
+            <div className='modal-footer'>
+                <Button className='mr-2' onClick={closeModal} theme='secondary'>
+                Cancel
+                </Button>
+                <Button
+                id='confirm-duplicate-segment-btn'
+                disabled={!challenge}
+                type='submit'
+                >
+                Duplicate
+                </Button>
+            </div>
+        </form>
+
+      )}
+    </ProjectProvider>
+  )
+}
+
+export default CreateDuplicateSegmentModal

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -324,7 +324,7 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
                               })
                               }
                             }}
-                            className='btn btn-with-icon me-2' // Add margin to the right
+                            className='btn btn-with-icon me-2'
                           >
                             <Icon name='copy' width={20} fill='#656D7B' />
                           </Button>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Added a new modal component CreateDuplicateSegmentModal.tsx to create duplicates of segments by copying their data without IDs.

Integrated this modal into SegmentsPage.tsx with a new duplicateSegment function that opens the modal and calls a callback on submission.

Added a "duplicate" button for each segment that triggers duplication using the modal and creates the new segment via API, showing success/error toasts.

Adjusted UI states to disable buttons during creation/removal to handle loading properly.

## How did you test this code?

Step 1: Navigate to the Segments page in the application.
Step 2: Find an existing segment from the list.
Step 3: Click the "duplicate" (copy) button next to the chosen segment.
Step 4: In the modal, enter a name for the new segment.
Step 5: Submit the form to create the duplicate segment.
Step 6: Verify the modal closes, the new segment appears in the list, and a success toast shows with the original segment’s name.
Step 7: Try submitting with an empty name to confirm the submit button is disabled, and test canceling the modal closes it without changes.
Step 8: Simulate an API failure (if possible) and verify the error toast appears.
Step 9: Confirm the duplicate and remove buttons are disabled during creation/removal loading states.

Note: Tested for feature specific segments as well.

Added below recording:
![fix-demo](https://github.com/user-attachments/assets/e25f4ac4-82c8-49fa-b5bb-2a74e258ed53)

