### PR TITLE
fix(cr/audit-log): Add history record to fs went live by audit log

### DIFF
--- a/api/audit/tasks.py
+++ b/api/audit/tasks.py
@@ -64,7 +64,7 @@ def _create_feature_state_audit_log_for_change_request(  # type: ignore[no-untyp
         feature_state.change_request.title,
     )
     # NOTE: This NEEDS to leverage btree indexes on AuditLog
-    AuditLog.objects.create(
+    AuditLog.objects.get_or_create(
         history_record_id=feature_state.history.latest().history_id,
         history_record_class_path=feature_state.history_record_class_path,
         created_date=feature_state.live_from,

--- a/api/tests/unit/audit/test_unit_audit_tasks.py
+++ b/api/tests/unit/audit/test_unit_audit_tasks.py
@@ -442,13 +442,6 @@ def test_create_feature_state_went_live_audit_log__rescheduled_feature_update__c
             ).count()
             == expected_audit_log_late_count
         )
-        assert expected_log_late == (
-            (
-                "INFO",
-                "FeatureState update audit log already exists. Likely the change request was rescheduled to an earlier date.",
-            )
-            in ((record.levelname, record.message) for record in caplog.records)
-        )
 
 
 def test_create_feature_state_went_live_audit_log__rescheduled_feature_update__schedules_call_to_feature_update_time(

--- a/api/tests/unit/audit/test_unit_audit_tasks.py
+++ b/api/tests/unit/audit/test_unit_audit_tasks.py
@@ -400,7 +400,7 @@ def test_create_feature_state_went_live_audit_log__rescheduled_feature_update__c
     change_request.committed_at = timezone.now()
     change_request.save()
 
-    # But the change request was rescheduled to go live at `rescheduled_time
+    # But the change request was rescheduled to go live at `rescheduled_time`
     change_request_feature_state.live_from = rescheduled_time
     change_request_feature_state.save()
     change_request.committed_at = timezone.now()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Add history record to audit log generated by `_create_feature_state_audit_log_for_change_request`
This will resolve #5894 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Update unit test
