### PR TITLE
fix: Diff strings considering spaces

### DIFF
--- a/frontend/web/components/diff/DiffString.tsx
+++ b/frontend/web/components/diff/DiffString.tsx
@@ -19,7 +19,7 @@ const sanitiseDiffString = (value: FlagsmithValue) => {
   return `${value}`
 }
 const DiffString: FC<DiffType> = ({
-  compareMethod = DiffMethod.WORDS,
+  compareMethod = DiffMethod.WORDS_WITH_SPACE,
   newValue,
   oldValue,
 }) => {

--- a/frontend/web/components/diff/DiffVariations.tsx
+++ b/frontend/web/components/diff/DiffVariations.tsx
@@ -46,7 +46,7 @@ const DiffVariations: FC<DiffVariationsType> = ({ diffs, projectFlag }) => {
             >
               <DiffString
                 data-test={`version-variation-${i}-weight`}
-                compareMethod={DiffMethod.WORDS}
+                compareMethod={DiffMethod.WORDS_WITH_SPACE}
                 oldValue={`${diff.oldWeight || 0}%`}
                 newValue={`${diff.newWeight || 0}%`}
               />

--- a/frontend/web/styles/3rdParty/_react-diff.scss
+++ b/frontend/web/styles/3rdParty/_react-diff.scss
@@ -73,10 +73,10 @@
   background-color: $success-alfa-16 !important;
 }
 .react-diff-hf3w1f-word-removed {
-  background-color: $danger-alfa-8 !important;
+  background-color: $danger-alfa-16 !important;
 }
 .react-diff-1u4zuq6-word-added {
-  background-color: $success-alfa-8 !important;
+  background-color: $success-alfa-16 !important;
 }
 .react-diff-1n5o7vh-diff-container pre {
   font-family: $font-family-monospace;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adjusts change requests to consider changes in just spaces

<img width="1150" height="415" alt="image" src="https://github.com/user-attachments/assets/403630a2-bab0-4819-9d3d-ca9117ea061b" />


## How did you test this code?

1. Create a feature with a yaml value with the following value: 

```yaml
key1:
  subkey1: foo
  subkey2: bar
 key2: baz
```

2. Modify the feature via a change request by changing the indentation level of some of the keys whitespace as follows:

```yaml
key1:
  subkey1: foo
    subkey2: bar
key2: baz
```