### PR TITLE
chore: Include Features, Segments in evaluation context schema

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -47,7 +47,6 @@
                     "type": "string"
                 },
                 "variants": {
-                    "default": [],
                     "description": "An array of environment default values associated with the feature. Contains a single value for standard features, or multiple values for multivariate features.",
                     "items": {
                         "$ref": "#/$defs/FeatureValue"
@@ -57,7 +56,7 @@
                 }
             },
             "required": [
-                "id",
+                "key",
                 "name",
                 "enabled",
                 "value"
@@ -127,9 +126,9 @@
         "SegmentContext": {
             "description": "Represents a segment context for feature flag evaluation.",
             "properties": {
-                "id": {
-                    "description": "The unique identifier for the segment.",
-                    "title": "ID",
+                "key": {
+                    "description": "Key used for % split segmentation.",
+                    "title": "Key",
                     "type": "string"
                 },
                 "name": {
@@ -138,46 +137,84 @@
                     "type": "string"
                 },
                 "rules": {
-                    "additionalProperties": {
+                    "items": {
                         "$ref": "#/$defs/SegmentRule"
                     },
                     "title": "Rules",
-                    "type": "object"
+                    "type": "array"
                 }
             },
             "required": [
-                "id",
+                "key",
                 "name",
                 "rules"
             ],
             "title": "SegmentContext",
             "type": "object"
         },
+        "SegmentCondition": {
+            "description": "Represents a condition within a segment rule for feature flag evaluation.",
+            "properties": {
+                "path": {
+                    "description": "The path to the trait or value in the evaluation context.",
+                    "title": "Property",
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "The operator to use for evaluating the condition.",
+                    "title": "Operator",
+                    "type": "string",
+                    "enum": [
+                        "EQUAL",
+                        "GREATER_THAN",
+                        "LESS_THAN",
+                        "LESS_THAN_INCLUSIVE",
+                        "CONTAINS",
+                        "GREATER_THAN_INCLUSIVE",
+                        "NOT_CONTAINS",
+                        "NOT_EQUAL",
+                        "REGEX",
+                        "PERCENTAGE_SPLIT",
+                        "MODULO",
+                        "IS_SET",
+                        "IS_NOT_SET",
+                        "IN"
+                    ]
+                },
+                "value": {
+                    "description": "The value to compare against the trait or context value.",
+                    "title": "Value",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path",
+                "operator",
+                "value"
+            ],
+            "title": "SegmentCondition",
+            "type": "object"
+        },
         "SegmentRule": {
             "description": "Represents a rule within a segment for feature flag evaluation.",
             "properties": {
-                "name": {
-                    "description": "The name of the segment rule.",
-                    "title": "Name",
-                    "type": "string"
+                "type": {
+                    "description": "Segment rule type. Represents a logical quantifier for the conditions and sub-rules.",
+                    "title": "Type",
+                    "type": "string",
+                    "enum": [
+                        "ALL",
+                        "ANY",
+                        "NONE"
+                    ]
                 },
                 "conditions": {
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "boolean"
-                            }
-                        ]
+                    "description": "Conditions that must be met for the rule to apply.",
+                    "items": {
+                        "$ref": "#/$defs/SegmentCondition"
                     },
-                    "description": "Conditions that define the segment rule.",
                     "title": "Conditions",
-                    "type": "object"
+                    "type": "array"
                 },
                 "sub_rules": {
                     "additionalProperties": {
@@ -189,7 +226,7 @@
                 }
             },
             "required": [
-                "name",
+                "type",
                 "conditions"
             ],
             "title": "SegmentRule",

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -211,7 +211,7 @@
                     "title": "Conditions",
                     "type": "array"
                 },
-                "sub_rules": {
+                "rules": {
                     "items": {
                         "$ref": "#/$defs/SegmentRule"
                     },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -50,7 +50,7 @@
                     "type": "array"
                 },
                 "priority": {
-                    "description": "Indicates the priority of the feature context. Higher values indicate higher priority in case when multiple feature contexts for the same feature are applicable.",
+                    "description": "Priority of the feature context. Higher values indicate a higher priority when multiple contexts apply to the same feature.",
                     "title": "Priority",
                     "type": "number"
                 }

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -23,6 +23,68 @@
             "title": "EnvironmentContext",
             "type": "object"
         },
+        "FeatureContext": {
+            "description": "Represents a feature context for feature flag evaluation.",
+            "properties": {
+                "key": {
+                    "description": "Key used when selecting a value for a multivariate feature. Set to an internal identifier or a UUID, depending on Flagsmith implementation.",
+                    "title": "Key",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the feature.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "enabled": {
+                    "description": "Indicates whether the feature is enabled in the environment.",
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "value": {
+                    "description": "A default environment value for the feature. If the feature is multivariate, this will be the control value.",
+                    "title": "Value",
+                    "type": "string"
+                },
+                "variants": {
+                    "default": [],
+                    "description": "An array of environment default values associated with the feature. Contains a single value for standard features, or multiple values for multivariate features.",
+                    "items": {
+                        "$ref": "#/$defs/FeatureValue"
+                    },
+                    "title": "Variants",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "enabled",
+                "value"
+            ],
+            "title": "FeatureContext",
+            "type": "object"
+        },
+        "FeatureValue": {
+            "description": "Represents a multivariate value for a feature flag.",
+            "properties": {
+                "value": {
+                    "description": "The value of the feature.",
+                    "title": "Value",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "The weight of the feature value variant, as a percentage number (i.e. 100.0).",
+                    "title": "Weight",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "value"
+            ],
+            "title": "FeatureValue",
+            "type": "object"
+        },
         "IdentityContext": {
             "description": "Represents an identity context for feature flag evaluation.",
             "properties": {
@@ -39,12 +101,20 @@
                     "x-flagsmith-engine-path": "$.identity.key"
                 },
                 "traits": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "A map of traits associated with the identity, where the key is the trait name and the value is the trait value.",
-                    "title": "Traits",
-                    "type": "object"
+                    "title": "Traits"
                 }
             },
             "required": [
@@ -53,12 +123,84 @@
             ],
             "title": "IdentityContext",
             "type": "object"
+        },
+        "SegmentContext": {
+            "description": "Represents a segment context for feature flag evaluation.",
+            "properties": {
+                "id": {
+                    "description": "The unique identifier for the segment.",
+                    "title": "ID",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the segment.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "rules": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/SegmentRule"
+                    },
+                    "title": "Rules",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "rules"
+            ],
+            "title": "SegmentContext",
+            "type": "object"
+        },
+        "SegmentRule": {
+            "description": "Represents a rule within a segment for feature flag evaluation.",
+            "properties": {
+                "name": {
+                    "description": "The name of the segment rule.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "conditions": {
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
+                    },
+                    "description": "Conditions that define the segment rule.",
+                    "title": "Conditions",
+                    "type": "object"
+                },
+                "sub_rules": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/SegmentRule"
+                    },
+                    "description": "Sub-rules nested within the segment rule.",
+                    "title": "Sub-rules",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "name",
+                "conditions"
+            ],
+            "title": "SegmentRule",
+            "type": "object"
         }
     },
-    "description": "Represents a context object containing the necessary information to evaluate Flagsmith feature flags.",
+    "description": "Represents a context object containing the necessary information to evaluate\\nFlagsmith feature flags.",
     "properties": {
         "environment": {
-            "$ref": "#/$defs/EnvironmentContext"
+            "$ref": "#/$defs/EnvironmentContext",
+            "description": "Environment context required for evaluation."
         },
         "identity": {
             "anyOf": [
@@ -69,7 +211,24 @@
                     "type": "null"
                 }
             ],
-            "default": null
+            "default": null,
+            "description": "Identity context used for identity-based evaluation; optional."
+        },
+        "segments": {
+            "additionalProperties": {
+                "$ref": "#/$defs/SegmentContext"
+            },
+            "description": "Segments applicable to the evaluation context.",
+            "title": "Segments",
+            "type": "object"
+        },
+        "features": {
+            "additionalProperties": {
+                "$ref": "#/$defs/FeatureContext"
+            },
+            "description": "Features to be evaluated in the context.",
+            "title": "Features",
+            "type": "object"
         }
     },
     "required": [

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -48,6 +48,11 @@
                     },
                     "title": "Variants",
                     "type": "array"
+                },
+                "priority": {
+                    "description": "Indicates the priority of the feature context. Higher values indicate higher priority in case when multiple feature contexts for the same feature are applicable",
+                    "title": "Priority",
+                    "type": "number"
                 }
             },
             "required": [

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -50,7 +50,7 @@
                     "type": "array"
                 },
                 "priority": {
-                    "description": "Indicates the priority of the feature context. Higher values indicate higher priority in case when multiple feature contexts for the same feature are applicable",
+                    "description": "Indicates the priority of the feature context. Higher values indicate higher priority in case when multiple feature contexts for the same feature are applicable.",
                     "title": "Priority",
                     "type": "number"
                 }

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -31,6 +31,11 @@
                     "title": "Key",
                     "type": "string"
                 },
+                "name": {
+                    "description": "Feature name.",
+                    "title": "Name",
+                    "type": "string"
+                },
                 "enabled": {
                     "description": "Indicates whether the feature is enabled in the environment.",
                     "title": "Enabled",
@@ -57,6 +62,7 @@
             },
             "required": [
                 "key",
+                "name",
                 "enabled",
                 "value"
             ],

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -60,7 +60,7 @@
                     "type": "array"
                 },
                 "priority": {
-                    "description": "Priority of the feature context. Higher values indicate a higher priority when multiple contexts apply to the same feature.",
+                    "description": "Priority of the feature context. Lower values indicate a higher priority when multiple contexts apply to the same feature.",
                     "title": "Priority",
                     "type": "number"
                 }

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -206,7 +206,7 @@
                 }
             },
             "required": [
-                "path",
+                "property",
                 "operator",
                 "value"
             ],

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -132,10 +132,19 @@
                     "type": "string"
                 },
                 "rules": {
+                    "description": "Rules that define the segment.",
                     "items": {
                         "$ref": "#/$defs/SegmentRule"
                     },
                     "title": "Rules",
+                    "type": "array"
+                },
+                "overrides": {
+                    "description": "Feature overrides for the segment.",
+                    "items": {
+                        "$ref": "#/$defs/FeatureContext"
+                    },
+                    "title": "Overrides",
                     "type": "array"
                 }
             },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -7,7 +7,7 @@
                     "description": "An environment's unique identifier.",
                     "title": "Key",
                     "type": "string",
-                    "x-flagsmith-engine-path": "$.environment.key"
+                    "x-flagsmith-engine-condition-property": "$.environment.key"
                 },
                 "name": {
                     "description": "An environment's human-readable name.",
@@ -91,13 +91,13 @@
                     "description": "A unique identifier for an identity, used for segment and multivariate feature flag targeting, and displayed in the Flagsmith UI.",
                     "title": "Identifier",
                     "type": "string",
-                    "x-flagsmith-engine-path": "$.identity.identifier"
+                    "x-flagsmith-engine-condition-property": "$.identity.identifier"
                 },
                 "key": {
                     "description": "Key used when selecting a value for a multivariate feature, or for % split segmentation. Set to an internal identifier or a composite value based on the environment key and identifier, depending on Flagsmith implementation.",
                     "title": "Key",
                     "type": "string",
-                    "x-flagsmith-engine-path": "$.identity.key"
+                    "x-flagsmith-engine-condition-property": "$.identity.key"
                 },
                 "traits": {
                     "additionalProperties": {
@@ -161,8 +161,8 @@
         "SegmentCondition": {
             "description": "Represents a condition within a segment rule for feature flag evaluation.",
             "properties": {
-                "path": {
-                    "description": "The path to the trait or value in the evaluation context.",
+                "property": {
+                    "description": "A reference to the identity trait or value in the evaluation context.",
                     "title": "Property",
                     "type": "string"
                 },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -233,7 +233,7 @@
             "type": "object"
         }
     },
-    "description": "Represents a context object containing the necessary information to evaluate\\nFlagsmith feature flags.",
+    "description": "A context object containing the necessary information to evaluate Flagsmith feature flags.",
     "properties": {
         "environment": {
             "$ref": "#/$defs/EnvironmentContext",

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -79,7 +79,8 @@
                 }
             },
             "required": [
-                "value"
+                "value",
+                "weight"
             ],
             "title": "FeatureValue",
             "type": "object"
@@ -217,17 +218,16 @@
                     "type": "array"
                 },
                 "sub_rules": {
-                    "additionalProperties": {
+                    "items": {
                         "$ref": "#/$defs/SegmentRule"
                     },
                     "description": "Sub-rules nested within the segment rule.",
                     "title": "Sub-rules",
-                    "type": "object"
+                    "type": "array"
                 }
             },
             "required": [
-                "type",
-                "conditions"
+                "type"
             ],
             "title": "SegmentRule",
             "type": "object"
@@ -249,7 +249,7 @@
                 }
             ],
             "default": null,
-            "description": "Identity context used for identity-based evaluation; optional."
+            "description": "Identity context used for identity-based evaluation."
         },
         "segments": {
             "additionalProperties": {

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -31,11 +31,6 @@
                     "title": "Key",
                     "type": "string"
                 },
-                "name": {
-                    "description": "The name of the feature.",
-                    "title": "Name",
-                    "type": "string"
-                },
                 "enabled": {
                     "description": "Indicates whether the feature is enabled in the environment.",
                     "title": "Enabled",
@@ -57,7 +52,6 @@
             },
             "required": [
                 "key",
-                "name",
                 "enabled",
                 "value"
             ],

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -13,7 +13,7 @@
                     "description": "An environment's human-readable name.",
                     "title": "Name",
                     "type": "string",
-                    "x-flagsmith-engine-path": "$.environment.name"
+                    "x-flagsmith-engine-condition-property": "$.environment.name"
                 }
             },
             "required": [
@@ -100,18 +100,15 @@
                     "x-flagsmith-engine-path": "$.identity.key"
                 },
                 "traits": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "type": "object",
                     "description": "A map of traits associated with the identity, where the key is the trait name and the value is the trait value.",
                     "title": "Traits"
                 }

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -31,6 +31,11 @@
                     "title": "Key",
                     "type": "string"
                 },
+                "feature_key": {
+                    "description": "Unique feature identifier.",
+                    "title": "Feature Key",
+                    "type": "string"
+                },
                 "name": {
                     "description": "Feature name.",
                     "title": "Name",
@@ -62,6 +67,7 @@
             },
             "required": [
                 "key",
+                "feature_key",
                 "name",
                 "enabled",
                 "value"

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -39,6 +39,11 @@
                         }
                     ]
                 },
+                "reason": {
+                    "description": "Reason for the feature flag evaluation.",
+                    "title": "Reason",
+                    "type": "string"
+                },
                 "feature": {
                     "$ref": "#/$defs/FeatureResult"
                 }

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -1,27 +1,17 @@
 {
     "$defs": {
-        "FeatureResult": {
+        "FlagResult": {
             "properties": {
-                "key": {
+                "feature_key": {
                     "description": "Unique feature identifier.",
-                    "title": "Key",
+                    "title": "Feature Key",
                     "type": "string"
                 },
                 "name": {
                     "description": "Feature name.",
                     "title": "Name",
                     "type": "string"
-                }
-            },
-            "required": [
-                "key",
-                "name"
-            ],
-            "title": "FeatureResult",
-            "type": "object"
-        },
-        "FlagResult": {
-            "properties": {
+                },
                 "enabled": {
                     "description": "Indicates if the feature flag is enabled.",
                     "title": "Enabled",
@@ -43,12 +33,11 @@
                     "description": "Reason for the feature flag evaluation.",
                     "title": "Reason",
                     "type": "string"
-                },
-                "feature": {
-                    "$ref": "#/$defs/FeatureResult"
                 }
             },
             "required": [
+                "feature_key",
+                "name",
                 "enabled",
                 "feature"
             ],
@@ -79,7 +68,7 @@
     "description": "Evaluation result object containing the used context, flag evaluation results, and segments used in the evaluation.",
     "properties": {
         "context": {
-            "$ref": "https://github.com/Flagsmith/flagsmith/blob/main/sdk/evaluation-context.json"
+            "$ref": "https://github.com/Flagsmith/flagsmith/blob/chore/features-contexts-in-eval-context-schema/sdk/evaluation-context.json"
         },
         "flags": {
             "description": "List of feature flags evaluated for the context.",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -1,0 +1,103 @@
+{
+    "$defs": {
+        "FeatureResult": {
+            "properties": {
+                "key": {
+                    "description": "Unique feature identifier.",
+                    "title": "Key",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Feature name.",
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "key",
+                "name"
+            ],
+            "title": "FeatureResult",
+            "type": "object"
+        },
+        "FlagResult": {
+            "properties": {
+                "enabled": {
+                    "description": "Indicates if the feature flag is enabled.",
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "value": {
+                    "description": "Feature flag value.",
+                    "title": "Value",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "feature": {
+                    "$ref": "#/$defs/FeatureResult"
+                }
+            },
+            "required": [
+                "enabled",
+                "feature"
+            ],
+            "title": "FlagResult",
+            "type": "object"
+        },
+        "SegmentResult": {
+            "properties": {
+                "key": {
+                    "description": "Unique segment identifier.",
+                    "title": "Key",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Segment name.",
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "key",
+                "name"
+            ],
+            "title": "SegmentResult",
+            "type": "object"
+        }
+    },
+    "description": "Evaluation result object containing the used context, flag evaluation results, and segments used in the evaluation.",
+    "properties": {
+        "context": {
+            "$ref": "https://github.com/Flagsmith/flagsmith/blob/main/sdk/evaluation-context.json"
+        },
+        "flags": {
+            "description": "List of feature flags evaluated for the context.",
+            "items": {
+                "$ref": "#/$defs/FlagResult"
+            },
+            "title": "Flags",
+            "type": "array"
+        },
+        "segments": {
+            "description": "List of segments which the provided context belongs to.",
+            "items": {
+                "$ref": "#/$defs/SegmentResult"
+            },
+            "title": "Segments",
+            "type": "array"
+        }
+    },
+    "required": [
+        "context",
+        "flags",
+        "segments"
+    ],
+    "title": "EvaluationResult",
+    "type": "object"
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/5808.

This PR adds:
- An `EvaluationResult` schema that includes flag and used segment information.
- `segments` and `features` keys to the `EvaluationContext` schema to have all data required for evaluation in a single DTO.

The design goal was to have a structure that is extensible, simple enough to parse and read through, and that provides all required engine data, excluding any data unrelated to engine.

Some new vocabulary is added here that, IMO, make sense for evaluation:
- String `"key"` fields are preferred to numeric `id` fields to more clearly state their purpose.
- A `"variants"` key is used to represent multivariate feature states, where each variant includes a `"weight"` indicating its distribution percentage. I considered using a unified `"values"` array for all feature states — including non-multivariate ones (with a single `{ "weight": 100 }` entry) — but opted against it to avoid ambiguous semantics around control values and the need to validate against empty arrays.

Both objects will be used by the new engine interface to be introduced in https://github.com/Flagsmith/flagsmith-engine/issues/234.

An example `EvaluationContext` object:

```json
{
  "environment": {
    "key": "abcde",
    "name": "Test Environment"
  },
  "features": {
    "feature_1": {
      "key": "1",
      "name": "feature_1",
      "enabled": true,
      "value": "foobar"
    },
    "feature_2": {
      "key": "2",
      "name": "feature_2",
      "enabled": false,
      "value": "control",
      "variants": [
        {
          "value": "a",
          "weight": 51.0
        },
        {
          "value": "b",
          "weight": 49.0
        }
      ]
    }
  },
  "segments": {
    "test_segment": {
      "key": "1",
      "name": "test_segment",
      "rules": [
        {
          "type": "ALL",
          "sub_rules": [
           {
          "type": "ANY",
          "conditions": [
            {
              "path": "$.identity.identifier",
              "operator": "IN",
              "value": "id1,id2"
            },
            {
              "path": "some-trait",
              "operator": "EQUALS",
              "value": "foobar"
            }
          ]
        }
          ]
        }
      ]
    }
  }
}
```

An example `EvaluationResult` object:

```json
{
  "context": {...},
  "flags": [
    {
      "enabled": false,
      "value": "foobar",
      "feature": {
        "key": "1",
        "name": "feature_1"
      }
    },
    {
      "enabled": true,
      "value": null,
      "feature": {
        "key": "2",
        "name": "feature_2"
      }
    }
  ],
  "segments": [
    {
      "key": "1",
      "name": "test_segment"
    }
  ]
}
```


## How did you test this code?

N/A