### PR TITLE
feat: Add Sentry to default integration data

### DIFF
--- a/frontend/common/stores/default-flags.ts
+++ b/frontend/common/stores/default-flags.ts
@@ -188,8 +188,7 @@ const defaultFlags = {
       'title': 'Segment',
     },
     'sentry': {
-      'description':
-        'Sends feature flag change events to Sentry for change tracking.',
+      'description': 'Send flag change events to Sentry.',
       'docs': 'https://docs.flagsmith.com/integrations/apm/sentry',
       'fields': [
         {
@@ -204,7 +203,7 @@ const defaultFlags = {
       ],
       'image': '/static/images/integrations/sentry.svg',
       'perEnvironment': true,
-      'tags': ['logging'],
+      'tags': ['Monitoring'],
       'title': 'Sentry',
     },
     'slack': {

--- a/frontend/common/stores/default-flags.ts
+++ b/frontend/common/stores/default-flags.ts
@@ -187,6 +187,26 @@ const defaultFlags = {
       'tags': ['analytics'],
       'title': 'Segment',
     },
+    'sentry': {
+      'description':
+        'Sends feature flag change events to Sentry for change tracking.',
+      'docs': 'https://docs.flagsmith.com/integrations/apm/sentry',
+      'fields': [
+        {
+          'key': 'webhook_url',
+          'label': 'Webhook URL',
+        },
+        {
+          'hidden': true,
+          'key': 'secret',
+          'label': 'Secret',
+        },
+      ],
+      'image': '/static/images/integrations/sentry.svg',
+      'perEnvironment': true,
+      'tags': ['logging'],
+      'title': 'Sentry',
+    },
     'slack': {
       'description':
         'Sends messages to Slack when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production.',


### PR DESCRIPTION
## Summary

- Adds Sentry change tracking integration to the default `integration_data` in `default-flags.ts`
- The backend was added in 2.184.0, but was missing from the frontend defaults
- This caused self-hosted customers to not see the Sentry integration in the UI

## Context

A customer on version 2.184.1 reported they couldn't see the Sentry integration. Investigation revealed the Sentry integration backend exists but was never added to the frontend's default integration list.

## Test plan

- [ ] Verify Sentry appears in the integrations list on a self-hosted instance
- [ ] Verify the integration form shows webhook_url and secret fields
- [ ] Verify the integration can be configured and saved
