### PR TITLE
feat(deploy): add SDK service to ECS deployment pipeline

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -18,6 +18,9 @@ inputs:
   aws_ecs_service_name:
     description: The name of the ECS service to deploy to.
     required: true
+  aws_ecs_sdk_service_name:
+    description: The name of the SDK ECS service to deploy to.
+    required: true
   aws_vpc_subnet_id:
     description: The id of the AWS VPC subnet to use for running migration tasks.
     required: true
@@ -97,6 +100,13 @@ runs:
         service: ${{ inputs.aws_ecs_service_name }}
         task-definition: ${{ steps.task-def-api.outputs.task-definition }}
 
+    - name: Deploy Amazon ECS SDK service task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        cluster: ${{ inputs.aws_ecs_cluster_name }}
+        service: ${{ inputs.aws_ecs_sdk_service_name }}
+        task-definition: ${{ steps.task-def-api.outputs.task-definition }}
+
     # The DynamoDB Identity Migrator uses the same task definition as the SQL schema migrator but overrides the container definition
     # with the new django execute target
     - name: Update Identity migrate rule with target
@@ -136,8 +146,8 @@ runs:
                 ]'
       shell: bash
 
-    - name: Wait for service to be stable
-      run:
-        aws ecs wait services-stable --cluster ${{ inputs.aws_ecs_cluster_name }} --services ${{
-        inputs.aws_ecs_service_name }}
+    - name: Wait for services to be stable
+      run: |
+        aws ecs wait services-stable --cluster ${{ inputs.aws_ecs_cluster_name }} --services ${{ inputs.aws_ecs_service_name }}
+        aws ecs wait services-stable --cluster ${{ inputs.aws_ecs_cluster_name }} --services ${{ inputs.aws_ecs_sdk_service_name }}
       shell: bash

--- a/.github/workflows/.reusable-deploy-ecs.yml
+++ b/.github/workflows/.reusable-deploy-ecs.yml
@@ -84,6 +84,7 @@ jobs:
           aws_ecs_cluster_name: ${{ vars.AWS_ECS_CLUSTER_NAME }}
           aws_ecs_cluster_arn: ${{ vars.AWS_ECS_CLUSTER_ARN }}
           aws_ecs_service_name: ${{ vars.AWS_ECS_SERVICE_NAME }}
+          aws_ecs_sdk_service_name: ${{ vars.AWS_ECS_SDK_SERVICE_NAME }}
           aws_vpc_subnet_id: ${{ vars.AWS_VPC_SUBNET_ID }}
           aws_ecs_security_group_id: ${{ vars.AWS_ECS_SECURITY_GROUP_ID }}
           aws_identity_migration_event_bus_name: ${{ vars.AWS_IDENTITY_MIGRATION_EVENT_BUS_NAME }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add deployment of SDK ECS service alongside the main API service. Both services share the same task definition family (`flagsmith-api`) and are deployed sequentially.

- Add `aws_ecs_sdk_service_name` input to `api-deploy-ecs` action
- Add SDK service deployment step using same task definition
- Update wait step to wait for both services to stabilize
- Pass new input from reusable workflow

**Manual Steps Required (Post-Merge):**
Configure GitHub Environment Variables in repository settings:
- **Staging environment**: Set `AWS_ECS_SDK_SERVICE_NAME` to the appropriate value
- **Production environment**: Set `AWS_ECS_SDK_SERVICE_NAME` to the appropriate value

## How did you test this code?

- Verified GitHub Actions workflow YAML syntax
- Deployment will be tested after adding environment variables to staging/production environments