### PR TITLE
fix: replaced-flex-1-with-justify-between

### DIFF
--- a/frontend/web/components/PageTitle.tsx
+++ b/frontend/web/components/PageTitle.tsx
@@ -1,5 +1,4 @@
 import { FC, PropsWithChildren, ReactNode } from 'react'
-import classNames from 'classnames'
 
 type PageTitleType = PropsWithChildren<{
   title: ReactNode
@@ -10,8 +9,8 @@ type PageTitleType = PropsWithChildren<{
 const PageTitle: FC<PageTitleType> = ({ children, className, cta, title }) => {
   return (
     <div className={className || 'mb-4'}>
-      <div className='flex-row flex-column flex-lg-row gap-2 align-items-start align-items-lg-center'>
-        <Flex>
+      <div className='flex-row flex-lg-row gap-2 align-items-start align-items-lg-center justify-content-between'>
+        <div className='flex'>
           <h4 className={children ? 'mb-1' : 'mb-0'}>{title}</h4>
           {children && (
             <Row>
@@ -20,7 +19,7 @@ const PageTitle: FC<PageTitleType> = ({ children, className, cta, title }) => {
               </div>
             </Row>
           )}
-        </Flex>
+        </div>
         {!!cta && <div className='float-right ms-lg-2'>{cta}</div>}
       </div>
       <hr className='mb-0 mt-3' />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Replaced flex-1 in title with justify-content-between in parent layout div
- 
## How did you test this code?
Before 
<img width="825" height="117" alt="image" src="https://github.com/user-attachments/assets/8736c33a-a81e-42bb-add4-fe5f391191db" />

After
<img width="621" height="137" alt="image" src="https://github.com/user-attachments/assets/6d04a20b-b001-40ce-9927-63b2a0d8a6d6" />
