### PR TITLE
ci: Increase `max_locks_per_transaction` for Python tests

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -25,20 +25,10 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     name: API Unit Tests
 
-    services:
-      postgres:
-        image: postgres:15.5-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports: ['5432:5432']
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Cloning repo
@@ -55,16 +45,10 @@ jobs:
       - name: Install Dependencies
         run: make install-packages
 
-      - name: Create analytics database
-        env:
-          PGPASSWORD: postgres
-        run: createdb -h localhost -U postgres -p 5432 analytics
-
       - name: Check for missing migrations
         env:
           opts: --no-input --dry-run --check
         run: make django-make-migrations
-
 
       - uses: liskin/gh-problem-matcher-wrap@v2
         with:
@@ -83,7 +67,7 @@ jobs:
         uses: nickcharlton/diff-check@v1.0.0
         with:
           command: make -C api generate-docs
-  
+
       - name: Run Tests
         run: make test
 

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -18,16 +18,6 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     name: API Tests
 
-    services:
-      postgres:
-        image: postgres:15.5-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports: ['5432:5432']
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
       - name: Cloning repo
         uses: actions/checkout@v5
@@ -37,7 +27,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: poetry
 
       - name: Install SAML Dependencies

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -8,7 +8,6 @@ on:
       - .release-please-manifest.json
     branches:
       - main
-      - ci/private-packages-test-improvements # branch for testing only
 
 defaults:
   run:

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -8,6 +8,7 @@ on:
       - .release-please-manifest.json
     branches:
       - main
+      - ci/private-packages-test-improvements # branch for testing only
 
 defaults:
   run:

--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,5 +1,5 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
-ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
+DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
+ANALYTICS_DATABASE_URL=postgresql://postgres:password@localhost:5433/analytics
 PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --ci
 GUNICORN_LOGGER_CLASS=util.logging.GunicornJsonCapableLogger
 COVERAGE_CORE=sysmon

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,3 +1,4 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
+ANALYTICS_DATABASE_URL=postgresql://postgres:password@localhost:5433/analytics
 DJANGO_SETTINGS_MODULE=app.settings.local
 PYTEST_ADDOPTS=--cov . --cov-report html -n auto

--- a/api/Makefile
+++ b/api/Makefile
@@ -72,17 +72,17 @@ test: docker-up
 	poetry run pytest $(opts)
 
 .PHONY: django-make-migrations
-django-make-migrations:
+django-make-migrations: docker-up
 	poetry run python manage.py waitfordb
 	poetry run python manage.py makemigrations $(opts)
 
 .PHONY: django-squash-migrations
-django-squash-migrations:
+django-squash-migrations: docker-up
 	poetry run python manage.py waitfordb
 	poetry run python manage.py squashmigrations $(opts)
 
 .PHONY: django-migrate
-django-migrate:
+django-migrate: docker-up
 	poetry run python manage.py waitfordb
 	poetry run python manage.py migrate
 	poetry run python manage.py createcachetable

--- a/api/Makefile
+++ b/api/Makefile
@@ -68,7 +68,7 @@ docker-build:
 		../
 
 .PHONY: test
-test:
+test: docker-up
 	poetry run pytest $(opts)
 
 .PHONY: django-make-migrations

--- a/docker/api/docker-compose.local.yml
+++ b/docker/api/docker-compose.local.yml
@@ -10,10 +10,24 @@ services:
     image: postgres:15.5-alpine
     pull_policy: always
     restart: unless-stopped
+    command: ["-c", "max_locks_per_transaction=256"]
     volumes:
       - pg_11_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     environment:
       POSTGRES_DB: flagsmith
+      POSTGRES_PASSWORD: password
+
+  analytics-db:
+    image: postgres:15.5-alpine
+    pull_policy: always
+    restart: unless-stopped
+    command: ["-c", "max_locks_per_transaction=256"]
+    volumes:
+      - pg_11_data_analytics:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_DB: analytics
       POSTGRES_PASSWORD: password

--- a/docker/api/docker-compose.local.yml
+++ b/docker/api/docker-compose.local.yml
@@ -4,6 +4,7 @@ name: flagsmith
 
 volumes:
   pg_11_data:
+  pg_11_data_analytics:
 
 services:
   db:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In this PR, we attempt to fix the `django.db.utils.OperationalError: out of shared memory` error in CI by increasing default `max_locks_per_transaction` for the test databases. As a side effect, we move from Postgres services defined in Github Actions to a more centralised Compose-based approach.

## How did you test this code?

This is a CI change.