### PR TITLE
fix(api-docs): Avoid `readOnly` properties with `required`

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -567,6 +567,7 @@ SPECTACULAR_SETTINGS = {
         "SegmentRuleTypeEnum": "segments.models.SegmentRule.RULE_TYPES",
         "FeatureValueTypeEnum": ["integer", "string", "boolean"],
     },
+    "COMPONENT_NO_READ_ONLY_REQUIRED": True,
 }
 
 

--- a/api/tests/integration/test_api_documentation.py
+++ b/api/tests/integration/test_api_documentation.py
@@ -12,7 +12,3 @@ def test_api_documentation_specification_loads(
     # Then
     assert response.status_code == 200
     assert response.json()["info"]["title"] == "Flagsmith API"
-
-
-def test_spectacular_settings__component_no_read_only_required__is_enabled() -> None:
-    assert settings.SPECTACULAR_SETTINGS["COMPONENT_NO_READ_ONLY_REQUIRED"] is True

--- a/api/tests/integration/test_api_documentation.py
+++ b/api/tests/integration/test_api_documentation.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import Client
 
 
@@ -11,3 +12,7 @@ def test_api_documentation_specification_loads(
     # Then
     assert response.status_code == 200
     assert response.json()["info"]["title"] == "Flagsmith API"
+
+
+def test_spectacular_settings__component_no_read_only_required__is_enabled() -> None:
+    assert settings.SPECTACULAR_SETTINGS["COMPONENT_NO_READ_ONLY_REQUIRED"] is True

--- a/api/tests/integration/test_api_documentation.py
+++ b/api/tests/integration/test_api_documentation.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.test import Client
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Claude analysis before / after
```
Full Schema Comparison Summary

  File Size
  ┌────────────────────────────────────────────┬───────────┐
  │                   Schema                   │   Lines   │
  ├────────────────────────────────────────────┼───────────┤
  │ Old (without setting)                      │ 24,077    │
  ├────────────────────────────────────────────┼───────────┤
  │ New (with COMPONENT_NO_READ_ONLY_REQUIRED) │ 23,599    │
  ├────────────────────────────────────────────┼───────────┤
  │ Removed                                    │ 478 lines │
  └────────────────────────────────────────────┴───────────┘
  Most Frequently Removed Fields from required Arrays
  ┌─────────────────────┬─────────────────────┐
  │        Field        │ Occurrences Removed │
  ├─────────────────────┼─────────────────────┤
  │ id                  │ 114                 │
  ├─────────────────────┼─────────────────────┤
  │ uuid                │ 32                  │
  ├─────────────────────┼─────────────────────┤
  │ created_at          │ 25                  │
  ├─────────────────────┼─────────────────────┤
  │ updated_at          │ 20                  │
  ├─────────────────────┼─────────────────────┤
  │ deleted_at          │ 13                  │
  ├─────────────────────┼─────────────────────┤
  │ environment         │ 11                  │
  ├─────────────────────┼─────────────────────┤
  │ project             │ 9                   │
  ├─────────────────────┼─────────────────────┤
  │ created_date        │ 8                   │
  ├─────────────────────┼─────────────────────┤
  │ committed_by        │ 7                   │
  ├─────────────────────┼─────────────────────┤
  │ committed_at        │ 7                   │
  ├─────────────────────┼─────────────────────┤
  │ user                │ 6                   │
  ├─────────────────────┼─────────────────────┤
  │ feature_state_value │ 6                   │
  ├─────────────────────┼─────────────────────┤
  │ created_by          │ 5                   │
  ├─────────────────────┼─────────────────────┤
  │ owners              │ 4                   │
  ├─────────────────────┼─────────────────────┤
  │ group_owners        │ 4                   │
  ├─────────────────────┼─────────────────────┤
  │ feature             │ 4                   │
  ├─────────────────────┼─────────────────────┤
  │ live_from           │ 4                   │
  └─────────────────────┴─────────────────────┘
  Impact

  The setting removes readOnly fields from all required arrays across the entire API schema (not just MCP endpoints). This is the
  correct behaviour since:
  - These fields are server-generated
  - Clients should not (and cannot) provide them in requests
  - Having them as "required" breaks client code generation
```
## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
