### PR TITLE
fix: add skip conditions for undefined environment ID queries

### DIFF
--- a/frontend/web/components/CompareIdentities.tsx
+++ b/frontend/web/components/CompareIdentities.tsx
@@ -59,10 +59,14 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
 }) => {
   const [leftId, setLeftId] = useState<IdentitySelectType['value']>()
   const [rightId, setRightId] = useState<IdentitySelectType['value']>()
-  const { data: projectFlags, refetch } = useGetProjectFlagsQuery({
-    environment: ProjectStore.getEnvironmentIdFromKey(_environmentId),
-    project: projectId,
-  })
+  const envId = ProjectStore.getEnvironmentIdFromKey(_environmentId)
+  const { data: projectFlags, refetch } = useGetProjectFlagsQuery(
+    {
+      environment: envId,
+      project: projectId,
+    },
+    { skip: !envId || !projectId },
+  )
   const [environmentId, setEnvironmentId] = useState(_environmentId)
   const [showArchived, setShowArchived] = useState(false)
 
@@ -74,11 +78,11 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
 
   const { data: leftUser } = useGetIdentityFeatureStatesAllQuery(
     { environment: environmentId, user: `${leftId?.value}` },
-    { skip: !leftId },
+    { skip: !leftId || !environmentId },
   )
   const { data: rightUser } = useGetIdentityFeatureStatesAllQuery(
     { environment: environmentId, user: `${rightId?.value}` },
-    { skip: !rightId },
+    { skip: !rightId || !environmentId },
   )
   const [createCloneIdentityFeatureStates] =
     useCreateCloneIdentityFeatureStatesMutation()

--- a/frontend/web/components/IdentitySelect.tsx
+++ b/frontend/web/components/IdentitySelect.tsx
@@ -28,11 +28,16 @@ const IdentitySelect: FC<IdentitySelectType> = ({
   const { data, isLoading, loadMore, searchItems } = useInfiniteScroll<
     Req['getIdentities'],
     Res['identities']
-  >(useGetIdentitiesQuery, {
-    environmentId,
-    isEdge,
-    page_size: 10,
-  })
+  >(
+    useGetIdentitiesQuery,
+    {
+      environmentId,
+      isEdge,
+      page_size: 10,
+    },
+    500,
+    { skip: !environmentId },
+  )
   const identityOptions = useMemo(() => {
     return filter(
       data?.results,


### PR DESCRIPTION
## Summary

- Add skip conditions to RTK Query hooks to prevent API requests with undefined/empty environment IDs
- Fix `IdentitySelect` component to skip `useGetIdentitiesQuery` when `environmentId` is undefined
- Fix `CompareIdentities` component to skip `useGetProjectFlagsQuery` when `envId` or `projectId` is missing
- Enhance `useGetIdentityFeatureStatesAllQuery` skip conditions to also check for `environmentId`

Fixes #6534
Fixes FLAGSMITH-FRONTEND-2FM (35,290 events affecting 482 users)

## Test plan

- [x] Navigate directly to the Compare Identities page without selecting an environment
- [x] Verify no 404 errors appear in the browser network tab for `/environments/undefined/` or `/environments//` paths
- [x] Select an environment and verify the page functions correctly
- [x] Select two identities and verify comparison works
- [x] Check browser console for no `[object Response]` unhandled promise rejection errors
