### PR TITLE
fix: Use data instead of parsed data for recording analytics

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -8,3 +8,4 @@ features/workflows/logic/
 
 # Unit test coverage
 .coverage
+.coverage.*

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -88,7 +88,9 @@ class SDKAnalyticsFlags(CreateAPIView):  # type: ignore[type-arg]
 
             def save(self, **kwargs: typing.Any) -> None:
                 request = self.context["request"]
-                for feature_name, evaluation_count in self.validated_data.items():
+                # validated_data splits out request body with '.' in feature name (e.g a.b.c).
+                # Instead, it's safe to use self.initial_data as keys are not altered.
+                for feature_name, evaluation_count in self.initial_data.items():
                     feature_evaluation_cache.track_feature_evaluation(
                         environment_id=request.environment.id,
                         feature_name=feature_name,

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -89,8 +89,8 @@ class SDKAnalyticsFlags(CreateAPIView):  # type: ignore[type-arg]
             def save(self, **kwargs: typing.Any) -> None:
                 request = self.context["request"]
                 # validated_data splits out request body with '.' in feature name (e.g a.b.c).
-                # Instead, it's safe to use self.initial_data as keys are not altered.
-                for feature_name, evaluation_count in self.initial_data.items():
+                # Instead, it's safe to use self.data as keys are not altered.
+                for feature_name, evaluation_count in self.data.items():
                     feature_evaluation_cache.track_feature_evaluation(
                         environment_id=request.environment.id,
                         feature_name=feature_name,

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -555,6 +555,10 @@ def api_client() -> APIClient:
 def feature(project: Project) -> Feature:
     return Feature.objects.create(name="Test Feature1", project=project)  # type: ignore[no-any-return]
 
+@pytest.fixture()
+def feauture_with_dots(project: Project) -> Feature:
+    return Feature.objects.create(name="feature.name", project=project)  # type: ignore[no-any-return]
+
 
 @pytest.fixture()
 def change_request(environment: Environment, admin_user: FFAdminUser) -> ChangeRequest:

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -555,10 +555,6 @@ def api_client() -> APIClient:
 def feature(project: Project) -> Feature:
     return Feature.objects.create(name="Test Feature1", project=project)  # type: ignore[no-any-return]
 
-@pytest.fixture()
-def feauture_with_dots(project: Project) -> Feature:
-    return Feature.objects.create(name="feature.name", project=project)  # type: ignore[no-any-return]
-
 
 @pytest.fixture()
 def change_request(environment: Environment, admin_user: FFAdminUser) -> ChangeRequest:

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -18,6 +18,7 @@ from app_analytics.dataclasses import UsageData
 from app_analytics.models import FeatureEvaluationRaw
 from environments.identities.models import Identity
 from environments.models import Environment
+from projects.models import Project
 from features.models import Feature
 from organisations.models import (
     Organisation,
@@ -25,6 +26,9 @@ from organisations.models import (
 )
 from tests.types import EnableFeaturesFixture
 
+@pytest.fixture()
+def feature_with_dots(project: Project) -> Feature:
+    return Feature.objects.create(name="feature.with.dots", project=project)  # type: ignore[no-any-return]
 
 def test_sdk_analytics_ignores_bad_data(
     mocker: MockerFixture,
@@ -61,13 +65,13 @@ def test_sdk_analytics_ignores_bad_data(
 def test_sdk_analytics_ignores_feature_data_with_dots(
     mocker: MockerFixture,
     environment: Environment,
-    feauture_with_dots: Feature,
+    feature_with_dots: Feature,
     api_client: APIClient,
 ) -> None:
     # Given
     api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
 
-    data = { feauture_with_dots.name: 20 }
+    data = { feature_with_dots.name: 20 }
     mocked_feature_eval_cache = mocker.patch(
         "app_analytics.views.feature_evaluation_cache"
     )
@@ -85,8 +89,8 @@ def test_sdk_analytics_ignores_feature_data_with_dots(
 
     mocked_feature_eval_cache.track_feature_evaluation.assert_called_once_with(
         environment_id=environment.id,
-        feature_name=feauture_with_dots.name,
-        evaluation_count=data[feauture_with_dots.name],
+        feature_name=feature_with_dots.name,
+        evaluation_count=data[feature_with_dots.name],
         labels={},
     )
 

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -18,17 +18,19 @@ from app_analytics.dataclasses import UsageData
 from app_analytics.models import FeatureEvaluationRaw
 from environments.identities.models import Identity
 from environments.models import Environment
-from projects.models import Project
 from features.models import Feature
 from organisations.models import (
     Organisation,
     OrganisationSubscriptionInformationCache,
 )
+from projects.models import Project
 from tests.types import EnableFeaturesFixture
+
 
 @pytest.fixture()
 def feature_with_dots(project: Project) -> Feature:
     return Feature.objects.create(name="feature.with.dots", project=project)  # type: ignore[no-any-return]
+
 
 def test_sdk_analytics_ignores_bad_data(
     mocker: MockerFixture,
@@ -62,6 +64,7 @@ def test_sdk_analytics_ignores_bad_data(
         labels={},
     )
 
+
 def test_sdk_analytics_ignores_feature_data_with_dots(
     mocker: MockerFixture,
     environment: Environment,
@@ -71,7 +74,7 @@ def test_sdk_analytics_ignores_feature_data_with_dots(
     # Given
     api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
 
-    data = { feature_with_dots.name: 20 }
+    data = {feature_with_dots.name: 20}
     mocked_feature_eval_cache = mocker.patch(
         "app_analytics.views.feature_evaluation_cache"
     )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- [This method](https://github.com/encode/django-rest-framework/blob/e045dc465270c18689dba4a970378cd9744e57b6/rest_framework/serializers.py#L345) of django does not parse the feature keys with `.` righly (Refer #5906 for the exact error)
- This will fix the same.
- Used `initial_data` instead of `validated_data` which has the wrong parsed format

_Please describe._

## How did you test this code?
Manual API testing
