### PR TITLE
fix: prevent invites with invalid permission groups

### DIFF
--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -137,7 +137,7 @@ class InviteViewSet(
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        if getattr(self.request, "swagger_fake_view", False):
+        if getattr(self.request, "swagger_fake_view", False):  # pragma: no cover
             return context
 
         context["organisation"] = int(self.kwargs["organisation_pk"])

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -137,7 +137,7 @@ class InviteViewSet(
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        context["organisation"] = self.kwargs["organisation_pk"]
+        context["organisation"] = self.kwargs.get("organisation_pk")
         return context
 
     @action(detail=True, methods=["POST"], throttle_classes=[ScopedRateThrottle])

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -132,6 +134,11 @@ class InviteViewSet(
         return Invite.objects.filter(organisation__in=user.organisations.all()).filter(  # type: ignore[misc,union-attr]  # noqa: E501
             organisation__id=organisation_pk
         )
+
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        context["organisation"] = self.kwargs["organisation_pk"]
+        return context
 
     @action(detail=True, methods=["POST"], throttle_classes=[ScopedRateThrottle])
     def resend(self, request, organisation_pk, pk):  # type: ignore[no-untyped-def]

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -137,7 +137,10 @@ class InviteViewSet(
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        context["organisation"] = self.kwargs.get("organisation_pk")
+        if getattr(self.request, "swagger_fake_view", False):
+            return context
+
+        context["organisation"] = int(self.kwargs["organisation_pk"])
         return context
 
     @action(detail=True, methods=["POST"], throttle_classes=[ScopedRateThrottle])

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -114,7 +114,9 @@ class _PermissionGroupPKRelatedField(
 
 
 class InviteSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
-    permission_groups = _PermissionGroupPKRelatedField(many=True)
+    permission_groups = _PermissionGroupPKRelatedField(
+        many=True, required=False, allow_null=True, allow_empty=True
+    )
 
     class Meta:
         model = Invite

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -110,7 +110,7 @@ class _PermissionGroupPKRelatedField(
     def get_queryset(self) -> QuerySet[UserPermissionGroup]:
         return UserPermissionGroup.objects.filter(
             organisation__id=typing.cast(
-                InviteSerializer, self.root
+                InviteSerializer, self.parent.parent
             ).get_organisation_id()
         )
 

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -109,9 +109,7 @@ class _PermissionGroupPKRelatedField(
 ):
     def get_queryset(self) -> QuerySet[UserPermissionGroup]:
         return UserPermissionGroup.objects.filter(
-            organisation__id=typing.cast(
-                InviteSerializer, self.parent.parent
-            ).get_organisation_id()
+            organisation__id=self.context["organisation"]
         )
 
 
@@ -125,15 +123,12 @@ class InviteSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
 
     def validate(self, attrs: typing.Any) -> typing.Any:
         if Invite.objects.filter(
-            email=attrs["email"], organisation__id=self.get_organisation_id()
+            email=attrs["email"], organisation__id=self.context["organisation"]
         ).exists():
             raise serializers.ValidationError(
                 {"email": "Invite for email %s already exists" % attrs["email"]}
             )
         return super(InviteSerializer, self).validate(attrs)
-
-    def get_organisation_id(self) -> int:
-        return int(self.context["view"].kwargs.get("organisation_pk"))
 
 
 class MultiInvitesSerializer(serializers.Serializer):  # type: ignore[type-arg]

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -258,7 +258,7 @@ def test_create_invite_with_permission_groups_fails_if_permission_group_belongs_
     response_json = response.json()
     assert response_json == {
         "permission_groups": [
-            f"The following group(s) do not belong to current organisation: {user_permission_group.name}"
+            f'Invalid pk "{user_permission_group.pk}" - object does not exist.'
         ]
     }
 

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -460,9 +460,13 @@ def test_can_invite_user_as_admin(
     data = {"invites": [{"email": invited_email, "role": OrganisationRole.ADMIN.name}]}
 
     # When
-    admin_client.post(url, data=json.dumps(data), content_type="application/json")
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
 
     # Then
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+
     assert Invite.objects.filter(email=invited_email).exists()
     assert Invite.objects.get(email=invited_email).role == OrganisationRole.ADMIN.name
 
@@ -481,12 +485,15 @@ def test_can_invite_user_as_user(
     data = {"invites": [{"email": invited_email, "role": OrganisationRole.USER.name}]}
 
     # When
-    admin_client.post(url, data=json.dumps(data), content_type="application/json")
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
 
     # Then
-    assert Invite.objects.filter(email=invited_email).exists()
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
 
     # and
+    assert Invite.objects.filter(email=invited_email).exists()
     assert Invite.objects.get(email=invited_email).role == OrganisationRole.USER.name
 
 


### PR DESCRIPTION
## Changes

Prevent invites being created with permission groups from other organisations. 

Note that, while the invite would have been created, and it would have been possible to consume the invite, the permissions wouldn't have been granted to the user (see [here](https://github.com/Flagsmith/flagsmith/blob/fff47b50ffb24b54dc3207134a071a37ebd9c085/api/permissions/permission_service.py#L216-L217), [here](https://github.com/Flagsmith/flagsmith/blob/fff47b50ffb24b54dc3207134a071a37ebd9c085/api/permissions/permission_service.py#L104-L105) and [here](https://github.com/Flagsmith/flagsmith/blob/fff47b50ffb24b54dc3207134a071a37ebd9c085/api/permissions/permission_service.py#L166-L167))

## How did you test this code?

Added new API test
