### PR TITLE
feat(frontend): add reusable EmptyState component for empty pages

### DIFF
--- a/frontend/web/components/EmptyState.tsx
+++ b/frontend/web/components/EmptyState.tsx
@@ -1,0 +1,51 @@
+import React, { FC, ReactNode } from 'react'
+import Icon, { IconName } from './Icon'
+
+type EmptyStateProps = {
+  title: string
+  description?: string | ReactNode
+  icon?: IconName
+  iconColour?: string
+  docsUrl?: string
+  docsLabel?: string
+  action?: ReactNode
+  className?: string
+}
+
+const EmptyState: FC<EmptyStateProps> = ({
+  action,
+  className,
+  description,
+  docsLabel = 'View docs',
+  docsUrl,
+  icon,
+  iconColour = '#9DA4AE',
+  title,
+}) => {
+  return (
+    <div className={`empty-state ${className || ''}`}>
+      {icon && (
+        <div className='empty-state__icon'>
+          <Icon name={icon} width={40} fill={iconColour} />
+        </div>
+      )}
+      <h5 className='empty-state__title'>{title}</h5>
+      {description && (
+        <div className='empty-state__description text-muted'>{description}</div>
+      )}
+      {docsUrl && (
+        <a
+          href={docsUrl}
+          target='_blank'
+          rel='noreferrer'
+          className='btn btn-link'
+        >
+          {docsLabel}
+        </a>
+      )}
+      {action}
+    </div>
+  )
+}
+
+export default EmptyState

--- a/frontend/web/components/pages/ScheduledChangesPage.tsx
+++ b/frontend/web/components/pages/ScheduledChangesPage.tsx
@@ -13,6 +13,7 @@ import PlanBasedBanner, {
   featureDescriptions,
 } from 'components/PlanBasedAccess'
 import PanelSearch from 'components/PanelSearch'
+import EmptyState from 'components/EmptyState'
 import JSONReference from 'components/JSONReference'
 import Icon from 'components/Icon'
 import getUserDisplayName from 'common/utils/getUserDisplayName'
@@ -83,6 +84,14 @@ const ScheduledChangesPage: FC<ScheduledChangesPageType> = ({ match }) => {
                 isLoading={isLoading || !dataScheduled || !organisation}
                 paging={dataScheduled}
                 items={dataScheduled?.results}
+                renderNoResults={
+                  <EmptyState
+                    icon='calendar'
+                    title='No scheduled changes'
+                    description='To schedule a change, edit a feature flag and use the "Schedule" option when saving your changes.'
+                    docsUrl={featureDescriptions.SCHEDULE_FLAGS.docs}
+                  />
+                }
                 renderFooter={() => (
                   <JSONReference
                     className='mt-4 ml-3'

--- a/frontend/web/styles/components/_empty-state.scss
+++ b/frontend/web/styles/components/_empty-state.scss
@@ -1,0 +1,17 @@
+.empty-state {
+  text-align: center;
+  padding: 2rem 1rem;
+
+  &__icon {
+    margin-bottom: 1rem;
+  }
+
+  &__title {
+    margin-bottom: 0.5rem;
+  }
+
+  &__description {
+    max-width: 400px;
+    margin: 0 auto 1rem;
+  }
+}

--- a/frontend/web/styles/components/_index.scss
+++ b/frontend/web/styles/components/_index.scss
@@ -16,3 +16,4 @@
 @import 'feature-pipeline-status';
 @import 'button-dropdown';
 @import 'feature-row-skeleton';
+@import 'empty-state';


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6163

Create a centralised, reusable `EmptyState` component that can be used across the project for consistent empty state UX. The component supports:
- Optional icon with customisable colour (40px, muted grey by default)
- Title and description text
- Optional documentation link
- Optional action button

Use the new component in the Scheduled Flags page to provide helpful guidance when there are no scheduled changes, displaying a calendar icon and instructions on how to create a scheduled change.

<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/6fb8e336-4a00-478a-945b-7eaeea49e671" />

### Files Changed
- `frontend/web/components/EmptyState.tsx` - New reusable component
- `frontend/web/components/pages/ScheduledChangesPage.tsx` - Uses the new EmptyState component
- `frontend/web/styles/components/_empty-state.scss` - BEM-style CSS for the component
- `frontend/web/styles/components/_index.scss` - Import the new stylesheet

## How did you test this code?

1. Run the frontend locally: `cd frontend && npm run dev`
2. Navigate to a project/environment with no scheduled changes
3. Verify the empty state displays:
   - Calendar icon (40px, muted grey)
   - Title: "No scheduled changes"
   - Description text centred below
   - "View docs" link to documentation
4. Test dark mode compatibility
5. Run frontend linter: `npm run lint`