### PR TITLE
fix(infra): increase MASTER_API_KEY_THROTTLE_RATE to 100/sec

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -143,7 +143,7 @@
                 },
                 {
                     "name": "MASTER_API_KEY_THROTTLE_RATE",
-                    "value": "10/sec"
+                    "value": "100/sec"
                 },
                 {
                     "name": "OAUTH_CLIENT_ID",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Increases `MASTER_API_KEY_THROTTLE_RATE` from `10/sec` to `100/sec` in production.

Lower rate limiting is now enforced by WAF.

## How did you test this code?

Config change only - no code changes.