### PR TITLE
fix: organisation billing styling issues

### DIFF
--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -152,7 +152,13 @@ const Payment = class extends Component {
                 <Row className='pricing-container align-start'>
                   <Flex className='pricing-panel p-2'>
                     <div className='panel panel-default'>
-                      <div className='panel-content p-3 pt-4'>
+                      <div
+                        className='panel-content p-3 pt-4 d-flex flex-column justify-content-between'
+                        style={{
+                          backgroundColor: 'rgba(39, 171, 149, 0.08)',
+                          minHeight: '250px',
+                        }}
+                      >
                         <Row className='pt-4 justify-content-center'>
                           <Icon name='flash' width={32} />
                           <h4 className='mb-0 ml-2'>Start-Up</h4>
@@ -264,8 +270,14 @@ const Payment = class extends Component {
                   </Flex>
                   <Flex className='pricing-panel bg-primary900 text-white p-2'>
                     <div className='panel panel-default'>
-                      <div className='panel-content p-3 pt-4'>
-                        <span className='featured text-body'>
+                      <div
+                        className='panel-content p-3 pt-4 d-flex flex-column justify-content-between'
+                        style={{
+                          backgroundColor: 'rgba(39, 171, 149, 0.08)',
+                          minHeight: '250px',
+                        }}
+                      >
+                        <span className='featured text-white'>
                           Optional{' '}
                           <a
                             className='text-primary fw-bold'
@@ -291,7 +303,7 @@ const Payment = class extends Component {
                           <h4 className='mb-0 ml-2 text-white'>Enterprise</h4>
                         </Row>
                         <Row className='pt-3 justify-content-center'></Row>
-                        <div className='pricing-type text-secondary pt-1 pb-4'>
+                        <div className='pricing-type text-secondary pt-1 pb-4 text-center'>
                           Maximum security and control
                         </div>
                         {!viewOnly ? (

--- a/frontend/web/styles/project/_PricingPage.scss
+++ b/frontend/web/styles/project/_PricingPage.scss
@@ -1,3 +1,16 @@
 .panel-content.p-4 {
-    padding: unset !important;
+  padding: unset !important;
+}
+
+.pricing-features > li {
+  list-style: none;
+}
+
+.pricing-features-item {
+  flex-wrap: nowrap;
+}
+
+.pricing-panel,
+.panel-content {
+  border-radius: 4px;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR fixes styling issues in the organisation billing section (closes #6246).
### Styling Fixes (Fixes #6246)

<img width="845" height="628" alt="image" src="https://github.com/user-attachments/assets/b2510eb3-d72e-480f-8e64-5fd69bab4164" />

- **Fixed Enterprise panel header readability:**

  - Improved text color contrast for header content in enterprise panels

- **Fixed bullet markers visibility:**

  - Removed list-style from pricing features list items
  - Added CSS rule to hide bullet markers (`.pricing-features > li { list-style: none; }`)

- **Fixed button alignment:**
  - Improved vertical alignment of buttons across pricing panels
  - Ensured consistent spacing and positioning


## Benefits
- ✅ **Fixed styling issues**: Resolves issues reported in #6246

## Testing
- ✅ Styling fixes verified:
  - Enterprise panel header is now readable
  - Bullet markers are hidden in feature lists
  - Buttons are properly aligned across panels

## Related Issues

Closes #6246