### PR TITLE
fix: #6397 - Inconsistent feature toggle behavior corrected

### DIFF
--- a/frontend/web/components/feature-summary/FeatureRow.tsx
+++ b/frontend/web/components/feature-summary/FeatureRow.tsx
@@ -372,6 +372,11 @@ const FeatureRow: FC<FeatureRowProps> = (props) => {
             <FeatureName name={projectFlag.name} />
             <FeatureTags editFeature={editFeature} projectFlag={projectFlag} />
           </div>
+                    <div
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+          >
           <Switch
             disabled={!permission || isReadOnly || isLoading}
             data-test={`feature-switch-${index}${
@@ -380,6 +385,7 @@ const FeatureRow: FC<FeatureRowProps> = (props) => {
             checked={displayEnabled}
             onChange={onChange}
           />
+          </div>
           <FeatureAction {...featureActionProps} disableE2E={true} />
         </div>
       </div>

--- a/frontend/web/components/feature-summary/FeatureRow.tsx
+++ b/frontend/web/components/feature-summary/FeatureRow.tsx
@@ -372,7 +372,7 @@ const FeatureRow: FC<FeatureRowProps> = (props) => {
             <FeatureName name={projectFlag.name} />
             <FeatureTags editFeature={editFeature} projectFlag={projectFlag} />
           </div>
-                    <div
+          <div
             onClick={(e) => {
               e.stopPropagation()
             }}


### PR DESCRIPTION
 Inconsistent feature toggle behavior fixed by preventing event bubbling

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/6397

Inconsistent feature toggle behavior based on window size

Description:

Full-width screens: Clicking the feature toggle switch displays a confirmation modal (correct behavior)
Narrow screens: Clicking the feature toggle switch opens the feature detail view instead of showing the confirmation modal (incorrect behavior)
**Root Cause:**
The feature flag list component (FeatureRow.tsx) had two responsive rendering branches:

Large screens (d-lg-flex): The toggle Switch was properly wrapped with onClick={(e) => { e.stopPropagation() }} to prevent event bubbling
Narrow screens (d-lg-none): The toggle Switch was missing this event propagation blocker
When users clicked the toggle on narrow screens, the click event bubbled up to the parent row's onClick={() => editFeature()} handler, which opened the feature detail view instead of allowing the toggle confirmation modal to appear.

**Solution**
Event Propagation Handler (FeatureRow.tsx)
Added onClick={(e) => { e.stopPropagation() }} wrapper around the narrow-screen Switch component to prevent click events from bubbling to the parent row's click handler.

## How did you test this code?

Open your browser (in my case chromium-based) at half-width
Click the toggle to enable/disable a feature in the dashboard
Notice how it opens the feature in a new view
