### PR TITLE
fix(Segments): Handle missing project in permissions

### DIFF
--- a/api/segments/permissions.py
+++ b/api/segments/permissions.py
@@ -16,7 +16,11 @@ class SegmentPermissions(IsAuthenticated):
         if not project_pk:
             return False
 
-        project = Project.objects.select_related("organisation").get(pk=project_pk)
+        projects = Project.objects.select_related("organisation")
+        try:
+            project = projects.get(pk=project_pk)
+        except Project.DoesNotExist:
+            return False
 
         if request.user.has_project_permission(MANAGE_SEGMENTS, project):
             return True

--- a/api/tests/unit/segments/test_unit_segments_permissions.py
+++ b/api/tests/unit/segments/test_unit_segments_permissions.py
@@ -21,6 +21,24 @@ mock_view = mock.MagicMock()
 segment_permissions = SegmentPermissions()
 
 
+def test_has_permission_returns_false_for_non_existent_project(
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    mock_request = mock.MagicMock()
+    mock_request.user = staff_user
+    mock_view = mock.MagicMock()
+    mock_view.kwargs = {"project_pk": 999999}
+    mock_view.action = "list"
+    segment_permissions = SegmentPermissions()
+
+    # When
+    result = segment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+
+    # Then
+    assert result is False
+
+
 def test_staff_user_has_permission(staff_user: FFAdminUser, project: Project) -> None:
     # Given
     mock_request = mock.MagicMock()


### PR DESCRIPTION
Return 403 when a non-existent project is referenced in segment endpoints.

## Changes
- [x] Handle `Project.DoesNotExist` exception in `SegmentPermissions.has_permission`

Closes #6335

Review effort: 1/5