### PR TITLE
feat: initial PoC for new endpoint to update a flag, regardless of versioning

### DIFF
--- a/api/environments/urls.py
+++ b/api/environments/urls.py
@@ -7,6 +7,7 @@ from edge_api.identities.views import (
     EdgeIdentityWithIdentifierFeatureStateView,
     get_edge_identity_overrides,
 )
+from features.feature_states.views import update_flag
 from features.views import (
     EnvironmentFeatureStateViewSet,
     IdentityFeatureStateViewSet,
@@ -166,5 +167,10 @@ urlpatterns = [
         "<str:environment_api_key>/edge-identity-overrides",
         get_edge_identity_overrides,
         name="edge-identity-overrides",
+    ),
+    path(
+        "<int:environment_id>/features/<str:feature_name>/update-flag/",
+        update_flag,
+        name="update-flag",
     ),
 ]

--- a/api/features/feature_states/views.py
+++ b/api/features/feature_states/views.py
@@ -1,0 +1,22 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from environments.models import Environment
+from features.models import Feature
+from features.serializers import UpdateFlagSerializer
+
+
+@api_view(http_method_names=["POST"])
+def update_flag(request: Request, environment_id: int, feature_name: str) -> Response:
+    environment = Environment.objects.get(id=environment_id)
+    feature = Feature.objects.get(name=feature_name, project_id=environment.project_id)
+
+    serializer = UpdateFlagSerializer(
+        data=request.data, context={"request": request, "view": update_flag}
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save(environment=environment, feature=feature)
+
+    return Response(serializer.data, status=status.HTTP_200_OK)

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -1,3 +1,4 @@
+import typing
 from datetime import datetime
 from typing import Any
 
@@ -18,6 +19,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from app_analytics.serializers import LabelsQuerySerializerMixin, LabelsSerializer
 from environments.identities.models import Identity
+from environments.models import Environment
 from environments.sdk.serializers_mixins import (
     HideSensitiveFieldsSerializerMixin,
 )
@@ -28,6 +30,7 @@ from projects.code_references.serializers import (
     FeatureFlagCodeReferencesRepositoryCountSerializer,
 )
 from projects.models import Project
+from users.models import FFAdminUser
 from users.serializers import (
     UserIdsSerializer,
     UserListSerializer,
@@ -47,6 +50,8 @@ from .feature_segments.serializers import (
 )
 from .models import Feature, FeatureState
 from .multivariate.serializers import NestedMultivariateFeatureOptionSerializer
+from .versioning.dataclasses import FlagChangeSet
+from .versioning.versioning_service import update_flag
 
 
 class FeatureStateSerializerSmall(serializers.ModelSerializer):  # type: ignore[type-arg]
@@ -671,3 +676,45 @@ class CustomCreateSegmentOverrideFeatureStateSerializer(
                 {"environment": SEGMENT_OVERRIDE_LIMIT_EXCEEDED_MESSAGE}
             )
         return super().create(validated_data)  # type: ignore[no-any-return,no-untyped-call]
+
+
+class UpdateFlagSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    enabled = serializers.BooleanField(required=False)
+
+    # TODO: this is introducing _another_ way of handling typing, but it feels closer
+    #  to what we should have done from the start. This might be out of scope for this
+    #  work though.
+    feature_state_value = serializers.CharField(required=False)
+    type = serializers.ChoiceField(
+        choices=["int", "string", "bool", "float"],
+        required=False,
+        default="string",
+    )
+
+    segment_id = serializers.IntegerField(required=False)
+
+    # TODO: multivariate?
+
+    @property
+    def flag_change_set(self) -> FlagChangeSet:
+        validated_data = self.validated_data
+        change_set = FlagChangeSet(
+            enabled=validated_data.get("enabled"),
+            feature_state_value=validated_data.get("feature_state_value"),
+            type_=validated_data.get("type"),
+            segment_id=validated_data.get("segment_id"),
+        )
+
+        request = self.context["request"]
+        if type(request.user) is FFAdminUser:
+            change_set.user = request.user
+        else:
+            change_set.api_key = request.user.key
+
+        return change_set
+
+    def save(self, **kwargs: typing.Any) -> FeatureState:
+        environment: Environment = kwargs["environment"]
+        feature: Feature = kwargs["feature"]
+
+        return update_flag(environment, feature, self.flag_change_set)

--- a/api/features/versioning/dataclasses.py
+++ b/api/features/versioning/dataclasses.py
@@ -1,6 +1,12 @@
+import typing
+from dataclasses import dataclass
 from datetime import datetime
 
 from pydantic import BaseModel, computed_field
+
+if typing.TYPE_CHECKING:
+    from api_keys.models import MasterAPIKey
+    from users.models import FFAdminUser
 
 
 class Conflict(BaseModel):
@@ -12,3 +18,15 @@ class Conflict(BaseModel):
     @property
     def is_environment_default(self) -> bool:
         return self.segment_id is None
+
+
+@dataclass
+class FlagChangeSet:
+    enabled: bool
+    feature_state_value: str
+    type_: str
+
+    user: typing.Optional["FFAdminUser"] = None
+    api_key: typing.Optional["MasterAPIKey"] = None
+
+    segment_id: str | None = None

--- a/api/tests/unit/features/feature_states/test_unit_feature_states_views.py
+++ b/api/tests/unit/features/feature_states/test_unit_feature_states_views.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+from common.environments.permissions import UPDATE_FEATURE_STATE
+from django.urls import reverse
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from environments.models import Environment
+from features.models import Feature
+from features.versioning.versioning_service import (
+    get_environment_flags_list,
+)
+from tests.types import WithEnvironmentPermissionsCallable
+
+
+@pytest.mark.parametrize(
+    "environment_",
+    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+)
+def test_update_flag(
+    staff_client: APIClient,
+    feature: Feature,
+    environment_: Environment,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    with_environment_permissions([UPDATE_FEATURE_STATE])  # type: ignore[call-arg]
+    url = reverse(
+        "api-v1:environments:update-flag",
+        kwargs={"environment_id": environment_.id, "feature_name": feature.name},
+    )
+
+    data = {"enabled": True, "feature_state_value": "42", "type": "int"}
+
+    # When
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    latest_flags = get_environment_flags_list(
+        environment=environment_, feature_name=feature.name
+    )
+
+    assert latest_flags[0].enabled is True
+    assert latest_flags[0].get_feature_state_value() == 42


### PR DESCRIPTION
## Changes

Contributes to #6029 

Adds a new endpoint to update a flag in a given environment, regardless of whether versioning is used or not. 

The reasoning behind creating a new endpoint is: 

 1. The API interactions to update a flag in a versioned environment are very convoluted
 2. The current API for updating a flag in a non-versioned environment relies on crud interactions from the django box of tricks

The new endpoint will look something like this: 

```
POST /environments/:id/features/:feature_name/update-flag

{
  "enabled": bool,
  "value": string,
  "type": OneOf["string" | "integer" | ...],
  "segment_id": number | null,
  "multivariate": TODO
}
```

### Other thoughts / outstanding questions:

 1. Should the URL use the environment key, or the environment ID? (realistically, it would be fairly easy to do both here by creating 2 endpoints that route to the same logic under the hood, only the environment retrieval changes)
 2. Do we want to add a separate bulk update endpoint here, or perhaps make this endpoint support bulk operations? 
 3. We still need to implement this functionality for multivariate values, but I don't think that will be too difficult. 
 4. Should this create the flag if it doesn't already exist (in the case of a segment override)
   a. How does the current create-segment-override endpoint currently behave in a versioned environment? 
 5. Error handling? 
   a. We need to consider the following scenarios here: 
      i. Flag is in a release pipeline - this should definitely error
      ii. Flag has a scheduled change - should this error? 
      iii. Change requests are enabled for the environment. 

Based on question (2), we could instead have the endpoint look something like: 

```
POST /environments/:id/update-flags/

{
  "data": [
    {
      "feature_name": string,
      "enabled": bool,
      "value": string,
      "type": OneOf["string" | "integer" | ...],
      "segment_id": number | null,
      "multivariate": TODO
    },
    ...
  ]
}
```

Or even, taking (2) into account: 

```
POST /bulk-update-flags/

{
  "data": {
    "environment_id": number,
    "environment_key": string,
    "flag_updates": [
      {
        "feature_name": string,
        "enabled": bool,
        "value": string,
        "type": OneOf["string" | "integer" | ...],
        "segment_id": number | null,
        "multivariate": TODO
      },
      ...
    ]
  }
}

Note: exactly one of environment_id, or environment_key is required.
```

### Answered questions

> 1. Can we just reimplement the current endpoint to update a feature state in v1? Although we're using Django's crud functionality, we could theoretically pull that method out of the ViewSet, and reimplement ourselves. This would probably be an AND, rather than an instead though as I think adding this generic endpoint still gives us more flexibility. 

Looking into this, the existing endpoint relies on sending a PUT to the endpoint `/environments/:key/featurestates/:id` which relies on the ID of the feature state itself. Since we'd be creating a new feature state as part of the logic for a v2 versioned environment (and hence changing the ID), this would either be really bad UX, or just wouldn't work. 

> 2. Should the URL use the feature name, or the ID? 

We agreed the URL shouldn't include the feature at all, and the name should be included in the payload. The URL will just be `/environments/:key|id/update-flag`

## How did you test this code?

Added a basic unit test, but more tests will need to be added when this becomes a real change that we want to make. 
