### PR TITLE
fix: re-enable sse usage tracking

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -126,6 +126,12 @@
                     "value": "https://eu-central-1-1.aws.cloud2.influxdata.com"
                 },
                 {
+
+                    "name": "AWS_SSE_LOGS_BUCKET_NAME",
+                    "value": "flagsmith-fastly-logs-production"
+
+                },
+                {
                     "name": "OAUTH_CLIENT_ID",
                     "value": "232959427810-br6ltnrgouktp0ngsbs04o14ueb9rch0.apps.googleusercontent.com"
                 },

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -126,10 +126,8 @@
                     "value": "https://eu-central-1-1.aws.cloud2.influxdata.com"
                 },
                 {
-
                     "name": "AWS_SSE_LOGS_BUCKET_NAME",
                     "value": "flagsmith-fastly-logs-production"
-
                 },
                 {
                     "name": "OAUTH_CLIENT_ID",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Add `AWS_SSE_LOGS_BUCKET_NAME` environment variable to re-enable SSE usage tracking.
Was disabled [here](https://github.com/Flagsmith/flagsmith/commit/9b43a379de18f0ddf18d7de470f94e9cb8531bf2) 
For more details, ref:  #6224 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
n/a
