### PR TITLE
fix(launch-darkly-importer): Seconds `X-Ratelimit-Reset` timestamps are expected for rate limited requests

### DIFF
--- a/api/tests/unit/integrations/launch_darkly/test_client.py
+++ b/api/tests/unit/integrations/launch_darkly/test_client.py
@@ -214,7 +214,7 @@ def test_launch_darkly_client__get_flag_tags__return_expected(
 
 @pytest.mark.parametrize(
     "response_headers",
-    [{"Retry-After": "0.1"}, {"X-Ratelimit-Reset": "1672531200.1"}],
+    [{"Retry-After": "0.1"}, {"X-Ratelimit-Reset": "1672531200100"}],
 )
 @pytest.mark.freeze_time("2023-01-01T00:00:00Z")
 def test_launch_darkly_client__rate_limit__expected_backoff(
@@ -252,7 +252,7 @@ def test_launch_darkly_client__rate_limit__expected_backoff(
 
 @pytest.mark.parametrize(
     "response_headers",
-    [{"Retry-After": "0.1"}, {"X-Ratelimit-Reset": "1672531200.1"}],
+    [{"Retry-After": "0.1"}, {"X-Ratelimit-Reset": "1672531200100"}],
 )
 @pytest.mark.freeze_time("2023-01-01T00:00:00Z")
 def test_launch_darkly_client__rate_limit_max_retries__raises_expected(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Currently, we interpret `X-Ratelimit-Reset` header values as seconds, which is not correct — they are in fact being returned as milliseconds, see [LD docs](https://launchdarkly.com/docs/api#global-rate-limits).

## How did you test this code?

Verified that millisecond timestamps are returned by manually triggering the rate limit.

Updated unit tests.