### PR TITLE
ci: bump checkout@v4 to v5 in GHA workflows

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-node@v4
       with:
         cache: npm

--- a/.github/workflows/.reusable-deploy-ecs.yml
+++ b/.github/workflows/.reusable-deploy-ecs.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -73,7 +73,7 @@ jobs:
     runs-on: depot-ubuntu-latest
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy API to ${{ inputs.environment }}
         id: deploy-api
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run E2E tests against ${{ inputs.environment }}
         uses: ./.github/actions/e2e-tests

--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to Github Container Registry
         if: ${{ env.GCR_TOKEN }}

--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: depot.json
           sparse-checkout-cone-mode: false

--- a/.github/workflows/.reusable-frontend-deploy.yml
+++ b/.github/workflows/.reusable-frontend-deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Poetry
         run: make install-poetry

--- a/.github/workflows/api-run-makefile-target.yml
+++ b/.github/workflows/api-run-makefile-target.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: depot-ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Poetry
         run: make install-poetry

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Poetry
         run: make install-poetry

--- a/.github/workflows/docs-pull-request.yml
+++ b/.github/workflows/docs-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run E2E tests against production
         uses: ./.github/actions/e2e-tests

--- a/.github/workflows/frontend-test-staging.yml
+++ b/.github/workflows/frontend-test-staging.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run E2E tests against staging
         uses: ./.github/actions/e2e-tests

--- a/.github/workflows/manual-e2e-tests.yml
+++ b/.github/workflows/manual-e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: depot-ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           cache: npm

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -228,7 +228,7 @@ jobs:
             }
 
       - name: Checkout Target Charts Repository to update yaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: flagsmith/flagsmith-charts
           path: chart

--- a/.github/workflows/platform-docker-trivy-scan.yml
+++ b/.github/workflows/platform-docker-trivy-scan.yml
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout trivy.yaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             trivy.yaml

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -53,7 +53,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: .github/
           sparse-checkout-cone-mode: false

--- a/.github/workflows/poc-github-code-references.yml
+++ b/.github/workflows/poc-github-code-references.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -17,7 +17,7 @@ jobs:
       FLAGSMITH_ON_FLAGSMITH_SERVER_KEY: ${{ secrets.FLAGSMITH_ON_FLAGSMITH_SERVER_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

* Bumps Github's checkout action from v4 to [v5](https://github.com/actions/checkout/releases/tag/v5.0.0).

## How did you test this code?

Local runs and have performed this bump on other repos.
