### PR TITLE
feat: add delete-segment-override experimental endpoint

### DIFF
--- a/api/api/urls/experiments.py
+++ b/api/api/urls/experiments.py
@@ -7,7 +7,11 @@ Use at your own risk - breaking changes may occur without prior notice.
 
 from django.urls import path
 
-from features.feature_states.views import update_flag_v1, update_flag_v2
+from features.feature_states.views import (
+    delete_segment_override,
+    update_flag_v1,
+    update_flag_v2,
+)
 
 app_name = "experiments"
 
@@ -21,5 +25,10 @@ urlpatterns = [
         "environments/<str:environment_key>/update-flag-v2/",
         update_flag_v2,
         name="update-flag-v2",
+    ),
+    path(
+        "environments/<str:environment_key>/delete-segment-override/",
+        delete_segment_override,
+        name="delete-segment-override",
     ),
 ]

--- a/api/features/feature_states/serializers.py
+++ b/api/features/feature_states/serializers.py
@@ -14,7 +14,6 @@ from features.versioning.versioning_service import (
     update_flag_v2,
 )
 from segments.models import Segment
-from users.models import FFAdminUser
 
 
 class BaseFeatureUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
@@ -211,9 +210,6 @@ class DeleteSegmentOverrideSerializer(BaseFeatureUpdateSerializer):
     def save(self, **kwargs: object) -> None:
         feature = self.get_feature()
         segment_id = self.validated_data["segment"]["id"]
+        author = AuthorData.from_request(self.context["request"])
 
-        request = self.context["request"]
-        user = request.user if isinstance(request.user, FFAdminUser) else None
-        api_key = getattr(request.user, "key", None) if user is None else None
-
-        delete_segment_override(self.environment, feature, segment_id, user, api_key)
+        delete_segment_override(self.environment, feature, segment_id, author)

--- a/api/features/feature_states/serializers.py
+++ b/api/features/feature_states/serializers.py
@@ -8,8 +8,13 @@ from features.versioning.dataclasses import (
     FlagChangeSetV2,
     SegmentOverrideChangeSet,
 )
-from features.versioning.versioning_service import update_flag, update_flag_v2
+from features.versioning.versioning_service import (
+    delete_segment_override,
+    update_flag,
+    update_flag_v2,
+)
 from segments.models import Segment
+from users.models import FFAdminUser
 
 
 class BaseFeatureUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
@@ -188,3 +193,27 @@ class UpdateFlagV2Serializer(BaseFeatureUpdateSerializer):
     def save(self, **kwargs: object) -> None:
         feature = self.get_feature()
         update_flag_v2(self.environment, feature, self.change_set_v2)
+
+
+class SegmentIdentifierSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField(required=True)
+
+
+class DeleteSegmentOverrideSerializer(BaseFeatureUpdateSerializer):
+    feature = FeatureIdentifierSerializer(required=True)
+    segment = SegmentIdentifierSerializer(required=True)
+
+    def validate_segment(self, value: dict) -> dict:  # type: ignore[type-arg]
+        if value and value.get("id"):
+            self.validate_segment_id(value["id"])
+        return value
+
+    def save(self, **kwargs: object) -> None:
+        feature = self.get_feature()
+        segment_id = self.validated_data["segment"]["id"]
+
+        request = self.context["request"]
+        user = request.user if isinstance(request.user, FFAdminUser) else None
+        api_key = getattr(request.user, "key", None) if user is None else None
+
+        delete_segment_override(self.environment, feature, segment_id, user, api_key)

--- a/api/features/feature_states/views.py
+++ b/api/features/feature_states/views.py
@@ -10,7 +10,11 @@ from rest_framework.response import Response
 from environments.models import Environment
 
 from .permissions import EnvironmentUpdateFeatureStatePermission
-from .serializers import UpdateFlagSerializer, UpdateFlagV2Serializer
+from .serializers import (
+    DeleteSegmentOverrideSerializer,
+    UpdateFlagSerializer,
+    UpdateFlagV2Serializer,
+)
 
 
 def _check_workflow_not_enabled(environment: Environment) -> None:
@@ -138,6 +142,55 @@ def update_flag_v2(request: Request, environment_key: str) -> Response:
     _check_workflow_not_enabled(environment)
 
     serializer = UpdateFlagV2Serializer(
+        data=request.data,
+        context={"request": request, "environment": environment},
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+
+    return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@swagger_auto_schema(
+    method="post",
+    operation_summary="Delete segment override",
+    operation_description="""
+    **EXPERIMENTAL ENDPOINT** - Subject to change without notice.
+
+    Deletes a segment override for a feature in the given environment.
+
+    **Feature Identification:**
+    - Use `feature.name` OR `feature.id` (mutually exclusive)
+    - Feature must belong to the environment's project
+
+    **Segment Identification:**
+    - Use `segment.id` (required)
+
+    The segment override must exist for the given feature/environment combination.
+    Returns 400 if the segment override does not exist.
+    """,
+    manual_parameters=[
+        openapi.Parameter(
+            "environment_key",
+            openapi.IN_PATH,
+            description="The environment API key",
+            type=openapi.TYPE_STRING,
+            required=True,
+        )
+    ],
+    request_body=DeleteSegmentOverrideSerializer,
+    responses={
+        204: openapi.Response(description="Segment override deleted successfully")
+    },
+    tags=["Experimental - Feature States"],
+)  # type: ignore[misc]
+@api_view(http_method_names=["POST"])
+@permission_classes([IsAuthenticated, EnvironmentUpdateFeatureStatePermission])
+def delete_segment_override(request: Request, environment_key: str) -> Response:
+    environment = Environment.objects.get(api_key=environment_key)
+    _check_workflow_not_enabled(environment)
+
+    serializer = DeleteSegmentOverrideSerializer(
         data=request.data,
         context={"request": request, "environment": environment},
     )

--- a/api/features/feature_states/views.py
+++ b/api/features/feature_states/views.py
@@ -182,7 +182,7 @@ def update_flag_v2(request: Request, environment_key: str) -> Response:
     responses={
         204: openapi.Response(description="Segment override deleted successfully")
     },
-    tags=["Experimental - Feature States"],
+    tags=["experimental"],
 )  # type: ignore[misc]
 @api_view(http_method_names=["POST"])
 @permission_classes([IsAuthenticated, EnvironmentUpdateFeatureStatePermission])


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Implements issue #6234 - adds endpoint to delete segment overrides for a feature in a given environment.

Endpoint: POST /api/experiments/environments/{environment_key}/delete-segment-override/

Request body:
- feature: {name: "x"} OR {id: 123}
- segment: {id: 456}

Response: 204 No Content

Features:
- Works with both V1 and V2 feature versioning
- V1: Direct deletion of FeatureSegment
- V2: Creates new version, removes segment override, publishes
- Reuses UPDATE_FEATURE_STATE permission
- Blocked when workflow/change requests are enabled
- Returns 400 if segment override doesn't exist


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit tests
