### PR TITLE
fix: updated-wording-to-view-in-segment-features-overrides-page

### DIFF
--- a/frontend/web/components/modals/AssociatedSegmentOverrides.js
+++ b/frontend/web/components/modals/AssociatedSegmentOverrides.js
@@ -380,7 +380,7 @@ export default class SegmentOverridesInner extends Component {
                           className='ml-2'
                           onClick={this.openPriorities}
                         >
-                          Edit
+                          View
                         </a>
                       </div>
                     }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Changed wording for less confusion
- Segment Overrides priorities are actually not draggable but the UI suggests it. As a quick shot we updated the wording

## How did you test this code?
Context
https://flagsmith.slack.com/archives/CTF0THS2D/p1760626870674349?thread_ts=1760537312.121999&cid=CTF0THS2D

Before
<img width="910" height="542" alt="image" src="https://github.com/user-attachments/assets/3180bd26-082e-4b2d-afda-566a0a2aa452" />

After
<img width="840" height="375" alt="image" src="https://github.com/user-attachments/assets/32421ac5-ecb2-4449-be2a-7adec1da43a0" />
