### PR TITLE
fix(frontend): add docs link to LaunchDarkly import screen

### DIFF
--- a/frontend/web/components/import-export/ImportPage.tsx
+++ b/frontend/web/components/import-export/ImportPage.tsx
@@ -113,7 +113,15 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
     <>
       <InfoMessage>
         Import operations will overwrite existing environments and flags in your
-        project.
+        project.{' '}
+        <a
+          target='_blank'
+          href='https://docs.flagsmith.com/system-administration/importing-and-exporting/launchdarkly'
+          rel='noreferrer'
+          onClick={(e) => e.stopPropagation()}
+        >
+          <strong>Visit the documentation for more details.</strong>
+        </a>
       </InfoMessage>
       <h5>Import LaunchDarkly Projects</h5>
       <label>Set LaunchDarkly key</label>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
<img width="888" height="488" alt="image" src="https://github.com/user-attachments/assets/64b45dfa-468a-406b-a988-9cf1fad3cd5d" />

Closes #6164

Adds a "View docs" link to the LaunchDarkly import screen that directs users to the documentation at https://docs.flagsmith.com/system-administration/importing-and-exporting/launchdarkly. This helps users understand how to import LaunchDarkly data and what format to use.

## How did you test this code?

1. Navigate to Project Settings > Import
2. Select the "LaunchDarkly" tab
3. Verify the "View docs" link appears within the info message
4. Click the link and confirm it opens the correct documentation page