### PR TITLE
fix: move AWS_SSE_LOGS_BUCKET_NAME to task-processor definition

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -172,6 +172,10 @@
                 {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
+                },
+                {
+                    "name": "AWS_SSE_LOGS_BUCKET_NAME",
+                    "value": "flagsmith-fastly-logs-production"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -126,10 +126,6 @@
                     "value": "https://eu-central-1-1.aws.cloud2.influxdata.com"
                 },
                 {
-                    "name": "AWS_SSE_LOGS_BUCKET_NAME",
-                    "value": "flagsmith-fastly-logs-production"
-                },
-                {
                     "name": "OAUTH_CLIENT_ID",
                     "value": "232959427810-br6ltnrgouktp0ngsbs04o14ueb9rch0.apps.googleusercontent.com"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

PR #6232 re-enabled SSE usage tracking by adding the AWS_SSE_LOGS_BUCKET_NAME environment variable, but it was incorrectly added to the web task definition (ecs-task-definition-web.json) instead of the task processor definition (ecs-task-definition-task-processor.json).

This commit fixes that by:
- Adding AWS_SSE_LOGS_BUCKET_NAME to ecs-task-definition-task-processor.json
- Removing AWS_SSE_LOGS_BUCKET_NAME from ecs-task-definition-web.json

The SSE usage tracking logic runs in the task processor, not the api service, so the environment variable needs to be configured in the correct task definition.


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

n/a
