### PR TITLE
fix: Lighten darker tag colors in dark mode

### DIFF
--- a/frontend/web/components/tags/Tag.tsx
+++ b/frontend/web/components/tags/Tag.tsx
@@ -7,6 +7,7 @@ import Utils from 'common/utils/utils'
 import TagContent from './TagContent'
 import Constants from 'common/constants'
 import { getDarkMode } from 'project/darkMode'
+import Color from 'color'
 
 type TagType = {
   className?: string
@@ -65,6 +66,7 @@ const Tag: FC<TagType> = ({
   selected,
   tag,
 }) => {
+  const shouldLighten = (color: Color) => getDarkMode() && color.isDark();
   const tagColor = Utils.colour(getTagColor(tag, selected))
   if (isDot) {
     return (
@@ -82,7 +84,7 @@ const Tag: FC<TagType> = ({
   if (!hideNames && !!onClick) {
     return (
       <ToggleChip
-        color={tagColor}
+        color={shouldLighten(tagColor) ? tagColor.lighten(0.5) : tagColor}
         active={selected}
         onClick={() => {
           if (!disabled) {
@@ -105,7 +107,7 @@ const Tag: FC<TagType> = ({
 
   return (
     <TagWrapper
-      tagColor={tagColor}
+      tagColor={shouldLighten(tagColor) ? tagColor.lighten(0.5) : tagColor}
       className={className}
       disabled={disabled}
       hideNames={hideNames}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- For darker tag colors, lighten it by 50% so that its visible
- This will fix #6128 

## How did you test this code?
Local testing. Added screenshots before and after

- `Before`

<img width="932" height="866" alt="image" src="https://github.com/user-attachments/assets/227cabdc-9207-4786-bd53-88b5cdad8a98" />


- `After`
<img width="936" height="877" alt="after-fix-tag-ui" src="https://github.com/user-attachments/assets/9cacf765-40fa-4a9f-91dd-1b811db06820" />


<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->


