### PR TITLE
fix: add throttling for influx query endpoints

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -320,6 +320,7 @@ REST_FRAMEWORK = {
         "mfa_code": "5/min",
         "invite": "10/min",
         "user": USER_THROTTLE_RATE,
+        "influx_query": "5/min",
     },
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_RENDERER_CLASSES": [

--- a/api/app/settings/test.py
+++ b/api/app/settings/test.py
@@ -11,6 +11,7 @@ REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
     "invite": "10/min",
     "signup": "100/min",
     "user": "100000/day",
+    "influx_query": "50/min",
 }
 
 AWS_SSE_LOGS_BUCKET_NAME = "test_bucket"

--- a/api/app_analytics/throttles.py
+++ b/api/app_analytics/throttles.py
@@ -17,7 +17,7 @@ class InfluxQueryThrottle(SimpleRateThrottle):
                 "scope": self.scope,
                 "ident": request.user.pk,
             }
-        return self.cache_format % {
+        return self.cache_format % {  # pragma: no cover
             "scope": self.scope,
             "ident": self.get_ident(request),
         }

--- a/api/app_analytics/throttles.py
+++ b/api/app_analytics/throttles.py
@@ -1,0 +1,5 @@
+from rest_framework.throttling import ScopedRateThrottle
+
+
+class InfluxQueryThrottle(ScopedRateThrottle):
+    scope = "influx_query"

--- a/api/app_analytics/throttles.py
+++ b/api/app_analytics/throttles.py
@@ -1,5 +1,23 @@
-from rest_framework.throttling import ScopedRateThrottle
+from django.views import View
+from rest_framework.request import Request
+from rest_framework.throttling import SimpleRateThrottle
 
 
-class InfluxQueryThrottle(ScopedRateThrottle):
+class InfluxQueryThrottle(SimpleRateThrottle):
     scope = "influx_query"
+
+    def get_cache_key(self, request: Request, view: View) -> str:
+        """
+        Since we want to throttle requests across multiple views and viewsets that don't
+        necessarily have the option to define the scope themselves, we override the
+        get_cache_key method to ensure that the throttling logic behaves as expected.
+        """
+        if request.user and request.user.is_authenticated:
+            return self.cache_format % {
+                "scope": self.scope,
+                "ident": request.user.pk,
+            }
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": self.get_ident(request),
+        }

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -21,6 +21,7 @@ from app_analytics.influxdb_wrapper import (
     get_events_for_organisation,
     get_multiple_event_list_for_organisation,
 )
+from app_analytics.throttles import InfluxQueryThrottle
 from core.helpers import get_current_site_url
 from organisations.chargebee import webhook_event_types, webhook_handlers
 from organisations.exceptions import OrganisationHasNoPaidSubscription
@@ -164,6 +165,7 @@ class OrganisationViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     @action(
         detail=True,
         methods=["GET"],
+        throttle_classes=[InfluxQueryThrottle],
     )
     def usage(self, request, pk):  # type: ignore[no-untyped-def]
         organisation = self.get_object()
@@ -240,7 +242,12 @@ class OrganisationViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         operation_description="Please use /api/v1/organisations/{organisation_pk}/usage-data/",
         query_serializer=InfluxDataQuerySerializer(),
     )
-    @action(detail=True, methods=["GET"], url_path="influx-data")
+    @action(
+        detail=True,
+        methods=["GET"],
+        url_path="influx-data",
+        throttle_classes=[InfluxQueryThrottle],
+    )
     def get_influx_data(self, request, pk):  # type: ignore[no-untyped-def]
         filters = InfluxDataQuerySerializer(data=request.query_params)
         filters.is_valid(raise_exception=True)

--- a/api/tests/integration/app_analytics/test_influx_query_throttle.py
+++ b/api/tests/integration/app_analytics/test_influx_query_throttle.py
@@ -1,0 +1,35 @@
+from django.urls import reverse
+from pytest_mock import MockerFixture
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+def test_influx_data_endpoint_is_throttled(
+    admin_client: APIClient,
+    organisation: int,
+    mocker: MockerFixture,
+    reset_cache: None,
+) -> None:
+    # Given
+    mocker.patch(
+        "app_analytics.throttles.InfluxQueryThrottle.get_rate", return_value="1/minute"
+    )
+    mocker.patch(
+        "organisations.views.get_multiple_event_list_for_organisation", return_value=[]
+    )
+
+    url = reverse(
+        "api-v1:organisations:organisation-get-influx-data",
+        args=[organisation],
+    )
+
+    # When - first request should be successful
+    first_response = admin_client.get(url)
+    second_response = admin_client.get(url)
+
+    # Then
+    # The first response should have been successful
+    assert first_response.status_code == status.HTTP_200_OK
+
+    # But the second request should have been throttled
+    assert second_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS


### PR DESCRIPTION
## Changes

Add throttling for endpoints that trigger queries to InfluxDB. 

## How did you test this code?

Added test for throttling behaviour. 
