### PR TITLE
ci: Add `flagsmith-api-private-test` image build

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -58,6 +58,14 @@ jobs:
       image-name: flagsmith-api-test
       scan: false
 
+  docker-build-api-private-test:
+    name: Build API Enterprise Test Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      target: api-private-test
+      image-name: flagsmith-api-private-test
+      scan: false
+
   docker-build-e2e:
     name: Build E2E Image
     uses: ./.github/workflows/.reusable-docker-build.yml

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/enterprise-test-image
   release:
     types:
       - released

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -66,6 +66,9 @@ jobs:
       target: api-private-test
       image-name: flagsmith-api-private-test
       scan: false
+    secrets:
+      secrets: |
+        github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
   docker-build-e2e:
     name: Build E2E Image

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/enterprise-test-image
   release:
     types:
       - released

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -43,7 +43,7 @@ jobs:
               "test": "testing",
               "chore": "chore"
             }
-          ignored_types: '[]'
+          ignored_types: "[]"
 
   docker-prepare-report-comment:
     if: github.event.pull_request.draft == false && needs.permissions-check.outputs.can-write == 'true'
@@ -103,6 +103,19 @@ jobs:
       ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       comment: ${{ needs.docker-prepare-report-comment.result == 'success' }}
       scan: false
+
+  docker-build-api-private-test:
+    if: needs.permissions-check.outputs.can-write == 'true'
+    needs: [permissions-check, docker-prepare-report-comment]
+    name: Build API Enterprise Test Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      target: api-private-test
+      image-name: flagsmith-api-private-test
+      scan: false
+    secrets:
+      secrets: |
+        github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
   docker-build-e2e:
     if: github.event.pull_request.draft == false && !cancelled()

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,8 +159,6 @@ RUN apk add xmlsec
 # * api-test [build-python]
 FROM build-python AS api-test
 
-WORKDIR /build
-
 COPY api /build/
 
 RUN make install-packages opts='--with dev'
@@ -169,8 +167,6 @@ CMD ["make test"]
 
 # * api-private-test [build-python-private]
 FROM build-python-private AS api-private-test
-
-WORKDIR /build
 
 COPY api /build/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,9 +159,9 @@ RUN apk add xmlsec
 # * api-test [build-python]
 FROM build-python AS api-test
 
-WORKDIR /app
+WORKDIR /build
 
-COPY api /app/
+COPY api /build/
 
 RUN make install-packages opts='--with dev'
 
@@ -170,9 +170,9 @@ CMD ["make test"]
 # * api-private-test [build-python-private]
 FROM build-python-private AS api-private-test
 
-WORKDIR /app
+WORKDIR /build
 
-COPY api /app/
+COPY api /build/
 
 RUN make install-packages opts='--with dev' && \
   make integrate-private-tests && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,9 @@ WORKDIR /app
 COPY api /app/
 
 RUN make install-packages opts='--with dev' && \
-  make integrate-private-tests
+  make integrate-private-tests && \
+  git config --global --unset credential.helper && \
+  rm -f ${HOME}/.git-credentials
 
 CMD ["make test"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ COPY api /build/
 
 RUN make install-packages opts='--with dev'
 
-CMD ["make test"]
+CMD ["make", "test"]
 
 # * api-private-test [build-python-private]
 FROM build-python-private AS api-private-test
@@ -175,7 +175,7 @@ RUN make install-packages opts='--with dev' && \
   git config --global --unset credential.helper && \
   rm -f ${HOME}/.git-credentials
 
-CMD ["make test"]
+CMD ["make", "test"]
 
 # - Target (shippable) stages
 # * private-cloud-api [api-runtime-private, build-python-private]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@
 
 # - Internal stages
 # * api-test [build-python]
+# * api-private-test [build-python-private]
 
 # - Target (shippable) stages
 # * private-cloud-api [api-runtime-private, build-python-private]
@@ -158,11 +159,23 @@ RUN apk add xmlsec
 # * api-test [build-python]
 FROM build-python AS api-test
 
+WORKDIR /app
+
+COPY api /app/
+
 RUN make install-packages opts='--with dev'
+
+CMD ["make test"]
+
+# * api-private-test [build-python-private]
+FROM build-python-private AS api-private-test
 
 WORKDIR /app
 
 COPY api /app/
+
+RUN make install-packages opts='--with dev' && \
+  make integrate-private-tests
 
 CMD ["make test"]
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds a test image that includes private dependencies to be used for development and integration testing.

## How did you test this code?

Added a trigger to build from this branch.

flagsmith-auth-controller integration tests run successfully on top of this image, see https://github.com/Flagsmith/flagsmith-auth-controller/pull/33.