### PR TITLE
fix(tests): Improper `skip_if_no_analytics_db` marker behaviour

### DIFF
--- a/api/tests/unit/app_analytics/conftest.py
+++ b/api/tests/unit/app_analytics/conftest.py
@@ -3,20 +3,22 @@ from django.conf import settings
 
 
 @pytest.fixture
-def skip_if_no_analytics_db() -> None:
+def use_analytics_db(request: pytest.FixtureRequest) -> None:
     """
-    Skip tests if no analytics database is configured.
+    Skip tests if no analytics database is configured,
+    and make sure the django_db fixture uses both default and analytics databases.
     This is useful to avoid running tests that require a specific database setup.
     """
     if "analytics" not in settings.DATABASES:  # pragma: no cover
         pytest.skip("No analytics database configured, skipping")
+    request.applymarker(pytest.mark.django_db(databases=["default", "analytics"]))
 
 
 @pytest.fixture(autouse=True)
-def skip_if_no_analytics_db_marked(request: pytest.FixtureRequest) -> None:
+def use_analytics_db_marked(request: pytest.FixtureRequest) -> None:
     """
-    Automatically skip tests that are marked with 'skip_if_no_analytics_db'.
+    Automatically skip tests that are marked with 'use_analytics_db'.
     This allows for selective skipping of tests based on the database configuration.
     """
-    if request.node.get_closest_marker("skip_if_no_analytics_db"):
-        request.getfixturevalue("skip_if_no_analytics_db")
+    if request.node.get_closest_marker("use_analytics_db"):
+        request.getfixturevalue("use_analytics_db")

--- a/api/tests/unit/app_analytics/conftest.py
+++ b/api/tests/unit/app_analytics/conftest.py
@@ -11,7 +11,9 @@ def use_analytics_db(request: pytest.FixtureRequest) -> None:
     """
     if "analytics" not in settings.DATABASES:  # pragma: no cover
         pytest.skip("No analytics database configured, skipping")
+        return
     request.applymarker(pytest.mark.django_db(databases=["default", "analytics"]))
+    request.getfixturevalue("db")
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/unit/app_analytics/test_analytics_db_service.py
+++ b/api/tests/unit/app_analytics/test_analytics_db_service.py
@@ -44,8 +44,7 @@ def cache(organisation: Organisation) -> OrganisationSubscriptionInformationCach
     )
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_usage_data_from_local_db(organisation, environment, settings):  # type: ignore[no-untyped-def]
     environment_id = environment.id
     now = timezone.now()
@@ -102,8 +101,7 @@ def test_get_usage_data_from_local_db(organisation, environment, settings):  # t
         assert data.day == today - timedelta(days=29 - count)
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_usage_data_from_local_db_project_id_filter(  # type: ignore[no-untyped-def]
     organisation: Organisation,
     project: Project,
@@ -150,8 +148,7 @@ def test_get_usage_data_from_local_db_project_id_filter(  # type: ignore[no-unty
     assert list(usage_data_for_project_two)[0].flags == total_count  # 1 environment
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_usage_data_from_local_db__environment_filter__returns_expected(
     organisation: Organisation,
     environment: Environment,
@@ -197,8 +194,7 @@ def test_get_usage_data_from_local_db__environment_filter__returns_expected(
     ]
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_usage_data_from_local_db__labels_filter__returns_expected(
     organisation: Organisation,
     environment: Environment,
@@ -270,8 +266,7 @@ def test_get_usage_data_from_local_db__labels_filter__returns_expected(
     ]
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_total_events_count(organisation, environment, settings):  # type: ignore[no-untyped-def]
     settings.USE_POSTGRES_FOR_ANALYTICS = True
     environment_id = environment.id
@@ -322,8 +317,7 @@ def test_get_total_events_count(organisation, environment, settings):  # type: i
     assert total_events_count == 20 * len(Resource) * 30
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_feature_evaluation_data_from_local_db(
     feature: Feature,
     environment: Environment,
@@ -391,8 +385,7 @@ def test_get_feature_evaluation_data_from_local_db(
         assert data.day == today - timedelta(days=29 - i)
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_get_feature_evaluation_data_from_local_db__labels_filter__returns_expected(
     feature: Feature,
     environment: Environment,

--- a/api/tests/unit/app_analytics/test_migrate_to_pg.py
+++ b/api/tests/unit/app_analytics/test_migrate_to_pg.py
@@ -6,8 +6,7 @@ from app_analytics.migrate_to_pg import migrate_feature_evaluations
 from app_analytics.models import FeatureEvaluationBucket
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_migrate_feature_evaluations(mocker: MockerFixture) -> None:
     # Given
     feature_name = "test_feature_one"

--- a/api/tests/unit/app_analytics/test_models.py
+++ b/api/tests/unit/app_analytics/test_models.py
@@ -8,10 +8,9 @@ from app_analytics.models import (
     Resource,
 )
 
-pytestmark = pytest.mark.skip_if_no_analytics_db
+pytestmark = pytest.mark.use_analytics_db
 
 
-@pytest.mark.django_db(databases=["analytics"])
 def test_creating_overlapping_api_usage_bucket_raises_error(db):  # type: ignore[no-untyped-def]
     # Given
     created_at = timezone.now()
@@ -40,7 +39,6 @@ def test_creating_overlapping_api_usage_bucket_raises_error(db):  # type: ignore
         )
 
 
-@pytest.mark.django_db(databases=["analytics"])
 def test_creating_overlapping_feature_evaluation_bucket_raises_error(db):  # type: ignore[no-untyped-def]
     # Given
     created_at = timezone.now()

--- a/api/tests/unit/app_analytics/test_tasks.py
+++ b/api/tests/unit/app_analytics/test_tasks.py
@@ -23,7 +23,7 @@ from app_analytics.tasks import (
 from app_analytics.types import TrackFeatureEvaluationsByEnvironmentData
 from environments.models import Environment
 
-pytestmark = pytest.mark.skip_if_no_analytics_db
+pytestmark = pytest.mark.use_analytics_db
 
 
 def _create_api_usage_event(environment_id: int, when: datetime) -> APIUsageRaw:
@@ -40,7 +40,7 @@ def _create_api_usage_event(environment_id: int, when: datetime) -> APIUsageRaw:
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_api_usage_bucket_multiple_runs(
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -113,7 +113,7 @@ def test_populate_api_usage_bucket_multiple_runs(
     [(15, 60), (10, 60), (10, 30), (30, 30), (60, 60), (10, 10), (60, 60 * 4)],
 )
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_api_usage_bucket(
     freezer: FrozenDateTimeFactory,
     bucket_size: int,
@@ -153,7 +153,7 @@ def test_populate_api_usage_bucket(
         assert bucket.total_count == bucket_size
 
 
-@pytest.mark.django_db(databases=["analytics", "default"])
+@pytest.mark.use_analytics_db
 def test_track_request__postgres__inserts_expected(
     settings: SettingsWrapper,
     environment: Environment,
@@ -205,7 +205,7 @@ def test_track_request__influx__calls_expected(
     )
 
 
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_track_feature_evaluation(settings: SettingsWrapper) -> None:
     # Given
     settings.USE_POSTGRES_FOR_ANALYTICS = True
@@ -244,7 +244,7 @@ def test_track_feature_evaluation(settings: SettingsWrapper) -> None:
     )
 
 
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_track_feature_evaluation__influx__calls_expected(
     settings: SettingsWrapper,
     mocker: MockerFixture,
@@ -287,7 +287,7 @@ def test_track_feature_evaluation__influx__calls_expected(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_feature_evaluation_bucket_15m(freezer: FrozenDateTimeFactory) -> None:
     # Given
     environment_id = 1
@@ -379,7 +379,7 @@ def test_populate_feature_evaluation_bucket_15m(freezer: FrozenDateTimeFactory) 
 
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_feature_evaluation_bucket__upserts_buckets(
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -415,7 +415,7 @@ def test_populate_feature_evaluation_bucket__upserts_buckets(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_feature_evaluation_bucket__source_bucket_size__returns_expected(
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -465,7 +465,7 @@ def test_populate_feature_evaluation_bucket__source_bucket_size__returns_expecte
 
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_api_usage_bucket__upserts_buckets(
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -501,7 +501,7 @@ def test_populate_api_usage_bucket__upserts_buckets(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_populate_api_usage_bucket_using_a_bucket(
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -548,7 +548,7 @@ def _create_feature_evaluation_event(
     return event
 
 
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_clean_up_old_analytics_data_does_nothing_if_no_data() -> None:
     # When
     clean_up_old_analytics_data()
@@ -557,7 +557,7 @@ def test_clean_up_old_analytics_data_does_nothing_if_no_data() -> None:
     # no exception was raised
 
 
-@pytest.mark.django_db(databases=["analytics"])
+@pytest.mark.use_analytics_db
 def test_clean_up_old_analytics_data_removes_old_data(
     settings: SettingsWrapper,
 ) -> None:

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -408,8 +408,7 @@ def test_get_total_usage_count_for_non_admin_user_returns_403(  # type: ignore[n
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["default", "analytics"])
+@pytest.mark.use_analytics_db
 def test_set_sdk_analytics_flags_with_identifier(
     api_client: APIClient,
     environment: Environment,
@@ -450,8 +449,7 @@ def test_set_sdk_analytics_flags_with_identifier(
     assert feature_evaluation_raw.evaluation_count is feature_request_count  # type: ignore[union-attr]
 
 
-@pytest.mark.skip_if_no_analytics_db
-@pytest.mark.django_db(databases=["default", "analytics"])
+@pytest.mark.use_analytics_db
 def test_set_sdk_analytics_flags_without_identifier(
     api_client: APIClient,
     environment: Environment,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This renames the `skip_if_no_analytics_db` fixture to `use_analytics_db` and makes sure the markers are initialised in the correct order.

## How did you test this code?

Ran the tests with and without the `ANALYTICS_DATABASE_URL` setting present.