### PR TITLE
fix(deploy): use same task definition for API and SDK services

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -94,18 +94,20 @@ runs:
       shell: bash
 
     - name: Deploy Amazon ECS web task definition
+      id: deploy-api-task-def
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         cluster: ${{ inputs.aws_ecs_cluster_name }}
         service: ${{ inputs.aws_ecs_service_name }}
         task-definition: ${{ steps.task-def-api.outputs.task-definition }}
 
-    - name: Deploy Amazon ECS SDK service task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-      with:
-        cluster: ${{ inputs.aws_ecs_cluster_name }}
-        service: ${{ inputs.aws_ecs_sdk_service_name }}
-        task-definition: ${{ steps.task-def-api.outputs.task-definition }}
+    - name: Deploy Amazon ECS SDK service with same task definition
+      run: |
+        aws ecs update-service \
+          --cluster ${{ inputs.aws_ecs_cluster_name }} \
+          --service ${{ inputs.aws_ecs_sdk_service_name }} \
+          --task-definition ${{ steps.deploy-api-task-def.outputs.task-definition-arn }}
+      shell: bash
 
     # The DynamoDB Identity Migrator uses the same task definition as the SQL schema migrator but overrides the container definition
     # with the new django execute target


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fix bug where API and SDK ECS services were using different task definition revisions.

**Problem:** The `amazon-ecs-deploy-task-definition` action registers a new task definition revision each time it's called. When called twice (once for API, once for SDK), the SDK service ended up with revision N+1 while API had revision N.

**Solution:** 
- Add an ID to the API deploy step to capture the registered task definition ARN
- Use `aws ecs update-service` for the SDK service with the same ARN instead of calling the deploy action again

Now both services use the exact same task definition revision.

## How did you test this code?

- By Triggering deployment here: https://github.com/Flagsmith/flagsmith/actions/runs/20809860720/job/59771357163