### PR TITLE
fix: Incorrect mapper behaviour for SDK metrics

### DIFF
--- a/api/app_analytics/constants.py
+++ b/api/app_analytics/constants.py
@@ -20,7 +20,7 @@ TRACK_HEADERS: dict[str, Label] = {
     "Flagsmith-Application-Version": "client_application_version",
     "User-Agent": "user_agent",
 }
-LABELS: tuple[Label, ...] = get_args(Label)
+LABELS: tuple[str, ...] = tuple(str(label) for label in get_args(Label))
 
 NO_ANALYTICS_DATABASE_CONFIGURED_WARNING = (
     "No analytics database configured. "

--- a/api/app_analytics/serializers.py
+++ b/api/app_analytics/serializers.py
@@ -119,6 +119,6 @@ class SDKAnalyticsFlagsSerializer(serializers.Serializer):  # type: ignore[type-
 
 def _get_label_fields() -> dict[str, serializers.Field[Any, Any, Any, Any]]:
     return {
-        str(label): serializers.CharField(allow_null=True, required=False)
+        label: serializers.CharField(allow_null=True, required=False)
         for label in LABELS
     }

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_mappers.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_mappers.py
@@ -1,0 +1,81 @@
+from datetime import date, datetime
+
+from influxdb_client.client.flux_table import FluxRecord, FluxTable
+
+from app_analytics.dataclasses import FeatureEvaluationData, UsageData
+from app_analytics.mappers import (
+    map_flux_tables_to_feature_evaluation_data,
+    map_flux_tables_to_usage_data,
+)
+
+
+def test_map_flux_tables_to_feature_evaluation_data__returns_expected() -> None:
+    # Given
+    flux_table = FluxTable()
+    flux_table.records.append(
+        FluxRecord(
+            flux_table,
+            values={
+                "_time": datetime.fromisoformat("2023-10-01T00:00:00Z"),
+                "_value": 5,
+                "feature_name": "feature_1",
+                "client_application_name": "test-app",
+                "unrelated": "value",
+            },
+        )
+    )
+
+    # When
+    result = map_flux_tables_to_feature_evaluation_data(flux_tables=[flux_table])
+
+    # Then
+    assert result == [
+        FeatureEvaluationData(
+            day=date(2023, 10, 1),
+            count=5,
+            labels={"client_application_name": "test-app"},
+        )
+    ]
+
+
+def test_map_flux_tables_to_usage_data__returns_expected() -> None:
+    # Given
+    flux_table = FluxTable()
+    flux_table.records.append(
+        FluxRecord(
+            flux_table,
+            values={
+                "_time": datetime.fromisoformat("2023-10-01T00:00:00Z"),
+                "_value": 10,
+                "resource": "flags",
+                "client_application_name": "test-app",
+                "unrelated": "value",
+            },
+        ),
+    )
+    flux_table.records.append(
+        FluxRecord(
+            flux_table,
+            values={
+                "_time": datetime.fromisoformat("2023-10-01T00:00:00Z"),
+                "_value": 10,
+                "resource": "identities",
+                "client_application_name": "test-app",
+                "unrelated": "value",
+            },
+        ),
+    )
+
+    # When
+    result = map_flux_tables_to_usage_data(flux_tables=[flux_table])
+
+    # Then
+    assert result == [
+        UsageData(
+            day=date(2023, 10, 1),
+            flags=10,
+            traits=0,
+            identities=10,
+            labels={"client_application_name": "test-app"},
+        )
+    ]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This solves two issues:
1. Closes #5815.
2. Fixes `map_annotated_api_usage_buckets_to_usage_data` so that it outputs aggregated resource usage instead of a `UsageData` object per resource returned from Influx.

## How did you test this code?

Added unit tests for the failing mappers.