### PR TITLE
refactor: Implement @with_metadata decorator to reduce boilerplate

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -23,7 +23,10 @@ from environments.sdk.serializers_mixins import (
 )
 from integrations.github.constants import GitHubEventType
 from integrations.github.github import call_github_task
-from metadata.serializers import MetadataSerializer, MetadataSerializerMixin
+from metadata.serializers import (
+    MetadataSerializer,
+    with_metadata,
+)
 from projects.code_references.serializers import (
     FeatureFlagCodeReferencesRepositoryCountSerializer,
 )
@@ -344,7 +347,12 @@ class CreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerializer):
         return getattr(instance, "last_modified_in_current_environment", None)
 
 
-class FeatureSerializerWithMetadata(MetadataSerializerMixin, CreateFeatureSerializer):
+@with_metadata(
+    lambda self, attrs: (
+        self.instance.project if self.instance else self.context["project"]
+    ).organisation
+)
+class FeatureSerializerWithMetadata(CreateFeatureSerializer):
     metadata = MetadataSerializer(required=False, many=True)
 
     code_references_counts = FeatureFlagCodeReferencesRepositoryCountSerializer(
@@ -357,25 +365,6 @@ class FeatureSerializerWithMetadata(MetadataSerializerMixin, CreateFeatureSerial
             "metadata",
             "code_references_counts",
         )
-
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        attrs = super().validate(attrs)
-        project = self.instance.project if self.instance else self.context["project"]  # type: ignore[union-attr]
-        organisation = project.organisation
-        self._validate_required_metadata(organisation, attrs.get("metadata", []))
-        return attrs
-
-    def create(self, validated_data: dict[str, Any]) -> Feature:
-        metadata_data = validated_data.pop("metadata", [])
-        feature = super().create(validated_data)
-        self._update_metadata(feature, metadata_data)
-        return feature
-
-    def update(self, feature: Feature, validated_data: dict[str, Any]) -> Feature:
-        metadata = validated_data.pop("metadata", [])
-        feature = super().update(feature, validated_data)
-        self._update_metadata(feature, metadata)
-        return feature
 
 
 class UpdateFeatureSerializerWithMetadata(FeatureSerializerWithMetadata):


### PR DESCRIPTION
# This is a POC to solve #6277 

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Introduces a decorator pattern to automatically handle metadata in serializers, eliminating the need to manually override create(), update(), and validate() methods.

Changes:
- Add @with_metadata decorator in metadata/serializers.py
- Add helper functions _validate_required_metadata_for_model and _update_metadata_for_instance
- Refactor FeatureSerializerWithMetadata to use decorator pattern
- Reduce boilerplate 

Benefits:
- Eliminates fragility: impossible to forget create() override
- No MRO issues: decorator works regardless of inheritance order
- More maintainable: metadata logic centralized in one place
- More explicit: @with_metadata makes intent clear




## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
