### PR TITLE
docs: add wording that slack support is an add-on

### DIFF
--- a/docs/docs/support/index.mdx
+++ b/docs/docs/support/index.mdx
@@ -15,7 +15,7 @@ We are here to help! You can contact us for support through any of these channel
 [Flagsmith Enterprise](https://www.flagsmith.com/pricing) customers can also use these support channels:
 
 * Dedicated Customer Success manager for personalised assistance and training.
-* Shared Slack channel for real-time group support between your organisation and the Flagsmith team available (available as an add-on).
+* Shared Slack channel for real-time group support between your organisation and the Flagsmith team (available as an add-on).
 
 ## Bug reports and pull requests
 

--- a/docs/docs/support/index.mdx
+++ b/docs/docs/support/index.mdx
@@ -15,7 +15,7 @@ We are here to help! You can contact us for support through any of these channel
 [Flagsmith Enterprise](https://www.flagsmith.com/pricing) customers can also use these support channels:
 
 * Dedicated Customer Success manager for personalised assistance and training.
-* Shared Slack channel for real-time group support between your organisation and the Flagsmith team.
+* Shared Slack channel for real-time group support between your organisation and the Flagsmith team available (available as an add-on).
 
 ## Bug reports and pull requests
 

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -360,8 +360,8 @@ const Payment = class extends Component {
                                 <Icon name='checkmark-circle' fill='#F7D56E' />
                               </span>
                               <div className='ml-2'>
-                                Priority real time technical support with the
-                                engineering team over Slack or Discord
+                                Priority Real Time Technical Support via chat and Discord,
+                                with Slack/Teams optional
                               </div>
                             </Row>
                           </li>

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -360,7 +360,7 @@ const Payment = class extends Component {
                                 <Icon name='checkmark-circle' fill='#F7D56E' />
                               </span>
                               <div className='ml-2'>
-                                Priority Real Time Technical Support via chat and Discord,
+                                Priority real-time technical support via chat and Discord,
                                 with Slack/Teams optional
                               </div>
                             </Row>


### PR DESCRIPTION
## Changes

We are making Slack support an add-on to our enterprise licence instead of the default. This updates the documentation, and content in the billing settings, to be in line with that. 

## How did you test this code?

Vercel previews.
