### PR TITLE
fix: Remove invalid close modal call for create segment change request

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -323,7 +323,6 @@ const CreateSegment: FC<CreateSegmentType> = ({
         project_id: `${projectId}`,
       })
 
-      closeModal()
       toast('Created change request')
     } catch (error) {
       console.error('Failed to create change request:', error)

--- a/frontend/web/components/pages/ProjectChangeRequestDetailPage.tsx
+++ b/frontend/web/components/pages/ProjectChangeRequestDetailPage.tsx
@@ -17,6 +17,7 @@ import { useGetSegmentQuery } from 'common/services/useSegment'
 import { useGetProjectQuery } from 'common/services/useProject'
 import DiffSegment from 'components/diff/DiffSegment'
 import ConfigProvider from 'common/providers/ConfigProvider'
+import { useHistory } from 'react-router-dom'
 
 type ProjectChangeRequestPageType = {
   router: RouterChildContext['router']
@@ -30,9 +31,9 @@ type ProjectChangeRequestPageType = {
 
 const ProjectChangeRequestDetailPage: FC<ProjectChangeRequestPageType> = ({
   match,
-  router,
 }) => {
   const { id, projectId } = match.params
+  const history = useHistory()
   const approvePermission = useHasPermission({
     id: projectId,
     level: 'project',
@@ -122,7 +123,7 @@ const ProjectChangeRequestDetailPage: FC<ProjectChangeRequestPageType> = ({
         }).then((res) => {
           // @ts-ignore
           if (!res.error) {
-            router.history.replace(`/project/${projectId}/change-requests`)
+            history.replace(`/project/${projectId}/change-requests`)
             toast('Deleted change request')
           } else {
             toast('Could not delete change request', 'danger')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Since edit segment is now on a page, we do not need to close a modal when creating a segment change request
- Fix delete change request not navigating back to the list page 

## How did you test this code?

Created a segment change request