### PR TITLE
feat: improve segment feature association

### DIFF
--- a/frontend/web/components/ConnectedFeatureOverrideRow.tsx
+++ b/frontend/web/components/ConnectedFeatureOverrideRow.tsx
@@ -1,0 +1,104 @@
+import React, { FC } from 'react'
+import { useGetProjectFlagQuery } from 'common/services/useProjectFlag'
+import { useGetFeatureStatesQuery } from 'common/services/useFeatureState'
+import FeatureOverrideRow from './feature-override/FeatureOverrideRow'
+import Utils from 'common/utils/utils'
+
+type ConnectedFeatureOverrideRowProps = {
+  featureId: number
+  projectId: number
+  environmentId: string
+  environmentIdNumeric: number
+  segmentId: number
+  shouldPreselect?: boolean
+  level?: 'segment' | 'identity'
+  index: number
+  openInNewTab?: boolean
+}
+
+const ConnectedFeatureOverrideRow: FC<ConnectedFeatureOverrideRowProps> = ({
+  environmentId,
+  environmentIdNumeric,
+  featureId,
+  index,
+  level = 'segment',
+  openInNewTab = false,
+  projectId,
+  segmentId,
+  shouldPreselect,
+}) => {
+  const { data: projectFlag, isLoading: flagLoading } = useGetProjectFlagQuery({
+    id: featureId,
+    project: projectId,
+  })
+
+  const { data: featureStates, isLoading: statesLoading } =
+    useGetFeatureStatesQuery({
+      environment: environmentIdNumeric,
+      feature: featureId,
+    })
+
+  if (flagLoading || statesLoading || !projectFlag || !featureStates) {
+    return (
+      <div className='list-item py-3'>
+        <Loader />
+      </div>
+    )
+  }
+
+  const _environmentFeatureState = featureStates.results.find(
+    (fs) => !fs.feature_segment,
+  )
+  const _segmentFeatureState = featureStates.results.find(
+    (fs) => fs.feature_segment?.segment === segmentId,
+  )
+  const environmentFeatureState = _environmentFeatureState
+    ? {
+        ..._environmentFeatureState,
+        feature_state_value: Utils.featureStateToValue(
+          _environmentFeatureState.feature_state_value,
+        ),
+      }
+    : _environmentFeatureState
+  const segmentFeatureState = _segmentFeatureState
+    ? {
+        ..._segmentFeatureState,
+        feature_state_value: Utils.featureStateToValue(
+          _segmentFeatureState.feature_state_value,
+        ),
+      }
+    : _segmentFeatureState
+
+  const handleClick = () => {
+    if (openInNewTab) {
+      window.open(
+        `/project/${projectId}/environment/${environmentId}/features?feature=${featureId}`,
+        '_blank',
+      )
+    }
+  }
+
+  if (!environmentFeatureState) {
+    return null
+  }
+  return (
+    <div
+      className='rounded border-1'
+      onClick={openInNewTab ? handleClick : undefined}
+    >
+      <FeatureOverrideRow
+        shouldPreselect={shouldPreselect}
+        environmentId={environmentId}
+        level={level}
+        valueDataTest={`user-feature-value-${index}`}
+        projectFlag={projectFlag}
+        dataTest={`user-feature-${index}`}
+        overrideFeatureState={segmentFeatureState || environmentFeatureState}
+        environmentFeatureState={environmentFeatureState}
+        highlightSegmentId={segmentId}
+      />
+    </div>
+  )
+}
+
+export default ConnectedFeatureOverrideRow

--- a/frontend/web/components/feature-override/FeatureOverrideRow.tsx
+++ b/frontend/web/components/feature-override/FeatureOverrideRow.tsx
@@ -210,7 +210,10 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
     permission,
     tags: projectFlag.tags,
   })
-  const showDefaultsHint = viewMode === 'default' && !hasAnyOverride
+
+  const hasSegmentOverride = level === 'segment' && !!overrideFeatureState?.feature_segment
+  const showDefaultsHint = viewMode === 'default' && !hasAnyOverride && !hasSegmentOverride
+  const shouldHighlight = hasAnyOverride || hasSegmentOverride
 
   const showMultivariateOverride = useMemo(() => {
     if (hasUserOverride || !hasValueDiff) return false
@@ -227,8 +230,8 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
   return (
     <div
       className={classNames('flex-row space list-item clickable py-2', {
-        'bg-primary-opacity-5': hasAnyOverride,
-        'list-item-xs': isCompact && !hasAnyOverride,
+        'bg-primary-opacity-5': shouldHighlight,
+        'list-item-xs': isCompact && !shouldHighlight,
       })}
       key={featureId}
       data-test={dataTest}
@@ -260,6 +263,11 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
                 controlEnabled={flagEnabled}
                 controlValue={flagValue}
               />
+            )}
+            {hasSegmentOverride && !hasAnyOverride && (
+              <div className='list-item-subtitle'>
+                This feature is being overridden for this segment
+              </div>
             )}
             {showDefaultsHint && (
               <div className='list-item-subtitle'>

--- a/frontend/web/components/feature-override/FeatureOverrideRow.tsx
+++ b/frontend/web/components/feature-override/FeatureOverrideRow.tsx
@@ -50,6 +50,7 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
   dataTest,
   environmentFeatureState,
   environmentId,
+  highlightSegmentId,
   identifier,
   identity,
   identityName,
@@ -59,7 +60,6 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
   shouldPreselect,
   toggleDataTest,
   valueDataTest,
-  highlightSegmentId,
 }) => {
   const hasUserOverride =
     !!overrideFeatureState?.identity ||
@@ -181,6 +181,9 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
     }
   }, [shouldPreselect, onClick])
 
+  const hasSegmentOverride =
+    level === 'segment' && !!overrideFeatureState?.feature_segment
+
   const { hasAnyOverride, hasEnabledDiff, hasValueDiff } = useMemo(() => {
     const enabledDiff = overrideFeatureState
       ? actualEnabled !== flagEnabled
@@ -189,7 +192,8 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
       ? !featureValuesEqual(actualValue, flagValue)
       : false
     return {
-      hasAnyOverride: enabledDiff || valueDiff || hasUserOverride,
+      hasAnyOverride:
+        enabledDiff || valueDiff || hasUserOverride || hasSegmentOverride,
       hasEnabledDiff: enabledDiff,
       hasValueDiff: valueDiff,
     }
@@ -200,6 +204,7 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
     flagEnabled,
     flagValue,
     hasUserOverride,
+    hasSegmentOverride,
   ])
 
   const { permission, permissionDescription } =
@@ -211,9 +216,7 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
     tags: projectFlag.tags,
   })
 
-  const hasSegmentOverride = level === 'segment' && !!overrideFeatureState?.feature_segment
-  const showDefaultsHint = viewMode === 'default' && !hasAnyOverride && !hasSegmentOverride
-  const shouldHighlight = hasAnyOverride || hasSegmentOverride
+  const showDefaultsHint = viewMode === 'default' && !hasAnyOverride
 
   const showMultivariateOverride = useMemo(() => {
     if (hasUserOverride || !hasValueDiff) return false
@@ -230,8 +233,8 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
   return (
     <div
       className={classNames('flex-row space list-item clickable py-2', {
-        'bg-primary-opacity-5': shouldHighlight,
-        'list-item-xs': isCompact && !shouldHighlight,
+        'bg-primary-opacity-5': hasAnyOverride,
+        'list-item-xs': isCompact && !hasAnyOverride,
       })}
       key={featureId}
       data-test={dataTest}
@@ -259,15 +262,10 @@ const FeatureOverrideRow: FC<FeatureOverrideRowProps> = ({
               <SegmentOverrideDescription
                 level={level}
                 showEnabledOverride={hasEnabledDiff}
-                showValueOverride={!hasEnabledDiff}
+                showValueOverride={!hasEnabledDiff && hasValueDiff}
                 controlEnabled={flagEnabled}
                 controlValue={flagValue}
               />
-            )}
-            {hasSegmentOverride && !hasAnyOverride && (
-              <div className='list-item-subtitle'>
-                This feature is being overridden for this segment
-              </div>
             )}
             {showDefaultsHint && (
               <div className='list-item-subtitle'>

--- a/frontend/web/components/feature-override/SegmentOverrideDescription.tsx
+++ b/frontend/web/components/feature-override/SegmentOverrideDescription.tsx
@@ -18,6 +18,18 @@ const SegmentOverrideDescription: FC<SegmentOverrideDescriptionType> = ({
   showEnabledOverride,
   showValueOverride,
 }) => {
+  // If neither enabled nor value override is shown, show a generic message
+  if (!showEnabledOverride && !showValueOverride) {
+    return (
+      <span className='d-flex list-item-subtitle text-primary align-items-center'>
+        <SegmentsIcon className='me-1' width={16} fill='#6837fc' />
+        {`This feature is being overridden by ${
+          level === 'segment' ? 'this segment' : 'a segment'
+        }${level === 'identity' ? ' for this user' : ''}`}
+      </span>
+    )
+  }
+
   return (
     <>
       {showEnabledOverride && (
@@ -26,13 +38,13 @@ const SegmentOverrideDescription: FC<SegmentOverrideDescriptionType> = ({
             <Flex>
               <span className='list-item-subtitle d-flex text-primary align-items-center'>
                 <SegmentsIcon className='me-1' width={16} fill='#6837fc' />
-                {`This flag is being overridden by ${
-                  level === 'segment' ? 'this' : 'a'
-                } segment and would normally be`}
+                {`This feature is being overridden by ${
+                  level === 'segment' ? 'this segment' : 'a segment'
+                } and would normally be`}
                 <div className='ph-1 ml-1 mr-1 fw-semibold'>
                   {controlEnabled ? 'on' : 'off'}
-                </div>{' '}
-                {level === 'identity' ? 'for this user' : ''}
+                </div>
+                {level === 'identity' ? ' for this user' : ''}
               </span>
             </Flex>
           </Row>
@@ -41,13 +53,15 @@ const SegmentOverrideDescription: FC<SegmentOverrideDescriptionType> = ({
       {showValueOverride && (
         <span className='d-flex list-item-subtitle text-primary align-items-center'>
           <SegmentsIcon className='me-1' width={16} fill='#6837fc' />
-          {`This feature is being overridden by a segment and would normally be`}
+          {`This feature is being overridden by ${
+            level === 'segment' ? 'this segment' : 'a segment'
+          } and would normally be`}
           <FeatureValue
             className='ml-1 chip--xs'
             includeEmpty
             value={`${controlValue}`}
-          />{' '}
-          {level === 'identity' ? 'for this user' : ''}
+          />
+          {level === 'identity' ? ' for this user' : ''}
         </span>
       )}
     </>

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -534,7 +534,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               />
             </div>
           </TabItem>
-          <TabItem tabLabel='Features'>
+          <TabItem tabLabel={segment.feature ? 'Feature' : 'Features'}>
             <div className='my-4'>
               <AssociatedSegmentOverrides
                 projectId={projectId as number}

--- a/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
+++ b/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
@@ -118,17 +118,9 @@ const CreateSegmentRulesTabForm: React.FC<CreateSegmentRulesTabFormProps> = ({
 
   return (
     <form id='create-segment-modal' onSubmit={save}>
-      {!condensed && (
+      {!condensed && segmentsLimitAlert.percentage && (
         <div className='mt-3'>
-          <InfoMessage collapseId={'value-type-conversions'}>
-            Learn more about rule and trait value type conversions{' '}
-            <a href='https://docs.flagsmith.com/basic-features/segments#rule-typing'>
-              here
-            </a>
-            .
-          </InfoMessage>
-          {segmentsLimitAlert.percentage &&
-            Utils.displayLimitAlert('segments', segmentsLimitAlert.percentage)}
+          {Utils.displayLimitAlert('segments', segmentsLimitAlert.percentage)}
         </div>
       )}
 
@@ -195,10 +187,17 @@ const CreateSegmentRulesTabForm: React.FC<CreateSegmentRulesTabFormProps> = ({
           <label className='cols-sm-2 control-label mb-1'>
             Include users when all of the following rules apply:
           </label>
-          <span className='fs-caption text-faint'>
-            Note: Trait names are case sensitive
-          </span>
         </Flex>
+        {!condensed && (
+          <InfoMessage collapseId={'value-type-conversions'} className='mb-3'>
+            Trait names are case sensitive. Learn more about rule and trait
+            value type conversions{' '}
+            <a href='https://docs.flagsmith.com/basic-features/segments#rule-typing'>
+              here
+            </a>
+            .
+          </InfoMessage>
+        )}
         {allWarnings?.map((warning, i) => (
           <InfoMessage key={i}>
             <div dangerouslySetInnerHTML={{ __html: warning }} />

--- a/frontend/web/components/segments/AssociatedSegmentOverrides.tsx
+++ b/frontend/web/components/segments/AssociatedSegmentOverrides.tsx
@@ -17,6 +17,7 @@ import { useHistory } from 'react-router-dom'
 import { Environment } from 'common/types/responses'
 import { useGetSegmentQuery } from 'common/services/useSegment'
 import PageTitle from 'components/PageTitle'
+import ConnectedFeatureOverrideRow from 'components/ConnectedFeatureOverrideRow'
 
 type AssociatedSegmentOverridesType = {
   projectId: number
@@ -43,6 +44,7 @@ const AssociatedSegmentOverrides: FC<AssociatedSegmentOverridesType> = ({
     },
   )
 
+  // For regular segments, fetch all flags with segment overrides
   const {
     data: projectFlags,
     isFetching: projectFlagsFetching,
@@ -55,7 +57,7 @@ const AssociatedSegmentOverrides: FC<AssociatedSegmentOverridesType> = ({
       segment: segmentId,
     },
     {
-      skip: !projectId || !environment || !segmentId,
+      skip: !projectId || !environment || !segmentId || !!segment?.feature,
     },
   )
 
@@ -73,6 +75,52 @@ const AssociatedSegmentOverrides: FC<AssociatedSegmentOverridesType> = ({
       setEnvironment(environments.results[0])
     }
   }, [environment, environments])
+
+  // Render the feature-specific segment view
+  if (segment?.feature && environment) {
+    return (
+      <>
+        <div>
+          <PageTitle
+            title={
+              <div className='d-flex gap-4'>
+                Associated Feature
+                <div style={{ width: 200 }}>
+                  <EnvironmentSelect
+                    showAll={false}
+                    value={environment?.api_key}
+                    projectId={projectId}
+                    onChange={(id) =>
+                      setEnvironment(
+                        environments?.results?.find((e) => e.api_key === id),
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            }
+          >
+            This feature is specifically associated with the segment{' '}
+            <strong className='text-primary'>{segment?.name}</strong>.
+          </PageTitle>
+        </div>
+        <div className='panel panel-without-heading no-pad overflow-visible'>
+          <ConnectedFeatureOverrideRow
+            featureId={segment.feature}
+            projectId={projectId}
+            environmentId={environment.api_key}
+            environmentIdNumeric={environment.id}
+            segmentId={segmentId!}
+            shouldPreselect={false}
+            index={0}
+            openInNewTab
+          />
+        </div>
+      </>
+    )
+  }
+
+  // Render the regular segment features list
   return (
     <>
       <div>

--- a/frontend/web/components/segments/AssociatedSegmentOverrides.tsx
+++ b/frontend/web/components/segments/AssociatedSegmentOverrides.tsx
@@ -120,7 +120,6 @@ const AssociatedSegmentOverrides: FC<AssociatedSegmentOverridesType> = ({
     )
   }
 
-  // Render the regular segment features list
   return (
     <>
       <div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/6474
Closes https://github.com/Flagsmith/flagsmith/issues/6473

- Feature-specific segments will now only show the feature that is relevant, it will open the feature in a new tab since removing segment overrides from here would push it into a weird state
- Segment overrides that appear to the be the same as environment defaults will now highlight

<img width="1285" height="393" alt="image" src="https://github.com/user-attachments/assets/e63ccce9-8d9b-4080-83e4-d110b8d39356" />

<img width="1247" height="392" alt="image" src="https://github.com/user-attachments/assets/e08a9ddc-59a3-4f1a-bccf-65b5c8247197" />
