### PR TITLE
fix: added-dark-mode-for-overflow-dropdown

### DIFF
--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -170,7 +170,7 @@ const Tabs: React.FC<TabsProps> = ({
         </div>
         {overflow.length > 0 && !isMeasuring && (
           <div
-            className='d-flex align-items-center justify-content-center ms-2 flex-shrink-0'
+            className='d-flex align-items-center justify-content-center ms-2 flex-shrink-0 btn btn-secondary'
             style={{
               backgroundColor: 'var(--bs-light300)',
               borderRadius: 6,

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -151,6 +151,12 @@
   display: block;
 }
 
+.dark {
+  .btn-tab {
+    color: white !important;
+  }
+}
+
 .btn-tab {
   position: relative;
   .unread {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Dropdown overflow was missing dark mode

## How did you test this code?
<img width="247" height="338" alt="image" src="https://github.com/user-attachments/assets/fe4d8c9c-904b-4826-b8c3-92bcfbf32876" />
