### PR TITLE
fix: segment change request warning shows on all segments

### DIFF
--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -655,7 +655,7 @@ export type Req = {
   }
   getProjectChangeRequests: PagedRequest<{
     project_id: string
-    version_of?: string
+    segment_id?: string
     live_from_after?: string
     committed?: boolean
   }>

--- a/frontend/web/components/ExistingProjectChangeRequestAlert.tsx
+++ b/frontend/web/components/ExistingProjectChangeRequestAlert.tsx
@@ -14,7 +14,7 @@ const ExistingProjectChangeRequestAlert: FC<
   const { data } = useGetProjectChangeRequestsQuery({
     committed: false,
     project_id: projectId,
-    version_of: segmentId,
+    segment_id: segmentId,
   })
 
   if (data?.results?.length) {

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -482,11 +482,11 @@ const CreateSegment: FC<CreateSegmentType> = ({
 
   return (
     <>
-      <ExistingProjectChangeRequestAlert
+      {segment.id && <ExistingProjectChangeRequestAlert
         className='m-2'
         projectId={`${projectId}`}
         segmentId={`${segment.id}`}
-      />
+      />}
       {isEdit && !condensed ? (
         <Tabs value={tab} onChange={(tab: UserTabs) => setTab(tab)}>
           <TabItem


### PR DESCRIPTION
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Fixes #6219 When a project has segment change requests enabled and a change request is created for one segment, all segments (including the "New segment" modal) incorrectly show the warning that there are open change requests. The warning should only appear on the segment that actually has an open change request.

## Changes

The issue was caused by a query parameter mismatch between the frontend and the backend API:
Frontend was sending: version_of: segmentId
Backend expected: segment_id
In the ExistingProjectChangeRequestAlert component, the API query was using an incorrect parameter name (version_of) that the backend API doesn't recognize. As a result, the filter wasn't being applied, and the API was returning all open change requests for the project instead of just those for the specific segment.


### Changes Made
- ExistingProjectChangeRequestAlert.tsx
   - Changed query parameter from version_of to segment_id
- requests.ts
   - Updated TypeScript type definition to match the correct API parameter name

## How did you test this code?

Manual Testing Steps:
- Create a segment in a project with workflows enabled
- Create a change request that modifies that segment
- Navigate to the segment list or segment details page
- ✅ Verify the warning only appears on the segment with the open change request
- ✅ Verify other segments don't show the warning
- ✅ Verify the "New segment" modal doesn't show the warning


## Impact
- Before: All segments showed change request warnings when any segment had an open change request
- After: Only the specific segment with an open change request shows the warning