### PR TITLE
chore(evaluation-context): Support segment metadata

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -171,11 +171,18 @@
                     "title": "Overrides",
                     "type": "array"
                 },
-                "virtual": {
-                    "description": "Indicates whether the segment is virtual (i.e., not stored in Flagsmith but provided at evaluation time).",
-                    "title": "Virtual",
-                    "type": "boolean",
-                    "default": false
+                "metadata": {
+                    "description": "Additional metadata associated with the segment.",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "title": "Metadata",
+                    "type": "object"
                 }
             },
             "required": [

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -54,6 +54,19 @@
                     "description": "Segment name.",
                     "title": "Name",
                     "type": "string"
+                },
+                "metadata": {
+                    "description": "Additional metadata associated with the segment.",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "title": "Metadata",
+                    "type": "object"
                 }
             },
             "required": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we add support for an optional metadata field both for `SegmentContext` and `SegmentResults` to be able to annotate and filter segments in Flagsmith implementations.

## How did you test this code?

N/A