### PR TITLE
fix(frontend): simplify tab overflow dropdown menu items

### DIFF
--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -181,28 +181,10 @@ const Tabs: React.FC<TabsProps> = ({
                 const actualIndex = i + visibleCount
                 const active = value === actualIndex
                 return {
-                  className: classNames('', [
-                    active
-                      ? 'text-primary fw-semibold bg-primary-opacity-5 fill-primary'
-                      : 'hover-color-primary',
-                  ]),
-                  label: (
-                    <div className='d-flex align-items-center text-nowrap tabs-nav full-width'>
-                      <TabButton
-                        key={`overflow-${actualIndex}`}
-                        isSelected={false}
-                        className={classNames(
-                          'full-width btn-no-focus width-100',
-                          active && 'text-primary fw-semibold fill-primary',
-                        )}
-                        noFocus={noFocus}
-                        child={child}
-                        buttonTheme={buttonTheme}
-                      >
-                        {child.props.tabLabel}
-                      </TabButton>
-                    </div>
-                  ) as React.ReactNode,
+                  className: classNames(
+                    active ? 'text-primary fw-semibold' : '',
+                  ),
+                  label: child.props.tabLabel,
                   onClick: (e: any) => {
                     handleChange(
                       e,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6592

UI cleanup for the tab overflow dropdown menu in the feature modal.

**Problem:** The dropdown menu items (Code References, Links, History, Settings) displayed with extra whitespace before the text and inconsistent purple backgrounds due to the `TabButton` component being unnecessarily used inside the dropdown.

**Solution:** Simplified the dropdown menu items to use `tabLabel` directly instead of wrapping it in a `TabButton` component. This removes:
- Unnecessary wrapper div with flexbox styling
- TabButton component with its own button styling
- Complex className combinations causing visual inconsistencies

## How did you test this code?

1. Open a feature modal with many tabs (so some overflow into dropdown)
2. Click the overflow menu button (three dots icon)
3. Verify menu items display cleanly without extra whitespace
4. Verify active tab is highlighted with primary colour text
5. Verify clicking a menu item correctly switches to that tab