### PR TITLE
fix: show whitespace warnings for IN operator comma-separated values

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -498,7 +498,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               </Row>
             }
           >
-            <div className='my-4 col-lg-8'>
+            <div className='my-4 col-lg-8 mx-auto'>
               <CreateSegmentRulesTabForm
                 is4Eyes={is4Eyes}
                 onCreateChangeRequest={onCreateChangeRequest}
@@ -526,7 +526,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
             </div>
           </TabItem>
           <TabItem tabLabel='Features'>
-            <div className='my-4 col-lg-8'>
+            <div className='my-4 col-lg-8 mx-auto'>
               <AssociatedSegmentOverrides
                 onUnsavedChange={() => {
                   setValueChanged(true)
@@ -539,7 +539,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
             </div>
           </TabItem>
           <TabItem tabLabel='Users'>
-            <div className='my-4 col-lg-8'>
+            <div className='my-4 col-lg-8 mx-auto'>
               <CreateSegmentUsersTabContent
                 projectId={projectId}
                 environmentId={environmentId}
@@ -566,7 +566,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 </Row>
               }
             >
-              <div className='my-4 col-lg-8'>{MetadataTab}</div>
+              <div className='my-4 col-lg-8 mx-auto'>{MetadataTab}</div>
             </TabItem>
           )}
         </Tabs>

--- a/frontend/web/components/segments/Rule/components/RuleConditionRow.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionRow.tsx
@@ -149,6 +149,7 @@ const RuleConditionRow: React.FC<RuleConditionRowProps> = ({
           style={{ width: '135px' }}
           projectId={projectId}
           showEnvironmentDropdown={showEnvironmentDropdown}
+          operator={operator}
           onChange={(value: string) => {
             setRuleProperty(ruleIndex, 'value', {
               value:

--- a/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
@@ -107,7 +107,7 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
     const TRAILING_WHITESPACE = /\s$/
 
     if (value.length >= 1 && value.trim() === '') {
-      return { hasWarning: true, message: 'This value is only whitespaces' }
+      return { message: 'This value is only whitespaces' }
     }
 
     const items = value.split(',')
@@ -137,26 +137,22 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
       if (totalIssues > 0) {
         if (hasMultipleIssues) {
           return {
-            hasWarning: true,
             message: `${totalIssues} item(s) have whitespace issues`,
           }
         }
         
         if (counts.both > 0) {
           return {
-            hasWarning: true,
             message: `${counts.both} item(s) have leading and trailing whitespaces`,
           }
         }
         if (counts.leading > 0) {
           return {
-            hasWarning: true,
             message: `${counts.leading} item(s) have leading whitespaces`,
           }
         }
         if (counts.trailing > 0) {
           return {
-            hasWarning: true,
             message: `${counts.trailing} item(s) have trailing whitespaces`,
           }
         }
@@ -168,22 +164,21 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
 
     if (hasLeading && hasTrailing) {
       return {
-        hasWarning: true,
         message: 'This value starts and ends with whitespaces',
       }
     }
     if (hasLeading) {
-      return { hasWarning: true, message: 'This value starts with whitespaces' }
+      return { message: 'This value starts with whitespaces' }
     }
     if (hasTrailing) {
-      return { hasWarning: true, message: 'This value ends with whitespaces' }
+      return { message: 'This value ends with whitespaces' }
     }
 
     return null
   }
 
   const whitespaceCheck = checkWhitespaceIssues()
-  const hasWarning = whitespaceCheck?.hasWarning || false
+  const hasWarning = !!whitespaceCheck
   const isLongText = String(value).length >= 10
 
   const validate = () => {

--- a/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import Input from 'components/base/forms/Input'
 import Icon from 'components/Icon'
-import InputGroup from 'components/base/forms/InputGroup'
-import Button from 'components/base/forms/Button'
 import Utils from 'common/utils/utils'
 
 import { getDarkMode } from 'project/darkMode'
-import ModalHR from 'components/modals/ModalHR'
 import EnvironmentSelectDropdown from './EnvironmentSelectDropdown'
+import TextAreaModal from './TextAreaModal'
+import { checkWhitespaceIssues } from '../utils/whitespaceValidation'
 
 type RuleConditionValueInputProps = {
   'data-test'?: string
@@ -23,73 +22,6 @@ type RuleConditionValueInputProps = {
   operator?: string
 }
 
-const TextAreaModal = ({
-  disabled,
-  isValid,
-  onChange,
-  placeholder,
-  readOnly,
-  style,
-  value,
-}: RuleConditionValueInputProps) => {
-  const [textAreaValue, setTextAreaValue] = React.useState(value)
-
-  return (
-    <div>
-      <div className='modal-body'>
-        <InputGroup
-          id='rule-value-textarea'
-          data-test='rule-value-textarea'
-          value={textAreaValue}
-          inputProps={{
-            style: style,
-          }}
-          isValid={isValid}
-          onChange={(e: InputEvent) => {
-            const value = Utils.safeParseEventValue(e)
-            setTextAreaValue(value.replace(/\n/g, ''))
-          }}
-          type='text'
-          className='w-100'
-          readOnly={readOnly}
-          placeholder={placeholder}
-          disabled={disabled}
-          textarea
-        />
-      </div>
-      <ModalHR />
-      <div className='modal-footer'>
-        <Button
-          className='mr-2'
-          theme='secondary'
-          id='rule-value-textarea-cancel'
-          data-tests='rule-value-textarea-cancel'
-          onClick={closeModal2}
-        >
-          Cancel
-        </Button>
-        <Button
-          type='button'
-          id='rule-value-textarea-save'
-          data-tests='rule-value-textarea-save'
-          onClick={() => {
-            const event = new InputEvent('input', { bubbles: true })
-            Object.defineProperty(event, 'target', {
-              value: { value: textAreaValue },
-              writable: false,
-            })
-            const value = Utils.getTypedValue(Utils.safeParseEventValue(event))
-            onChange?.(value)
-            closeModal2()
-          }}
-        >
-          Apply
-        </Button>
-      </div>
-    </div>
-  )
-}
-
 const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
   isValid,
   onChange,
@@ -99,85 +31,7 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
   value,
   ...props
 }) => {
-  const checkWhitespaceIssues = () => {
-    if (operator !== 'IN') return null
-    if (typeof value !== 'string') return null
-
-    const LEADING_WHITESPACE = /^\s/
-    const TRAILING_WHITESPACE = /\s$/
-
-    if (value.length >= 1 && value.trim() === '') {
-      return { message: 'This value is only whitespaces' }
-    }
-
-    const items = value.split(',')
-    
-    if (items.length > 1) {
-      const counts = items.reduce(
-        (acc, item) => {
-          const hasLeading = LEADING_WHITESPACE.test(item)
-          const hasTrailing = TRAILING_WHITESPACE.test(item)
-          
-          if (hasLeading && hasTrailing) acc.both++
-          else if (hasLeading) acc.leading++
-          else if (hasTrailing) acc.trailing++
-          
-          return acc
-        },
-        { leading: 0, trailing: 0, both: 0 },
-      )
-
-      const totalIssues = counts.both + counts.leading + counts.trailing
-      const hasMultipleIssues = [
-        counts.both > 0,
-        counts.leading > 0,
-        counts.trailing > 0,
-      ].filter(Boolean).length > 1
-
-      if (totalIssues > 0) {
-        if (hasMultipleIssues) {
-          return {
-            message: `${totalIssues} item(s) have whitespace issues`,
-          }
-        }
-        
-        if (counts.both > 0) {
-          return {
-            message: `${counts.both} item(s) have leading and trailing whitespaces`,
-          }
-        }
-        if (counts.leading > 0) {
-          return {
-            message: `${counts.leading} item(s) have leading whitespaces`,
-          }
-        }
-        if (counts.trailing > 0) {
-          return {
-            message: `${counts.trailing} item(s) have trailing whitespaces`,
-          }
-        }
-      }
-    }
-
-    const hasLeading = LEADING_WHITESPACE.test(value)
-    const hasTrailing = TRAILING_WHITESPACE.test(value)
-
-    if (hasLeading && hasTrailing) {
-      return {
-        message: 'This value starts and ends with whitespaces',
-      }
-    }
-    if (hasLeading) {
-      return { message: 'This value starts with whitespaces' }
-    }
-    if (hasTrailing) {
-      return { message: 'This value ends with whitespaces' }
-    }
-
-    return null
-  }
-
-  const whitespaceCheck = checkWhitespaceIssues()
+  const whitespaceCheck = checkWhitespaceIssues(value, operator)
   const hasWarning = !!whitespaceCheck
   const isLongText = String(value).length >= 10
 
@@ -223,20 +77,13 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
               <Tooltip
                 title={
                   <div
-                    className={`flex ${
+                    className={`rule-value-icon flex ${
                       isDarkMode ? 'bg-white' : 'bg-black'
-                    } bg-opacity-10 rounded-2 p-1 ${
-                      hasWarning ? '' : 'cursor-pointer'
-                    }`}
+                    } bg-opacity-10 rounded-2 p-1 cursor-pointer`}
                     onClick={() => {
-                      if (hasWarning) return
                       openModal2(
                         'Edit Value',
-                        <TextAreaModal
-                          value={value}
-                          onChange={onChange}
-                          isValid={isValid}
-                        />,
+                        <TextAreaModal value={value} onChange={onChange} />,
                       )
                     }}
                   >

--- a/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
@@ -6,7 +6,7 @@ import Utils from 'common/utils/utils'
 import { getDarkMode } from 'project/darkMode'
 import EnvironmentSelectDropdown from './EnvironmentSelectDropdown'
 import TextAreaModal from './TextAreaModal'
-import { checkWhitespaceIssues } from '../utils/whitespaceValidation'
+import { checkWhitespaceIssues } from '../utils'
 
 type RuleConditionValueInputProps = {
   'data-test'?: string
@@ -62,6 +62,8 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
           <Input
             type='text'
             data-test={props['data-test']}
+            name='rule-condition-value-input'
+            aria-label='Rule condition value input'
             value={value}
             inputClassName={
               showIcon ? `pr-5 ${hasWarning ? 'border-warning' : ''}` : ''
@@ -83,7 +85,11 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
                     onClick={() => {
                       openModal2(
                         'Edit Value',
-                        <TextAreaModal value={value} onChange={onChange} />,
+                        <TextAreaModal 
+                          value={value} 
+                          onChange={onChange} 
+                          operator={operator}
+                        />,
                       )
                     }}
                   >

--- a/frontend/web/components/segments/Rule/components/TextAreaModal.tsx
+++ b/frontend/web/components/segments/Rule/components/TextAreaModal.tsx
@@ -1,20 +1,25 @@
 import React, { useState, FC } from 'react'
 import InputGroup from 'components/base/forms/InputGroup'
 import Button from 'components/base/forms/Button'
+import Icon from 'components/Icon'
 import Utils from 'common/utils/utils'
 import ModalHR from 'components/modals/ModalHR'
+import { checkWhitespaceIssues } from '../utils'
 
 type TextAreaModalProps = {
   value: string | number | boolean
   onChange?: (value: string) => void
+  operator?: string
 }
 
-const TextAreaModal: FC<TextAreaModalProps> = ({ onChange, value }) => {
+const TextAreaModal: FC<TextAreaModalProps> = ({ onChange, value, operator }) => {
   const [textAreaValue, setTextAreaValue] = useState(value)
+  const whitespaceCheck = checkWhitespaceIssues(textAreaValue, operator)
+  const hasWarning = !!whitespaceCheck
 
   return (
     <div>
-      <div className='modal-body'>
+      <div className='modal-body d-flex flex-column gap-1'>
         <InputGroup
           id='rule-value-textarea'
           data-test='rule-value-textarea'
@@ -23,10 +28,30 @@ const TextAreaModal: FC<TextAreaModalProps> = ({ onChange, value }) => {
             const value = Utils.safeParseEventValue(e)
             setTextAreaValue(value.replace(/\n/g, ''))
           }}
+          noMargin
+          inputProps={{
+            className: hasWarning ? 'border-warning' : '',
+          }}
           type='text'
           className='w-100'
           textarea
         />
+        <div
+          style={{
+            minHeight: '20px',
+            transition: 'opacity 0.25s ease-in-out',
+            opacity: hasWarning ? 1 : 0,
+          }}
+        >
+          {hasWarning && (
+            <div className='text-warning d-flex align-items-start gap-2'>
+              <span className='d-flex' style={{ alignSelf: 'center' }}>
+                <Icon name='warning' width={16} height={16} />
+              </span>
+              <span>{whitespaceCheck?.message}</span>
+            </div>
+          )}
+        </div>
       </div>
       <ModalHR />
       <div className='modal-footer'>

--- a/frontend/web/components/segments/Rule/components/TextAreaModal.tsx
+++ b/frontend/web/components/segments/Rule/components/TextAreaModal.tsx
@@ -1,0 +1,64 @@
+import React, { useState, FC } from 'react'
+import InputGroup from 'components/base/forms/InputGroup'
+import Button from 'components/base/forms/Button'
+import Utils from 'common/utils/utils'
+import ModalHR from 'components/modals/ModalHR'
+
+type TextAreaModalProps = {
+  value: string | number | boolean
+  onChange?: (value: string) => void
+}
+
+const TextAreaModal: FC<TextAreaModalProps> = ({ onChange, value }) => {
+  const [textAreaValue, setTextAreaValue] = useState(value)
+
+  return (
+    <div>
+      <div className='modal-body'>
+        <InputGroup
+          id='rule-value-textarea'
+          data-test='rule-value-textarea'
+          value={textAreaValue}
+          onChange={(e: InputEvent) => {
+            const value = Utils.safeParseEventValue(e)
+            setTextAreaValue(value.replace(/\n/g, ''))
+          }}
+          type='text'
+          className='w-100'
+          textarea
+        />
+      </div>
+      <ModalHR />
+      <div className='modal-footer'>
+        <Button
+          className='mr-2'
+          theme='secondary'
+          id='rule-value-textarea-cancel'
+          data-tests='rule-value-textarea-cancel'
+          onClick={closeModal2}
+        >
+          Cancel
+        </Button>
+        <Button
+          type='button'
+          id='rule-value-textarea-save'
+          data-tests='rule-value-textarea-save'
+          onClick={() => {
+            const event = new InputEvent('input', { bubbles: true })
+            Object.defineProperty(event, 'target', {
+              value: { value: textAreaValue },
+              writable: false,
+            })
+            const value = Utils.getTypedValue(Utils.safeParseEventValue(event))
+            onChange?.(value)
+            closeModal2()
+          }}
+        >
+          Apply
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default TextAreaModal

--- a/frontend/web/components/segments/Rule/utils/index.ts
+++ b/frontend/web/components/segments/Rule/utils/index.ts
@@ -1,0 +1,1 @@
+export { checkWhitespaceIssues } from './whitespaceValidation'

--- a/frontend/web/components/segments/Rule/utils/whitespaceValidation.ts
+++ b/frontend/web/components/segments/Rule/utils/whitespaceValidation.ts
@@ -1,0 +1,84 @@
+/**
+ * Checks for whitespace issues in rule condition values, particularly for IN operator
+ * @param value - The value to check for whitespace issues
+ * @param operator - The operator being used (e.g., 'IN')
+ * @returns Object with warning message if issues found, null otherwise
+ */
+export const checkWhitespaceIssues = (
+  value: string | number | boolean,
+  operator?: string,
+): { message: string } | null => {
+  if (operator !== 'IN') return null
+  if (typeof value !== 'string') return null
+
+  const LEADING_WHITESPACE = /^\s/
+  const TRAILING_WHITESPACE = /\s$/
+
+  if (value.length >= 1 && value.trim() === '') {
+    return { message: 'This value is only whitespaces' }
+  }
+
+  const items = value.split(',')
+
+  if (items.length > 1) {
+    const counts = items.reduce(
+      (acc, item) => {
+        const hasLeading = LEADING_WHITESPACE.test(item)
+        const hasTrailing = TRAILING_WHITESPACE.test(item)
+
+        if (hasLeading && hasTrailing) acc.both++
+        else if (hasLeading) acc.leading++
+        else if (hasTrailing) acc.trailing++
+
+        return acc
+      },
+      { both: 0, leading: 0, trailing: 0 },
+    )
+
+    const totalIssues = counts.both + counts.leading + counts.trailing
+    const hasMultipleIssues =
+      [counts.both > 0, counts.leading > 0, counts.trailing > 0].filter(Boolean)
+        .length > 1
+
+    if (totalIssues > 0) {
+      if (hasMultipleIssues) {
+        return {
+          message: `${totalIssues} item(s) have whitespace issues`,
+        }
+      }
+
+      if (counts.both > 0) {
+        return {
+          message: `${counts.both} item(s) have leading and trailing whitespaces`,
+        }
+      }
+      if (counts.leading > 0) {
+        return {
+          message: `${counts.leading} item(s) have leading whitespaces`,
+        }
+      }
+      if (counts.trailing > 0) {
+        return {
+          message: `${counts.trailing} item(s) have trailing whitespaces`,
+        }
+      }
+    }
+  }
+
+  const hasLeading = LEADING_WHITESPACE.test(value)
+  const hasTrailing = TRAILING_WHITESPACE.test(value)
+
+  if (hasLeading && hasTrailing) {
+    return {
+      message: 'This value starts and ends with whitespaces',
+    }
+  }
+  if (hasLeading) {
+    return { message: 'This value starts with whitespaces' }
+  }
+  if (hasTrailing) {
+    return { message: 'This value ends with whitespaces' }
+  }
+
+  return null
+}

--- a/frontend/web/styles/project/_forms.scss
+++ b/frontend/web/styles/project/_forms.scss
@@ -123,6 +123,19 @@
     font-weight: 500;
 }
 
+.rule-value-icon {
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        transform: scale(1.05);
+    }
+
+    &:active {
+        transform: scale(0.95);
+        transition: all 0.1s ease-in-out;
+    }
+}
+
 .setting {
     label {
         font-size: $font-size-base;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Add whitespace detection for individual items in comma-separated lists
- Show warning only when operator is 'IN'
- Display combined count when multiple whitespace issue types exist
- Optimize performance with single-pass iteration using reduce

## How did you test this code?

## Testing Instructions

### Prerequisites
1. Go to the Segments page

### Test Case 1: Verify Warning Only Shows for IN Operator

**Steps:**
1. Click "Create Segment" or edit an existing segment
2. Add a new condition
3. Select the **IN** operator
4. In the value field, enter: `value1, value2,value3 `
5. Observe the warning icon appears with a yellow border
6. Hover over the warning icon to see the tooltip message

**Expected Result:** 
- Warning icon is displayed
- Tooltip shows: "2 item(s) have whitespace issues"

**Steps (continued):**
7. Change the operator to **Exactly Matches(=)** (keeping the same value)
8. Observe the warning icon disappears

**Expected Result:** 
- No warning icon is shown for non-IN operators

**Additional Operators to Test:**
- Does not match (!=), Contains, Does not contain, Matches regex
- None should show whitespace warnings ✅

---

### Test Case 2: Individual Items with Different Whitespace Issues

**Steps:**
1. Create a condition with the **IN** operator
2. Enter value: `firstvalue,goodexample, badexample1,badexample2 ,goodexample`
   - Note: `" badexample1"` has a leading space
   - Note: `"badexample2 "` has a trailing space

**Expected Result:**
- Warning icon displayed
- Tooltip shows: "2 item(s) have whitespace issues"

---

### Test Case 3: Single Issue Type - Leading Spaces

**Steps:**
1. Create a condition with the **IN** operator
2. Enter value: ` value1, value2, value3`
   - Note: All items have leading spaces

**Expected Result:**
- Warning icon displayed
- Tooltip shows: "3 item(s) have leading whitespaces"

---

### Test Case 4: Single Issue Type - Trailing Spaces

**Steps:**
1. Create a condition with the **IN** operator
2. Enter value: `value1 ,value2 ,value3 `
   - Note: All items have trailing spaces

**Expected Result:**
- Warning icon displayed
- Tooltip shows: "3 item(s) have trailing whitespaces"

---

### Test Case 5: Items with Both Leading and Trailing Spaces

**Steps:**
1. Create a condition with the **IN** operator
2. Enter value: ` value1 , value2 `
   - Note: Both items have leading AND trailing spaces

**Expected Result:**
- Warning icon displayed
- Tooltip shows: "2 item(s) have leading and trailing whitespaces"

---

### Test Case 6: Only Whitespace Value

**Steps:**
1. Create a condition with the **IN** operator
2. Enter value: `   ` (only spaces, no other characters)

**Expected Result:**
- Warning icon displayed
- Tooltip shows: "This value is only whitespaces"

---

### Test Case 7: Non-Comma-Separated Value with Spaces

**Steps:**
1. Create a condition with the **IN** operator
2. Enter value: ` single value with spaces `
   - Note: Single value with leading and trailing spaces

**Expected Result:**
- Warning icon displayed
- Tooltip shows: "This value starts and ends with whitespaces"

---

### Test Case 8: Valid Values (No Warnings)

**Steps:**
1. Create a condition with the **IN** operator
2. Test the following values:
   - `value1,value2,value3` (no spaces)
   - `single_value` (single value, no spaces)
   - `` (empty value)

**Expected Result:**
- No warning icon displayed for any of these values ✅

---

### Test Case 9: Performance with Large Lists

**Steps:**
1. Create a condition with the **IN** operator
2. Enter a value with 50+ comma-separated items, some with spaces
```
value1,value2, value3,value4,value5 ,value6,value7,value8,value9,value10,value11, value12,value13,value14,value15,value16 ,value17,value18,value19,value20,value21,value22,value23, value24,value25,value26,value27,value28,value29,value30 ,value31,value32,value33,value34,value35,value36, value37,value38,value39,value40 ,value41,value42,value43,value44,value45, value46,value47,value48 ,value49,value50,value51,value52,value53, value54,value55,value56,value57,value58 ,value59,value60
```

With this test case I noticed some topics to discuss:

### 1. Modal Not Accessible When Warning is Present  (handled on the PR)

**Issue:** When whitespace warnings are displayed, the warning icon is not clickable and users cannot open the textarea modal to edit long comma-separated lists.

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/b1e0770d-1aa3-44ce-91cf-5309ea3c00be" />


**Impact:** For large lists with whitespace issues (e.g., 50+ items), users must fix whitespace problems in the small input field, which is difficult and error-prone.

**Workaround:** Users need to manually remove whitespace issues in the small input field before they can access the modal for easier editing.

**Future Improvement:** Consider one of the following approaches:
- **Option A:** Show both warning and expand icons side-by-side (⚠️ ⤢) - warning for information, expand for modal access
- **Option B:** Add expand icon on hover when warnings are present

---

### 2. Segment Page Layout - Not Full Width (handled on the PR)

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/29fd36b7-dfb2-4334-b0b7-82095f909df4" />


**Observation:** The Segments creation/editing page does not utilize the full width of the browser window. There are substantial space on the right side

**Suggestion:** Consider making the segment full width