### PR TITLE
fix: catch-error-on-segment-creation-or-update

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -211,41 +211,39 @@ const CreateSegment: FC<CreateSegmentType> = ({
     setRules(newRules)
   }
 
-  const removeRule = (rulesIndex: number, elementNumber: number) => {
-    const newRules = cloneDeep(rules)
-    newRules[0].rules.splice(elementNumber, 1)
-    setRules(newRules)
-  }
-
-  const save = (e: FormEvent) => {
-    Utils.preventDefault(e)
-    setValueChanged(false)
-    setMetadataValueChanged(false)
-    const segmentData: Omit<Segment, 'id' | 'uuid'> = {
-      description,
-      feature: feature,
-      metadata: metadata as Metadata[],
-      name,
-      project: projectId,
-      rules,
-    }
-    if (name) {
-      if (segment.id) {
-        editSegment({
-          projectId,
-          segment: {
-            ...segmentData,
-            id: segment.id,
-            project: segment.project as number,
-            uuid: segment.uuid as string,
-          },
-        })
-      } else {
-        createSegment({
-          projectId,
-          segment: segmentData,
-        })
+  const save = async (e: FormEvent) => {
+    try {
+      Utils.preventDefault(e)
+      setValueChanged(false)
+      setMetadataValueChanged(false)
+      const segmentData: Omit<Segment, 'id' | 'uuid'> = {
+        description,
+        feature: feature,
+        metadata: metadata as Metadata[],
+        name,
+        project: projectId,
+        rules,
       }
+      if (name) {
+        if (segment.id) {
+          await editSegment({
+            projectId,
+            segment: {
+              ...segmentData,
+              id: segment.id,
+              project: segment.project as number,
+              uuid: segment.uuid as string,
+            },
+          }).unwrap()
+        } else {
+          await createSegment({
+            projectId,
+            segment: segmentData,
+          }).unwrap()
+        }
+      }
+    } catch (error: any) {
+      toast(error?.data?.metadata?.[0] || 'Error creating segment', 'danger')
     }
   }
 
@@ -420,6 +418,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
             entity={segmentContentType?.model}
             onChange={(m) => {
               setMetadata(m as Metadata[])
+              // Need to fix this to be more robust and handle post save
               if (isEdit) {
                 setMetadataValueChanged(true)
               }

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -166,7 +166,7 @@ const Payment = class extends Component {
                         {!viewOnly ? (
                           <>
                             <PaymentButton
-                              data-cb-plan-id={Project.plans.startup.annual}
+                              data-cb-plan-id={Project.plans?.startup?.annual}
                               className={classNames(
                                 'btn btn-primary btn-lg full-width mt-3',
                                 { 'd-none': !this.state.yearly },
@@ -178,7 +178,7 @@ const Payment = class extends Component {
                                 : '14 Day Free Trial'}
                             </PaymentButton>
                             <PaymentButton
-                              data-cb-plan-id={Project.plans.startup.monthly}
+                              data-cb-plan-id={Project.plans?.startup?.monthly}
                               className={classNames(
                                 'btn btn-primary btn-lg full-width mt-3',
                                 { 'd-none': this.state.yearly },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Made segment on save callback async to catch error
- Added error message: Metadata if identifier or generic segment error
- Fixed conditional access to plan startup

N.B: after saving metadata is shown as being edited. But that is already existing on prod

## How did you test this code?
1. Add a required metadata to segment
2. Update segment without setting the metadata
3. Verify error message is here

<img width="884" height="700" alt="image" src="https://github.com/user-attachments/assets/d2ac1515-e8c9-4658-8b86-709414ad58bb" />
