### PR TITLE
fix: remove AWS_SSE_LOGS_BUCKET_NAME from task processor definition

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -172,10 +172,6 @@
                 {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
-                },
-                {
-                    "name": "AWS_SSE_LOGS_BUCKET_NAME",
-                    "value": "flagsmith-fastly-logs-production"
                 }
             ],
             "secrets": [


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Removing AWS_SSE_LOGS_BUCKET_NAME from the task processor for now. The data processing doesn't seem fast enough yet, so we need to investigate and optimize before enabling this again.

This temporarily reverts the change from PR #6284.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

n/a