### PR TITLE
test: move pytestmark to module level for migration test module

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -14,12 +14,10 @@ from common.environments.permissions import (
     VIEW_IDENTITIES,
 )
 from common.projects.permissions import CREATE_ENVIRONMENT, DELETE_FEATURE, VIEW_PROJECT
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.test.utils import setup_databases
-from django_test_migrations.migrator import Migrator
 from flag_engine.segments.constants import EQUAL
 from flagsmith import Flagsmith
 from flagsmith.models import Flags
@@ -87,7 +85,6 @@ from tests.test_helpers import fix_issue_3869
 from tests.types import (
     AdminClientAuthType,
     EnableFeaturesFixture,
-    MigratorFactory,
     WithEnvironmentPermissionsCallable,
     WithOrganisationPermissionsCallable,
     WithProjectPermissionsCallable,
@@ -1311,11 +1308,3 @@ def enable_features(
 def clear_content_type_cache() -> typing.Generator[None, None, None]:
     yield
     ContentType.objects.clear_cache()
-
-
-@pytest.fixture()
-def migrator(migrator_factory: MigratorFactory) -> Migrator:
-    if settings.SKIP_MIGRATION_TESTS:
-        pytest.skip("Skip migration tests to speed up tests where necessary")
-    migrator: Migrator = migrator_factory()
-    return migrator

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -14,10 +14,12 @@ from common.environments.permissions import (
     VIEW_IDENTITIES,
 )
 from common.projects.permissions import CREATE_ENVIRONMENT, DELETE_FEATURE, VIEW_PROJECT
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.test.utils import setup_databases
+from django_test_migrations.migrator import Migrator
 from flag_engine.segments.constants import EQUAL
 from flagsmith import Flagsmith
 from flagsmith.models import Flags
@@ -1308,3 +1310,11 @@ def enable_features(
 def clear_content_type_cache() -> typing.Generator[None, None, None]:
     yield
     ContentType.objects.clear_cache()
+
+
+@pytest.fixture()
+def migrator(request: pytest.FixtureRequest) -> Migrator:
+    if settings.SKIP_MIGRATION_TESTS:
+        pytest.skip("Skip migration tests to speed up tests where necessary")
+    migrator: Migrator = request.getfixturevalue("migrator")
+    return migrator

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -87,6 +87,7 @@ from tests.test_helpers import fix_issue_3869
 from tests.types import (
     AdminClientAuthType,
     EnableFeaturesFixture,
+    MigratorFactory,
     WithEnvironmentPermissionsCallable,
     WithOrganisationPermissionsCallable,
     WithProjectPermissionsCallable,
@@ -1313,8 +1314,8 @@ def clear_content_type_cache() -> typing.Generator[None, None, None]:
 
 
 @pytest.fixture()
-def migrator(request: pytest.FixtureRequest) -> Migrator:
+def migrator(migrator_factory: MigratorFactory) -> Migrator:
     if settings.SKIP_MIGRATION_TESTS:
         pytest.skip("Skip migration tests to speed up tests where necessary")
-    migrator: Migrator = request.getfixturevalue("migrator")
+    migrator: Migrator = migrator_factory()
     return migrator

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -934,7 +934,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1632,18 +1632,18 @@ files = [
 
 [[package]]
 name = "django-test-migrations"
-version = "1.2.0"
+version = "1.5.0"
 description = "Test django schema and data migrations, including ordering"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = "<4.0,>=3.10"
 groups = ["dev"]
 files = [
-    {file = "django-test-migrations-1.2.0.tar.gz", hash = "sha256:874884ff4e980583cd9f1c986bb9fbfe72b436e759be23004e4f52c26a15f363"},
-    {file = "django_test_migrations-1.2.0-py3-none-any.whl", hash = "sha256:9e8b9b4364fef70dde10a5f85c5a75d447ca2189ec648325610fab1268daec97"},
+    {file = "django_test_migrations-1.5.0-py3-none-any.whl", hash = "sha256:96a08f085fc8bfaa53d44618341d82a2d22fd194c821cd81b147b66f0bec0da8"},
+    {file = "django_test_migrations-1.5.0.tar.gz", hash = "sha256:1cbff04b1e82c5564a6f635284907b381cc11a2ff883adff46776d9126824f07"},
 ]
 
 [package.dependencies]
-typing_extensions = ">=3.6,<5"
+typing_extensions = ">=4.0"
 
 [[package]]
 name = "djangorestframework"
@@ -2864,16 +2864,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -4294,7 +4284,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -4302,16 +4291,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -4328,7 +4309,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -4336,7 +4316,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -5453,4 +5432,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "ab02ed0cab3e1db81d247da5368027b96878d4c68841766aef0df0e982b69a18"
+content-hash = "ede63e91bec9698b149361a06586877dce93f4415d519fd892d19cd1269e0974"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -215,7 +215,7 @@ flagsmith-private = { git = "https://github.com/Flagsmith/flagsmith-private/", r
 
 
 [tool.poetry.group.dev.dependencies]
-django-test-migrations = "~1.2.0"
+django-test-migrations = "^1.2.0"
 responses = "~0.22.0"
 pre-commit = "^4.0.1"
 pytest-mock = "~3.10.0"

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,6 +1,8 @@
 import typing
 
 import pytest
+from django.conf import settings
+from django_test_migrations.migrator import Migrator
 from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 from pytest_django.fixtures import SettingsWrapper
 
@@ -10,6 +12,7 @@ from environments.dynamodb import (
     DynamoIdentityWrapper,
 )
 from environments.models import Environment
+from tests.types import MigratorFactory
 from util.mappers import (
     map_environment_to_environment_document,
     map_environment_to_environment_v2_document,
@@ -108,3 +111,11 @@ def dynamo_environment_wrapper(
     wrapper = DynamoEnvironmentWrapper()
     wrapper.table_name = flagsmith_environment_table.name
     return wrapper
+
+
+@pytest.fixture()
+def migrator(migrator_factory: MigratorFactory) -> Migrator:
+    if settings.SKIP_MIGRATION_TESTS:
+        pytest.skip("Skip migration tests to speed up tests where necessary")
+    migrator: Migrator = migrator_factory()
+    return migrator

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -115,7 +115,7 @@ def dynamo_environment_wrapper(
 
 @pytest.fixture()
 def migrator(migrator_factory: MigratorFactory) -> Migrator:
-    if settings.SKIP_MIGRATION_TESTS:
+    if settings.SKIP_MIGRATION_TESTS:  # pragma: no cover
         pytest.skip("Skip migration tests to speed up tests where necessary")
     migrator: Migrator = migrator_factory()
     return migrator

--- a/api/tests/types.py
+++ b/api/tests/types.py
@@ -1,4 +1,7 @@
+import typing
 from typing import Callable, Literal, Protocol
+
+from django_test_migrations.migrator import Migrator
 
 from environments.permissions.models import UserEnvironmentPermission
 from organisations.permissions.models import UserOrganisationPermission
@@ -34,3 +37,7 @@ class GetIdentityFlagsResponseJSONCallable(Protocol):
 
 class EnableFeaturesFixture(Protocol):
     def __call__(self, *feature_names: str) -> None: ...
+
+
+class MigratorFactory(typing.Protocol):
+    def __call__(self, name: typing.Optional[str] = None) -> Migrator: ...

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions_migrations.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions_migrations.py
@@ -1,4 +1,5 @@
-import pytest
+from typing import Type
+
 from common.environments.permissions import (
     APPROVE_CHANGE_REQUEST,
     CREATE_CHANGE_REQUEST,
@@ -6,18 +7,13 @@ from common.environments.permissions import (
     UPDATE_FEATURE_STATE,
     VIEW_IDENTITIES,
 )
-from django.conf import settings
-
-if settings.SKIP_MIGRATION_TESTS is True:
-    pytest.skip(
-        "Skip migration tests to speed up tests where necessary",
-        allow_module_level=True,
-    )
+from django.db.models import Model
+from django_test_migrations.migrator import Migrator
 
 
-def test_add_change_request_permissions_adds_correct_permissions_if_user_has_update_fs(  # type: ignore[no-untyped-def]  # noqa: E501
-    django_user_model, migrator
-):
+def test_add_change_request_permissions_adds_correct_permissions_if_user_has_update_fs(  # noqa: E501
+    django_user_model: Type[Model], migrator: Migrator
+) -> None:
     # Given
     old_state = migrator.apply_initial_migration(
         ("environment_permissions", "0003_add_manage_identities_permission")
@@ -229,11 +225,7 @@ def test_add_view_identity_permissions_does_nothing_if_user_does_not_have_manage
     )
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_merge_duplicate_permissions_migration(migrator):  # type: ignore[no-untyped-def]
+def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
     # Given - the migration state is at 0005 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("environment_permissions", "0005_add_view_identity_permissions")

--- a/api/tests/unit/environments/test_unit_environments_migrations.py
+++ b/api/tests/unit/environments/test_unit_environments_migrations.py
@@ -1,12 +1,7 @@
-import pytest
-from django.conf import settings
+from django_test_migrations.migrator import Migrator
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_migrate_use_mv_v2_evaluation(migrator):  # type: ignore[no-untyped-def]
+def test_migrate_use_mv_v2_evaluation(migrator: Migrator) -> None:
     # Given
     old_state = migrator.apply_initial_migration(
         ("environments", "0027_auto_20230106_0626")

--- a/api/tests/unit/features/multivariate/test_migrations.py
+++ b/api/tests/unit/features/multivariate/test_migrations.py
@@ -1,16 +1,11 @@
 import typing
 
-import pytest
-from django.conf import settings
+from django_test_migrations.migrator import Migrator
 
 from core.constants import STRING
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_remove_duplicate_mv_feature_state_values(migrator):  # type: ignore[no-untyped-def]
+def test_remove_duplicate_mv_feature_state_values(migrator: Migrator) -> None:
     # Given
     # We set the DB to be in the state prior to the migration we want to test
     old_state = migrator.apply_initial_migration(("multivariate", "0001_initial"))

--- a/api/tests/unit/features/test_migrations.py
+++ b/api/tests/unit/features/test_migrations.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from django_test_migrations.migrator import Migrator
 
 from features.feature_types import MULTIVARIATE, STANDARD
 
 
-def test_migrate_feature_segments_forward(migrator):  # type: ignore[no-untyped-def]
+def test_migrate_feature_segments_forward(migrator: Migrator) -> None:
     # Given - the migration state is at 0017 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("features", "0017_auto_20200607_1005")
@@ -81,7 +82,7 @@ def test_migrate_feature_segments_forward(migrator):  # type: ignore[no-untyped-
     assert NewFeatureState.objects.values("feature_segment").distinct().count() == 4
 
 
-def test_migrate_feature_segments_reverse(migrator):  # type: ignore[no-untyped-def]
+def test_migrate_feature_segments_reverse(migrator: Migrator) -> None:
     # Given - migration state is at 0018, after the migration we want to test in reverse
     old_state = migrator.apply_initial_migration(
         ("features", "0018_auto_20200607_1057")
@@ -135,7 +136,7 @@ def test_migrate_feature_segments_reverse(migrator):  # type: ignore[no-untyped-
     assert NewFeatureSegment.objects.first().segment.pk == segment.pk
 
 
-def test_revert_feature_state_versioning_migrations(migrator):  # type: ignore[no-untyped-def]
+def test_revert_feature_state_versioning_migrations(migrator: Migrator) -> None:
     # Given
     old_state = migrator.apply_initial_migration(
         ("features", "0038_remove_old_versions_and_drafts")
@@ -182,7 +183,7 @@ def test_revert_feature_state_versioning_migrations(migrator):  # type: ignore[n
     assert NewFeatureState.objects.filter(id=v2.id).exists()
 
 
-def test_fix_feature_type_migration(migrator):  # type: ignore[no-untyped-def]
+def test_fix_feature_type_migration(migrator: Migrator) -> None:
     # Given
     old_state = migrator.apply_initial_migration(
         ("features", "0058_alter_boolean_values")
@@ -225,7 +226,7 @@ def test_fix_feature_type_migration(migrator):  # type: ignore[no-untyped-def]
     assert NewFeature.objects.get(id=mv_feature.id).type == MULTIVARIATE
 
 
-def test_migrate_sample_to_webhook_forward(migrator):  # type: ignore[no-untyped-def]
+def test_migrate_sample_to_webhook_forward(migrator: Migrator) -> None:
     # Given
     old_state = migrator.apply_initial_migration(
         ("feature_health", "0002_featurehealthevent_add_external_id_alter_created_at")
@@ -269,7 +270,7 @@ def test_migrate_sample_to_webhook_forward(migrator):  # type: ignore[no-untyped
     assert not NewFeatureHealthEvent.objects.filter(provider_name="Sample").exists()
 
 
-def test_migrate_sample_to_webhook_reverse(migrator):  # type: ignore[no-untyped-def]
+def test_migrate_sample_to_webhook_reverse(migrator: Migrator) -> None:
     # Given
     old_state = migrator.apply_initial_migration(
         ("feature_health", "0003_migrate_sample_to_webhook")

--- a/api/tests/unit/features/test_migrations.py
+++ b/api/tests/unit/features/test_migrations.py
@@ -243,6 +243,10 @@ def test_fix_feature_type_migration(migrator):  # type: ignore[no-untyped-def]
     assert NewFeature.objects.get(id=mv_feature.id).type == MULTIVARIATE
 
 
+@pytest.mark.skipif(
+    settings.SKIP_MIGRATION_TESTS is True,
+    reason="Skip migration tests to speed up tests where necessary",
+)
 def test_migrate_sample_to_webhook_forward(migrator):  # type: ignore[no-untyped-def]
     # Given
     old_state = migrator.apply_initial_migration(

--- a/api/tests/unit/features/test_migrations.py
+++ b/api/tests/unit/features/test_migrations.py
@@ -6,11 +6,12 @@ from django.utils import timezone
 
 from features.feature_types import MULTIVARIATE, STANDARD
 
-
-@pytest.mark.skipif(
+pytestmark = pytest.mark.skipif(
     settings.SKIP_MIGRATION_TESTS is True,
     reason="Skip migration tests to speed up tests where necessary",
 )
+
+
 def test_migrate_feature_segments_forward(migrator):  # type: ignore[no-untyped-def]
     # Given - the migration state is at 0017 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
@@ -87,10 +88,6 @@ def test_migrate_feature_segments_forward(migrator):  # type: ignore[no-untyped-
     assert NewFeatureState.objects.values("feature_segment").distinct().count() == 4
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 def test_migrate_feature_segments_reverse(migrator):  # type: ignore[no-untyped-def]
     # Given - migration state is at 0018, after the migration we want to test in reverse
     old_state = migrator.apply_initial_migration(
@@ -145,10 +142,6 @@ def test_migrate_feature_segments_reverse(migrator):  # type: ignore[no-untyped-
     assert NewFeatureSegment.objects.first().segment.pk == segment.pk
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 def test_revert_feature_state_versioning_migrations(migrator):  # type: ignore[no-untyped-def]
     # Given
     old_state = migrator.apply_initial_migration(
@@ -196,10 +189,6 @@ def test_revert_feature_state_versioning_migrations(migrator):  # type: ignore[n
     assert NewFeatureState.objects.filter(id=v2.id).exists()
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 def test_fix_feature_type_migration(migrator):  # type: ignore[no-untyped-def]
     # Given
     old_state = migrator.apply_initial_migration(
@@ -243,10 +232,6 @@ def test_fix_feature_type_migration(migrator):  # type: ignore[no-untyped-def]
     assert NewFeature.objects.get(id=mv_feature.id).type == MULTIVARIATE
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 def test_migrate_sample_to_webhook_forward(migrator):  # type: ignore[no-untyped-def]
     # Given
     old_state = migrator.apply_initial_migration(
@@ -291,10 +276,6 @@ def test_migrate_sample_to_webhook_forward(migrator):  # type: ignore[no-untyped
     assert not NewFeatureHealthEvent.objects.filter(provider_name="Sample").exists()
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 def test_migrate_sample_to_webhook_reverse(migrator):  # type: ignore[no-untyped-def]
     # Given
     old_state = migrator.apply_initial_migration(

--- a/api/tests/unit/features/test_migrations.py
+++ b/api/tests/unit/features/test_migrations.py
@@ -1,15 +1,8 @@
 from datetime import timedelta
 
-import pytest
-from django.conf import settings
 from django.utils import timezone
 
 from features.feature_types import MULTIVARIATE, STANDARD
-
-pytestmark = pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 
 
 def test_migrate_feature_segments_forward(migrator):  # type: ignore[no-untyped-def]

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_migrations.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_migrations.py
@@ -1,12 +1,6 @@
-import pytest
-from django.conf import settings
 from django_test_migrations.migrator import Migrator
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
 def test_migrate_add_project_to_change_request(migrator: Migrator) -> None:
     old_state = migrator.apply_initial_migration(
         ("workflows_core", "0010_add_ignore_conflicts_option"),

--- a/api/tests/unit/organisations/permissions/test_unit_organisations_migrations.py
+++ b/api/tests/unit/organisations/permissions/test_unit_organisations_migrations.py
@@ -1,5 +1,3 @@
-import pytest
-from django.conf import settings
 from django_test_migrations.migrator import Migrator
 
 from organisations.models import OrganisationRole
@@ -10,11 +8,9 @@ from organisations.permissions.permissions import (
 from permissions.models import ORGANISATION_PERMISSION_TYPE
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_migration_creates_create_project_permissions_for_org_users(migrator):  # type: ignore[no-untyped-def]
+def test_migration_creates_create_project_permissions_for_org_users(
+    migrator: Migrator,
+) -> None:
     # Given
     # we use one of the dependencies of the migration we want to test to set the
     # initial state of the database correctly
@@ -71,11 +67,7 @@ def test_migration_creates_create_project_permissions_for_org_users(migrator):  
     ).exists()
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_merge_duplicate_permissions_migration(migrator):  # type: ignore[no-untyped-def]
+def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
     # Given - the migration state is at 0002 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("organisation_permissions", "0002_add_related_query_name")

--- a/api/tests/unit/organisations/test_unit_organisations_migrations.py
+++ b/api/tests/unit/organisations/test_unit_organisations_migrations.py
@@ -1,14 +1,9 @@
-import pytest
-from django.conf import settings
+from django_test_migrations.migrator import Migrator
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_migration_creates_default_subscription_for_organisations_without_subscription(  # type: ignore[no-untyped-def]  # noqa: E501
-    migrator,
-):
+def test_migration_creates_default_subscription_for_organisations_without_subscription(  # noqa: E501
+    migrator: Migrator,
+) -> None:
     # Given
     # we use one of the dependencies of the migration we want to test to set the
     # initial state of the database correctly

--- a/api/tests/unit/permissions/test_migrations.py
+++ b/api/tests/unit/permissions/test_migrations.py
@@ -1,16 +1,11 @@
-import pytest
-from django.conf import settings
+from django_test_migrations.migrator import Migrator
 
 from organisations.models import OrganisationRole
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_migration_only_remove_permissions_for_users_that_are_not_part_of_the_organisation(  # type: ignore[no-untyped-def]  # noqa: E501
-    migrator,
-):
+def test_migration_only_remove_permissions_for_users_that_are_not_part_of_the_organisation(  # noqa: E501
+    migrator: Migrator,
+) -> None:
     # Given - the migration state is at 0004 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("permissions", "0004_add_create_project_permission"),

--- a/api/tests/unit/projects/test_migrations.py
+++ b/api/tests/unit/projects/test_migrations.py
@@ -1,16 +1,11 @@
-import pytest
 from common.projects.permissions import (
     CREATE_ENVIRONMENT,
     VIEW_PROJECT,
 )
-from django.conf import settings
+from django_test_migrations.migrator import Migrator
 
 
-@pytest.mark.skipif(
-    settings.SKIP_MIGRATION_TESTS is True,
-    reason="Skip migration tests to speed up tests where necessary",
-)
-def test_merge_duplicate_permissions_migration(migrator):  # type: ignore[no-untyped-def]
+def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
     # Given - the migration state is at 0016 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("projects", "0016_soft_delete_projects")


### PR DESCRIPTION
## Changes

Factors out the `SKIP_MIGRATION_TESTS` logic into a custom `migrator` fixture. This PR is being introduced because one of the tests in the `tests/unit/features/test_migrations.py` file didn't have the pytest mark decorator. This change also prevents this from occurring again when adding new migration tests.

I've also included some bonus removals of `type: ignore` statements since I was working in the area. 

## How did you test this code?

Ran the following 2 example test commands and verified that the tests were / weren't skipped when I expected. 

```
SKIP_MIGRATION_TESTS=true make test opts="-n 0 --dist worksteal tests/unit/features/test_migrations.py"
```

```
SKIP_MIGRATION_TESTS=false make test opts="-n 0 --dist worksteal tests/unit/features/test_migrations.py"
```

