### PR TITLE
fix: Show pipeline remove button for all if more than one stage

### DIFF
--- a/frontend/web/components/release-pipelines/CreateReleasePipeline.tsx
+++ b/frontend/web/components/release-pipelines/CreateReleasePipeline.tsx
@@ -359,7 +359,7 @@ function CreateReleasePipeline() {
                       handleOnChange(stageData, index)
                     }
                     projectId={Number(projectId)}
-                    showRemoveButton={index > 0}
+                    showRemoveButton={pipelineData.stages.length > 1}
                     onRemove={() => handleRemoveStage(index)}
                   />
                   <div className='flex-1'>


### PR DESCRIPTION
Fixes #6025

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Show remove button whenever the length of stages is greater than 1
- This will make sure that only one remaining stage cannot be deleted to a dead UI state

## How did you test this code?
Local testing. Refer below screenshots


1. <img width="924" height="763" alt="Screenshot 2025-10-12 200506" src="https://github.com/user-attachments/assets/d719c480-b409-4a4e-b0ca-8f7ada651159" />
2. <img width="1171" height="663" alt="image" src="https://github.com/user-attachments/assets/01c3b1b4-2aa2-499f-9ef0-4dca50f3b0ae" />
3. <img width="862" height="661" alt="image" src="https://github.com/user-attachments/assets/e018b768-dd76-42a7-bdc6-7934a8deb3c7" />

