### PR TITLE
fix: add pylon selector to hidden on modal

### DIFF
--- a/frontend/web/styles/project/_modals.scss
+++ b/frontend/web/styles/project/_modals.scss
@@ -317,7 +317,7 @@ $side-width: 750px;
 }
 
 .modal-open {
-  #crisp-chatbox {
+  #crisp-chatbox, #pylon-chat-bubble {
     opacity: 0;
     pointer-events: none;
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Hides Pylon on modal open just like crisp. Note: we still do have Crisp code and this should be removed if/when we deprecate the Pylon feature flag.


## How did you test this code?

Open modal