### PR TITLE
docs: Add version-comparison redirects

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,6 +1,10 @@
 {
     "redirects": [
         {
+          "source": "/version-comparison",
+          "destination": "https://www.flagsmith.com/pricing"
+        },
+        {
             "source": "/managing-identities",
             "destination": "/flagsmith-concepts/identities"
         },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes 404 at https://docs.flagsmith.com/version-comparison

## How did you test this code?

Go to [/version-comparison ](https://docs-git-docs-version-comparison-link-flagsmith.vercel.app/version-comparison)