### PR TITLE
fix: skip-organization-test-in-enterprise-e2e

### DIFF
--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -51,11 +51,18 @@ createTestCafe()
             .clientScripts('e2e/add-error-logs.js')
             .src(['./e2e/init.cafe.js'])
             .concurrency(parseInt(concurrentInstances))
-            .filter((_, __, ___, testMeta, fixtureMeta) =>
-                 metaConditions.some(({ key, value }) =>
-                      testMeta[key] === value || fixtureMeta[key] === value
-                 )
-           )
+            .filter((_, __, ___, testMeta, fixtureMeta) => {
+                const matchesCategory = metaConditions.some(({ key, value }) =>
+                    testMeta[key] === value || fixtureMeta[key] === value
+                )
+                const isEnterpriseRun = metaConditions.some(({ key, value }) =>
+                    key === 'category' && value === 'enterprise'
+                )
+                if (isEnterpriseRun && testMeta.skipEnterprise) {
+                    return false
+                }
+                return matchesCategory
+            })
             .run(options)
     })
     .then(async (v) => {

--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -52,16 +52,15 @@ createTestCafe()
             .src(['./e2e/init.cafe.js'])
             .concurrency(parseInt(concurrentInstances))
             .filter((_, __, ___, testMeta, fixtureMeta) => {
-                const matchesCategory = metaConditions.some(({ key, value }) =>
-                    testMeta[key] === value || fixtureMeta[key] === value
-                )
                 const isEnterpriseRun = metaConditions.some(({ key, value }) =>
                     key === 'category' && value === 'enterprise'
                 )
                 if (isEnterpriseRun && testMeta.skipEnterprise) {
                     return false
                 }
-                return matchesCategory
+                return metaConditions.some(({ key, value }) =>
+                    testMeta[key] === value || fixtureMeta[key] === value
+                )
             })
             .run(options)
     })

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -113,7 +113,7 @@ test('Environment', environmentTest).meta({ autoLogout: true, category: 'oss' })
 
 test('Project', projectTest).meta({ autoLogout: true, category: 'oss' })
 
-test('Organization', organisationTest).meta({ autoLogout: true, category: 'oss' })
+test('Organization', organisationTest).meta({ autoLogout: true, category: 'oss', skipEnterprise: true })
 
 test('Versioning', versioningTests).meta({ autoLogout: true, category: 'oss' })
 

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -113,7 +113,7 @@ test('Environment', environmentTest).meta({ autoLogout: true, category: 'oss' })
 
 test('Project', projectTest).meta({ autoLogout: true, category: 'oss' })
 
-test('Organization', organisationTest).meta({ autoLogout: true, category: 'oss', skipEnterprise: true })
+test('Organization', organisationTest).meta({ autoLogout: true, category: 'oss', skipEnterprise: false })
 
 test('Versioning', versioningTests).meta({ autoLogout: true, category: 'oss' })
 

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -113,7 +113,7 @@ test('Environment', environmentTest).meta({ autoLogout: true, category: 'oss' })
 
 test('Project', projectTest).meta({ autoLogout: true, category: 'oss' })
 
-test('Organization', organisationTest).meta({ autoLogout: true, category: 'oss', skipEnterprise: false })
+test('Organization', organisationTest).meta({ autoLogout: true, category: 'oss', skipEnterprise: true })
 
 test('Versioning', versioningTests).meta({ autoLogout: true, category: 'oss' })
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Organization test might be modifying a shared state when ran alongside `category: enterprise` test suites.
- Deactivate this test when run in enterprise mode

## How did you test this code?
- CI