### PR TITLE
docs: Docs/remove public roadmap

### DIFF
--- a/docs/docs/project-and-community/roadmap.md
+++ b/docs/docs/project-and-community/roadmap.md
@@ -1,6 +1,0 @@
----
-title: Public Roadmap
-sidebar_position: 4
----
-
-You can view our public roadmap on [GitHub](https://github.com/orgs/Flagsmith/projects/7).

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -152,12 +152,6 @@ export default function Home() {
             icon={documentText} 
           />
           <Card 
-            title="Public Roadmap" 
-            description="Features coming soon" 
-            link="/project-and-community/roadmap/"
-            icon={map} 
-          />
-          <Card 
             title="Contribute to Flagsmith" 
             description="How to file issues, PRs, and contribute" 
             link="/project-and-community/contributing/"

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -469,10 +469,6 @@
             "destination": "/project-and-community/release-notes"
         },
         {
-            "source": "/platform/roadmap",
-            "destination": "/project-and-community/roadmap"
-        },
-        {
             "source": "/guides-and-examples/integration-approaches",
             "destination": "/best-practices/integration-approaches"
         },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR removes the public roadmap from our docs, and remove the links to it from other page (as well as an old redirect)

## How did you test this code?

manually.
