### PR TITLE
fix: update permission test query counts for RBAC

### DIFF
--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -746,7 +746,7 @@ def test_view_environment_with_staff__query_count_is_expected_with_rbac(
         environment_metadata_b,
         required_a_environment_metadata_field,
         environment_content_type,
-        expected_query_count=12,
+        expected_query_count=13,
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follows up on #6537

Updates expected query counts in permission tests to account for the additional RBAC role permission check when `IS_RBAC_INSTALLED` is True.

- `test_is_user_environment_admin__short_circuits_on_direct_permission`: 6 → 7 queries with RBAC
- `test_is_user_environment_admin__short_circuits_on_group_permission`: 7 → 8 queries with RBAC
- `test_view_environment_with_staff__query_count_is_expected_with_rbac`: 12 → 13 queries

## How did you test this code?

Ran the affected tests with RBAC enabled in CI.