### PR TITLE
fix: accessing-length-on-undefined-code-reference-count

### DIFF
--- a/frontend/web/components/feature-summary/FeatureTags.tsx
+++ b/frontend/web/components/feature-summary/FeatureTags.tsx
@@ -79,7 +79,7 @@ const FeatureTags: FC<FeatureTagsType> = ({ editFeature, projectFlag }) => {
           }
           place='top'
         >
-          {`Scanned ${codeReferencesCounts?.toString()} times in ${projectFlag?.code_references_counts.length?.toString()} repositories`}
+          {`Scanned ${codeReferencesCounts?.toString()} times in ${projectFlag?.code_references_counts?.length?.toString()} repositories`}
         </Tooltip>
       )}
       {projectFlag.is_server_key_only && (

--- a/frontend/web/components/feature-summary/FeatureTags.tsx
+++ b/frontend/web/components/feature-summary/FeatureTags.tsx
@@ -48,7 +48,7 @@ const FeatureTags: FC<FeatureTagsType> = ({ editFeature, projectFlag }) => {
     ? projectFlag?.code_references_counts?.reduce(
         (acc, curr) => acc + curr.count,
         0,
-      )
+      ) || 0
     : 0
 
   return (

--- a/frontend/web/components/feature-summary/FeatureTags.tsx
+++ b/frontend/web/components/feature-summary/FeatureTags.tsx
@@ -41,13 +41,15 @@ const FeatureTags: FC<FeatureTagsType> = ({ editFeature, projectFlag }) => {
   const isCodeReferencesEnabled = Utils.getFlagsmithHasFeature(
     'git_code_references',
   )
+
   const hasScannedCodeReferences =
-    projectFlag?.code_references_counts.length > 0
-  const codeReferencesCounts =
-    projectFlag?.code_references_counts.reduce(
-      (acc, curr) => acc + curr.count,
-      0,
-    ) || 0
+    isCodeReferencesEnabled && projectFlag?.code_references_counts?.length > 0
+  const codeReferencesCounts = isCodeReferencesEnabled
+    ? projectFlag?.code_references_counts?.reduce(
+        (acc, curr) => acc + curr.count,
+        0,
+      )
+    : 0
 
   return (
     <>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Ensure code references is enabled for identity before accessing the count. Added conditional access on length

## How did you test this code?
- With previously failing import file