### PR TITLE
fix: use-query-from-workflow-list-change-request

### DIFF
--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1174,9 +1174,16 @@ def test_environment_metric_query_helpers_match_expected_counts(
         version += 1
 
     for i in range(scheduled_change_count):
+        cr = ChangeRequest.objects.create(
+            environment=env,
+            title=f"Scheduled-CR-{i}",
+            user_id=admin_user.id,
+            committed_at=timezone.now(),
+        )
         FeatureState.objects.update_or_create(
             feature=random.choice(features),
             environment=env,
+            change_request=cr,
             identity=None,
             enabled=True,
             live_from=timezone.now() + timedelta(days=5),


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Scheduled changes calculation was solely relying on feature states while real use case is based on change requests (and depending on environment versioning).

Reworked the calculation by using the query used in flagsmith-workflows `GET list-change-requests` as to count exactly the  records that would be shown in scheduled changes page

## How did you test this code?
- Created scheduled changes and verified the count
- Reworked the tests