### PR TITLE
fix: project-settings-export-import-missing

### DIFF
--- a/frontend/web/components/import-export/ImportPage.tsx
+++ b/frontend/web/components/import-export/ImportPage.tsx
@@ -16,17 +16,13 @@ import FeatureImport from './FeatureImport'
 import AccountStore from 'common/stores/account-store'
 import Constants from 'common/constants'
 import { useHistory } from 'react-router-dom'
+
 type ImportPageType = {
   projectId: string
-  environmentId: string
   projectName: string
 }
 
-const ImportPage: FC<ImportPageType> = ({
-  environmentId,
-  projectId,
-  projectName,
-}) => {
+const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
   const history = useHistory()
   const [LDKey, setLDKey] = useState<string>('')
   const [importId, setImportId] = useState<number>()

--- a/frontend/web/components/pages/project-settings/ProjectSettingsPage.tsx
+++ b/frontend/web/components/pages/project-settings/ProjectSettingsPage.tsx
@@ -15,6 +15,7 @@ import { SDKSettingsTab } from './tabs/SDKSettingsTab'
 import { PermissionsTab } from './tabs/PermissionsTab'
 import { CustomFieldsTab } from './tabs/CustomFieldsTab'
 import { ImportTab } from './tabs/ImportTab'
+import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 
 type ProjectSettingsTab = {
   component: ReactNode
@@ -32,6 +33,10 @@ const ProjectSettingsPage = () => {
     isLoading,
     isUninitialized,
   } = useGetProjectQuery({ id: String(projectId) }, { skip: !projectId })
+  const { data: environments } = useGetEnvironmentsQuery(
+    { projectId: String(projectId) },
+    { skip: !projectId },
+  )
 
   useEffect(() => {
     API.trackPage(Constants.pages.PROJECT_SETTINGS)
@@ -62,7 +67,7 @@ const ProjectSettingsPage = () => {
   }
 
   // Derive data from project after all early returns
-  const hasEnvironments = !!project.environments?.length
+  const hasEnvironments = (environments?.results?.length || 0) > 0
   const hasFeatureHealth = Utils.getFlagsmithHasFeature('feature_health')
   const organisationId = project.organisation
 
@@ -115,7 +120,6 @@ const ProjectSettingsPage = () => {
       component: (
         <ImportTab
           projectId={String(project.id)}
-          environmentId={environmentId}
           projectName={project?.name || ''}
         />
       ),

--- a/frontend/web/components/pages/project-settings/tabs/ImportTab.tsx
+++ b/frontend/web/components/pages/project-settings/tabs/ImportTab.tsx
@@ -1,33 +1,11 @@
-import ImportPage from 'components/import-export/ImportPage'
-import InfoMessage from 'components/InfoMessage'
 import React from 'react'
+import ImportPage from 'components/import-export/ImportPage'
 
 type ImportTabProps = {
   projectName: string
   projectId: string
-  environmentId?: string
 }
 
-export const ImportTab = ({
-  environmentId,
-  projectId,
-  projectName,
-}: ImportTabProps) => {
-  if (!environmentId) {
-    return (
-      <div className='mt-4'>
-        <InfoMessage>
-          Please select an environment to import features
-        </InfoMessage>
-      </div>
-    )
-  }
-
-  return (
-    <ImportPage
-      environmentId={environmentId}
-      projectId={projectId}
-      projectName={projectName}
-    />
-  )
+export const ImportTab = ({ projectId, projectName }: ImportTabProps) => {
+  return <ImportPage projectId={projectId} projectName={projectName} />
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Migrating from store to RTK only lacked the environments (and typing hinted that it was there)
- useless confusing environmentID prop in ImportPage
- Removed them and properly get the environment lists

## How did you test this code?
- Exported and re-imported environments

<img width="720" height="146" alt="image" src="https://github.com/user-attachments/assets/b5ef0ba4-4f04-492b-a215-44c9d1f65b7e" />
<img width="720" height="509" alt="image" src="https://github.com/user-attachments/assets/50acc88f-0846-4f8b-8766-3fb73e1bd237" />
<img width="720" height="211" alt="image" src="https://github.com/user-attachments/assets/debf84c2-7ca9-471d-8818-f3ef0015c3b4" />
<img width="720" height="251" alt="image" src="https://github.com/user-attachments/assets/0f80626b-9609-49c3-9b48-c051815faeae" />
<img width="720" height="253" alt="image" src="https://github.com/user-attachments/assets/56246702-6b96-4ed7-a0ce-a2e72a2aa69f" />
<img width="720" height="367" alt="image" src="https://github.com/user-attachments/assets/80407ed2-9c07-40da-a316-56c0fce3738c" />
<img width="719" height="409" alt="image" src="https://github.com/user-attachments/assets/dd6f034f-9f7a-4df4-8e1b-f54e30b45035" />
