### PR TITLE
fix: clean-up-ci-cafe-port-3000-on-error

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -44,6 +44,8 @@ runs:
         max_attempts: 2
         retry_on: error
         timeout_minutes: 20
+        on_retry_command: |
+          lsof -ti:3000 | xargs kill -9 || true
       env:
         E2E_TEST_TOKEN: ${{ inputs.e2e_test_token }}
         SLACK_TOKEN: ${{ inputs.slack_token }}

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -76,6 +76,9 @@ jobs:
           max_attempts: 2
           retry_on: error
           timeout_minutes: 20
+          on_retry_command: |
+            cd frontend
+            docker compose down --remove-orphans || true
         env:
           opts: ${{ inputs.args }}
           API_IMAGE: ${{ inputs.api-image }}

--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -16,6 +16,7 @@ const dir = path.join(__dirname, '../reports/screen-captures');
 if (fs.existsSync(dir)) {
     fs.rmdirSync(dir, { recursive: true });
 }
+
 const start = Date.now().valueOf();
 // Parse CLI arg --meta-filter
 const args = minimist(process.argv.slice(2));
@@ -79,4 +80,9 @@ createTestCafe()
         server.kill('SIGINT');
         testcafe.close();
         process.exit(v);
+    }) .catch(async (err) => {
+        console.error('TestCafe initialisation error:', err);
+        if (server) server.kill('SIGINT');
+        if (testcafe) testcafe.close();
+        process.exit(1);
     });


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

This PR fixes an issue where E2E test retries would hang because port 3000 was still busy with a previous failed attempt.

TestCafe failed during initialization (one concurrent browser failed). There was no error handler and the CI retry wouldn't clean up the port.

The error was in the child process, the parent had no error handler, so it just exited without a proper error code which CI considered a success

## Changes
- Added a proper error handling on café initialization (`e2e/index.cafe.js`)
- Clean up port 3000 in between attempts (`.github/workflows/.reusable-docker-e2e-tests.yml`)

## How did you test this code?
With failing testcafe config:

```
module.exports = {
    "browsers": "test:headless",
    browserInitTimeout: 1,
    ...
    ...
}

```