### PR TITLE
perf: optimize sales dashboard OrganisationList query to eliminate Ca…

### DIFF
--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Count, F, OuterRef, Q, Subquery, Value
-from django.db.models.functions import Greatest
+from django.db.models.functions import Coalesce, Greatest
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -78,23 +78,32 @@ class OrganisationList(ListView):  # type: ignore[type-arg]
             queryset = Organisation.objects.all()
 
         queryset = queryset.annotate(
-            num_projects=Subquery(
-                Project.objects.filter(organisation_id=OuterRef("pk"))
-                .values("organisation_id")
-                .annotate(count=Count("id"))
-                .values("count")[:1]
+            num_projects=Coalesce(
+                Subquery(
+                    Project.objects.filter(organisation_id=OuterRef("pk"))
+                    .values("organisation_id")
+                    .annotate(count=Count("id"))
+                    .values("count")[:1]
+                ),
+                Value(0),
             ),
-            num_users=Subquery(
-                UserOrganisation.objects.filter(organisation_id=OuterRef("pk"))
-                .values("organisation_id")
-                .annotate(count=Count("user_id", distinct=True))
-                .values("count")[:1]
+            num_users=Coalesce(
+                Subquery(
+                    UserOrganisation.objects.filter(organisation_id=OuterRef("pk"))
+                    .values("organisation_id")
+                    .annotate(count=Count("user_id", distinct=True))
+                    .values("count")[:1]
+                ),
+                Value(0),
             ),
-            num_features=Subquery(
-                Feature.objects.filter(project__organisation_id=OuterRef("pk"))
-                .values("project__organisation_id")
-                .annotate(count=Count("id", distinct=True))
-                .values("count")[:1]
+            num_features=Coalesce(
+                Subquery(
+                    Feature.objects.filter(project__organisation_id=OuterRef("pk"))
+                    .values("project__organisation_id")
+                    .annotate(count=Count("id", distinct=True))
+                    .values("count")[:1]
+                ),
+                Value(0),
             ),
             overage=Greatest(
                 Value(0),

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -304,3 +304,23 @@ def test_end_trial(
         subscription_information_cache.feature_history_visibility_days
         == DEFAULT_VERSION_LIMIT_DAYS
     )
+
+
+@pytest.mark.django_db
+def test_list_organisations_with_empty_organisation_returns_zero_counts_not_none(
+    rf: RequestFactory,
+) -> None:
+    # Given
+    organisation = Organisation.objects.create(name="Empty Test Org")
+
+    request = rf.get("/sales-dashboard")
+    view = OrganisationList()
+    view.request = request
+
+    # When
+    result = view.get_queryset().get(pk=organisation.id)  # type: ignore[no-untyped-call]
+
+    # Then
+    assert result.num_projects == 0
+    assert result.num_users == 0
+    assert result.num_features == 0


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The OrganisationList view was generating a PostgreSQL query that created a Cartesian product, resulting in 3.7M intermediate rows that required a 1.1GB disk sort and took ~27 seconds to execute.

Problem:
The query used COUNT with DISTINCT across multiple LEFT JOINs:
- COUNT("projects", distinct=True)
- COUNT("users", distinct=True)
- COUNT("projects__features", distinct=True)

This caused PostgreSQL to cross-join all tables (organisations × projects × features × users), creating millions of intermediate rows, then GROUP BY and COUNT(DISTINCT) to collapse back to ~669 organisation rows.

Solution:
Replace JOIN-based counts with scalar subqueries using Subquery() and OuterRef(). Each count is now calculated independently in the SELECT clause rather than creating a massive Cartesian product in the FROM clause.


Changes:
- Added OuterRef and Subquery imports from django.db.models
- Converted num_projects, num_users, and num_features annotations to use scalar subqueries instead of JOIN-based COUNT(DISTINCT)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Ran the SQL generated on production with the following response:
```
 Planning Time: 0.716 ms
 Execution Time: 33.531 ms
```
