### PR TITLE
infra: Set per-user rate limit to 500/min for Admin API

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -147,7 +147,7 @@
                 },
                 {
                     "name": "USER_THROTTLE_RATE",
-                    "value": "20/sec"
+                    "value": "500/min"
                 },
                 {
                     "name": "OAUTH_CLIENT_ID",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

This relaxes the 20/sec throttle limit we deployed initially to 500/minute.

Note that this PR doesn't warrant a release; it's mirroring the already applied task definition.

## How did you test this code?

This task definition works in prod.
