### PR TITLE
perf(code-references): skip expensive annotation for projects without scans

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -156,7 +156,9 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         query_serializer.is_valid(raise_exception=True)
         query_data = query_serializer.validated_data
 
-        queryset = annotate_feature_queryset_with_code_references_summary(queryset)
+        queryset = annotate_feature_queryset_with_code_references_summary(
+            queryset, project.id
+        )
 
         queryset = self._filter_queryset(queryset)
 

--- a/api/projects/code_references/services.py
+++ b/api/projects/code_references/services.py
@@ -2,7 +2,17 @@ from datetime import timedelta
 from urllib.parse import urljoin
 
 from django.contrib.postgres.expressions import ArraySubquery
-from django.db.models import BooleanField, F, Func, OuterRef, QuerySet, Subquery, Value
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import (
+    BooleanField,
+    F,
+    Func,
+    JSONField,
+    OuterRef,
+    QuerySet,
+    Subquery,
+    Value,
+)
 from django.db.models.functions import JSONObject
 from django.utils import timezone
 
@@ -37,7 +47,9 @@ def annotate_feature_queryset_with_code_references_summary(
     ).exists()
 
     if not has_scans:
-        return queryset
+        return queryset.annotate(
+            code_references_counts=Value([], output_field=ArrayField(JSONField()))
+        )
     last_feature_found_at = (
         FeatureFlagCodeReferencesScan.objects.annotate(
             feature_name=OuterRef("feature_name"),

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3672,7 +3672,7 @@ def test_FeatureViewSet_list__no_scans__returns_empty_code_references_counts(
     with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
     # Given - project has no code reference scans
-    with_project_permissions([VIEW_PROJECT])
+    with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
 
     # When
     response = staff_client.get(

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3664,6 +3664,29 @@ def test_FeatureViewSet_list__includes_code_references_counts(
     ]
 
 
+def test_FeatureViewSet_list__no_scans__returns_empty_code_references_counts(
+    staff_client: APIClient,
+    project: Project,
+    feature: Feature,
+    environment: Environment,
+    with_project_permissions: WithProjectPermissionsCallable,
+) -> None:
+    # Given - project has no code reference scans
+    with_project_permissions([VIEW_PROJECT])
+
+    # When
+    response = staff_client.get(
+        f"/api/v1/projects/{project.id}/features/?environment={environment.id}"
+    )
+
+    # Then - response should include code_references_counts as empty list
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert "code_references_counts" in results[0]
+    assert results[0]["code_references_counts"] == []
+
+
 def test_simple_feature_state_returns_only_latest_versions(
     staff_client: APIClient,
     staff_user: FFAdminUser,

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3117,7 +3117,7 @@ def test_list_features_n_plus_1_without_rbac(
         with_project_permissions,
         django_assert_num_queries,
         environment,
-        num_queries=17,
+        num_queries=18,
     )
 
 
@@ -3140,7 +3140,7 @@ def test_list_features_n_plus_1_with_rbac(
         with_project_permissions,
         django_assert_num_queries,
         environment,
-        num_queries=18,
+        num_queries=19,
     )
 
 
@@ -3737,7 +3737,7 @@ def test_feature_list_last_modified_values_without_rbac(
         feature,
         with_project_permissions,
         django_assert_num_queries,
-        num_queries=19,
+        num_queries=20,
     )
 
 
@@ -3763,7 +3763,7 @@ def test_feature_list_last_modified_values_with_rbac(
         feature,
         with_project_permissions,
         django_assert_num_queries,
-        num_queries=20,
+        num_queries=21,
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds early exit to `annotate_feature_queryset_with_code_references_summary()` that checks if any code reference scans exist for the project before running expensive `jsonb_path_query_array` and `jsonb_path_exists` queries.

For projects without code reference scans (the majority), this skips the expensive JSON path annotation entirely, trading one cheap `.exists()` query for the expensive annotation queries.

## How did you test this code?

- Existing N+1 query tests updated and passing
- Manual verification that endpoint skips expensive queries for projects without scans