### PR TITLE
docs: add redirect for integrating with flagsmith

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -699,6 +699,10 @@
         {
             "source": "/clients/server-side",
             "destination": "/integrating-with-flagsmith/sdks/server-side"
+        },
+        {
+            "source": "/integrating-with-flagsmith/",
+            "destination": "/integrating-with-flagsmith/integration-overview"
         }
     ]
 }


### PR DESCRIPTION
## Changes

Add redirect for `/integrating-with-flagsmith/` (see conversation [here](https://flagsmith.slack.com/archives/CTF0THS2D/p1761927920622149) for context)

## How did you test this code?

N/a
