### PR TITLE
ci: Upload coverage for private tests, use OIDC

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -1,5 +1,9 @@
 name: API Pull Request
 
+permissions:
+  contents: read     # For actions/checkout
+  id-token: write    # For Codecov OIDC
+
 on:
   pull_request:
     paths:
@@ -80,5 +84,5 @@ jobs:
         env:
           PYTHON: ${{ matrix.python-version }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: PYTHON
+          use_oidc: true

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -1,4 +1,8 @@
-name: Run API tests with private package
+name: API Pull Request with Private Packages
+
+permissions:
+  contents: read     # For actions/checkout
+  id-token: write    # For Codecov OIDC
 
 on:
   pull_request:
@@ -24,7 +28,12 @@ defaults:
 jobs:
   test:
     runs-on: depot-ubuntu-latest-16
-    name: API Tests
+    name: API Unit Tests
+
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Cloning repo
@@ -35,7 +44,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: poetry
 
       - name: Install SAML Dependencies
@@ -55,3 +64,12 @@ jobs:
         env:
           DOTENV_OVERRIDE_FILE: .env-ci
         run: make test
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
+        env:
+          PRIVATE_PACKAGES: "true"
+          PYTHON: ${{ matrix.python-version }}
+        with:
+          env_vars: PRIVATE_PACKAGES,PYTHON
+          use_oidc: true


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In this PR, we:
1. Run private package tests on both supported Python versions.
1. Upload coverage for private package tests to improve project coverage for PRs.
1. Switch to OIDC-based auth for Codecov.

## How did you test this code?

This is a CI change — once CI passes, it's ready to go.