### PR TITLE
chore: Tidy page title description

### DIFF
--- a/frontend/web/components/PageTitle.tsx
+++ b/frontend/web/components/PageTitle.tsx
@@ -10,7 +10,7 @@ const PageTitle: FC<PageTitleType> = ({ children, className, cta, title }) => {
   return (
     <div className={className || 'mb-4'}>
       <div className='flex-row flex-lg-row gap-2 align-items-start align-items-lg-center justify-content-between'>
-        <div className='flex'>
+        <div className='flex flex-fill'>
           <h4 className={children ? 'mb-1' : 'mb-0'}>{title}</h4>
           {children && (
             <Row>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The page title description was squashed

Before

<img width="863" height="200" alt="image" src="https://github.com/user-attachments/assets/2b7c374a-53aa-42d8-ada2-88465396418d" />

After

<img width="977" height="389" alt="image" src="https://github.com/user-attachments/assets/e19c38e1-d11e-4165-ae4a-1ebb129eec3e" />



## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
