### PR TITLE
fix:  Pin firefox version

### DIFF
--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -1,6 +1,9 @@
 name: Build E2E Frontend Base Image
 
 on:
+  push:
+    paths:
+      - frontend/Dockerfile-base.e2e
   schedule:
     # Update the E2E Firefox testcafe version on the first of every month
     - cron: 0 0 1 * *

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - frontend/Dockerfile-base.e2e
+      - .github/workflows/platform-docker-build-e2e-image.yml
   schedule:
     # Update the E2E Firefox testcafe version on the first of every month
     - cron: 0 0 1 * *

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -1,13 +1,10 @@
 name: Build E2E Frontend Base Image
 
 on:
-  push:
-    paths:
-      - frontend/Dockerfile-base.e2e
-      - .github/workflows/platform-docker-build-e2e-image.yml
   schedule:
     # Update the E2E Firefox testcafe version on the first of every month
     - cron: 0 0 1 * *
+  workflow_dispatch:
 
 jobs:
   build-e2e-docker-image:

--- a/frontend/Dockerfile-base.e2e
+++ b/frontend/Dockerfile-base.e2e
@@ -6,7 +6,7 @@ ENV NODE_VERSION 16.20.1
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-# Install dependencies and download Firefox 143.0 from Mozilla
+# Install dependencies
 RUN apt-get update && apt-get install -y \
     g++ make libssl-dev python3 python3-setuptools gnupg2 curl wget \
     libgtk-3-0 libdbus-glib-1-2 libxt6 libx11-xcb1 libasound2 \

--- a/frontend/Dockerfile-base.e2e
+++ b/frontend/Dockerfile-base.e2e
@@ -6,9 +6,19 @@ ENV NODE_VERSION 16.20.1
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-# Bring in firefox into debian sources
-RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update && apt-get install -y g++ make libssl-dev python3 python3-setuptools gnupg2 firefox curl && apt-get -y autoclean
+# Install dependencies and download Firefox 143.0 from Mozilla
+RUN apt-get update && apt-get install -y \
+    g++ make libssl-dev python3 python3-setuptools gnupg2 curl wget \
+    libgtk-3-0 libdbus-glib-1-2 libxt6 libx11-xcb1 libasound2 \
+    && apt-get -y autoclean
+
+# Download and install Firefox 143.0
+RUN ARCH=$(uname -m) && \
+    apt-get install -y xz-utils && \
+    wget -O /tmp/firefox.tar.xz "https://ftp.mozilla.org/pub/firefox/releases/143.0/linux-${ARCH}/en-US/firefox-143.0.tar.xz" && \
+    tar -xJf /tmp/firefox.tar.xz -C /opt && \
+    ln -s /opt/firefox/firefox /usr/local/bin/firefox && \
+    rm /tmp/firefox.tar.xz
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Pins Firefox to 143.0, 144.0 has a breaking change with TestCafe which is breaking our e2e whereby none of the tests appear to run. Here's an example where tests have started hanging https://github.com/Flagsmith/flagsmith/actions/runs/19045462728/job/54392661526#step:6:937.

This PR also adds a `workflow_dispatch` trigger to the workflow which builds the E2E base image, since we had to temporarily add a push trigger in this PR (see [here](https://github.com/Flagsmith/flagsmith/pull/6244/commits/de15693b321ebfa102e84435f5e5b916024f47cc)). Having a workflow dispatch would have negated the need for this so it's been added here for any future needs. 

Possibly related: https://github.com/DevExpress/testcafe/issues/8452

## How did you test this code?

Passing E2E tests on this PR (e.g. https://github.com/Flagsmith/flagsmith/actions/runs/19086275598/job/54527223362?pr=6244)
