### PR TITLE
fix: add loading state for MultiSelect in Create Segment modal

### DIFF
--- a/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionValueInput.tsx
@@ -53,17 +53,22 @@ const RuleConditionValueInput: React.FC<RuleConditionValueInputProps> = ({
     useConditionInputType(operator, property)
 
   if (showMultiEnvironmentSelect) {
+    const isLoading = !projectId || !data?.results
+
     return (
       <div className={className}>
         <MultiSelect
-          selectedValues={safeParseArray(value)}
+          selectedValues={isLoading ? [] : safeParseArray(value)}
           onSelectionChange={(selectedValues: string[]) => {
             onChange?.(selectedValues.join(','))
           }}
-          placeholder='Select environments...'
+          placeholder={
+            isLoading ? 'Loading environments...' : 'Select environments...'
+          }
           options={environmentOptions}
           className='w-100'
           hideSelectedOptions={false}
+          disabled={isLoading}
           inline
         />
       </div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6544

Adds a loading state check for the `MultiSelect` component in `RuleConditionValueInput` to prevent crashes when opening the Create Segment modal with environment-based operators.

**Root Cause:** When `showMultiEnvironmentSelect` is `true` but `projectId` is undefined or environments haven't loaded yet, react-select crashes internally with:
- Chrome: `TypeError: Cannot read properties of null (reading 'reduce')`
- Safari: `null is not an object (evaluating 'e.options.reduce')`

**Fix:**
- Added `isLoading` check for when `projectId` is undefined or `data?.results` hasn't loaded
- When loading: disable the MultiSelect, show "Loading environments..." placeholder, and use empty selectedValues
- When loaded: normal behaviour with environments available

**Sentry Issues:**
- [FLAGSMITH-FRONTEND-4G8](https://flagsmith.sentry.io/issues/7195142826/) - 3 events, 1 user
- FLAGSMITH-FRONTEND-4G9 - 2 events, 1 user
- FLAGSMITH-FRONTEND-4DP - 1 event, 1 user
- FLAGSMITH-FRONTEND-4DQ - 1 event, 1 user

## How to reproduce

1. Navigate to a project's Segments page (`/project/{id}/segments`)
2. Click "Create Segment" button
3. Add a rule condition
4. Select the property `environment`
5. Select an operator that triggers multi-environment selection (e.g., `IN`, `NOT_IN`)
6. **Before fix:** Modal crashes with TypeError
7. **After fix:** MultiSelect shows "Loading environments..." until data is ready, then displays environment options

**Alternative reproduction (simulating the race condition):**

1. Open Chrome DevTools → Network tab
2. Set throttling to "Slow 3G"
3. Follow steps 1-5 above
4. The loading state should be visible briefly before environments load

## How did you test this code?

- ESLint passed via pre-commit hook
- Manual testing following the reproduction steps above
- Verified the MultiSelect displays correctly once environments are loaded
- Verified the disabled state prevents interaction while loading