### PR TITLE
fix: menu tab highlight disappear for other Environments sub-options

### DIFF
--- a/frontend/web/components/navigation/NavSubLink.tsx
+++ b/frontend/web/components/navigation/NavSubLink.tsx
@@ -1,17 +1,23 @@
 import React, { FC, ReactNode } from 'react'
-import { LinkProps, NavLink } from 'react-router-dom'
+import type * as H from 'history';
+import { LinkProps, NavLink, match } from 'react-router-dom'
 import { IonIcon } from '@ionic/react'
 import classNames from 'classnames'
 
 type NavSubLinkType = LinkProps & {
   icon: string | ReactNode
   children: ReactNode
+  isActive?<Params extends { [K in keyof Params]?: string }, S = unknown>(
+    match: match<Params> | null,
+    location: H.Location<S>
+  ): boolean;
 }
 
-const NavSubLink: FC<NavSubLinkType> = ({ children, icon, ...rest }) => {
+const NavSubLink: FC<NavSubLinkType> = ({ children, icon, isActive, ...rest }) => {
   return (
     <NavLink
       {...rest}
+      isActive={isActive}
       activeClassName='active'
       className={classNames(rest.className, 'py-md-2 py-1 px-1 nav-sub-link')}
     >

--- a/frontend/web/components/navigation/navbars/ProjectNavbar.tsx
+++ b/frontend/web/components/navigation/navbars/ProjectNavbar.tsx
@@ -34,6 +34,9 @@ const ProjectNavbar: FC<ProjectNavType> = ({ environmentId, projectId }) => {
       <NavSubLink
         icon={gitBranch}
         id={`features-link`}
+        isActive={(_, location) =>
+          location.pathname.startsWith(`/project/${projectId}/environment/${environmentId}`)
+        }
         to={`/project/${projectId}/environment/${environmentId}/features`}
       >
         Environments


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #6162 

- Ideally, the routes should be grouped under environment [here](https://github.com/Flagsmith/flagsmith/blob/main/frontend/web/routes.js#L72)
- The default `isActive` behavior of `NavLink` is the root cause of this as it matches the exact path
- Made sure all the sidebar options of Environments don't exactly match but starts with environments path to make sure tab highlighting is consistent

## How did you test this code?

Manual testing

1.
<img width="1916" height="880" alt="image" src="https://github.com/user-attachments/assets/35a30226-28dc-4a1e-b68d-8e73d6dbdc1a" />


2.
<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/24819acb-5155-41ef-8d85-90834ed4540d" />

