### PR TITLE
fix: removed-hover-class-on-color

### DIFF
--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -193,11 +193,7 @@ const Tabs: React.FC<TabsProps> = ({
                         isSelected={false}
                         className={classNames(
                           'full-width btn-no-focus width-100',
-                          [
-                            active
-                              ? 'text-primary fw-semibold fill-primary'
-                              : 'hover-color-primary',
-                          ],
+                          active && 'text-primary fw-semibold fill-primary',
                         )}
                         noFocus={noFocus}
                         child={child}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Fixed text color in overflow nav on hover

## How did you test this code?
- Visually

**Before** 
<img width="231" height="188" alt="image" src="https://github.com/user-attachments/assets/4e88f35b-41cd-4571-b431-4492600fbabb" />

**After**
<img width="249" height="222" alt="image" src="https://github.com/user-attachments/assets/38219231-f501-45ad-b24b-23dcef49c800" />
