### PR TITLE
feat(throttling): Throttle only requests authorised by master API keys

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -303,6 +303,7 @@ TASK_PROCESSOR_DATABASES = env.list(
 LOGIN_THROTTLE_RATE = env("LOGIN_THROTTLE_RATE", "20/min")
 SIGNUP_THROTTLE_RATE = env("SIGNUP_THROTTLE_RATE", "10000/min")
 USER_THROTTLE_RATE = env("USER_THROTTLE_RATE", "500/min")
+MASTER_API_KEY_THROTTLE_RATE = env("MASTER_API_KEY_THROTTLE_RATE", USER_THROTTLE_RATE)
 DEFAULT_THROTTLE_CLASSES = env.list("DEFAULT_THROTTLE_CLASSES", subcast=str, default=[])
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
@@ -318,6 +319,7 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "login": LOGIN_THROTTLE_RATE,
         "signup": SIGNUP_THROTTLE_RATE,
+        "master_api_key": MASTER_API_KEY_THROTTLE_RATE,
         "mfa_code": "5/min",
         "invite": "10/min",
         "user": USER_THROTTLE_RATE,

--- a/api/app/settings/test.py
+++ b/api/app/settings/test.py
@@ -11,6 +11,7 @@ REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
     "invite": "10/min",
     "signup": "100/min",
     "user": "100000/day",
+    "master_api_key": "100000/day",
     "influx_query": "50/min",
 }
 

--- a/api/app/settings/test.py
+++ b/api/app/settings/test.py
@@ -4,9 +4,7 @@ from app.settings.common import REST_FRAMEWORK
 # We dont want to track tests
 ENABLE_TELEMETRY = False
 MAX_PROJECTS_IN_FREE_PLAN = 10
-REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
-    "core.throttling.MasterAPIKeyUserRateThrottle"
-]
+REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = ["core.throttling.UserRateThrottle"]
 REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
     "login": "100/min",
     "mfa_code": "5/min",

--- a/api/app/settings/test.py
+++ b/api/app/settings/test.py
@@ -4,7 +4,9 @@ from app.settings.common import REST_FRAMEWORK
 # We dont want to track tests
 ENABLE_TELEMETRY = False
 MAX_PROJECTS_IN_FREE_PLAN = 10
-REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = ["core.throttling.UserRateThrottle"]
+REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
+    "core.throttling.MasterAPIKeyUserRateThrottle"
+]
 REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
     "login": "100/min",
     "mfa_code": "5/min",

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -5,14 +5,21 @@ from django.core.cache import caches
 from rest_framework import throttling
 from rest_framework.request import Request
 
+from api_keys.user import APIKeyUser
+
 if TYPE_CHECKING:
     from rest_framework.views import APIView
+
+
+class UserRateThrottle(throttling.UserRateThrottle):
+    cache = caches[settings.USER_THROTTLE_CACHE_NAME]
 
 
 class MasterAPIKeyUserRateThrottle(throttling.UserRateThrottle):
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
 
-    def allow_request(self, request: Request, view: "APIView") -> bool:
-        if not getattr(request.user, "is_master_api_key_user", False):
-            return True
-        return super().allow_request(request, view)
+    def get_cache_key(self, request: Request, view: "APIView") -> str | None:
+        if getattr(request.user, "is_master_api_key_user", False):
+            assert isinstance(request.user, APIKeyUser)
+            return str(request.user.key.id)
+        return None

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -1,7 +1,18 @@
+from typing import TYPE_CHECKING
+
 from django.conf import settings
 from django.core.cache import caches
 from rest_framework import throttling
+from rest_framework.request import Request
+
+if TYPE_CHECKING:
+    from rest_framework.views import APIView
 
 
-class UserRateThrottle(throttling.UserRateThrottle):
+class MasterAPIKeyUserRateThrottle(throttling.UserRateThrottle):
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
+
+    def allow_request(self, request: Request, view: "APIView") -> bool:
+        if not getattr(request.user, "is_master_api_key_user", False):
+            return True
+        return super().allow_request(request, view)

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -15,7 +15,8 @@ class UserRateThrottle(throttling.UserRateThrottle):
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
 
 
-class MasterAPIKeyUserRateThrottle(throttling.UserRateThrottle):
+class MasterAPIKeyUserRateThrottle(throttling.SimpleRateThrottle):
+    scope = "master_api_key"
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
 
     def get_cache_key(self, request: "Request", view: "APIView") -> str | None:

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -23,6 +23,6 @@ class MasterAPIKeyUserRateThrottle(throttling.UserRateThrottle):
             assert isinstance(request.user, APIKeyUser)
             return self.cache_format % {
                 "scope": self.scope,
-                "ident": str(request.user.api_key.id),
+                "ident": str(request.user.key.id),
             }
         return None

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -21,5 +21,8 @@ class MasterAPIKeyUserRateThrottle(throttling.UserRateThrottle):
     def get_cache_key(self, request: Request, view: "APIView") -> str | None:
         if getattr(request.user, "is_master_api_key_user", False):
             assert isinstance(request.user, APIKeyUser)
-            return str(request.user.key.id)
+            return self.cache_format % {
+                "scope": self.scope,
+                "ident": str(request.user.api_key.id),
+            }
         return None

--- a/api/core/throttling.py
+++ b/api/core/throttling.py
@@ -3,11 +3,11 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.core.cache import caches
 from rest_framework import throttling
-from rest_framework.request import Request
 
 from api_keys.user import APIKeyUser
 
 if TYPE_CHECKING:
+    from rest_framework.request import Request
     from rest_framework.views import APIView
 
 
@@ -18,7 +18,7 @@ class UserRateThrottle(throttling.UserRateThrottle):
 class MasterAPIKeyUserRateThrottle(throttling.UserRateThrottle):
     cache = caches[settings.USER_THROTTLE_CACHE_NAME]
 
-    def get_cache_key(self, request: Request, view: "APIView") -> str | None:
+    def get_cache_key(self, request: "Request", view: "APIView") -> str | None:
         if getattr(request.user, "is_master_api_key_user", False):
             assert isinstance(request.user, APIKeyUser)
             return self.cache_format % {

--- a/api/tests/integration/core/test_user_rate_throttle.py
+++ b/api/tests/integration/core/test_user_rate_throttle.py
@@ -6,55 +6,6 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 
-def test_master_api_key_user_throttle__master_api_key_request__throttles(
-    admin_master_api_key_client: APIClient,
-    project: int,
-    mocker: MockerFixture,
-    reset_cache: None,
-) -> None:
-    # Given
-    mocker.patch(
-        "core.throttling.UserRateThrottle.get_rate",
-        return_value="1/minute",
-    )
-
-    url = reverse("api-v1:projects:project-list")
-
-    # When - first request should be successful
-    response = admin_master_api_key_client.get(url, content_type="application/json")
-
-    # Then
-    assert response.status_code == status.HTTP_200_OK
-
-    # When - second request should be throttled
-    response = admin_master_api_key_client.get(url, content_type="application/json")
-
-    # Then
-    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
-
-
-def test_master_api_key_user_throttle__authenticated_user_request__does_not_throttle(
-    admin_client: APIClient,
-    project: int,
-    mocker: MockerFixture,
-    reset_cache: None,
-) -> None:
-    # Given
-    mocker.patch(
-        "core.throttling.UserRateThrottle.get_rate",
-        return_value="1/minute",
-    )
-
-    url = reverse("api-v1:projects:project-list")
-
-    # When
-    for _ in range(10):
-        response = admin_client.get(url, content_type="application/json")
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-
-
 def test_get_flags_is_not_throttled_by_user_throttle(
     sdk_client: APIClient,
     environment: int,

--- a/api/tests/integration/core/test_user_rate_throttle.py
+++ b/api/tests/integration/core/test_user_rate_throttle.py
@@ -14,7 +14,7 @@ def test_master_api_key_user_throttle__master_api_key_request__throttles(
 ) -> None:
     # Given
     mocker.patch(
-        "core.throttling.MasterAPIKeyUserRateThrottle.get_rate",
+        "core.throttling.UserRateThrottle.get_rate",
         return_value="1/minute",
     )
 
@@ -41,7 +41,7 @@ def test_master_api_key_user_throttle__authenticated_user_request__does_not_thro
 ) -> None:
     # Given
     mocker.patch(
-        "core.throttling.MasterAPIKeyUserRateThrottle.get_rate",
+        "core.throttling.UserRateThrottle.get_rate",
         return_value="1/minute",
     )
 

--- a/api/tests/integration/core/test_user_rate_throttle.py
+++ b/api/tests/integration/core/test_user_rate_throttle.py
@@ -1,32 +1,58 @@
 import json
 
-import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
 
 
-@pytest.mark.parametrize(
-    "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
-)
-def test_user_throttle_can_throttle_admin_endpoints(
-    client: APIClient, project: int, mocker: MockerFixture, reset_cache: None
+def test_master_api_key_user_throttle__master_api_key_request__throttles(
+    admin_master_api_key_client: APIClient,
+    project: int,
+    mocker: MockerFixture,
+    reset_cache: None,
 ) -> None:
     # Given
-    mocker.patch("core.throttling.UserRateThrottle.get_rate", return_value="1/minute")
+    mocker.patch(
+        "core.throttling.MasterAPIKeyUserRateThrottle.get_rate",
+        return_value="1/minute",
+    )
 
     url = reverse("api-v1:projects:project-list")
 
-    # Then - first request should be successful
-    response = client.get(url, content_type="application/json")
+    # When - first request should be successful
+    response = admin_master_api_key_client.get(url, content_type="application/json")
+
+    # Then
     assert response.status_code == status.HTTP_200_OK
 
-    # Second request should be throttled
-    response = client.get(url, content_type="application/json")
+    # When - second request should be throttled
+    response = admin_master_api_key_client.get(url, content_type="application/json")
+
+    # Then
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+def test_master_api_key_user_throttle__authenticated_user_request__does_not_throttle(
+    admin_client: APIClient,
+    project: int,
+    mocker: MockerFixture,
+    reset_cache: None,
+) -> None:
+    # Given
+    mocker.patch(
+        "core.throttling.MasterAPIKeyUserRateThrottle.get_rate",
+        return_value="1/minute",
+    )
+
+    url = reverse("api-v1:projects:project-list")
+
+    # When
+    for _ in range(10):
+        response = admin_client.get(url, content_type="application/json")
+
+        # Then
+        assert response.status_code == status.HTTP_200_OK
 
 
 def test_get_flags_is_not_throttled_by_user_throttle(

--- a/api/tests/unit/core/test_unit_core_throttling.py
+++ b/api/tests/unit/core/test_unit_core_throttling.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+from pytest_mock import MockerFixture
+from rest_framework.request import Request
+
+from api_keys.models import MasterAPIKey
+from api_keys.user import APIKeyUser
+from core.throttling import MasterAPIKeyUserRateThrottle
+from users.models import FFAdminUser
+
+
+def test_master_api_key_user_rate_throttle__master_api_key_user__throttled(
+    mocker: MockerFixture,
+    admin_master_api_key_object: MasterAPIKey,
+) -> None:
+    # Given
+    throttle = MasterAPIKeyUserRateThrottle()
+    user = APIKeyUser(admin_master_api_key_object)
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.user = user
+
+    mock_view = MagicMock()
+
+    mock_parent_allow_request = mocker.patch(
+        "rest_framework.throttling.UserRateThrottle.allow_request",
+        return_value=False,
+    )
+
+    # When
+    result = throttle.allow_request(mock_request, mock_view)
+
+    # Then
+    mock_parent_allow_request.assert_called_once_with(mock_request, mock_view)
+    assert result is False
+
+
+def test_master_api_key_user_rate_throttle__regular_user__not_throttled(
+    mocker: MockerFixture,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    throttle = MasterAPIKeyUserRateThrottle()
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.user = admin_user
+
+    mock_view = MagicMock()
+
+    mock_parent_allow_request = mocker.patch(
+        "rest_framework.throttling.UserRateThrottle.allow_request",
+        return_value=False,
+    )
+
+    # When
+    result = throttle.allow_request(mock_request, mock_view)
+
+    # Then
+    mock_parent_allow_request.assert_not_called()
+    assert result is True
+
+
+def test_master_api_key_user_rate_throttle__anonymous_user__not_throttled(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    throttle = MasterAPIKeyUserRateThrottle()
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.user = None
+
+    mock_view = MagicMock()
+
+    mock_parent_allow_request = mocker.patch(
+        "rest_framework.throttling.UserRateThrottle.allow_request",
+        return_value=False,
+    )
+
+    # When
+    result = throttle.allow_request(mock_request, mock_view)
+
+    # Then
+    mock_parent_allow_request.assert_not_called()
+    assert result is True

--- a/api/tests/unit/core/test_unit_core_throttling.py
+++ b/api/tests/unit/core/test_unit_core_throttling.py
@@ -47,16 +47,10 @@ def test_master_api_key_user_rate_throttle__regular_user__not_throttled(
 
     mock_view = MagicMock()
 
-    mock_parent_allow_request = mocker.patch(
-        "rest_framework.throttling.UserRateThrottle.allow_request",
-        return_value=False,
-    )
-
     # When
     result = throttle.allow_request(mock_request, mock_view)
 
     # Then
-    mock_parent_allow_request.assert_not_called()
     assert result is True
 
 
@@ -71,14 +65,8 @@ def test_master_api_key_user_rate_throttle__anonymous_user__not_throttled(
 
     mock_view = MagicMock()
 
-    mock_parent_allow_request = mocker.patch(
-        "rest_framework.throttling.UserRateThrottle.allow_request",
-        return_value=False,
-    )
-
     # When
     result = throttle.allow_request(mock_request, mock_view)
 
     # Then
-    mock_parent_allow_request.assert_not_called()
     assert result is True

--- a/api/tests/unit/core/test_unit_core_throttling.py
+++ b/api/tests/unit/core/test_unit_core_throttling.py
@@ -15,6 +15,8 @@ def test_master_api_key_user_rate_throttle__master_api_key_user__throttled(
 ) -> None:
     # Given
     throttle = MasterAPIKeyUserRateThrottle()
+    setattr(throttle, "num_requests", 1)
+    setattr(throttle, "duration", 60)  # 1 minute
     user = APIKeyUser(admin_master_api_key_object)
 
     mock_request = MagicMock(spec=Request)
@@ -22,16 +24,12 @@ def test_master_api_key_user_rate_throttle__master_api_key_user__throttled(
 
     mock_view = MagicMock()
 
-    mock_parent_allow_request = mocker.patch(
-        "rest_framework.throttling.UserRateThrottle.allow_request",
-        return_value=False,
-    )
+    throttle.allow_request(mock_request, mock_view)
 
     # When
     result = throttle.allow_request(mock_request, mock_view)
 
     # Then
-    mock_parent_allow_request.assert_called_once_with(mock_request, mock_view)
     assert result is False
 
 
@@ -41,11 +39,15 @@ def test_master_api_key_user_rate_throttle__regular_user__not_throttled(
 ) -> None:
     # Given
     throttle = MasterAPIKeyUserRateThrottle()
+    setattr(throttle, "num_requests", 1)
+    setattr(throttle, "duration", 60)  # 1 minute
 
     mock_request = MagicMock(spec=Request)
     mock_request.user = admin_user
 
     mock_view = MagicMock()
+
+    throttle.allow_request(mock_request, mock_view)
 
     # When
     result = throttle.allow_request(mock_request, mock_view)
@@ -59,11 +61,15 @@ def test_master_api_key_user_rate_throttle__anonymous_user__not_throttled(
 ) -> None:
     # Given
     throttle = MasterAPIKeyUserRateThrottle()
+    setattr(throttle, "num_requests", 1)
+    setattr(throttle, "duration", 60)  # 1 minute
 
     mock_request = MagicMock(spec=Request)
     mock_request.user = None
 
     mock_view = MagicMock()
+
+    throttle.allow_request(mock_request, mock_view)
 
     # When
     result = throttle.allow_request(mock_request, mock_view)

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -127,7 +127,7 @@
                 },
                 {
                     "name": "DEFAULT_THROTTLE_CLASSES",
-                    "value": "core.throttling.MasterAPIKeyUserRateThrottle"
+                    "value": "core.throttling.UserRateThrottle,core.throttling.MasterAPIKeyUserRateThrottle"
                 },
                 {
                     "name": "USER_THROTTLE_CACHE_BACKEND",
@@ -142,8 +142,8 @@
                     "value": "CLIENT_CLASS=core.redis_cluster.SafeRedisClusterClient"
                 },
                 {
-                    "name": "USER_THROTTLE_RATE",
-                    "value": "500/min"
+                    "name": "MASTER_API_KEY_THROTTLE_RATE",
+                    "value": "10/sec"
                 },
                 {
                     "name": "OAUTH_CLIENT_ID",

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -127,7 +127,7 @@
                 },
                 {
                     "name": "DEFAULT_THROTTLE_CLASSES",
-                    "value": "core.throttling.UserRateThrottle"
+                    "value": "core.throttling.MasterAPIKeyUserRateThrottle"
                 },
                 {
                     "name": "USER_THROTTLE_CACHE_BACKEND",

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -195,7 +195,7 @@
                 },
                 {
                     "name": "DEFAULT_THROTTLE_CLASSES",
-                    "value": "core.throttling.UserRateThrottle"
+                    "value": "core.throttling.MasterAPIKeyUserRateThrottle"
                 },
                 {
                     "name": "USER_THROTTLE_CACHE_BACKEND",

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -195,7 +195,7 @@
                 },
                 {
                     "name": "DEFAULT_THROTTLE_CLASSES",
-                    "value": "core.throttling.MasterAPIKeyUserRateThrottle"
+                    "value": "core.throttling.UserRateThrottle,core.throttling.MasterAPIKeyUserRateThrottle"
                 },
                 {
                     "name": "USER_THROTTLE_CACHE_BACKEND",
@@ -208,6 +208,10 @@
                 {
                     "name": "USER_THROTTLE_CACHE_OPTIONS",
                     "value": "CLIENT_CLASS=core.redis_cluster.SafeRedisClusterClient"
+                },
+                {
+                    "name": "MASTER_API_KEY_THROTTLE_RATE",
+                    "value": "10/sec"
                 },
                 {
                     "name": "GITHUB_APP_ID",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In this PR, we limit throttling to requests authorised by master API keys. This helps us to be more flexible when configuring throttle rates without risking unexpected 429 responses in the UI.

## How did you test this code?

Added unit tests; will test with a low rate limit on staging.