### PR TITLE
docs: use-component-split-request-setting

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -567,6 +567,7 @@ SPECTACULAR_SETTINGS = {
         "SegmentRuleTypeEnum": "segments.models.SegmentRule.RULE_TYPES",
         "FeatureValueTypeEnum": ["integer", "string", "boolean"],
     },
+    "COMPONENT_SPLIT_REQUEST": True,
 }
 
 

--- a/api/tests/integration/test_api_documentation.py
+++ b/api/tests/integration/test_api_documentation.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import Client
 
 
@@ -11,3 +12,7 @@ def test_api_documentation_specification_loads(
     # Then
     assert response.status_code == 200
     assert response.json()["info"]["title"] == "Flagsmith API"
+
+
+def test_spectacular_settings__component_split_request__is_enabled() -> None:
+    assert settings.SPECTACULAR_SETTINGS["COMPONENT_SPLIT_REQUEST"] is True


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Claude Analysis

```
Comparison Summary

  Full API Schema
  ┌─────────────────────────────────┬────────┬────────────────────────────┬──────────────────────┐
  │             Setting             │ Lines  │     Schema Definitions     │ Change from Original │
  ├─────────────────────────────────┼────────┼────────────────────────────┼──────────────────────┤
  │ Original (no setting)           │ 24,077 │ 351                        │ -                    │
  ├─────────────────────────────────┼────────┼────────────────────────────┼──────────────────────┤
  │ COMPONENT_NO_READ_ONLY_REQUIRED │ 23,599 │ 351                        │ -478 lines           │
  ├─────────────────────────────────┼────────┼────────────────────────────┼──────────────────────┤
  │ COMPONENT_SPLIT_REQUEST         │ 25,720 │ 462 (+111 Request schemas) │ +1,643 lines         │
  └─────────────────────────────────┴────────┴────────────────────────────┴──────────────────────┘
  MCP Schema
  ┌─────────────────────────────────┬────────┐
  │             Setting             │ Lines  │
  ├─────────────────────────────────┼────────┤
  │ COMPONENT_NO_READ_ONLY_REQUIRED │ 10,178 │
  ├─────────────────────────────────┼────────┤
  │ COMPONENT_SPLIT_REQUEST         │ 12,296 │
  └─────────────────────────────────┴────────┘
  Key Differences

  COMPONENT_NO_READ_ONLY_REQUIRED:
  - Removes readOnly fields from required arrays globally
  - Same schema used for request and response
  - Simpler, smaller schema
  - ReadOnly fields still present in schema, just not required

  COMPONENT_SPLIT_REQUEST:
  - Creates separate *Request schemas (196 new schemas)
  - Request schemas exclude readOnly fields entirely
  - Response schemas remain unchanged (still have readOnly in required)
  - Larger schema size
  - More explicit separation of request/response contracts

  Example: ListFeature

  With COMPONENT_SPLIT_REQUEST:
  ListFeature:           # Response - has readOnly fields in required
    required: [id, uuid, created_date, owners, project, ...]

  ListFeatureRequest:    # Request - only writable fields
    required: [name]

  With COMPONENT_NO_READ_ONLY_REQUIRED:
  ListFeature:           # Same schema for both
    required: [name]     # ReadOnly fields removed from required
```
## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
