### PR TITLE
fix: use-correct-count-in-tooltip

### DIFF
--- a/frontend/web/components/feature-summary/FeatureTags.tsx
+++ b/frontend/web/components/feature-summary/FeatureTags.tsx
@@ -77,7 +77,7 @@ const FeatureTags: FC<FeatureTagsType> = ({ editFeature, projectFlag }) => {
           }
           place='top'
         >
-          {`Scanned ${projectFlag?.code_references_counts.length?.toString()} times in ${projectFlag?.code_references_counts.length?.toString()} repositories`}
+          {`Scanned ${codeReferencesCounts?.toString()} times in ${projectFlag?.code_references_counts.length?.toString()} repositories`}
         </Tooltip>
       )}
       {projectFlag.is_server_key_only && (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Wrong variable used in the tooltip
- 
## How did you test this code?
<img width="473" height="107" alt="image" src="https://github.com/user-attachments/assets/e144175c-9bc7-4e35-bd65-6e61032d83f6" />
