### PR TITLE
docs: reinstate help and support page

### DIFF
--- a/docs/docs/support/index.mdx
+++ b/docs/docs/support/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Help and Support
+sidebar_position: 130
+sidebar_label: Help and Support
+---
+
+We are here to help! You can contact us for support through any of these channels:
+
+* Click the <a class="open-chat">chat bubble (💬)</a> at the bottom right of this page, or from the Flagsmith dashboard.
+* Email [support@flagsmith.com](mailto:support@flagsmith.com).
+
+## Enterprise support
+
+[Flagsmith Enterprise](https://www.flagsmith.com/pricing) customers can also use these support channels:
+
+* Dedicated Customer Success manager for personalised assistance and training.
+* Shared Slack channel for real-time group support between your organisation and the Flagsmith team.
+
+## Bug reports and pull requests
+
+Flagsmith is open source, and we encourage contributions from the community. If you want to submit a specific bug
+report or code change, you can open an issue or pull request directly in the relevant GitHub repository:
+
+* [Flagsmith API, dashboard and documentation](https://github.com/Flagsmith/flagsmith)
+* Client-side SDKs:
+  - [JavaScript, React](https://github.com/Flagsmith/flagsmith-js-client)
+  - [iOS](https://github.com/Flagsmith/flagsmith-ios-client)
+  - [Android](https://github.com/Flagsmith/flagsmith-kotlin-android-client)
+  - [Flutter](https://github.com/flagsmith/flagsmith-flutter-client)
+* [Server-side SDKs](/clients/server-side)
+* [Edge Proxy](https://github.com/Flagsmith/edge-proxy)
+* [Terraform provider](https://github.com/Flagsmith/terraform-provider-flagsmith)
+* [Flagsmith CLI](https://github.com/Flagsmith/flagsmith-cli)
+* [Kubernetes Helm charts](https://github.com/Flagsmith/flagsmith-charts)

--- a/docs/docs/support/index.mdx
+++ b/docs/docs/support/index.mdx
@@ -27,7 +27,7 @@ report or code change, you can open an issue or pull request directly in the rel
   - [iOS](https://github.com/Flagsmith/flagsmith-ios-client)
   - [Android](https://github.com/Flagsmith/flagsmith-kotlin-android-client)
   - [Flutter](https://github.com/flagsmith/flagsmith-flutter-client)
-* [Server-side SDKs](/clients/server-side)
+* [Server-side SDKs](/integrating-with-flagsmith/sdks/server-side)
 * [Edge Proxy](https://github.com/Flagsmith/edge-proxy)
 * [Terraform provider](https://github.com/Flagsmith/terraform-provider-flagsmith)
 * [Flagsmith CLI](https://github.com/Flagsmith/flagsmith-cli)


### PR DESCRIPTION
## Changes

Reinstate the support page lost in the documentation rewrite. 

## How did you test this code?

Ran the docs locally and confirmed that the page showed again correctly. 
