### PR TITLE
deps: bump flagsmith-common from 2.2.4 to 2.2.5

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "f3cadf428cc06e9326251343a2a0a6cfa77fa966"
+resolved_reference = "709b05ebd12cf67680b4fcc81a27368f2d47a1de"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "a2ef2a5962c6e690480da7cf603bd4932dd2778e"
+resolved_reference = "4a34e083f1796b2747820c64d94469a32df7a2f0"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "a45278b1aba12d8f7fb72c43427df7d3b78b2b68"
+resolved_reference = "cc03e9a493d7f0a548e68239c1f50f3eab00964c"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "3ec55b18e53bb184689274cd8cb94228ba216a47"
+resolved_reference = "6e741bca976e56e569c942f6eecf49e418971cd7"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "74ca0e3cfcc9d1ed738ba93815c08442ba52d638"
+resolved_reference = "f3cadf428cc06e9326251343a2a0a6cfa77fa966"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "cc03e9a493d7f0a548e68239c1f50f3eab00964c"
+resolved_reference = "2fbb7e43b921b8834b89eb89ccb4acdd87556888"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "4af7e3be768e65449ce00756d33ece12d5771724"
+resolved_reference = "3ec55b18e53bb184689274cd8cb94228ba216a47"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "2fbb7e43b921b8834b89eb89ccb4acdd87556888"
+resolved_reference = "74ca0e3cfcc9d1ed738ba93815c08442ba52d638"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "709b05ebd12cf67680b4fcc81a27368f2d47a1de"
+resolved_reference = "a2ef2a5962c6e690480da7cf603bd4932dd2778e"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "14022154e4ab8348966694240e06c27f2bc91f3d"
+resolved_reference = "a127cc218c533ea2ae891f42c26eb38f028832a0"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "4a34e083f1796b2747820c64d94469a32df7a2f0"
+resolved_reference = "c5e983447837966818c97fbc0b5e4cfe1c2e136d"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1995,12 +1995,10 @@ name = "flagsmith-common"
 version = "2.2.5"
 description = "Flagsmith's common library"
 optional = false
-python-versions = "<4.0,>=3.11"
+python-versions = ">=3.11,<4.0"
 groups = ["main", "dev", "split-testing", "workflows"]
-files = [
-    {file = "flagsmith_common-2.2.5-py3-none-any.whl", hash = "sha256:42c75237166b33ffcf2e64e638e9dab95e3f6413dfccdd2e259e6539ce3e3c92"},
-    {file = "flagsmith_common-2.2.5.tar.gz", hash = "sha256:aa872dc78d13f2e63a57b3302cb915b1c323c1cd8cd74a088618b7d1875c62bc"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 backoff = ">=2.2.1,<3.0.0"
@@ -2022,6 +2020,12 @@ simplejson = ">=3,<4"
 
 [package.extras]
 test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/flagsmith/flagsmith-common"
+reference = "fix/os-dir-permissions"
+resolved_reference = "a45278b1aba12d8f7fb72c43427df7d3b78b2b68"
 
 [[package]]
 name = "flagsmith-flag-engine"
@@ -5451,4 +5455,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "072ba726a64b4f1e4cea871817c76888cbb8e758fecdcc15149f804dd3844f1a"
+content-hash = "3888d54da0e22a40405a3d9edae3278726941b79a536badc380937dbb6bec224"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "a127cc218c533ea2ae891f42c26eb38f028832a0"
+resolved_reference = "1aae629de018cd9c4b21d0b51399748c931c5f1d"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "1aae629de018cd9c4b21d0b51399748c931c5f1d"
+resolved_reference = "4af7e3be768e65449ce00756d33ece12d5771724"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -934,7 +934,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1992,14 +1992,14 @@ resolved_reference = "303954ba54fd2f402c75806b3b9ba7f2d42aa426"
 
 [[package]]
 name = "flagsmith-common"
-version = "2.2.4"
+version = "2.2.5"
 description = "Flagsmith's common library"
 optional = false
 python-versions = "<4.0,>=3.11"
 groups = ["main", "dev", "split-testing", "workflows"]
 files = [
-    {file = "flagsmith_common-2.2.4-py3-none-any.whl", hash = "sha256:cbd460375ff86d9871e2f488771de61321fbc22677296c141934d5d1ccec0c86"},
-    {file = "flagsmith_common-2.2.4.tar.gz", hash = "sha256:6a1d1a7bff47f9b099474e1a75624f4c2176372b0d875decb1a8f7628f2d313c"},
+    {file = "flagsmith_common-2.2.5-py3-none-any.whl", hash = "sha256:42c75237166b33ffcf2e64e638e9dab95e3f6413dfccdd2e259e6539ce3e3c92"},
+    {file = "flagsmith_common-2.2.5.tar.gz", hash = "sha256:aa872dc78d13f2e63a57b3302cb915b1c323c1cd8cd74a088618b7d1875c62bc"},
 ]
 
 [package.dependencies]
@@ -2866,16 +2866,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -4296,7 +4286,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -4304,16 +4293,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -4330,7 +4311,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -4338,7 +4318,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2025,7 +2025,7 @@ test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
 reference = "fix/os-dir-permissions"
-resolved_reference = "c5e983447837966818c97fbc0b5e4cfe1c2e136d"
+resolved_reference = "14022154e4ab8348966694240e06c27f2bc91f3d"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -163,7 +163,7 @@ pygithub = "2.1.1"
 hubspot-api-client = "^8.2.1"
 djangorestframework-dataclasses = "^1.3.1"
 pyotp = "^2.9.0"
-flagsmith-common = "^2.2.4"
+flagsmith-common = { git = "https://github.com/flagsmith/flagsmith-common", branch = "fix/os-dir-permissions" }
 django-stubs = "^5.1.3"
 tzdata = "^2024.1"
 djangorestframework-simplejwt = "^5.5.1"

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -9,12 +9,6 @@ waitfordb() {
      python manage.py waitfordb "$@"
   fi
 }
-setupprometheusmultiproc() {
-  export PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-"/tmp/flagsmith-prometheus"}
-  rm -rf "$PROMETHEUS_MULTIPROC_DIR"
-  mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
-  chmod 0777 "$PROMETHEUS_MULTIPROC_DIR"
-}
 migrate () {
     waitfordb \
       && python manage.py showmigrations --verbosity 2 \
@@ -86,20 +80,17 @@ if [ "$1" = "migrate" ]; then
     migrate_analytics_db
     migrate_task_processor_db
 elif [ "$1" = "serve" ]; then
-    setupprometheusmultiproc
     serve
 elif [ "$1" = "run-task-processor" ]; then
     migrate
     migrate_analytics_db
     migrate_task_processor_db
-    setupprometheusmultiproc
     run_task_processor
 elif [ "$1" = "migrate-and-serve" ]; then
     migrate
     migrate_analytics_db
     migrate_task_processor_db
     bootstrap
-    setupprometheusmultiproc
     serve
 else
    default "$@"

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -9,7 +9,12 @@ waitfordb() {
      python manage.py waitfordb "$@"
   fi
 }
-
+setupprometheusmultiproc() {
+  export PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-"/tmp/flagsmith-prometheus"}
+  rm -rf "$PROMETHEUS_MULTIPROC_DIR"
+  mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+  chmod 0777 "$PROMETHEUS_MULTIPROC_DIR"
+}
 migrate () {
     waitfordb \
       && python manage.py showmigrations --verbosity 2 \
@@ -81,6 +86,7 @@ if [ "$1" = "migrate" ]; then
     migrate_analytics_db
     migrate_task_processor_db
 elif [ "$1" = "serve" ]; then
+    setupprometheusmultiproc
     serve
 elif [ "$1" = "run-task-processor" ]; then
     migrate
@@ -92,6 +98,7 @@ elif [ "$1" = "migrate-and-serve" ]; then
     migrate_analytics_db
     migrate_task_processor_db
     bootstrap
+    setupprometheusmultiproc
     serve
 else
    default "$@"

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -92,6 +92,7 @@ elif [ "$1" = "run-task-processor" ]; then
     migrate
     migrate_analytics_db
     migrate_task_processor_db
+    setupprometheusmultiproc
     run_task_processor
 elif [ "$1" = "migrate-and-serve" ]; then
     migrate


### PR DESCRIPTION
## Changes

Update flagsmith-common from 2.2.4 to 2.2.6. 

Contributes to https://github.com/Flagsmith/flagsmith/issues/5990 and resolves [this Sentry issue](https://flagsmith.sentry.io/issues/6994120980). 

See the following PRs in flagsmith-common for more context. 

flagsmith/flagsmith-common#118
flagsmith/flagsmith-common#120

## How did you test this code?

Tested in flagsmith-common repo. 
