### PR TITLE
fix: add null checks for multivariate_options in feature-list-store

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -219,9 +219,10 @@ const controller = {
         : flag
     Promise.all(
       (flag.multivariate_options || []).map((v, i) => {
-        const originalMV = v.id
-          ? originalFlag.multivariate_options.find((m) => m.id === v.id)
-          : null
+        const originalMV =
+          v.id && originalFlag?.multivariate_options
+            ? originalFlag.multivariate_options.find((m) => m.id === v.id)
+            : null
         const url = `${Project.api}projects/${projectId}/features/${flag.id}/mv-options/`
         const mvData = {
           ...v,
@@ -243,7 +244,7 @@ const controller = {
       }),
     )
       .then(() => {
-        const deletedMv = originalFlag.multivariate_options.filter(
+        const deletedMv = (originalFlag?.multivariate_options || []).filter(
           (v) => !flag.multivariate_options.find((x) => v.id === x.id),
         )
         return Promise.all(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6552

Adds defensive null checks for `originalFlag.multivariate_options` in the `editFeatureMv` function to prevent crashes when editing multivariate feature flags with incomplete store data.

**Root Cause:** When `originalFlag` exists in the store but `multivariate_options` is undefined, the code crashes with:
```
TypeError: Cannot read properties of undefined (reading 'multivariate_options')
```

**Fix:**
- Line 222-225: Added `originalFlag?.multivariate_options` check before accessing `.find()`
- Line 247: Added fallback to empty array `(originalFlag?.multivariate_options || [])`

**Sentry Issue:** [FLAGSMITH-FRONTEND-48Y](https://flagsmith.sentry.io/issues/6738226282/) - 47 events, 15 users affected

## How to reproduce

1. Navigate to a project's Features page
2. Create or select a feature with multivariate options
3. Open the feature modal to edit it
4. The error occurs when the store has the feature but `multivariate_options` is undefined (race condition or stale data)

**Alternative reproduction (simulating the bug):**

1. Open Chrome DevTools → Sources tab
2. Navigate to a feature with multivariate options
3. Set a breakpoint in `feature-list-store.ts` at the `editFeatureMv` function
4. Manually set `originalFlag.multivariate_options = undefined` in the console
5. Continue execution → observe the crash

**After the fix:** The code gracefully handles undefined `multivariate_options` by using optional chaining and fallback to empty array.

## How did you test this code?

- Verified the fix aligns with the proposed solution in #6552
- ESLint passed via pre-commit hook
- The changes are defensive null checks that won't affect normal operation when `multivariate_options` exists