### PR TITLE
fix: Show segment identities tab regardless of environment being set

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -538,7 +538,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               />
             </div>
           </TabItem>
-          <TabItem tabLabel='Users'>
+          <TabItem tabLabel='Identities'>
             <div className='my-4'>
               <CreateSegmentUsersTabContent
                 projectId={projectId}

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -145,7 +145,11 @@ const CreateSegment: FC<CreateSegmentType> = ({
   const [description, setDescription] = useState(segment.description)
   const [name, setName] = useState<Segment['name']>(segment.name)
   const [rules, setRules] = useState<Segment['rules']>(segment.rules)
-
+  useEffect(() => {
+    if (_segment) {
+      setSegment(_segment)
+    }
+  }, [_segment])
   useEffect(() => {
     if (segment) {
       setRules(segment.rules)

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -540,20 +540,18 @@ const CreateSegment: FC<CreateSegmentType> = ({
           </TabItem>
           <TabItem tabLabel='Users'>
             <div className='my-4'>
-              {!!identities && (
-                <CreateSegmentUsersTabContent
-                  projectId={projectId}
-                  environmentId={environmentId}
-                  setEnvironmentId={setEnvironmentId}
-                  identitiesLoading={identitiesLoading}
-                  identities={identities}
-                  page={page}
-                  setPage={setPage}
-                  name={name}
-                  searchInput={searchInput}
-                  setSearchInput={setSearchInput}
-                />
-              )}
+              <CreateSegmentUsersTabContent
+                projectId={projectId}
+                environmentId={environmentId}
+                setEnvironmentId={setEnvironmentId}
+                identitiesLoading={identitiesLoading}
+                identities={identities}
+                page={page}
+                setPage={setPage}
+                name={name}
+                searchInput={searchInput}
+                setSearchInput={setSearchInput}
+              />
             </div>
           </TabItem>
           {metadataEnable && segmentContentType?.id && (

--- a/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
+++ b/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
@@ -17,7 +17,7 @@ interface CreateSegmentUsersTabContentProps {
   environmentId: string
   setEnvironmentId: (environmentId: string) => void
   identitiesLoading: boolean
-  identities: Res['identities']
+  identities: Res['identities'] | undefined
   page: any
   setPage: (page: any) => void
   name: string


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Some views of segments have context to a specific environmemt, the segment page does not and was hiding the identities tab. In this case we can make the environment optional and allow users to select
<img width="1284" height="548" alt="image" src="https://github.com/user-attachments/assets/cdc3a1da-5e52-41e0-b98f-9565496f9d0b" />


## How did you test this code?

Viewed and filtered segment identities