### PR TITLE
docs(Context values): Remove the local evaluation warning

### DIFF
--- a/docs/docs/flagsmith-concepts/segments/index.md
+++ b/docs/docs/flagsmith-concepts/segments/index.md
@@ -72,7 +72,7 @@ Identity overrides always take precedence over segment overrides. Simply put, th
 
 :::info
 
-See [minimum required SDK versions](segment-rule-operators#minimum-sdk-versions-for-local-evaluation-mode) to use Context values in local evaluation mode.
+See [minimum required SDK versions](/flagsmith-concepts/segments/segment-rule-operators#minimum-sdk-versions-for-local-evaluation-mode) to use Context values in local evaluation mode.
 
 :::
 

--- a/docs/docs/flagsmith-concepts/segments/index.md
+++ b/docs/docs/flagsmith-concepts/segments/index.md
@@ -70,6 +70,12 @@ Identity overrides always take precedence over segment overrides. Simply put, th
 
 ## Context values
 
+:::info
+
+See [minimum required SDK versions](segment-rule-operators#minimum-sdk-versions-for-local-evaluation-mode) to use Context values in local evaluation mode.
+
+:::
+
 In addition to identity [traits](/flagsmith-concepts/identities#identity-traits), you can use the following context values as Segment rule properties. For more information about identities and traits, see the [Identities documentation](/flagsmith-concepts/identities).
 
 - **Identifier**: a unique identifier for an identity, used for segment and multivariate feature flag targeting, and displayed in the Flagsmith UI. Useful for bucketing via the [`% Split`](./segment-rule-operators#percentage-split) operator, or managing a list of users via the [`In`](./segment-rule-operators#in) operator.

--- a/docs/docs/flagsmith-concepts/segments/index.md
+++ b/docs/docs/flagsmith-concepts/segments/index.md
@@ -70,12 +70,6 @@ Identity overrides always take precedence over segment overrides. Simply put, th
 
 ## Context values
 
-:::warning
-
-Currently, context values are only available for remote evaluation. In local evaluation, rules using context values will evaluate to `false`.
-
-:::
-
 In addition to identity [traits](/flagsmith-concepts/identities#identity-traits), you can use the following context values as Segment rule properties. For more information about identities and traits, see the [Identities documentation](/flagsmith-concepts/identities).
 
 - **Identifier**: a unique identifier for an identity, used for segment and multivariate feature flag targeting, and displayed in the Flagsmith UI. Useful for bucketing via the [`% Split`](./segment-rule-operators#percentage-split) operator, or managing a list of users via the [`In`](./segment-rule-operators#in) operator.

--- a/docs/docs/flagsmith-concepts/segments/segment-rule-operators.md
+++ b/docs/docs/flagsmith-concepts/segments/segment-rule-operators.md
@@ -77,19 +77,19 @@ This segment will include all identities having a `user_id` trait that is divisi
 
 When running in local evaluation mode, SDK clients evaluate segment rules locally, which means they must be updated to support the latest operators.
 
-If an SDK client tries to evaluate a segment rule that has an unrecognised operator, that rule will silently evaluate to `false`. The table below lists the minimum required SDK version required by each operator:
+If an SDK client tries to evaluate a segment rule that has an unrecognised operator or context value, that rule will silently evaluate to `false`. The table below lists the minimum required SDK version required by each operator or a context value:
 
-|         | Modulo | In    |
-| ------- | ------ | ----- |
-| Python  | 2.3.0  | 3.3.0 |
-| Java    | 5.1.0  | 7.1.0 |
-| .NET    | 4.2.0  | 5.0.0 |
-| Node.js | 2.4.0  | 2.5.0 |
-| Ruby    | 3.1.0  | 3.2.0 |
-| PHP     | 3.1.0  | 4.1.0 |
-| Go      | 2.2.0  | 3.1.0 |
-| Rust    | 0.2.0  | 1.3.0 |
-| Elixir  | 1.1.0  | 2.0.0 |
+|         | Modulo Operator | In Operator | Environment Name context value | Identifier context value |
+| ------- | --------------- | ----------- | ------------------------------ | ------------------------ |
+| Python  | 2.3.0           | 3.3.0       | 5.0.3                          | 5.0.3                    |
+| Java    | 5.1.0           | 7.1.0       | 8.0.0                          | 8.0.0                    |
+| .NET    | 4.2.0           | 5.0.0       | 9.0.0                          | 9.0.0                    |
+| Node.js | 2.4.0           | 2.5.0       | 7.0.2                          | 7.0.2                    |
+| Ruby    | 3.1.0           | 3.2.0       | 5.0.0                          | 5.0.0                    |
+| PHP     | 3.1.0           | 4.1.0       | 5.0.0                          | 5.0.0                    |
+| Go      | 2.2.0           | 3.1.0       | 5.0.0                          | 5.0.0                    |
+| Rust    | 0.2.0           | 1.3.0       | 2.1.0                          | 2.1.0                    |
+| Elixir  | 1.1.0           | 2.0.0       | N/A                            | N/A                      |
 
 ## Limits
 

--- a/frontend/web/components/segments/Rule/components/RuleConditionRow.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionRow.tsx
@@ -11,7 +11,6 @@ import Button from 'components/base/forms/Button'
 import ErrorMessage from 'components/ErrorMessage'
 import RuleConditionPropertySelect from './RuleConditionPropertySelect'
 import RuleConditionValueInput from './RuleConditionValueInput'
-import { RuleContextValues } from 'common/types/rules.types'
 import { useRuleOperator, useRuleContext } from 'components/segments/Rule/hooks'
 import classNames from 'classnames'
 
@@ -69,11 +68,6 @@ const RuleConditionRow: React.FC<RuleConditionRowProps> = ({
   if (rule.delete) {
     return null
   }
-
-  const showEvaluationContextWarning = isLastRule && isValueFromContext
-  const isSkippingEvaluationContextWarning =
-    operator === 'PERCENTAGE_SPLIT' &&
-    rule.property === RuleContextValues.IDENTITY_KEY
 
   return (
     <div className='rule__row reveal' key={ruleIndex}>
@@ -179,16 +173,6 @@ const RuleConditionRow: React.FC<RuleConditionRowProps> = ({
         </Row>
       )}
 
-      {showEvaluationContextWarning && !isSkippingEvaluationContextWarning && (
-        <Row className='mt-2'>
-          <div className='d-flex align-items-center gap-1'>
-            <Icon name='info-outlined' width={16} height={16} />
-            <span>
-              Context values are only compatible with remote evaluation
-            </span>
-          </div>
-        </Row>
-      )}
       {(ruleErrors?.property || ruleErrors?.value) && (
         <Row className='mt-2'>
           <ErrorMessage error={ruleErrors} />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This removes the local evaluation warning for Context values from docs and UI, and adds Context values to the SDK compatibility matrix.

## How did you test this code?

Checking the Vercel previews for relevant changes to be correct.