### PR TITLE
ci: private packages test improvements

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     paths:
       - api/**
+      - docker/api/**
       - .github/**
+      - .release-please-manifest.json
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     paths:
       - api/**
+      - docker/api/**
       - .github/**
+      - .release-please-manifest.json
     branches:
       - main
 

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -25,20 +25,10 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     name: API Unit Tests
 
-    services:
-      postgres:
-        image: postgres:15.5-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports: ['5432:5432']
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Cloning repo
@@ -55,16 +45,10 @@ jobs:
       - name: Install Dependencies
         run: make install-packages
 
-      - name: Create analytics database
-        env:
-          PGPASSWORD: postgres
-        run: createdb -h localhost -U postgres -p 5432 analytics
-
       - name: Check for missing migrations
         env:
           opts: --no-input --dry-run --check
         run: make django-make-migrations
-
 
       - uses: liskin/gh-problem-matcher-wrap@v2
         with:
@@ -83,7 +67,7 @@ jobs:
         uses: nickcharlton/diff-check@v1.0.0
         with:
           command: make -C api generate-docs
-  
+
       - name: Run Tests
         run: make test
 

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -2,6 +2,11 @@ name: Run API tests with private package
 
 on:
   pull_request:
+    paths:
+      - api/**
+      - .github/**
+      - api/Makefile
+      - .release-please-manifest.json
     branches:
       - main
 

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -7,6 +7,13 @@ on:
       - docker/api/**
       - .github/**
       - .release-please-manifest.json
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    paths:
+      - api/**
+      - docker/api/**
+      - .github/**
+      - .release-please-manifest.json
     branches:
       - main
 

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - api/**
+      - docker/api/**
       - .github/**
       - .release-please-manifest.json
     branches:

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - api/**
       - .github/**
-      - api/Makefile
       - .release-please-manifest.json
     branches:
       - main

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -18,16 +18,6 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     name: API Tests
 
-    services:
-      postgres:
-        image: postgres:15.5-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports: ['5432:5432']
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
       - name: Cloning repo
         uses: actions/checkout@v5
@@ -37,7 +27,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: poetry
 
       - name: Install SAML Dependencies

--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,5 +1,5 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
-ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
+DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
+ANALYTICS_DATABASE_URL=postgresql://postgres:password@localhost:5433/analytics
 PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --ci
 GUNICORN_LOGGER_CLASS=util.logging.GunicornJsonCapableLogger
 COVERAGE_CORE=sysmon

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,3 +1,4 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
+ANALYTICS_DATABASE_URL=postgresql://postgres:password@localhost:5433/analytics
 DJANGO_SETTINGS_MODULE=app.settings.local
 PYTEST_ADDOPTS=--cov . --cov-report html -n auto

--- a/api/Makefile
+++ b/api/Makefile
@@ -30,8 +30,8 @@ install-packages:
 .PHONY: install-private-modules
 install-private-modules:
 	$(eval SITE_PACKAGES_DIR := $(shell poetry run python -c 'import site; print(site.getsitepackages()[0])'))
-	git clone https://github.com/flagsmith/flagsmith-saml --depth 1 --branch ${SAML_REVISION} && cp -f ./flagsmith-saml/saml $(SITE_PACKAGES_DIR)
-	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && cp -f ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
+	git clone https://github.com/flagsmith/flagsmith-saml --depth 1 --branch ${SAML_REVISION} && cp -rf ./flagsmith-saml/saml $(SITE_PACKAGES_DIR)
+	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && cp -rf ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
 	rm -rf ./flagsmith-saml ./flagsmith-rbac
 
 .PHONY: install

--- a/api/Makefile
+++ b/api/Makefile
@@ -67,23 +67,27 @@ docker-build:
 		--target=oss-api \
 		../
 
+.PHONY: wait-for-db
+wait-for-db:
+	poetry run python manage.py waitfordb 
+	poetry run python manage.py waitfordb --database analytics
+
 .PHONY: test
-test: docker-up
-	poetry run python manage.py waitfordb
+test: docker-up wait-for-db
 	poetry run pytest $(opts)
 
 .PHONY: django-make-migrations
-django-make-migrations: docker-up
+django-make-migrations: docker-up wait-for-db
 	poetry run python manage.py waitfordb
 	poetry run python manage.py makemigrations $(opts)
 
 .PHONY: django-squash-migrations
-django-squash-migrations: docker-up
+django-squash-migrations: docker-up wait-for-db
 	poetry run python manage.py waitfordb
 	poetry run python manage.py squashmigrations $(opts)
 
 .PHONY: django-migrate
-django-migrate: docker-up
+django-migrate: docker-up wait-for-db
 	poetry run python manage.py waitfordb
 	poetry run python manage.py migrate
 	poetry run python manage.py createcachetable
@@ -97,11 +101,11 @@ django-collect-static:
 	poetry run python manage.py collectstatic --noinput
 
 .PHONY: serve
-serve: docker-up
+serve: docker-up wait-for-db
 	poetry run flagsmith start --reload api
 
 .PHONY: run-task-processor
-run-task-processor: docker-up
+run-task-processor: docker-up wait-for-db
 	poetry run flagsmith start --reload --bind 0.0.0.0:8001 task-processor
 
 .PHONY: serve-with-task-processor

--- a/api/Makefile
+++ b/api/Makefile
@@ -69,6 +69,7 @@ docker-build:
 
 .PHONY: test
 test: docker-up
+	poetry run python manage.py waitfordb
 	poetry run pytest $(opts)
 
 .PHONY: django-make-migrations

--- a/api/Makefile
+++ b/api/Makefile
@@ -30,8 +30,8 @@ install-packages:
 .PHONY: install-private-modules
 install-private-modules:
 	$(eval SITE_PACKAGES_DIR := $(shell poetry run python -c 'import site; print(site.getsitepackages()[0])'))
-	git clone https://github.com/flagsmith/flagsmith-saml --depth 1 --branch ${SAML_REVISION} && mv ./flagsmith-saml/saml $(SITE_PACKAGES_DIR)
-	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && mv ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
+	git clone https://github.com/flagsmith/flagsmith-saml --depth 1 --branch ${SAML_REVISION} && cp -f ./flagsmith-saml/saml $(SITE_PACKAGES_DIR)
+	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && cp -f ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
 	rm -rf ./flagsmith-saml ./flagsmith-rbac
 
 .PHONY: install

--- a/api/Makefile
+++ b/api/Makefile
@@ -30,8 +30,9 @@ install-packages:
 .PHONY: install-private-modules
 install-private-modules:
 	$(eval SITE_PACKAGES_DIR := $(shell poetry run python -c 'import site; print(site.getsitepackages()[0])'))
-	git clone https://github.com/flagsmith/flagsmith-saml --depth 1 --branch ${SAML_REVISION} && cp -rf ./flagsmith-saml/saml $(SITE_PACKAGES_DIR)
-	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && cp -rf ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
+	rm -rf $(SITE_PACKAGES_DIR)/saml $(SITE_PACKAGES_DIR)/rbac
+	git clone https://github.com/flagsmith/flagsmith-saml --depth 1 --branch ${SAML_REVISION} && mv ./flagsmith-saml/saml $(SITE_PACKAGES_DIR)
+	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && mv ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
 	rm -rf ./flagsmith-saml ./flagsmith-rbac
 
 .PHONY: install

--- a/api/Makefile
+++ b/api/Makefile
@@ -68,21 +68,21 @@ docker-build:
 		../
 
 .PHONY: test
-test:
+test: docker-up
 	poetry run pytest $(opts)
 
 .PHONY: django-make-migrations
-django-make-migrations:
+django-make-migrations: docker-up
 	poetry run python manage.py waitfordb
 	poetry run python manage.py makemigrations $(opts)
 
 .PHONY: django-squash-migrations
-django-squash-migrations:
+django-squash-migrations: docker-up
 	poetry run python manage.py waitfordb
 	poetry run python manage.py squashmigrations $(opts)
 
 .PHONY: django-migrate
-django-migrate:
+django-migrate: docker-up
 	poetry run python manage.py waitfordb
 	poetry run python manage.py migrate
 	poetry run python manage.py createcachetable

--- a/docker/api/docker-compose.local.yml
+++ b/docker/api/docker-compose.local.yml
@@ -4,16 +4,31 @@ name: flagsmith
 
 volumes:
   pg_11_data:
+  pg_11_data_analytics:
 
 services:
   db:
     image: postgres:15.5-alpine
     pull_policy: always
     restart: unless-stopped
+    command: ["-c", "max_locks_per_transaction=256"]
     volumes:
       - pg_11_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     environment:
       POSTGRES_DB: flagsmith
+      POSTGRES_PASSWORD: password
+
+  analytics-db:
+    image: postgres:15.5-alpine
+    pull_policy: always
+    restart: unless-stopped
+    command: ["-c", "max_locks_per_transaction=256"]
+    volumes:
+      - pg_11_data_analytics:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_DB: analytics
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
## Changes

This PR improves the workflow which runs the tests with private packages installed. In order to do so, 2 changes are made: 

 1. `rm` the existing dirs before `mv` to resolve errors seen in CI where the `saml` / `rbac` directory already exists (likely because of pip caching). 
 2. Only runs the private packages tests for changes to BE code and a few other relevant files

## How did you test this code?

Using the workflows on this PR
