### PR TITLE
fix(docs): Invalid link to Contributing Guide in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thanks for submitting a PR! Please check the boxes below:
 
-- [ ] I have read the [Contributing Guide](/CONTRIBUTING.md).
+- [ ] I have read the [Contributing Guide](CONTRIBUTING.md).
 - [ ] I have added information to `docs/` if required so people know about the feature.
 - [ ] I have filled in the "Changes" section below.
 - [ ] I have filled in the "How did you test this code" section below.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thanks for submitting a PR! Please check the boxes below:
 
-- [ ] I have read the [Contributing Guide](CONTRIBUTING.md).
+- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
 - [ ] I have added information to `docs/` if required so people know about the feature.
 - [ ] I have filled in the "Changes" section below.
 - [ ] I have filled in the "How did you test this code" section below.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

We were linking to GitHub's HR site by accident.

## How did you test this code?

In this very PR description.