### PR TITLE
feat(frontend): add subscription limit info to Usage and Billing pages

### DIFF
--- a/frontend/common/services/useOrganisationUsage.ts
+++ b/frontend/common/services/useOrganisationUsage.ts
@@ -34,7 +34,6 @@ export const organisationUsageService = service
             environmentDocument += v.environment_document || 0
             identities += v.identities || 0
           })
-
           return {
             events_list: data,
             totals: {

--- a/frontend/common/services/useOrganisationUsage.ts
+++ b/frontend/common/services/useOrganisationUsage.ts
@@ -34,6 +34,7 @@ export const organisationUsageService = service
             environmentDocument += v.environment_document || 0
             identities += v.identities || 0
           })
+
           return {
             events_list: data,
             totals: {

--- a/frontend/web/components/StatItem.tsx
+++ b/frontend/web/components/StatItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, KeyboardEvent } from 'react'
 import { IonIcon } from '@ionic/react'
 import { checkmarkSharp } from 'ionicons/icons'
 import Icon, { IconName } from './Icon'
@@ -30,6 +30,13 @@ const StatItem: FC<StatItemProps> = ({
   const formattedValue =
     typeof value === 'number' ? Utils.numberWithCommas(value) : value
 
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      visibilityToggle?.onToggle()
+    }
+  }
+
   return (
     <div className='d-flex flex-row align-items-start gap-2'>
       <div className='plan-icon flex-shrink-0'>
@@ -48,18 +55,17 @@ const StatItem: FC<StatItemProps> = ({
         </h4>
         {visibilityToggle && (
           <div
+            role='checkbox'
+            aria-checked={visibilityToggle.isVisible}
+            aria-label={`Toggle ${label} visibility`}
+            tabIndex={0}
             className='cursor-pointer d-flex align-items-center gap-2 mt-1'
             onClick={visibilityToggle.onToggle}
+            onKeyDown={handleKeyDown}
           >
             <div
-              className='d-flex align-items-center justify-content-center text-white'
-              style={{
-                backgroundColor: visibilityToggle.colour,
-                borderRadius: 2,
-                flexShrink: 0,
-                height: 16,
-                width: 16,
-              }}
+              className='visibility-checkbox'
+              style={{ backgroundColor: visibilityToggle.colour }}
             >
               {visibilityToggle.isVisible && (
                 <IonIcon size={'8px'} color='white' icon={checkmarkSharp} />

--- a/frontend/web/components/StatItem.tsx
+++ b/frontend/web/components/StatItem.tsx
@@ -1,0 +1,76 @@
+import React, { FC } from 'react'
+import { IonIcon } from '@ionic/react'
+import { checkmarkSharp } from 'ionicons/icons'
+import Icon, { IconName } from './Icon'
+import Utils from 'common/utils/utils'
+
+type VisibilityToggleProps = {
+  colour: string
+  isVisible: boolean
+  onToggle: () => void
+}
+
+export type StatItemProps = {
+  icon: IconName
+  label: string
+  value: string | number
+  // Optional: for displaying limits (e.g., "1,000 / 10,000")
+  limit?: number | null
+  // Optional: for visibility toggle in charts
+  visibilityToggle?: VisibilityToggleProps
+}
+
+const StatItem: FC<StatItemProps> = ({
+  icon,
+  label,
+  limit,
+  value,
+  visibilityToggle,
+}) => {
+  const formattedValue =
+    typeof value === 'number' ? Utils.numberWithCommas(value) : value
+
+  return (
+    <div className='d-flex flex-row align-items-start gap-2'>
+      <div className='plan-icon flex-shrink-0'>
+        <Icon name={icon} width={32} fill='#1A2634' />
+      </div>
+      <div>
+        <p className='fs-small lh-sm mb-0'>{label}</p>
+        <h4 className='mb-0'>
+          {formattedValue}
+          {limit !== null && limit !== undefined && (
+            <span className='text-muted fs-small fw-normal'>
+              {' '}
+              / {Utils.numberWithCommas(limit)}
+            </span>
+          )}
+        </h4>
+        {visibilityToggle && (
+          <div
+            className='cursor-pointer d-flex align-items-center gap-2 mt-1'
+            onClick={visibilityToggle.onToggle}
+          >
+            <div
+              className='d-flex align-items-center justify-content-center text-white'
+              style={{
+                backgroundColor: visibilityToggle.colour,
+                borderRadius: 2,
+                flexShrink: 0,
+                height: 16,
+                width: 16,
+              }}
+            >
+              {visibilityToggle.isVisible && (
+                <IonIcon size={'8px'} color='white' icon={checkmarkSharp} />
+              )}
+            </div>
+            <span className='text-muted fs-small'>Visible</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default StatItem

--- a/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
+++ b/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
@@ -1,74 +1,7 @@
 import React, { FC } from 'react'
-import Utils from 'common/utils/utils'
-import { IonIcon } from '@ionic/react'
-import { checkmarkSharp } from 'ionicons/icons'
 import { Res } from 'common/types/responses'
-import Icon, { IconName } from 'components/Icon'
-
-type LegendItemType = {
-  title: string
-  value: number
-  limit?: number | null
-  selection: string[]
-  onChange: (v: string) => void
-  colour?: string
-  icon: IconName
-}
-
-const LegendItem: FC<LegendItemType> = ({
-  colour,
-  icon,
-  limit,
-  onChange,
-  selection,
-  title,
-  value,
-}) => {
-  if (!value) {
-    return null
-  }
-  return (
-    <div className='d-flex flex-row align-items-start gap-2 mr-4'>
-      <div className='plan-icon flex-shrink-0'>
-        <Icon name={icon} width={32} fill='#1A2634' />
-      </div>
-      <div>
-        <p className='fs-small lh-sm mb-0'>{title}</p>
-        <h4 className='mb-0'>
-          {Utils.numberWithCommas(value)}
-          {limit !== null && limit !== undefined && (
-            <span className='text-muted fs-small fw-normal'>
-              {' '}
-              / {Utils.numberWithCommas(limit)}
-            </span>
-          )}
-        </h4>
-        {!!colour && (
-          <div
-            className='cursor-pointer d-flex align-items-center gap-2 mt-1'
-            onClick={() => onChange(title)}
-          >
-            <div
-              className='d-flex align-items-center justify-content-center text-white'
-              style={{
-                backgroundColor: colour,
-                borderRadius: 2,
-                flexShrink: 0,
-                height: 16,
-                width: 16,
-              }}
-            >
-              {selection.includes(title) && (
-                <IonIcon size={'8px'} color='white' icon={checkmarkSharp} />
-              )}
-            </div>
-            <span className='text-muted fs-small'>Visible</span>
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
+import { IconName } from 'components/Icon'
+import StatItem from 'components/StatItem'
 
 export interface UsageChartTotalsProps {
   data: Res['organisationUsage'] | undefined
@@ -137,18 +70,26 @@ const UsageChartTotals: FC<UsageChartTotalsProps> = ({
 
   return (
     <Row className='plan p-4 mb-4 flex-wrap gap-4'>
-      {totalItems.map((item) => (
-        <LegendItem
-          key={item.title}
-          selection={selection}
-          onChange={updateSelection}
-          colour={!withColor ? undefined : item.colour}
-          icon={item.icon}
-          limit={item.limit}
-          value={item.value}
-          title={item.title}
-        />
-      ))}
+      {totalItems
+        .filter((item) => item.value)
+        .map((item) => (
+          <StatItem
+            key={item.title}
+            icon={item.icon}
+            label={item.title}
+            value={item.value}
+            limit={item.limit}
+            visibilityToggle={
+              withColor && item.colour
+                ? {
+                    colour: item.colour,
+                    isVisible: selection.includes(item.title),
+                    onToggle: () => updateSelection(item.title),
+                  }
+                : undefined
+            }
+          />
+        ))}
     </Row>
   )
 }

--- a/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
+++ b/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
@@ -49,7 +49,7 @@ const LegendItem: FC<LegendItemType> = ({
             onClick={() => onChange(title)}
           >
             <div
-              className='d-flex align-items-center justify-content-center'
+              className='d-flex align-items-center justify-content-center text-white'
               style={{
                 backgroundColor: colour,
                 borderRadius: 2,

--- a/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
+++ b/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
@@ -136,21 +136,19 @@ const UsageChartTotals: FC<UsageChartTotalsProps> = ({
   ]
 
   return (
-    <Row className='plan p-4 mb-4'>
-      <Row className='flex-wrap gap-4'>
-        {totalItems.map((item) => (
-          <LegendItem
-            key={item.title}
-            selection={selection}
-            onChange={updateSelection}
-            colour={!withColor ? undefined : item.colour}
-            icon={item.icon}
-            limit={item.limit}
-            value={item.value}
-            title={item.title}
-          />
-        ))}
-      </Row>
+    <Row className='plan p-4 mb-4 flex-wrap gap-4'>
+      {totalItems.map((item) => (
+        <LegendItem
+          key={item.title}
+          selection={selection}
+          onChange={updateSelection}
+          colour={!withColor ? undefined : item.colour}
+          icon={item.icon}
+          limit={item.limit}
+          value={item.value}
+          title={item.title}
+        />
+      ))}
     </Row>
   )
 }

--- a/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
+++ b/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
@@ -3,6 +3,14 @@ import { Res } from 'common/types/responses'
 import { IconName } from 'components/Icon'
 import StatItem from 'components/StatItem'
 
+type TotalItem = {
+  colour: string | undefined
+  icon: IconName
+  limit: number | null | undefined
+  title: string
+  value: number
+}
+
 export interface UsageChartTotalsProps {
   data: Res['organisationUsage'] | undefined
   selection: string[]
@@ -24,13 +32,7 @@ const UsageChartTotals: FC<UsageChartTotalsProps> = ({
     return null
   }
 
-  const totalItems: Array<{
-    colour: string | undefined
-    icon: IconName
-    limit: number | null | undefined
-    title: string
-    value: number
-  }> = [
+  const totalItems: TotalItem[] = [
     {
       colour: colours[0],
       icon: 'features',

--- a/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
+++ b/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
@@ -3,17 +3,22 @@ import Utils from 'common/utils/utils'
 import { IonIcon } from '@ionic/react'
 import { checkmarkSharp } from 'ionicons/icons'
 import { Res } from 'common/types/responses'
+import Icon, { IconName } from 'components/Icon'
 
 type LegendItemType = {
   title: string
   value: number
+  limit?: number | null
   selection: string[]
   onChange: (v: string) => void
   colour?: string
+  icon: IconName
 }
 
 const LegendItem: FC<LegendItemType> = ({
   colour,
+  icon,
+  limit,
   onChange,
   selection,
   title,
@@ -23,29 +28,43 @@ const LegendItem: FC<LegendItemType> = ({
     return null
   }
   return (
-    <div className='mb-4'>
-      <h3 className='mb-2'>{Utils.numberWithCommas(value)}</h3>
-      <div
-        className='cursor-pointer d-flex align-items-center gap-2'
-        onClick={() => onChange(title)}
-      >
+    <div className='d-flex flex-row align-items-start gap-2 mr-4'>
+      <div className='plan-icon flex-shrink-0'>
+        <Icon name={icon} width={32} fill='#1A2634' />
+      </div>
+      <div>
+        <p className='fs-small lh-sm mb-0'>{title}</p>
+        <h4 className='mb-0'>
+          {Utils.numberWithCommas(value)}
+          {limit !== null && limit !== undefined && (
+            <span className='text-muted fs-small fw-normal'>
+              {' '}
+              / {Utils.numberWithCommas(limit)}
+            </span>
+          )}
+        </h4>
         {!!colour && (
           <div
-            className='text-white d-flex align-items-center justify-content-center'
-            style={{
-              backgroundColor: colour,
-              borderRadius: 2,
-              flexShrink: 0,
-              height: 16,
-              width: 16,
-            }}
+            className='cursor-pointer d-flex align-items-center gap-2 mt-1'
+            onClick={() => onChange(title)}
           >
-            {selection.includes(title) && (
-              <IonIcon size={'8px'} color='white' icon={checkmarkSharp} />
-            )}
+            <div
+              className='d-flex align-items-center justify-content-center'
+              style={{
+                backgroundColor: colour,
+                borderRadius: 2,
+                flexShrink: 0,
+                height: 16,
+                width: 16,
+              }}
+            >
+              {selection.includes(title) && (
+                <IonIcon size={'8px'} color='white' icon={checkmarkSharp} />
+              )}
+            </div>
+            <span className='text-muted fs-small'>Visible</span>
           </div>
         )}
-        <span className='text-muted'>{title}</span>
       </div>
     </div>
   )
@@ -57,11 +76,13 @@ export interface UsageChartTotalsProps {
   updateSelection: (key: string) => void
   colours: string[]
   withColor?: boolean
+  maxApiCalls?: number | null
 }
 
 const UsageChartTotals: FC<UsageChartTotalsProps> = ({
   colours,
   data,
+  maxApiCalls,
   selection,
   updateSelection,
   withColor = true,
@@ -70,47 +91,67 @@ const UsageChartTotals: FC<UsageChartTotalsProps> = ({
     return null
   }
 
-  const totalItems = [
+  const totalItems: Array<{
+    colour: string | undefined
+    icon: IconName
+    limit: number | null | undefined
+    title: string
+    value: number
+  }> = [
     {
       colour: colours[0],
+      icon: 'features',
+      limit: undefined,
       title: 'Flags',
       value: data.totals.flags,
     },
     {
       colour: colours[1],
+      icon: 'person',
+      limit: undefined,
       title: 'Identities',
       value: data.totals.identities,
     },
     {
       colour: colours[2],
+      icon: 'file-text',
+      limit: undefined,
       title: 'Environment Document',
       value: data.totals.environmentDocument,
     },
     {
       colour: colours[3],
+      icon: 'layers',
+      limit: undefined,
       title: 'Traits',
       value: data.totals.traits,
     },
     {
       colour: undefined,
+      icon: 'bar-chart',
+      limit: maxApiCalls,
       title: 'Total API Calls',
       value: data.totals.total,
     },
   ]
 
   return (
-    <div className='d-flex gap-5 align-items-start'>
-      {totalItems.map((item) => (
-        <LegendItem
-          key={item.title}
-          selection={selection}
-          onChange={updateSelection}
-          colour={!withColor && item.colour ? '#6837fc' : item.colour}
-          value={item.value}
-          title={item.title}
-        />
-      ))}
-    </div>
+    <Row className='plan p-4 mb-4'>
+      <Row className='flex-wrap gap-4'>
+        {totalItems.map((item) => (
+          <LegendItem
+            key={item.title}
+            selection={selection}
+            onChange={updateSelection}
+            colour={!withColor ? undefined : item.colour}
+            icon={item.icon}
+            limit={item.limit}
+            value={item.value}
+            title={item.title}
+          />
+        ))}
+      </Row>
+    </Row>
   )
 }
 

--- a/frontend/web/components/pages/OrganisationUsagePage.tsx
+++ b/frontend/web/components/pages/OrganisationUsagePage.tsx
@@ -12,6 +12,7 @@ import AccountStore from 'common/stores/account-store'
 import { planNames } from 'common/utils/utils'
 import { Req } from 'common/types/requests'
 import { useGetOrganisationUsageQuery } from 'common/services/useOrganisationUsage'
+import { useGetSubscriptionMetadataQuery } from 'common/services/useSubscriptionMetadata'
 import UsageChartFilters from 'components/organisation-settings/usage/components/UsageChartFilters'
 import UsageChartTotals from 'components/organisation-settings/usage/components/UsageChartTotals'
 
@@ -27,7 +28,7 @@ const OrganisationUsagePage: FC = () => {
     }
     const params = new URLSearchParams(location.search)
     return params.get('p') === 'user-agents' ? 'user-agents' : 'global'
-  }, [location.search])
+  }, [isSdkViewEnabled, location.search])
 
   const [chartsView, setChartsView] = useState<'global' | 'user-agents'>(
     getInitialView(),
@@ -59,6 +60,11 @@ const OrganisationUsagePage: FC = () => {
       organisationId: organisationId?.toString() || '',
       projectId: project,
     },
+    { skip: !organisationId },
+  )
+
+  const { data: subscriptionMeta } = useGetSubscriptionMetadataQuery(
+    { id: organisationId?.toString() || '' },
     { skip: !organisationId },
   )
 
@@ -161,6 +167,7 @@ const OrganisationUsagePage: FC = () => {
             updateSelection={updateSelection}
             colours={colours}
             withColor={chartsView !== 'user-agents'}
+            maxApiCalls={subscriptionMeta?.max_api_calls}
           />
           {chartsView === 'user-agents' ? (
             <OrganisationUsageMetrics data={data} selectedMetrics={selection} />

--- a/frontend/web/components/pages/OrganisationUsagePage.tsx
+++ b/frontend/web/components/pages/OrganisationUsagePage.tsx
@@ -57,14 +57,14 @@ const OrganisationUsagePage: FC = () => {
     {
       billing_period: billingPeriod,
       environmentId: environment,
-      organisationId: organisationId?.toString() || '',
+      organisationId: organisationId || 0,
       projectId: project,
     },
     { skip: !organisationId },
   )
 
   const { data: subscriptionMeta } = useGetSubscriptionMetadataQuery(
-    { id: organisationId?.toString() || '' },
+    { id: organisationId || 0 },
     { skip: !organisationId },
   )
 
@@ -152,7 +152,7 @@ const OrganisationUsagePage: FC = () => {
           )}
         >
           <UsageChartFilters
-            organisationId={organisationId?.toString() || ''}
+            organisationId={organisationId || 0}
             project={project}
             setProject={setProject}
             environment={environment}

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -1,27 +1,10 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { Organisation } from 'common/types/responses'
-import Icon, { IconName } from 'components/Icon'
+import Icon from 'components/Icon'
 import Utils from 'common/utils/utils'
 import Payment from 'components/modals/Payment'
 import { useGetSubscriptionMetadataQuery } from 'common/services/useSubscriptionMetadata'
-
-type LimitItemProps = {
-  icon: IconName
-  label: string
-  value: string
-}
-
-const LimitItem: FC<LimitItemProps> = ({ icon, label, value }) => (
-  <Row>
-    <div className='plan-icon'>
-      <Icon name={icon} width={32} />
-    </div>
-    <div>
-      <p className='fs-small lh-sm mb-0'>{label}</p>
-      <h4 className='mb-0'>{value}</h4>
-    </div>
-  </Row>
-)
+import StatItem, { StatItemProps } from 'components/StatItem'
 
 type BillingTabProps = {
   organisation: Organisation
@@ -58,7 +41,9 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
     Utils.getFlagsmithHasFeature('feature_versioning') &&
     feature_history_visibility_days !== 0
 
-  const limitItems: LimitItemProps[] = [
+  type LimitItem = Pick<StatItemProps, 'icon' | 'label'> & { value: string }
+
+  const limitItems: LimitItem[] = [
     {
       icon: 'bar-chart',
       label: 'API Calls',
@@ -80,7 +65,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
           value: formatDays(feature_history_visibility_days),
         }
       : undefined,
-  ].filter((item): item is LimitItemProps => item !== undefined)
+  ].filter((item): item is LimitItem => item !== undefined)
 
   return (
     <div className='mt-4'>
@@ -144,7 +129,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
           <Row className='plan p-4 mb-4 flex-wrap gap-5 row-gap-4'>
             {limitItems.map((item) => (
-              <LimitItem
+              <StatItem
                 key={item.label}
                 icon={item.icon}
                 label={item.label}

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -29,7 +29,7 @@ type BillingTabProps = {
 
 export const BillingTab = ({ organisation }: BillingTabProps) => {
   const { data: subscriptionMeta } = useGetSubscriptionMetadataQuery({
-    id: String(organisation.id),
+    id: organisation.id,
   })
 
   const {
@@ -52,6 +52,35 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
     if (value === 0) return 'Not available'
     return `${value} days`
   }
+
+  const showAuditLog = audit_log_visibility_days !== 0
+  const showFeatureHistory =
+    Utils.getFlagsmithHasFeature('feature_versioning') &&
+    feature_history_visibility_days !== 0
+
+  const limitItems: LimitItemProps[] = [
+    {
+      icon: 'bar-chart',
+      label: 'API Calls',
+      value: formatLimit(max_api_calls),
+    },
+    { icon: 'people', label: 'Team Seats', value: formatLimit(max_seats) },
+    { icon: 'layers', label: 'Projects', value: formatLimit(max_projects) },
+    showAuditLog
+      ? {
+          icon: 'list',
+          label: 'Audit Log',
+          value: formatDays(audit_log_visibility_days),
+        }
+      : undefined,
+    showFeatureHistory
+      ? {
+          icon: 'clock',
+          label: 'Feature History',
+          value: formatDays(feature_history_visibility_days),
+        }
+      : undefined,
+  ].filter((item): item is LimitItemProps => item !== undefined)
 
   return (
     <div className='mt-4'>
@@ -115,36 +144,14 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
           <Row className='plan p-4 mb-4'>
             <Row className='flex-wrap gap-5'>
-              <LimitItem
-                icon='bar-chart'
-                label='API Calls'
-                value={formatLimit(max_api_calls)}
-              />
-              <LimitItem
-                icon='people'
-                label='Team Seats'
-                value={formatLimit(max_seats)}
-              />
-              <LimitItem
-                icon='layers'
-                label='Projects'
-                value={formatLimit(max_projects)}
-              />
-              {audit_log_visibility_days !== 0 && (
+              {limitItems.map((item) => (
                 <LimitItem
-                  icon='list'
-                  label='Audit Log'
-                  value={formatDays(audit_log_visibility_days)}
+                  key={item.label}
+                  icon={item.icon}
+                  label={item.label}
+                  value={item.value}
                 />
-              )}
-              {Utils.getFlagsmithHasFeature('feature_versioning') &&
-                feature_history_visibility_days !== 0 && (
-                  <LimitItem
-                    icon='clock'
-                    label='Feature History'
-                    value={formatDays(feature_history_visibility_days)}
-                  />
-                )}
+              ))}
             </Row>
           </Row>
         </>

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -114,7 +114,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
         <>
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
           <Row className='plan p-4 mb-4'>
-            <Row className='flex-wrap gap-4'>
+            <Row className='flex-wrap gap-5'>
               <LimitItem
                 icon='bar-chart'
                 label='API Calls'

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -142,7 +142,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
       {subscriptionMeta && (
         <>
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
-          <Row className='plan p-4 mb-4 flex-wrap gap-5'>
+          <Row className='plan p-4 mb-4 flex-wrap gap-5 row-gap-4'>
             {limitItems.map((item) => (
               <LimitItem
                 key={item.label}

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -14,8 +14,26 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
     id: String(organisation.id),
   })
 
-  const { chargebee_email } = subscriptionMeta || {}
+  const {
+    audit_log_visibility_days,
+    chargebee_email,
+    feature_history_visibility_days,
+    max_api_calls,
+    max_projects,
+    max_seats,
+  } = subscriptionMeta || {}
   const planName = Utils.getPlanName(organisation.subscription?.plan) || 'Free'
+
+  const formatLimit = (value: number | null | undefined): string => {
+    if (value === null || value === undefined) return 'Unlimited'
+    return Utils.numberWithCommas(value)
+  }
+
+  const formatDays = (value: number | null | undefined): string => {
+    if (value === null || value === undefined) return 'Unlimited'
+    if (value === 0) return 'Not available'
+    return `${value} days`
+  }
 
   return (
     <div className='mt-4'>
@@ -74,6 +92,68 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
           )}
         </div>
       </Row>
+      {subscriptionMeta && (
+        <>
+          <h5 className='mt-4 mb-3'>Subscription Limits</h5>
+          <Row className='plan p-4 mb-4'>
+            <Row className='flex-wrap gap-4'>
+              <Row className='mr-3' style={{ width: '180px' }}>
+                <div className='plan-icon'>
+                  <Icon name='bar-chart' width={32} />
+                </div>
+                <div>
+                  <p className='fs-small lh-sm mb-0'>API Calls</p>
+                  <h4 className='mb-0'>{formatLimit(max_api_calls)}</h4>
+                </div>
+              </Row>
+              <Row className='mr-3' style={{ width: '180px' }}>
+                <div className='plan-icon'>
+                  <Icon name='people' width={32} />
+                </div>
+                <div>
+                  <p className='fs-small lh-sm mb-0'>Team Seats</p>
+                  <h4 className='mb-0'>{formatLimit(max_seats)}</h4>
+                </div>
+              </Row>
+              <Row className='mr-3' style={{ width: '180px' }}>
+                <div className='plan-icon'>
+                  <Icon name='layers' width={32} />
+                </div>
+                <div>
+                  <p className='fs-small lh-sm mb-0'>Projects</p>
+                  <h4 className='mb-0'>{formatLimit(max_projects)}</h4>
+                </div>
+              </Row>
+              {!!audit_log_visibility_days && (
+                <Row className='mr-3' style={{ width: '180px' }}>
+                  <div className='plan-icon'>
+                    <Icon name='list' width={32} />
+                  </div>
+                  <div>
+                    <p className='fs-small lh-sm mb-0'>Audit Log</p>
+                    <h4 className='mb-0'>
+                      {formatDays(audit_log_visibility_days)}
+                    </h4>
+                  </div>
+                </Row>
+              )}
+              {!!feature_history_visibility_days && (
+                <Row style={{ width: '180px' }}>
+                  <div className='plan-icon'>
+                    <Icon name='clock' width={32} />
+                  </div>
+                  <div>
+                    <p className='fs-small lh-sm mb-0'>Feature History</p>
+                    <h4 className='mb-0'>
+                      {formatDays(feature_history_visibility_days)}
+                    </h4>
+                  </div>
+                </Row>
+              )}
+            </Row>
+          </Row>
+        </>
+      )}
       <h5>Manage Payment Plan</h5>
       <Payment viewOnly={false} />
     </div>

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -130,7 +130,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
                 label='Projects'
                 value={formatLimit(max_projects)}
               />
-              {!!audit_log_visibility_days && (
+              {audit_log_visibility_days !== 0 && (
                 <LimitItem
                   icon='list'
                   label='Audit Log'
@@ -138,7 +138,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
                 />
               )}
               {Utils.getFlagsmithHasFeature('feature_versioning') &&
-                !!feature_history_visibility_days && (
+                feature_history_visibility_days !== 0 && (
                   <LimitItem
                     icon='clock'
                     label='Feature History'

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -10,6 +10,8 @@ type BillingTabProps = {
   organisation: Organisation
 }
 
+type LimitItem = Pick<StatItemProps, 'icon' | 'label'> & { value: string }
+
 export const BillingTab = ({ organisation }: BillingTabProps) => {
   const { data: subscriptionMeta } = useGetSubscriptionMetadataQuery({
     id: organisation.id,
@@ -41,8 +43,6 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
     Utils.getFlagsmithHasFeature('feature_versioning') &&
     feature_history_visibility_days !== 0
 
-  type LimitItem = Pick<StatItemProps, 'icon' | 'label'> & { value: string }
-
   const limitItems: LimitItem[] = [
     {
       icon: 'bar-chart',
@@ -69,11 +69,11 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
 
   return (
     <div className='mt-4'>
-      <Row space className='plan p-4 mb-4'>
+      <Row space className='plan p-4 mb-4 flex-wrap gap-4'>
         <div>
-          <Row>
+          <Row className='flex-wrap gap-4'>
             <div>
-              <Row className='mr-3' style={{ width: '230px' }}>
+              <Row style={{ width: '230px' }}>
                 <div className='plan-icon'>
                   <Icon name='layers' width={32} />
                 </div>
@@ -84,7 +84,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
               </Row>
             </div>
             <div>
-              <Row style={{ width: '230px' }} className='mr-3'>
+              <Row style={{ width: '230px' }}>
                 <div className='plan-icon'>
                   <h4 className='mb-0 text-center' style={{ width: '32px' }}>
                     ID
@@ -111,7 +111,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
             )}
           </Row>
         </div>
-        <div className='align-self-start'>
+        <div className='align-self-center'>
           {organisation.subscription?.subscription_id && (
             <Button
               theme='secondary'
@@ -127,7 +127,7 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
       {subscriptionMeta && (
         <>
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
-          <Row className='plan p-4 mb-4 flex-wrap gap-5 row-gap-4'>
+          <Row className='plan p-4 mb-4 flex-wrap gap-4'>
             {limitItems.map((item) => (
               <StatItem
                 key={item.label}

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -1,9 +1,27 @@
-import React from 'react'
+import React, { FC } from 'react'
 import { Organisation } from 'common/types/responses'
-import Icon from 'components/Icon'
+import Icon, { IconName } from 'components/Icon'
 import Utils from 'common/utils/utils'
 import Payment from 'components/modals/Payment'
 import { useGetSubscriptionMetadataQuery } from 'common/services/useSubscriptionMetadata'
+
+type LimitItemProps = {
+  icon: IconName
+  label: string
+  value: string
+}
+
+const LimitItem: FC<LimitItemProps> = ({ icon, label, value }) => (
+  <Row>
+    <div className='plan-icon'>
+      <Icon name={icon} width={32} />
+    </div>
+    <div>
+      <p className='fs-small lh-sm mb-0'>{label}</p>
+      <h4 className='mb-0'>{value}</h4>
+    </div>
+  </Row>
+)
 
 type BillingTabProps = {
   organisation: Organisation
@@ -97,58 +115,34 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
           <Row className='plan p-4 mb-4'>
             <Row className='flex-wrap gap-4'>
-              <Row className='mr-3' style={{ width: '180px' }}>
-                <div className='plan-icon'>
-                  <Icon name='bar-chart' width={32} />
-                </div>
-                <div>
-                  <p className='fs-small lh-sm mb-0'>API Calls</p>
-                  <h4 className='mb-0'>{formatLimit(max_api_calls)}</h4>
-                </div>
-              </Row>
-              <Row className='mr-3' style={{ width: '180px' }}>
-                <div className='plan-icon'>
-                  <Icon name='people' width={32} />
-                </div>
-                <div>
-                  <p className='fs-small lh-sm mb-0'>Team Seats</p>
-                  <h4 className='mb-0'>{formatLimit(max_seats)}</h4>
-                </div>
-              </Row>
-              <Row className='mr-3' style={{ width: '180px' }}>
-                <div className='plan-icon'>
-                  <Icon name='layers' width={32} />
-                </div>
-                <div>
-                  <p className='fs-small lh-sm mb-0'>Projects</p>
-                  <h4 className='mb-0'>{formatLimit(max_projects)}</h4>
-                </div>
-              </Row>
+              <LimitItem
+                icon='bar-chart'
+                label='API Calls'
+                value={formatLimit(max_api_calls)}
+              />
+              <LimitItem
+                icon='people'
+                label='Team Seats'
+                value={formatLimit(max_seats)}
+              />
+              <LimitItem
+                icon='layers'
+                label='Projects'
+                value={formatLimit(max_projects)}
+              />
               {!!audit_log_visibility_days && (
-                <Row className='mr-3' style={{ width: '180px' }}>
-                  <div className='plan-icon'>
-                    <Icon name='list' width={32} />
-                  </div>
-                  <div>
-                    <p className='fs-small lh-sm mb-0'>Audit Log</p>
-                    <h4 className='mb-0'>
-                      {formatDays(audit_log_visibility_days)}
-                    </h4>
-                  </div>
-                </Row>
+                <LimitItem
+                  icon='list'
+                  label='Audit Log'
+                  value={formatDays(audit_log_visibility_days)}
+                />
               )}
               {!!feature_history_visibility_days && (
-                <Row style={{ width: '180px' }}>
-                  <div className='plan-icon'>
-                    <Icon name='clock' width={32} />
-                  </div>
-                  <div>
-                    <p className='fs-small lh-sm mb-0'>Feature History</p>
-                    <h4 className='mb-0'>
-                      {formatDays(feature_history_visibility_days)}
-                    </h4>
-                  </div>
-                </Row>
+                <LimitItem
+                  icon='clock'
+                  label='Feature History'
+                  value={formatDays(feature_history_visibility_days)}
+                />
               )}
             </Row>
           </Row>

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -142,17 +142,15 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
       {subscriptionMeta && (
         <>
           <h5 className='mt-4 mb-3'>Subscription Limits</h5>
-          <Row className='plan p-4 mb-4'>
-            <Row className='flex-wrap gap-5'>
-              {limitItems.map((item) => (
-                <LimitItem
-                  key={item.label}
-                  icon={item.icon}
-                  label={item.label}
-                  value={item.value}
-                />
-              ))}
-            </Row>
+          <Row className='plan p-4 mb-4 flex-wrap gap-5'>
+            {limitItems.map((item) => (
+              <LimitItem
+                key={item.label}
+                icon={item.icon}
+                label={item.label}
+                value={item.value}
+              />
+            ))}
           </Row>
         </>
       )}

--- a/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/BillingTab.tsx
@@ -137,13 +137,14 @@ export const BillingTab = ({ organisation }: BillingTabProps) => {
                   value={formatDays(audit_log_visibility_days)}
                 />
               )}
-              {!!feature_history_visibility_days && (
-                <LimitItem
-                  icon='clock'
-                  label='Feature History'
-                  value={formatDays(feature_history_visibility_days)}
-                />
-              )}
+              {Utils.getFlagsmithHasFeature('feature_versioning') &&
+                !!feature_history_visibility_days && (
+                  <LimitItem
+                    icon='clock'
+                    label='Feature History'
+                    value={formatDays(feature_history_visibility_days)}
+                  />
+                )}
             </Row>
           </Row>
         </>

--- a/frontend/web/styles/project/_panel.scss
+++ b/frontend/web/styles/project/_panel.scss
@@ -95,6 +95,17 @@
   }
 }
 
+.visibility-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  color: white;
+}
+
 /*Change text in autofill textbox*/
 .dark {
   input:-webkit-autofill,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #5404

This PR adds subscription limit information to the Usage and Billing pages so users can see their API request quota alongside their current usage.

### Usage Page (`/organisation/{id}/usage`)
- Added subscription metadata query to fetch `max_api_calls`
- Updated `UsageChartTotals` component to display limits alongside usage values
- Shows "X / Y" format for Total API Calls when a limit is available
- Card-based layout with icons for each metric (Flags, Identities, Environment Document, Traits, Total API Calls)

### Billing Tab (Organisation Settings)
- Added new "Subscription Limits" section below the plan information
- Displays all subscription limits:
  - API Calls (`max_api_calls`)
  - Team Seats (`max_seats`)
  - Projects (`max_projects`) - shows "Unlimited" if null
  - Audit Log retention (`audit_log_visibility_days`) - hidden if 0/unavailable
  - Feature History retention (`feature_history_visibility_days`) - hidden if 0/unavailable, gated behind `feature_versioning` flag

### Shared StatItem Component
- Created reusable `StatItem` component (`web/components/StatItem.tsx`)
- Consolidates the duplicate `LimitItem` (BillingTab) and `LegendItem` (UsageChartTotals) components
- Supports both static display and interactive visibility toggle modes
- Ensures consistent styling across Usage and Billing pages

## How did you test this code?

1. Ran the frontend locally with `npm run dev`
2. Navigated to Organisation Settings > Billing tab
   - Verified subscription limits section displays correctly
   - Verified unavailable features (Audit Log, Feature History) are hidden when value is 0
   - Verified proper vertical spacing between limit items
3. Navigated to Organisation Usage page (`/organisation/{id}/usage`)
   - Verified "Total API Calls" shows "X / Y" format with the subscription limit
   - Verified card-based layout with icons displays correctly
   - Verified visibility toggle checkmark appears white on coloured background
4. Tested with different plan types to ensure correct display of limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)