### PR TITLE
chore: move python typecheck to pre push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,12 +41,16 @@ repos:
         require_serial: true
         pass_filenames: false
         types: [python]
+        stages: [pre-push]
 
   - repo: https://github.com/python-poetry/poetry
     rev: 2.2.1
     hooks:
       - id: poetry-check
         args: ["-C", "api"]
+
+default_install_hook_types: [pre-commit, pre-push]
+default_stages: [pre-commit]
 
 ci:
   skip: [generate-docs, python-typecheck]


### PR DESCRIPTION
## Changes

Moves the typecheck pre-commit job to a pre-push hook. 

The rationale here is that the typecheck job takes a long time and is a slightly painful experience to have on every commit. Preventing this at push stage feels more aligned with the correct approach here. 

## How did you test this code?

Added a commit that broke the typecheck and tried to push it, confirmed that it failed. 
