### PR TITLE
chore: update issue report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Flagsmith Bug Report 🐛
 description: Report a bug or unexpected behavior in Flagsmith
-labels: [bug]
+projects: ["engineering"]
+type: bug
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,7 @@
 name: Feature request 🏗️
 description: Suggest a new feature or change for Flagsmith
+project: ["engineering"]
+type: "enhancement"
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request 🏗️
 description: Suggest a new feature or change for Flagsmith
-project: ["engineering"]
+projects: ["engineering"]
 type: "enhancement"
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request 🏗️
 description: Suggest a new feature or change for Flagsmith
 projects: ["engineering"]
-type: "enhancement"
+type: enhancement
 
 body:
   - type: markdown


### PR DESCRIPTION
## Changes

Update issue report templates to add items directly to the engineering project, and give them the required type. 

## How did you test this code?

N/a - needs merging to test. Based on documentation [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). 
