### PR TITLE
fix: check-split-length-before-accessing-with-index

### DIFF
--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -1,8 +1,12 @@
+import re
 from typing import Any
 
 from common.core.utils import is_saas
 from django.conf import settings
-from djoser.serializers import UserCreateSerializer  # type: ignore[import-untyped]
+from djoser.serializers import (  # type: ignore[import-untyped]
+    TokenCreateSerializer,
+    UserCreateSerializer,
+)
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import PermissionDenied
@@ -18,6 +22,15 @@ from .constants import (
     INVALID_PASSWORD_ERROR,
     USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE,
 )
+
+EMAIL_REGEX = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
+
+
+class CustomTokenCreateSerializer(TokenCreateSerializer):  # type: ignore[misc]
+    def validate_email(self, value: str) -> str:
+        if not EMAIL_REGEX.match(value):
+            raise serializers.ValidationError("Invalid email format.")
+        return value
 
 
 class CustomTokenSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -23,7 +23,7 @@ from .constants import (
     USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE,
 )
 
-EMAIL_REGEX = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
+EMAIL_REGEX = re.compile(r"^[^@]+@(?:\w+\.)+\w{2,}$")
 
 
 class CustomTokenCreateSerializer(TokenCreateSerializer):  # type: ignore[misc]

--- a/api/custom_auth/views.py
+++ b/api/custom_auth/views.py
@@ -30,7 +30,7 @@ from custom_auth.mfa.trench.models import MFAMethod
 from custom_auth.mfa.trench.responses import ErrorResponse
 from custom_auth.mfa.trench.serializers import CodeLoginSerializer
 from custom_auth.mfa.trench.utils import user_token_generator
-from custom_auth.serializers import CustomUserDelete
+from custom_auth.serializers import CustomTokenCreateSerializer, CustomUserDelete
 from integrations.lead_tracking.hubspot.services import (
     register_hubspot_tracker_and_track_user,
 )
@@ -46,6 +46,7 @@ class CustomAuthTokenLoginOrRequestMFACode(TokenCreateView):  # type: ignore[mis
     Class to handle throttling for login requests
     """
 
+    serializer_class = CustomTokenCreateSerializer
     authentication_classes = []  # type: ignore[var-annotated]
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = "login"

--- a/api/integrations/lead_tracking/hubspot/services.py
+++ b/api/integrations/lead_tracking/hubspot/services.py
@@ -69,7 +69,9 @@ def register_hubspot_tracker(
 def create_self_hosted_onboarding_lead(
     email: str, first_name: str, last_name: str, organisation_name: str
 ) -> None:
-    email_domain = email.split("@")[1]
+    email_parts = email.split("@")
+    if len(email_parts) > 1:
+        email_domain = email_parts[1]
     hubspot_client = HubspotClient()
     company = hubspot_client.get_company_by_domain(email_domain)
     if not company:

--- a/api/integrations/lead_tracking/hubspot/services.py
+++ b/api/integrations/lead_tracking/hubspot/services.py
@@ -70,8 +70,7 @@ def create_self_hosted_onboarding_lead(
     email: str, first_name: str, last_name: str, organisation_name: str
 ) -> None:
     email_parts = email.split("@")
-    if len(email_parts) > 1:
-        email_domain = email_parts[1]
+    email_domain = email_parts[1] if len(email_parts) > 1 else organisation_name
     hubspot_client = HubspotClient()
     company = hubspot_client.get_company_by_domain(email_domain)
     if not company:

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -730,3 +730,32 @@ def test_marketing_consent_given_defaults_to_true(
     # Then
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["marketing_consent_given"] is True
+
+
+@pytest.mark.parametrize(
+    "invalid_email",
+    [
+        "invalid_email",
+        "12345",
+        "invalid@email@com.com",
+        "invalid_email.com",
+        "invalid_email@com",
+    ],
+)
+def test_create_user_returns_error_if_email_is_invalid(
+    staff_client: APIClient,
+    invalid_email: str,
+) -> None:
+    # Given
+    url = reverse("api-v1:custom_auth:custom-mfa-authtoken-login")
+    register_data = {
+        "email": invalid_email,
+        "password": "password",
+    }
+
+    # When
+    response = staff_client.post(url, data=register_data)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["email"][0] == "Invalid email format."

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -740,6 +740,7 @@ def test_marketing_consent_given_defaults_to_true(
         "invalid@email@com.com",
         "invalid_email.com",
         "invalid_email@com",
+        "foo@..!.bar.",
     ],
 )
 def test_create_user_returns_error_if_email_is_invalid(

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -232,17 +232,3 @@ def test_delete_user():  # type: ignore[no-untyped-def]
     user3.delete(delete_orphan_organisations=False)
     assert not FFAdminUser.objects.filter(email=email3).exists()
     assert Organisation.objects.filter(name="org1").count() == 1
-
-
-@pytest.mark.parametrize(
-    "email, expected_email_domain",
-    [
-        ("test@example.com", "example.com"),
-        ("test@subdomain.example.co.uk", "subdomain.example.co.uk"),
-        ("incorrect_email", None),
-    ],
-)
-def test_user_email_domain_property(
-    email: str, expected_email_domain: str | None
-) -> None:
-    assert FFAdminUser(email=email).email_domain == expected_email_domain

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -232,3 +232,7 @@ def test_delete_user():  # type: ignore[no-untyped-def]
     user3.delete(delete_orphan_organisations=False)
     assert not FFAdminUser.objects.filter(email=email3).exists()
     assert Organisation.objects.filter(name="org1").count() == 1
+
+
+def test_user_email_domain_property() -> None:
+    assert FFAdminUser(email="test@example.com").email_domain == "example.com"

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -234,5 +234,13 @@ def test_delete_user():  # type: ignore[no-untyped-def]
     assert Organisation.objects.filter(name="org1").count() == 1
 
 
-def test_user_email_domain_property():  # type: ignore[no-untyped-def]
-    assert FFAdminUser(email="test@example.com").email_domain == "example.com"
+@pytest.mark.parametrize(
+    "email, expected_email_domain",
+    [
+        ("test@example.com", "example.com"),
+        ("test@subdomain.example.co.uk", "subdomain.example.co.uk"),
+        ("incorrect_email", None),
+    ],
+)
+def test_user_email_domain_property(email, expected_email_domain):  # type: ignore[no-untyped-def]
+    assert FFAdminUser(email=email).email_domain == expected_email_domain

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -242,5 +242,7 @@ def test_delete_user():  # type: ignore[no-untyped-def]
         ("incorrect_email", None),
     ],
 )
-def test_user_email_domain_property(email: str, expected_email_domain: str | None) -> None:
+def test_user_email_domain_property(
+    email: str, expected_email_domain: str | None
+) -> None:
     assert FFAdminUser(email=email).email_domain == expected_email_domain

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -242,5 +242,5 @@ def test_delete_user():  # type: ignore[no-untyped-def]
         ("incorrect_email", None),
     ],
 )
-def test_user_email_domain_property(email, expected_email_domain):  # type: ignore[no-untyped-def]
+def test_user_email_domain_property(email: str, expected_email_domain: str | None) -> None:
     assert FFAdminUser(email=email).email_domain == expected_email_domain

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -194,7 +194,10 @@ class FFAdminUser(LifecycleModel, AbstractUser):  # type: ignore[django-manager-
 
     @property
     def email_domain(self):  # type: ignore[no-untyped-def]
-        return self.email.split("@")[1]
+        email_parts = self.email.split("@")
+        if len(email_parts) > 1:
+            return email_parts[1]
+        return None
 
     def get_full_name(self):  # type: ignore[no-untyped-def]
         if not self.first_name:

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -194,10 +194,7 @@ class FFAdminUser(LifecycleModel, AbstractUser):  # type: ignore[django-manager-
 
     @property
     def email_domain(self):  # type: ignore[no-untyped-def]
-        email_parts = self.email.split("@")
-        if len(email_parts) > 1:
-            return email_parts[1]
-        return None
+        return self.email.split("@")[1]
 
     def get_full_name(self):  # type: ignore[no-untyped-def]
         if not self.first_name:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

closes #4951 
## Changes
- Check split length before accessing

## How did you test this code?
Added test in models
To reproduce:
Try login with invalid email 


New error (without auth-controller cf this [PR](https://github.com/Flagsmith/flagsmith-auth-controller/pull/28)):

``` {
    "non_field_errors": [
        "Unable to log in with provided credentials."
    ]
}
```