### PR TITLE
docs: update contact us messages and remove real-time callout in flutter

### DIFF
--- a/docs/docs/integrating-with-flagsmith/sdks/client-side-sdks/flutter.md
+++ b/docs/docs/integrating-with-flagsmith/sdks/client-side-sdks/flutter.md
@@ -249,12 +249,6 @@ final flagsmithClient = FlagsmithClient(
 
 ## Real-time Flag Updates
 
-:::tip
-
-Real-time Flags are part of our SaaS Scale-Up and Enterprise plans.
-
-:::
-
 Real-time flag updates are disabled by default. You can enable them simply by changing the configuration as follows:
 
 ```dart
@@ -277,6 +271,8 @@ final flagsmithClient = FlagsmithClient(
           reconnctToSSEInterval: 15000,
       ), apiKey: 'YOUR_ENV_API_KEY');
 ```
+
+For further information on real-time flags see the full documentation [here](../../../performance/real-time-flags)
 
 ## Known issues
 

--- a/docs/docs/integrating-with-flagsmith/sdks/client-side-sdks/flutter.md
+++ b/docs/docs/integrating-with-flagsmith/sdks/client-side-sdks/flutter.md
@@ -253,8 +253,6 @@ final flagsmithClient = FlagsmithClient(
 
 Real-time Flags are part of our SaaS Scale-Up and Enterprise plans.
 
-Real-time Flags are currently in beta. Please contact us to join the beta!
-
 :::
 
 Real-time flag updates are disabled by default. You can enable them simply by changing the configuration as follows:

--- a/docs/docs/managing-flags/release-pipeline.md
+++ b/docs/docs/managing-flags/release-pipeline.md
@@ -6,9 +6,7 @@ sidebar_position: 4
 
 :::info
 
-Release Pipelines is currently in a closed beta, please contact us if you'd like to gain access.
-
-<a class="open-chat button button--primary" data-crisp-chat-message="Hello, I'm interested in joining the Release Pipelines beta.">Contact Us</a>
+Release Pipelines is currently in a closed beta, please contact support@flagsmith.com if you'd like to gain access.
 
 :::
 

--- a/docs/docs/performance/real-time-flags.md
+++ b/docs/docs/performance/real-time-flags.md
@@ -4,12 +4,13 @@ sidebar_label: Real-time Flags
 sidebar_position: 20
 ---
 
+:::info
+
+Real-time flag updates require an Enterprise subscription.
+
+:::
+
 When an application fetches its current feature flags, it usually caches the flags for a certain amount of time to make [efficient use](/best-practices/efficient-api-usage) of the Flagsmith API and network resources. In some cases, you may want an application to be notified about feature flag updates without needing to repeatedly call the Flagsmith API. This guide explains how to achieve this by subscribing to real-time flag updates.
-
-## Prerequisites
-
-- Real-time flag updates require an Enterprise subscription.
-- Real-time flag updates are only available on the public SaaS Flagsmith instance. Self-hosted and private cloud Flagsmith installations do not support real-time flag updates.
 
 ## Setup
 

--- a/docs/docs/third-party-integrations/project-management/servicenow.md
+++ b/docs/docs/third-party-integrations/project-management/servicenow.md
@@ -7,6 +7,4 @@ hide_title: true
 ![Adobe](/img/integrations/servicenow/servicenow-logo.svg)
 
 Flagsmith does not currently support integrating with ServiceNow, but we are eager to build this integration based on
-your requirements.
-<a class="open-chat" data-crisp-chat-message="Hello, I'm interested in integrating with ServiceNow.">Contact us</a> if
-you are interested in this or any other integrations.
+your requirements. Contact support@flagsmith.com if you are interested in this or any other integrations.


### PR DESCRIPTION
## Changes

This PR makes 2 distinct changes: 

 1. Update all locations where we attempt to route users to contact us via crisp (which no longer exists on our docs site)
 2. Tidies up the real-time information on the flutter SDK pages

## How did you test this code?

Ran the site locally
