### PR TITLE
fix: inconsistent Capitalization for Badges - capitalized beta badge

### DIFF
--- a/frontend/web/components/BetaFlag.tsx
+++ b/frontend/web/components/BetaFlag.tsx
@@ -18,7 +18,7 @@ const BetaFlag: FC<BetaFlagType> = ({ children, flagName }) => {
         <div>
           <a className='chip cursor-pointer chip--xs d-flex align-items-center fw-semibold text-white bg-primary900'>
             {<IonIcon className='me-1' icon={rocket} />}
-            beta
+            Beta
           </a>
         </div>
       )}


### PR DESCRIPTION
Bug Fix (6480) - Inconsistent Capitalization for Badges - capitalized beta badge

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/6480
Capitalized the text "Beta" in BetaFlag.tsx.


<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->


## How did you test this code?

Manually. 
Go to settings, view badges
