### PR TITLE
fix: handle intermittent redis connection failures in throttling logic

### DIFF
--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -1,7 +1,21 @@
 from django.conf import settings
 from django.core.cache import caches
+from redis.exceptions import RedisClusterException
 from rest_framework import throttling
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 
 class UserRateThrottle(throttling.UserRateThrottle):
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
+
+    def allow_request(
+        self, request: Request, view: APIView
+    ) -> bool:  # pragma: no cover
+        try:
+            return super(UserRateThrottle, self).allow_request(request, view)
+        except RedisClusterException:
+            # Handle intermittent redis connection failures.
+            # Allow the request without calling throttle_success which
+            # would also try to establish a connection to Redis.
+            return True

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -1,16 +1,20 @@
+import typing
+
 from django.conf import settings
 from django.core.cache import caches
 from redis.exceptions import RedisClusterException
 from rest_framework import throttling
-from rest_framework.request import Request
-from rest_framework.views import APIView
+
+if typing.TYPE_CHECKING:
+    from rest_framework.request import Request
+    from rest_framework.views import APIView
 
 
 class UserRateThrottle(throttling.UserRateThrottle):
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
 
     def allow_request(
-        self, request: Request, view: APIView
+        self, request: "Request", view: "APIView"
     ) -> bool:  # pragma: no cover
         try:
             return super(UserRateThrottle, self).allow_request(request, view)


### PR DESCRIPTION
## Changes

'Fixes' [this sentry issue](https://flagsmith.sentry.io/issues/6771071554/) by just handling the redis connection exception and blindly allowing the request instead. 

## How did you test this code?

N/a - this is only some fallback logic based on an intermittent exception that we can only reproduce in production. 
