### PR TITLE
feat(redis): enable read_from_replicas for Redis Cluster by default

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -852,6 +852,12 @@ DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = env.bool(
     "DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS", True
 )
 
+# Enable reading from replicas in Redis Cluster mode.
+# Distributes read traffic to replica nodes (port 6380 on ElastiCache Serverless).
+REDIS_CLUSTER_READ_FROM_REPLICAS = env.bool(
+    "REDIS_CLUSTER_READ_FROM_REPLICAS", default=True
+)
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",

--- a/api/core/redis_cluster.py
+++ b/api/core/redis_cluster.py
@@ -24,6 +24,7 @@ Include the following configuration in Django project's settings.py file:
 import threading
 from copy import deepcopy
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django_redis.client.default import DefaultClient  # type: ignore[import-untyped]
 from django_redis.exceptions import (  # type: ignore[import-untyped]
@@ -125,6 +126,9 @@ class ClusterConnectionFactory(ConnectionFactory):  # type: ignore[misc]
             # Add explicit socket timeout
             client_cls_kwargs["socket_timeout"] = SOCKET_TIMEOUT
             client_cls_kwargs["socket_keepalive"] = True
+            client_cls_kwargs["read_from_replicas"] = (
+                settings.REDIS_CLUSTER_READ_FROM_REPLICAS
+            )
             # ... and then build and return the client
             return RedisCluster(**client_cls_kwargs)  # type: ignore[abstract]
         except Exception as e:

--- a/api/tests/unit/core/test_redis_cluster.py
+++ b/api/tests/unit/core/test_redis_cluster.py
@@ -2,6 +2,7 @@ import pytest
 from django_redis.exceptions import (  # type: ignore[import-untyped]
     ConnectionInterrupted,
 )
+from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 from redis.exceptions import RedisClusterException
 
@@ -42,8 +43,10 @@ def test_cluster_connection_factory__connect_cache(mocker: MockerFixture):  # ty
 
 def test_cluster_connection_factory__get_connection_with_non_conflicting_params(  # type: ignore[no-untyped-def]
     mocker: MockerFixture,
+    settings: SettingsWrapper,
 ):
     # Given
+    settings.REDIS_CLUSTER_READ_FROM_REPLICAS = False
     mockRedisCluster = mocker.patch("core.redis_cluster.RedisCluster")
     connection_factory = ClusterConnectionFactory(
         options={"REDIS_CLIENT_KWARGS": {"decode_responses": False}}
@@ -60,6 +63,7 @@ def test_cluster_connection_factory__get_connection_with_non_conflicting_params(
         port=6379,
         socket_keepalive=True,
         socket_timeout=0.2,
+        read_from_replicas=False,
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds `REDIS_CLUSTER_READ_FROM_REPLICAS` setting (default: `True`) to enable reading from Redis Cluster replica nodes.

This improves performance with ElastiCache Serverless by utilizing the reader endpoint on port 6380, distributing read traffic to replica nodes for better scalability and lower latency.

AWS best practices recommend this approach:
> Read from replicas – If you are using ElastiCache serverless or have provisioned read replicas (node-based clusters), direct reads to replicas to achieve better scalability and/or lower latency. Reads from replicas are eventually consistent with the primary.

Ref: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WorkingWithRedis.html

## How did you test this code?

- Unit tests added and passing
- Verified `env.bool()` correctly parses the environment variable
- Verified the setting is passed through to `RedisCluster` client via `read_from_replicas` kwarg