### PR TITLE
fix(e2e): increase wait time before Try It button click

### DIFF
--- a/frontend/e2e/tests/flag-tests.ts
+++ b/frontend/e2e/tests/flag-tests.ts
@@ -46,7 +46,7 @@ export default async function () {
   await toggleFeature(0, true)
 
   log('Try it')
-  await t.wait(500)
+  await t.wait(2000)
   await click('#try-it-btn')
   await t.wait(500)
   let json = await parseTryItResults()


### PR DESCRIPTION
## Summary
- Fixes failing Flag E2E test after RTK Query migration
- Increases wait time from 500ms to 2000ms before clicking "Try It" button
- The RTK Query migration introduced async refetches that need more time to settle after toggling a feature

## Test plan
- [x] Run the Flag E2E test locally to verify it passes
- [x] CI E2E tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)