### PR TITLE
chore(evaluation-result): `EvaluationResult` improvements

### DIFF
--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -64,18 +64,13 @@
     },
     "description": "Evaluation result object containing the used context, flag evaluation results, and segments used in the evaluation.",
     "properties": {
-        "context": {
-            "existingJavaType": "com.flagsmith.flagengine.EvaluationContext",
-            "goType": "evalcontext.EvaluationContext",
-            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json"
-        },
         "flags": {
-            "description": "List of feature flags evaluated for the context.",
-            "items": {
+            "description": "Feature flags evaluated for the context, mapped by feature names.",
+            "additionalProperties": {
                 "$ref": "#/$defs/FlagResult"
             },
             "title": "Flags",
-            "type": "array"
+            "type": "object"
         },
         "segments": {
             "description": "List of segments which the provided context belongs to.",
@@ -87,7 +82,6 @@
         }
     },
     "required": [
-        "context",
         "flags",
         "segments"
     ],

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -36,7 +36,9 @@
             "required": [
                 "feature_key",
                 "name",
-                "enabled"
+                "enabled",
+                "value",
+                "reason"
             ],
             "title": "FlagResult",
             "type": "object"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes #6121, #6120.

In this PR, we:
- Remove the `EvaluationResult.context` property.
- Switch `EvaluationResult.flags` to a map of feature names to flag objects.
These changes are breaking and should be addressed in engine implementations and SDKs.

## How did you test this code?

The SDKs codegen will be run against the branch.