### PR TITLE
fix(DB replication): Prevent replica lag in environment document endpoint

### DIFF
--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -4,7 +4,6 @@ import uuid
 from copy import deepcopy
 from typing import TYPE_CHECKING, Literal
 
-from common.core.utils import using_database_replica
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.cache import caches
@@ -577,8 +576,7 @@ class Environment(
         cls,
         api_key: str,
     ) -> dict[str, typing.Any]:
-        manager = using_database_replica(cls.objects)
-        environment = manager.filter_for_document_builder(
+        environment = cls.objects.filter_for_document_builder(
             api_key=api_key,
             extra_prefetch_related=[
                 Prefetch(


### PR DESCRIPTION
Removes database replica usage from `/api/v1/environment-document` to prevent stale data from replica lag.

## Changes
- [x] Remove `using_database_replica` from `Environment._get_environment_document_from_db`

Review effort: 1/5