### PR TITLE
docs: add `USE_POSTGRES_FOR_ANALYTICS` to docs

### DIFF
--- a/docs/docs/advanced-use/flag-analytics.md
+++ b/docs/docs/advanced-use/flag-analytics.md
@@ -33,6 +33,13 @@ Flag analytics are disabled by default in our SDKs. You need to explicitly enabl
 client. Please refer to the corresponding SDK documentation for more details. For the Javascript family SDKs please
 refer to [Initialisation options](https://docs.flagsmith.com/clients/javascript#initialisation-options).
 
+:::info
+
+If you are self-hosting Flagsmith, you'll also need to ensure that the `USE_POSTGRES_FOR_ANALYTICS` is set to `True` 
+in your Flagsmith API containers.
+
+:::
+
 ## How does it work?
 
 Every time a flag is evaluated within the SDK (generally a call to a method like

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -169,6 +169,8 @@ the below variables will be ignored.
 - `INFLUXDB_TOKEN`: If you want to send API events to InfluxDB, specify this write token.
 - `INFLUXDB_URL`: The URL for your InfluxDB database
 - `INFLUXDB_ORG`: The organisation string for your InfluxDB API call.
+- `USE_POSTGRES_FOR_ANALYTICS`: Set this to `True` to send analytics data to the postgres database. Required for using 
+  [flag analytics](/advanced-use/flag-analytics) when self-hosting.
 - `GA_TABLE_ID`: GA table ID (view) to query when looking for organisation usage
 - `USER_CREATE_PERMISSIONS`: set the permissions for creating new users, using a comma separated list of djoser or
   rest_framework permissions. Use this to turn off public user creation for self hosting. e.g.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds missing environment variable `USE_POSTGRES_FOR_ANALYTICS` to the docs. 

Marked as draft because I'm not happy with the aesthetic of the 'Enabling Flag Analytics' section with the 2 callouts. 

<img width="995" alt="image" src="https://github.com/user-attachments/assets/95c86745-07c4-4b97-bc5b-cb5cc35885bf" />

## How did you test this code?

Ran the docs locally to confirm new documentation was added as expected. 
