### PR TITLE
docs: improve rbac and permissions readability

### DIFF
--- a/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
+++ b/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
@@ -24,12 +24,6 @@ Change Requests are configured at the environment level. To enable and set up Ch
 
 Once an environment is configured with Change Requests enabled, attempting to change a flag value will prompt you to create a new Change Request.
 
-:::info
-
-Any user with permission to *update* a feature within the environment can create a Change Request.
-
-:::
-
 When creating a Change Request, you will need to provide the following:
 
 * The **title** of the Change Request.
@@ -40,17 +34,20 @@ When creating a Change Request, you will need to provide the following:
 
 Change Requests awaiting approval are listed in the **Change Request** area.
 
-:::info
-
-Any user with permission to write to the environment containing the Change Request can approve it.
-
-:::
-
 1.  Click on a **Change Request** to view its details.
 2.  Review the current and new Flag values.
+3.  Click **Approve** or **Deny** to record your decision.
 
 ## Publish a Change Request
 
-When the required number of approvals have been made, you will be able to publish the Change Request.
+When the required number of approvals have been made, you will be able to publish the Change Request. The Change Request will immediately come into effect once the **Publish Change** button is clicked.
 
-The Change Request will immediately come into effect once the **Publish Change** button is clicked.
+## Permissions
+
+| Action                  | Required permission      |
+| ----------------------- | ------------------------ |
+| Create a Change Request | Create change request    |
+| Approve a Change Request| Approve change request   |
+| Publish a Change Request| Update feature state     |
+
+These permissions can be configured at both the project level and the environment level. For example, you might allow all developers to create change requests in Production, but only senior engineers to approve and publish them. See [Role-based access control](/administration-and-security/access-control/rbac) for details on configuring permissions.

--- a/docs/docs/flagsmith-concepts/data-model.md
+++ b/docs/docs/flagsmith-concepts/data-model.md
@@ -52,3 +52,32 @@ For more information, see [Traits](/flagsmith-concepts/identities#identity-trait
 Segments define a group of users by traits such as login count, device, location, or any number of custom-defined traits. Similar to individual users, you can override environment defaults for features for a segment. For example, you might show certain features for a "power user" segment.
 
 For more information, see [Segments](/flagsmith-concepts/segments).
+
+## Permissions and the data model
+
+Permissions in Flagsmith are managed at three levels that align with the data hierarchy:
+
+- **Organisation**: User management, project creation
+- **Project**: Feature and segment creation/deletion, environment creation
+- **Environment**: Flag state changes, identity management, change requests
+
+Understanding which level controls what is important when setting up access control:
+
+| Resource       | Defined at    | Values controlled at | Implication for permissions                                                         |
+| -------------- | ------------- | -------------------- | ----------------------------------------------------------------------------------- |
+| Features       | Project       | Environment          | Creating/deleting a feature is project-level; changing its state is environment-level |
+| Segments       | Project       | Project              | Segment rules are project-wide and affect all environments                           |
+| Segment overrides | Environment | Environment       | Override values for a segment can differ per environment                             |
+| Identities     | Environment   | Environment          | Each environment has its own set of identities                                       |
+
+:::tip Key insight
+
+Features and Segments are defined at the **Project level** and shared across all Environments. This means:
+
+- **Creating or deleting** a feature affects all environments simultaneously
+- **Managing segments** is a project-wide capability, not per-environment
+- To control **flag values** per environment, use environment-level permissions
+
+:::
+
+For detailed information on configuring access control, see [Role-based access control](/administration-and-security/access-control/rbac).

--- a/docs/static/img/permission-hierarchy.svg
+++ b/docs/static/img/permission-hierarchy.svg
@@ -1,0 +1,46 @@
+<svg viewBox="0 0 580 80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="2" dy="2" stdDeviation="2" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <style>
+    .box-org { fill: #e0f2fe; stroke: #0284c7; stroke-width: 2; rx: 8; }
+    .box-proj { fill: #fef3c7; stroke: #d97706; stroke-width: 2; rx: 8; }
+    .box-env { fill: #dcfce7; stroke: #16a34a; stroke-width: 2; rx: 8; }
+    .label-bold { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; fill: #1e293b; font-weight: 600; }
+    .label-small { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; fill: #64748b; }
+    .arrow { stroke: #64748b; stroke-width: 1.5; fill: none; marker-end: url(#arrowhead); }
+  </style>
+
+  <!-- Organisation -->
+  <g filter="url(#shadow)">
+    <rect x="10" y="15" width="150" height="50" class="box-org"/>
+    <text x="85" y="37" text-anchor="middle" class="label-bold">Organisation</text>
+    <text x="85" y="52" text-anchor="middle" class="label-small">Org-wide settings</text>
+  </g>
+
+  <!-- Arrow -->
+  <line x1="160" y1="40" x2="200" y2="40" class="arrow"/>
+
+  <!-- Project -->
+  <g filter="url(#shadow)">
+    <rect x="205" y="15" width="160" height="50" class="box-proj"/>
+    <text x="285" y="37" text-anchor="middle" class="label-bold">Project</text>
+    <text x="285" y="52" text-anchor="middle" class="label-small">Features &amp; Segments</text>
+  </g>
+
+  <!-- Arrow -->
+  <line x1="365" y1="40" x2="405" y2="40" class="arrow"/>
+
+  <!-- Environment -->
+  <g filter="url(#shadow)">
+    <rect x="410" y="15" width="160" height="50" class="box-env"/>
+    <text x="490" y="37" text-anchor="middle" class="label-bold">Environment</text>
+    <text x="490" y="52" text-anchor="middle" class="label-small">Flag values &amp; Identities</text>
+  </g>
+</svg>

--- a/docs/static/img/rbac-permissions-diagram.svg
+++ b/docs/static/img/rbac-permissions-diagram.svg
@@ -1,0 +1,79 @@
+<svg viewBox="0 0 810 310" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="2" dy="2" stdDeviation="2" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <style>
+    .box { fill: #e0f2fe; stroke: #0284c7; stroke-width: 2; rx: 8; }
+    .label-bold { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; fill: #1e293b; font-weight: 600; }
+    .label-arrow { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; fill: #475569; font-weight: 600; }
+    .arrow { stroke: #64748b; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+    .arrow-no-head { stroke: #64748b; stroke-width: 2; fill: none; }
+  </style>
+
+  <!-- Permissions box (left) -->
+  <g filter="url(#shadow)">
+    <rect x="10" y="105" width="120" height="50" class="box"/>
+    <text x="70" y="135" text-anchor="middle" class="label-bold">Permissions</text>
+  </g>
+
+  <!-- Built-in roles box (top middle) -->
+  <g filter="url(#shadow)">
+    <rect x="260" y="10" width="130" height="50" class="box"/>
+    <text x="325" y="40" text-anchor="middle" class="label-bold">Built-in roles</text>
+  </g>
+
+  <!-- Custom roles box (bottom middle) -->
+  <g filter="url(#shadow)">
+    <rect x="260" y="180" width="130" height="50" class="box"/>
+    <text x="325" y="210" text-anchor="middle" class="label-bold">Custom roles</text>
+  </g>
+
+  <!-- Users box (top right) -->
+  <g filter="url(#shadow)">
+    <rect x="680" y="10" width="120" height="50" class="box"/>
+    <text x="740" y="40" text-anchor="middle" class="label-bold">Users</text>
+  </g>
+
+  <!-- Groups box (middle right) -->
+  <g filter="url(#shadow)">
+    <rect x="530" y="125" width="130" height="50" class="box"/>
+    <text x="595" y="155" text-anchor="middle" class="label-bold">Groups</text>
+  </g>
+
+  <!-- Admin API Keys box (bottom right, aligned with Groups) -->
+  <g filter="url(#shadow)">
+    <rect x="530" y="250" width="130" height="50" class="box"/>
+    <text x="595" y="280" text-anchor="middle" class="label-bold">Admin API Keys</text>
+  </g>
+
+  <!-- Permissions merged outbound: longer horizontal trunk, then split up/down -->
+  <path d="M 130 130 L 220 130" class="arrow-no-head"/>
+  <path d="M 220 130 L 220 35 L 255 35" class="arrow"/>
+  <path d="M 220 130 L 220 205 L 255 205" class="arrow"/>
+  <text x="175" y="122" text-anchor="middle" class="label-arrow">Assigned to</text>
+
+  <!-- Built-in roles → Users (straight right) -->
+  <line x1="390" y1="35" x2="675" y2="35" class="arrow"/>
+  <text x="445" y="27" text-anchor="middle" class="label-arrow">Assigned to</text>
+
+  <!-- Custom roles merged outbound: longer horizontal trunk, then splits vertically -->
+  <path d="M 390 205 L 490 205" class="arrow-no-head"/>
+  <!-- Branch up to Users -->
+  <path d="M 490 205 L 490 95 L 730 95 L 730 65" class="arrow"/>
+  <!-- Branch up to Groups -->
+  <path d="M 490 205 L 490 150 L 525 150" class="arrow"/>
+  <!-- Branch down to Admin API Keys -->
+  <path d="M 490 205 L 490 275 L 525 275" class="arrow"/>
+  <text x="440" y="197" text-anchor="middle" class="label-arrow">Assigned to</text>
+
+  <!-- Arrow: Groups → Users -->
+  <path d="M 660 150 L 770 150 L 770 65" class="arrow"/>
+  <text x="715" y="142" text-anchor="middle" class="label-arrow">Contains many</text>
+
+</svg>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Restructured RBAC docs with clearer explanations of permission levels (organisation/project/environment) and role types
- Added practical examples for common permission setups (developers with production restrictions, QA read-only access, etc.)
- Updated change requests docs with a permissions table for create/approve/publish actions
- Added permissions section to data model docs explaining how permissions align with the data hierarchy

## How did you test this code?
Ran docs locally, verified SVGs look good, that links work, that the text makes sense and that the general order concepts are presented in makes sense.