### PR TITLE
chore(evaluation-context): Remove extra fields, clarify `key` semantics

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -3,12 +3,6 @@
         "EnvironmentContext": {
             "description": "Represents an environment context for feature flag evaluation.",
             "properties": {
-                "key": {
-                    "description": "An environment's unique identifier.",
-                    "title": "Key",
-                    "type": "string",
-                    "x-flagsmith-engine-condition-property": "$.environment.key"
-                },
                 "name": {
                     "description": "An environment's human-readable name.",
                     "title": "Name",
@@ -27,13 +21,8 @@
             "description": "Represents a feature context for feature flag evaluation.",
             "properties": {
                 "key": {
-                    "description": "Key used when selecting a value for a multivariate feature. Set to an internal identifier or a UUID, depending on Flagsmith implementation.",
+                    "description": "Unique feature key used when selecting a variant if the feature is multivariate. Set to an internal identifier or a UUID, depending on Flagsmith implementation.",
                     "title": "Key",
-                    "type": "string"
-                },
-                "feature_key": {
-                    "description": "Unique feature identifier.",
-                    "title": "Feature Key",
                     "type": "string"
                 },
                 "name": {
@@ -122,7 +111,7 @@
             "description": "Represents an identity context for feature flag evaluation.",
             "properties": {
                 "identifier": {
-                    "description": "A unique identifier for an identity, used for segment and multivariate feature flag targeting, and displayed in the Flagsmith UI.",
+                    "description": "A unique identifier for an identity as displayed in the Flagsmith UI.",
                     "title": "Identifier",
                     "type": "string",
                     "x-flagsmith-engine-condition-property": "$.identity.identifier"
@@ -158,7 +147,7 @@
             "description": "Represents a segment context for feature flag evaluation.",
             "properties": {
                 "key": {
-                    "description": "Key used for % split segmentation.",
+                    "description": "Unique segment key used for % split segmentation.",
                     "title": "Key",
                     "type": "string"
                 },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -67,7 +67,6 @@
             },
             "required": [
                 "key",
-                "feature_key",
                 "name",
                 "enabled",
                 "value"

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -141,8 +141,7 @@
                 }
             },
             "required": [
-                "identifier",
-                "key"
+                "identifier"
             ],
             "title": "IdentityContext",
             "type": "object"

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -3,6 +3,11 @@
         "EnvironmentContext": {
             "description": "Represents an environment context for feature flag evaluation.",
             "properties": {
+                "key": {
+                    "description": "Unique environment key. May be used for selecting a value for a multivariate feature, or for % split segmentation.",
+                    "title": "Key",
+                    "type": "string"
+                },
                 "name": {
                     "description": "An environment's human-readable name.",
                     "title": "Name",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -51,11 +51,6 @@
         },
         "SegmentResult": {
             "properties": {
-                "key": {
-                    "description": "Unique segment identifier.",
-                    "title": "Key",
-                    "type": "string"
-                },
                 "name": {
                     "description": "Segment name.",
                     "title": "Name",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -2,11 +2,6 @@
     "$defs": {
         "FlagResult": {
             "properties": {
-                "feature_key": {
-                    "description": "Unique feature identifier.",
-                    "title": "Feature Key",
-                    "type": "string"
-                },
                 "name": {
                     "description": "Feature name.",
                     "title": "Name",
@@ -40,7 +35,6 @@
                 }
             },
             "required": [
-                "feature_key",
                 "name",
                 "enabled",
                 "value",
@@ -64,7 +58,6 @@
                 }
             },
             "required": [
-                "key",
                 "name"
             ],
             "title": "SegmentResult",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes #6192.

In this PR, we:
- Remove `FeatureContext.feature_key`. Engine implementations should now use `FeatureContext.name` to match overrides.
- Remove `FlagResult.feature_key`.
- Remove `SegmentResult.key` as segment metadata is now used by SDKs to present the segment IDs in `get_segment_result` return values.
- Improve documentation for the remaining `key` fields.

## How did you test this code?

engine-test-data PR: https://github.com/Flagsmith/engine-test-data/pull/33