### PR TITLE
fix: improve _is_user_object_admin query performance

### DIFF
--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -717,7 +717,7 @@ def test_view_environment_with_staff__query_count_is_expected_without_rbac(
         environment_metadata_b,
         required_a_environment_metadata_field,
         environment_content_type,
-        expected_query_count=9,
+        expected_query_count=11,
     )
 
 
@@ -746,7 +746,7 @@ def test_view_environment_with_staff__query_count_is_expected_with_rbac(
         environment_metadata_b,
         required_a_environment_metadata_field,
         environment_content_type,
-        expected_query_count=10,
+        expected_query_count=12,
     )
 
 

--- a/api/tests/unit/permissions/permission_service/conftest.py
+++ b/api/tests/unit/permissions/permission_service/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from environments.models import Environment
 from environments.permissions.models import (
     UserEnvironmentPermission,
     UserPermissionGroupEnvironmentPermission,
@@ -43,7 +44,9 @@ def project_admin_via_user_permission_group(  # type: ignore[no-untyped-def]
 
 @pytest.fixture
 def environment_admin_via_user_permission(
-    staff_user: FFAdminUser, user_environment_permission: UserEnvironmentPermission
+    staff_user: FFAdminUser,
+    environment: Environment,  # Explicitly depend on environment to ensure same instance
+    user_environment_permission: UserEnvironmentPermission,
 ) -> UserEnvironmentPermission:
     user_environment_permission.admin = True
     user_environment_permission.save()
@@ -61,6 +64,7 @@ def environment_admin_via_user_permission_group(
     user_environment_permission_group: UserPermissionGroupEnvironmentPermission,
     staff_user: FFAdminUser,
     user_permission_group: UserPermissionGroup,
+    environment: Environment,  # Explicitly depend on environment to ensure same instance
 ) -> UserPermissionGroupEnvironmentPermission:
     user_permission_group.users.add(staff_user)
 

--- a/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
@@ -96,3 +96,32 @@ def test_is_user_project_admin__does_not_return_project_for_orphan_group_permiss
 
     # Then
     assert not is_user_project_admin(user=staff_user, project=project)
+
+
+def test_is_user_project_admin__short_circuits_on_direct_permission(
+    staff_user: FFAdminUser,
+    project: Project,
+    project_admin_via_user_permission: UserProjectPermission,
+    django_assert_num_queries: typing.Any,
+) -> None:
+    # When/Then - should take only 3 queries:
+    # 1. Check if user is org admin (is_user_organisation_admin)
+    # 2. Check organisation membership (_is_user_object_admin)
+    # 3. Check direct user permission (short-circuits here)
+    with django_assert_num_queries(3):
+        assert is_user_project_admin(staff_user, project) is True
+
+
+def test_is_user_project_admin__short_circuits_on_group_permission(
+    staff_user: FFAdminUser,
+    project: Project,
+    project_admin_via_user_permission_group: UserPermissionGroupProjectPermission,
+    django_assert_num_queries: typing.Any,
+) -> None:
+    # When/Then - should take only 4 queries:
+    # 1. Check if user is org admin (is_user_organisation_admin)
+    # 2. Check organisation membership (_is_user_object_admin)
+    # 3. Check direct user permission (not found)
+    # 4. Check group permission (short-circuits here)
+    with django_assert_num_queries(4):
+        assert is_user_project_admin(staff_user, project) is True


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The original `_is_user_object_admin()` implementation used a single combined query with OR conditions across user, group, and role permissions. This caused Django ORM to generate LEFT OUTER JOINs, resulting in cartesian product explosion and slow queries on large datasets.

Replace with separate queries using early returns:
1. Organisation membership check (security + fast fail)
2. Direct user permission check
3. Group permission check
4. Role permission check (RBAC, if enabled)

## How did you test this code?

- Added tests for early exit behaviour with expected query counts
- Manually verified that the generated SQL ran under a millisecond on the production database