### PR TITLE
fix: Avoid double transactions when cloning segments

### DIFF
--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -147,7 +147,6 @@ class Segment(
         self.version_of = self
         self.save_without_historical_record()
 
-    @transaction.atomic
     def clone(self, is_revision: bool = False, **extra_attrs: typing.Any) -> "Segment":
         """
         Create a revision of the segment


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This change helps us avoid transactions unnecessarily wrapped in transactions that might be the cause of lock contention in prod SaaS. 

## How did you test this code?

We'll see what CI says, and then test in production.