### PR TITLE
chore(sales-dashboard): add multiselect to plan filter

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/home.html
+++ b/api/sales_dashboard/templates/sales_dashboard/home.html
@@ -32,11 +32,11 @@
         <label for="include-deleted" class="mr-1">Include deleted:</label>
         <input type="checkbox" name="include_deleted" id="include-deleted" class="mr-1" {% if include_deleted %}checked{% endif %}>
         <label for="filter-plan">Filter: </label>
-          <select name="filter_plan" id="filter-plan" class="custom-select m-1">
-            <option value="" {% if not filter_plan %}selected{% endif %}>Filter Plan</option>
-            <option value="free" {% if filter_plan == "free" %}selected{% endif %}>Free</option>
-            <option value="start" {% if filter_plan == "start" %}selected{% endif %}>Start Up</option>
-            <option value="scale" {% if filter_plan == "scale" %}selected{% endif %}>Scale Up</option>
+          <select name="filter_plan" id="filter-plan" class="custom-select m-1" multiple>
+            <option value="free" {% if "free" in filter_plan %}selected{% endif %}>Free</option>
+            <option value="start" {% if "start" in filter_plan %}selected{% endif %}>Start Up</option>
+            <option value="scale" {% if "scale" in filter_plan %}selected{% endif %}>Scale Up</option>
+            <option value="enterprise" {% if "enterprise" in filter_plan %}selected{% endif %}>Enterprise</option>
           </select>
           <label for="sort-field">Sort: </label>
           <select name="sort_field" id="sort-field" class="custom-select m-1" value="{{ sort_field }}">

--- a/api/tests/integration/sales_dashboard/test_integration_sales_dashboard.py
+++ b/api/tests/integration/sales_dashboard/test_integration_sales_dashboard.py
@@ -3,6 +3,7 @@ from rest_framework import status
 
 from environments.dynamodb.migrator import IdentityMigrator
 from organisations.models import Organisation
+from organisations.subscriptions.constants import ENTERPRISE
 
 
 def test_sales_dashboard_index(  # type: ignore[no-untyped-def]
@@ -15,9 +16,11 @@ def test_sales_dashboard_index(  # type: ignore[no-untyped-def]
     # Given
     url = reverse("sales_dashboard:index")
 
-    # create some organisations so we can ensure there aren't any N+1 issues
+    # create some organisations, so we can ensure there aren't any N+1 issues
     for i in range(10):
-        Organisation.objects.create(name=f"Test organisation {i}")
+        organisation = Organisation.objects.create(name=f"Test organisation {i}")
+        organisation.subscription.plan = ENTERPRISE
+        organisation.subscription.save()
 
     # When
     with django_assert_num_queries(5):

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -30,6 +30,7 @@ from users.models import FFAdminUser
 )
 def test_organisation_subscription_get_api_call_overage(
     organisation: Organisation,
+    enterprise_subscription: Subscription,
     allowed_calls_30d: int,
     actual_calls_30d: int,
     expected_overage: int,
@@ -82,6 +83,7 @@ def test_get_organisation_info__get_event_list_for_organisation(
 
 def test_list_organisations_search_by_name(
     organisation: Organisation,
+    enterprise_subscription: Subscription,
     superuser_client: Client,
 ) -> None:
     # Given
@@ -119,6 +121,7 @@ def test_list_organisations_search_by_subscription_id(
 
 def test_list_organisations_search_by_user_email(
     organisation: Organisation,
+    enterprise_subscription: Subscription,
     superuser_client: Client,
     admin_user: FFAdminUser,
 ) -> None:
@@ -157,6 +160,7 @@ def test_list_organisations_search_by_user_email_for_non_existent_user(
 
 def test_list_organisations_search_by_domain(
     organisation: Organisation,
+    enterprise_subscription: Subscription,
     superuser_client: Client,
 ) -> None:
     # Given


### PR DESCRIPTION
## Changes

Adds multiselect to the plan filter in the sales dashboard. 

The reasoning behind doing this is to remove the free plan by default to reduce the impact of loading the sales dashboard. 

<img width="1108" height="399" alt="image" src="https://github.com/user-attachments/assets/0f60e0e1-6473-4ad1-b152-37267c1314ef" />

## How did you test this code?

Ran the sales dashboard locally and validated the behaviour. 
