### PR TITLE
fix: skip-audit-log-for-soft-deleted-CR

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -106,7 +106,10 @@ def _create_initial_feature_versions(environment: "Environment"):  # type: ignor
             feature_states__in=latest_feature_states
         )
 
-        latest_feature_states.update(environment_feature_version=ef_version)
+        latest_feature_states.update(
+            environment_feature_version=ef_version,
+            change_request=None,
+        )
         related_feature_segments.update(environment_feature_version=ef_version)
 
         scheduled_feature_states = FeatureState.objects.filter(

--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -106,10 +106,7 @@ def _create_initial_feature_versions(environment: "Environment"):  # type: ignor
             feature_states__in=latest_feature_states
         )
 
-        latest_feature_states.update(
-            environment_feature_version=ef_version,
-            change_request=None,
-        )
+        latest_feature_states.update(environment_feature_version=ef_version)
         related_feature_segments.update(environment_feature_version=ef_version)
 
         scheduled_feature_states = FeatureState.objects.filter(

--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -18,7 +18,7 @@ from django_lifecycle import (  # type: ignore[import-untyped]
     LifecycleModelMixin,
     hook,
 )
-from django_lifecycle.conditions import WhenFieldValueIs, WhenFieldValueIsNot
+from django_lifecycle.conditions import WhenFieldValueIs, WhenFieldValueIsNot  # type: ignore[import-untyped]
 
 from audit.constants import (
     CHANGE_REQUEST_APPROVED_MESSAGE,
@@ -196,8 +196,8 @@ class ChangeRequest(  # type: ignore[django-manager-missing]
     @hook(
         AFTER_SAVE,
         condition=(
-            WhenFieldValueIsNot("committed_at", value=None)
-            & WhenFieldValueIs("deleted_at", value=None)
+            WhenFieldValueIsNot("committed_at", None)
+            & WhenFieldValueIs("deleted_at", None)
         ),
     )
     def create_audit_log_for_related_feature_state(self):  # type: ignore[no-untyped-def]

--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -18,7 +18,10 @@ from django_lifecycle import (  # type: ignore[import-untyped]
     LifecycleModelMixin,
     hook,
 )
-from django_lifecycle.conditions import WhenFieldValueIs, WhenFieldValueIsNot  # type: ignore[import-untyped]
+from django_lifecycle.conditions import (  # type: ignore[import-untyped]
+    WhenFieldValueIs,
+    WhenFieldValueIsNot,
+)
 
 from audit.constants import (
     CHANGE_REQUEST_APPROVED_MESSAGE,

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -26,7 +26,7 @@ from features.versioning.models import (
     EnvironmentFeatureVersion,
     VersionChangeSet,
 )
-from features.versioning.tasks import publish_version_change_set
+from features.versioning.tasks import enable_v2_versioning, publish_version_change_set
 from features.versioning.versioning_service import get_environment_flags_list
 from features.workflows.core.exceptions import (
     CannotApproveOwnChangeRequest,

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -26,7 +26,7 @@ from features.versioning.models import (
     EnvironmentFeatureVersion,
     VersionChangeSet,
 )
-from features.versioning.tasks import enable_v2_versioning, publish_version_change_set
+from features.versioning.tasks import publish_version_change_set
 from features.versioning.versioning_service import get_environment_flags_list
 from features.workflows.core.exceptions import (
     CannotApproveOwnChangeRequest,

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 from flag_engine.segments.constants import EQUAL, PERCENTAGE_SPLIT
 from freezegun.api import FrozenDateTimeFactory
 from pytest_mock import MockerFixture
-from features.versioning.tasks import enable_v2_versioning
 
 from audit.constants import (
     CHANGE_REQUEST_APPROVED_MESSAGE,
@@ -27,7 +26,7 @@ from features.versioning.models import (
     EnvironmentFeatureVersion,
     VersionChangeSet,
 )
-from features.versioning.tasks import publish_version_change_set
+from features.versioning.tasks import enable_v2_versioning, publish_version_change_set
 from features.versioning.versioning_service import get_environment_flags_list
 from features.workflows.core.exceptions import (
     CannotApproveOwnChangeRequest,

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -1032,13 +1032,42 @@ def test_delete_organisation_with_committed_change_request(
     assert organisation.deleted_at is not None
 
 
-def test_soft_delete_committed_change_request_does_not_trigger_audit_log(
-    change_request_no_required_approvals: ChangeRequest,
+def test_delete_project_with_v2_versioning_does_not_trigger_audit_log(
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    admin_user: FFAdminUser,
     mocker: MockerFixture,
 ) -> None:
     # Given
-    committer = FFAdminUser.objects.create(email="committer@example.com")
-    change_request_no_required_approvals.commit(committer)
+    pre_existing_cr = ChangeRequest.objects.create(
+        environment=environment,
+        title="immediate",
+        user=admin_user,
+    )
+    FeatureState.objects.create(
+        environment=environment,
+        feature=feature,
+        change_request=pre_existing_cr,
+        version=None,
+    )
+    pre_existing_cr.commit(admin_user)
+
+    scheduled_cr = ChangeRequest.objects.create(
+        environment=environment,
+        title="scheduled",
+        user=admin_user,
+    )
+    FeatureState.objects.create(
+        environment=environment,
+        feature=feature,
+        change_request=scheduled_cr,
+        live_from=timezone.now() + timedelta(days=2),
+        version=None,
+    )
+    scheduled_cr.commit(admin_user)
+
+    enable_v2_versioning(environment_id=environment.id)
 
     mock_went_live_task = mocker.patch(
         "features.workflows.core.models.create_feature_state_went_live_audit_log"
@@ -1048,10 +1077,9 @@ def test_soft_delete_committed_change_request_does_not_trigger_audit_log(
     )
 
     # When
-    environment = change_request_no_required_approvals.environment
-    environment.delete()
-    change_request_no_required_approvals.delete()
+    project.delete()
 
     # Then
+    assert project.deleted_at is not None
     mock_went_live_task.delay.assert_not_called()
     mock_updated_task.delay.assert_not_called()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Closes #6248 

## Context

Edge-case that is a combination between data corruption when migrating to `feature versioning` and trying to delete a project.
When migrating, feature states from committed CR where linked to EFV with:
- A change_request_id
- `live_from = None`
When deleting the project, the soft-delete was triggering the hook [here](https://github.com/Flagsmith/flagsmith/blob/main/api/features/workflows/core/models.py#L195-L206) without `live_from` which raised the NoneType error

## Changes
- Updated hook `AFTER_SAVE` to ignore CR with `deleted_at`

## How did you test this code?
- Added a test (fails without change)
- Manually
1. Create a new project (feature_versioning_v2 disabled)
2. Create and publish a change request now (it must have existing CR)
3. Create a change request in the future
4. Publish it
5. Enable feature_versioning_v2
6. Delete the project
