### PR TITLE
docs: remove erroneous statement on replication of identity data

### DIFF
--- a/docs/docs/performance/edge-api.md
+++ b/docs/docs/performance/edge-api.md
@@ -79,8 +79,6 @@ As of Dec 1st, 2023, we will no longer be replicating identities from the Core A
 
 If you have a product like a mobile app, where you cannot immediately force your users to upgrade (as opposed to a web app, for example), you will likely generate identity writes to the old Core API.
 
-Following and during the migration, if we receive a request to an `identity` endpoint that results in a write to the Core API, we will persist the data in the Core API _and replay the request into the Edge API_. You can then update your API endpoints/SDKs in your own time to gradually move over the Edge API. This will give you time to migrate your users over to the new version of your application.
-
 Note that writes to the Core API will still work into the future, but the data will not be synchronised across the two platforms (Core and Edge).
 
 ### Step 3 - Deploy your applications


### PR DESCRIPTION
## Changes

Removes a no longer true statement on the replication of identity data from core to edge API after migration. 

## How did you test this code?

N/a - just removing documentation. 
