### PR TITLE
fix: Flagsmith Environment Webhook incorrect payload values

### DIFF
--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -9,7 +9,7 @@ from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from audit.serializers import AuditLogListSerializer
 from audit.services import get_audited_instance_from_audit_log_record
-from features.models import FeatureState
+from features.models import FeatureState, FeatureStateValue
 from features.signals import feature_state_change_went_live
 from integrations.common.models import IntegrationsModel
 from integrations.datadog.datadog import DataDogWrapper
@@ -212,14 +212,21 @@ def send_audit_log_event_to_slack(sender, instance, **kwargs):  # type: ignore[n
 @receiver(post_save, sender=AuditLog)
 @track_only([RelatedObjectType.FEATURE_STATE])
 def send_feature_flag_went_live_signal(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
-    feature_state = get_audited_instance_from_audit_log_record(instance)
-    if not isinstance(feature_state, FeatureState):
+    audited_instance = get_audited_instance_from_audit_log_record(instance)
+
+    # Handle both FeatureState and FeatureStateValue audit logs
+    # FeatureStateValue changes also have related_object_type=FEATURE_STATE
+    if isinstance(audited_instance, FeatureStateValue):
+        feature_state = audited_instance.feature_state
+    elif isinstance(audited_instance, FeatureState):
+        feature_state = audited_instance
+    else:
         return
 
     if feature_state.is_scheduled:
         return  # This is handled by audit.tasks.create_feature_state_went_live_audit_log
 
-    feature_state_change_went_live.send(instance)
+    feature_state_change_went_live.send(instance, feature_state=feature_state)
 
 
 @receiver(feature_state_change_went_live)
@@ -238,3 +245,40 @@ def send_audit_log_event_to_sentry(sender: AuditLog, **kwargs: Any) -> None:
     )
 
     _track_event_async(sender, sentry_change_tracking)  # type: ignore[no-untyped-call]
+
+
+@receiver(feature_state_change_went_live)
+def trigger_feature_state_webhooks(
+    sender: AuditLog,
+    feature_state: FeatureState,
+    **kwargs: Any,
+) -> None:
+    """
+    Trigger FLAG_UPDATED webhooks when a feature state change goes live.
+
+    Triggered from AuditLog post_save. Fetches a fresh feature state from the
+    database to ensure we get the latest data (including FeatureStateValue),
+    since drf-writable-nested saves the parent before nested objects.
+    """
+    from features.tasks import trigger_feature_state_change_webhooks
+
+    # Fetch fresh data from the database to ensure we have the latest state
+    # This is necessary because:
+    # 1. drf-writable-nested saves FeatureState before FeatureStateValue
+    # 2. The history record's instance may have stale cached values
+    try:
+        fresh_feature_state = FeatureState.objects.all_with_deleted().get(
+            id=feature_state.id
+        )
+    except FeatureState.DoesNotExist:
+        return
+
+    # Skip versioned environments - handled by trigger_update_version_webhooks
+    if fresh_feature_state.environment_feature_version_id:
+        return
+
+    # Skip deleted feature states - handled in views
+    if fresh_feature_state.deleted_at:
+        return
+
+    trigger_feature_state_change_webhooks(fresh_feature_state)

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -250,7 +250,7 @@ def send_audit_log_event_to_sentry(
 
 
 @receiver(feature_state_change_went_live)
-def trigger_feature_state_webhooks(
+def trigger_feature_state_change_webhooks(
     sender: FeatureState,
     **kwargs: Any,
 ) -> None:
@@ -261,7 +261,7 @@ def trigger_feature_state_webhooks(
     database to ensure we get the latest data (including FeatureStateValue),
     since drf-writable-nested saves the parent before nested objects.
     """
-    from features.tasks import trigger_feature_state_change_webhooks
+    from features import tasks
 
     # Fetch fresh data from the database to ensure we have the latest state
     # This is necessary because:
@@ -277,4 +277,4 @@ def trigger_feature_state_webhooks(
     if fresh_feature_state.environment_feature_version_id:
         return
 
-    trigger_feature_state_change_webhooks(fresh_feature_state)
+    tasks.trigger_feature_state_change_webhooks(fresh_feature_state)

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -268,16 +268,13 @@ def trigger_feature_state_webhooks(
     # 1. drf-writable-nested saves FeatureState before FeatureStateValue
     # 2. The history record's instance may have stale cached values
     try:
-        fresh_feature_state = FeatureState.objects.all_with_deleted().get(id=sender.id)
+        fresh_feature_state = FeatureState.objects.get(id=sender.id)
     except FeatureState.DoesNotExist:
+        # Skip deleted feature states - handled in views
         return
 
     # Skip versioned environments - handled by trigger_update_version_webhooks
     if fresh_feature_state.environment_feature_version_id:
-        return
-
-    # Skip deleted feature states - handled in views
-    if fresh_feature_state.deleted_at:
         return
 
     trigger_feature_state_change_webhooks(fresh_feature_state)

--- a/api/features/signals.py
+++ b/api/features/signals.py
@@ -1,19 +1,7 @@
 import logging
 
-from django.db.models.signals import post_save
-from django.dispatch import Signal, receiver
-
-# noinspection PyUnresolvedReferences
-from .models import FeatureState
-from .tasks import trigger_feature_state_change_webhooks
+from django.dispatch import Signal
 
 logger = logging.getLogger(__name__)
 
 feature_state_change_went_live = Signal()
-
-
-@receiver(post_save, sender=FeatureState)
-def trigger_feature_state_change_webhooks_signal(instance, **kwargs):  # type: ignore[no-untyped-def]
-    if instance.environment_feature_version_id or instance.deleted_at:
-        return
-    trigger_feature_state_change_webhooks(instance)

--- a/api/tests/integration/features/featurestate/test_webhooks.py
+++ b/api/tests/integration/features/featurestate/test_webhooks.py
@@ -1,0 +1,89 @@
+import json
+
+from django.urls import reverse
+from pytest_mock import MockerFixture
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+def test_update_segment_override__webhook_payload_has_correct_previous_and_new_values(
+    admin_client: APIClient,
+    environment: int,
+    feature: int,
+    segment: int,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test for issue #6050: Webhook payload shows incorrect previous_state values
+    when updating a segment override value via the API.
+
+    The bug occurs because:
+    1. The webhook signal fires on FeatureState.post_save
+    2. drf-writable-nested saves the parent (FeatureState) before nested (FeatureStateValue)
+    3. So the webhook captures stale values
+    """
+    # Given
+    old_value = 0
+    new_value = 1
+
+    # First create a feature_segment
+    feature_segment_url = reverse("api-v1:features:feature-segment-list")
+    feature_segment_data = {
+        "feature": feature,
+        "segment": segment,
+        "environment": environment,
+    }
+    feature_segment_response = admin_client.post(
+        feature_segment_url,
+        data=json.dumps(feature_segment_data),
+        content_type="application/json",
+    )
+    assert feature_segment_response.status_code == status.HTTP_201_CREATED
+    feature_segment_id = feature_segment_response.json()["id"]
+
+    # Create segment override with initial value via API
+    create_url = reverse("api-v1:features:featurestates-list")
+    create_data = {
+        "enabled": False,
+        "feature_state_value": {"type": "int", "integer_value": old_value},
+        "environment": environment,
+        "feature": feature,
+        "feature_segment": feature_segment_id,
+    }
+    create_response = admin_client.post(
+        create_url, data=json.dumps(create_data), content_type="application/json"
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    segment_override_id = create_response.json()["id"]
+
+    # Mock call_environment_webhooks to capture the actual payload
+    mock_call_environment_webhooks = mocker.patch(
+        "features.tasks.call_environment_webhooks"
+    )
+    mocker.patch("features.tasks.call_organisation_webhooks")
+
+    # When - update the segment override via API
+    url = reverse("api-v1:features:featurestates-detail", args=[segment_override_id])
+    data = {
+        "enabled": False,
+        "feature_state_value": {"type": "int", "integer_value": new_value},
+        "environment": environment,
+        "feature": feature,
+        "feature_segment": feature_segment_id,
+    }
+    response = admin_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify webhook was called
+    mock_call_environment_webhooks.delay.assert_called_once()
+    webhook_args = mock_call_environment_webhooks.delay.call_args.kwargs["args"]
+    webhook_payload = webhook_args[1]  # (environment_id, data, event_type)
+
+    # Verify the payload has correct values
+    assert webhook_payload["new_state"]["feature_segment"] is not None
+    assert webhook_payload["new_state"]["feature_state_value"] == new_value
+    assert webhook_payload["previous_state"]["feature_state_value"] == old_value

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -1,6 +1,8 @@
 import json
+from datetime import timedelta
 
 import responses
+from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 
@@ -548,10 +550,6 @@ def test_send_feature_flag_went_live_signal__scheduled_feature_state__skips_sign
     mocker: MockerFixture,
 ) -> None:
     # Given
-    from datetime import timedelta
-
-    from django.utils import timezone
-
     feature_state = FeatureState.objects.get(
         environment=environment, feature=feature, feature_segment__isnull=True
     )

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -11,7 +11,7 @@ from audit.signals import (
     send_audit_log_event_to_dynatrace,
     send_audit_log_event_to_grafana,
     send_feature_flag_went_live_signal,
-    trigger_feature_state_webhooks,
+    trigger_feature_state_change_webhooks,
 )
 from environments.models import Environment
 from features.models import Feature, FeatureState
@@ -356,7 +356,7 @@ def _create_and_publish_environment_feature_version(
     return version, audit_log_record
 
 
-def test_trigger_feature_state_webhooks__feature_state_update__triggers_webhook(
+def test_trigger_feature_state_change_webhooks__feature_state_update__triggers_webhook(
     environment: Environment,
     feature: Feature,
     mocker: MockerFixture,
@@ -379,13 +379,13 @@ def test_trigger_feature_state_webhooks__feature_state_update__triggers_webhook(
     )
 
     # When
-    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
+    trigger_feature_state_change_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_called_once()
 
 
-def test_trigger_feature_state_webhooks__versioned_environment__skips_webhook(
+def test_trigger_feature_state_change_webhooks__versioned_environment__skips_webhook(
     environment_v2_versioning: Environment,
     feature: Feature,
     mocker: MockerFixture,
@@ -410,13 +410,13 @@ def test_trigger_feature_state_webhooks__versioned_environment__skips_webhook(
     )
 
     # When
-    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
+    trigger_feature_state_change_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_not_called()
 
 
-def test_trigger_feature_state_webhooks__deleted_feature_state__skips_webhook(
+def test_trigger_feature_state_change_webhooks__deleted_feature_state__skips_webhook(
     environment: Environment,
     feature: Feature,
     mocker: MockerFixture,
@@ -441,13 +441,13 @@ def test_trigger_feature_state_webhooks__deleted_feature_state__skips_webhook(
     )
 
     # When
-    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
+    trigger_feature_state_change_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_not_called()
 
 
-def test_trigger_feature_state_webhooks__feature_state_value_update__triggers_webhook(
+def test_trigger_feature_state_change_webhooks__feature_state_value_update__triggers_webhook(
     environment: Environment,
     feature: Feature,
     mocker: MockerFixture,
@@ -478,7 +478,7 @@ def test_trigger_feature_state_webhooks__feature_state_value_update__triggers_we
     )
 
     # When
-    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
+    trigger_feature_state_change_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_called_once()

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -379,7 +379,7 @@ def test_trigger_feature_state_webhooks__feature_state_update__triggers_webhook(
     )
 
     # When
-    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_called_once()
@@ -410,7 +410,7 @@ def test_trigger_feature_state_webhooks__versioned_environment__skips_webhook(
     )
 
     # When
-    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_not_called()
@@ -441,7 +441,7 @@ def test_trigger_feature_state_webhooks__deleted_feature_state__skips_webhook(
     )
 
     # When
-    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_not_called()
@@ -478,7 +478,7 @@ def test_trigger_feature_state_webhooks__feature_state_value_update__triggers_we
     )
 
     # When
-    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+    trigger_feature_state_webhooks(sender=feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_called_once()
@@ -521,7 +521,7 @@ def test_trigger_feature_state_webhooks__feature_state_does_not_exist__skips_web
 
     # When
     # Pass the stale feature_state - the function will try to fetch fresh and fail
-    trigger_feature_state_webhooks(sender=audit_log, feature_state=stale_feature_state)
+    trigger_feature_state_webhooks(sender=stale_feature_state, audit_log=audit_log)
 
     # Then
     mock_trigger_webhooks.assert_not_called()
@@ -551,7 +551,7 @@ def test_send_feature_flag_went_live_signal__feature_state__sends_signal(
     send_feature_flag_went_live_signal(sender=AuditLog, instance=audit_log)
 
     # Then
-    mock_signal_send.assert_called_once_with(audit_log, feature_state=feature_state)
+    mock_signal_send.assert_called_once_with(feature_state, audit_log=audit_log)
 
 
 def test_send_feature_flag_went_live_signal__feature_state_value__sends_signal(
@@ -580,7 +580,7 @@ def test_send_feature_flag_went_live_signal__feature_state_value__sends_signal(
 
     # Then
     # The signal should be called with the parent FeatureState extracted from FeatureStateValue
-    mock_signal_send.assert_called_once_with(audit_log, feature_state=feature_state)
+    mock_signal_send.assert_called_once_with(feature_state, audit_log=audit_log)
 
 
 def test_send_feature_flag_went_live_signal__scheduled_feature_state__skips_signal(

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -10,9 +10,11 @@ from audit.signals import (
     call_webhooks,
     send_audit_log_event_to_dynatrace,
     send_audit_log_event_to_grafana,
+    send_feature_flag_went_live_signal,
+    trigger_feature_state_webhooks,
 )
 from environments.models import Environment
-from features.models import Feature
+from features.models import Feature, FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
 from integrations.dynatrace.dynatrace import EVENTS_API_URI
 from integrations.dynatrace.models import DynatraceConfiguration
@@ -352,3 +354,288 @@ def _create_and_publish_environment_feature_version(
         .first()
     )
     return version, audit_log_record
+
+
+def test_trigger_feature_state_webhooks__feature_state_update__triggers_webhook(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state.id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state.history.first().history_id,
+        history_record_class_path=feature_state.history_record_class_path,
+    )
+
+    mock_trigger_webhooks = mocker.patch(
+        "features.tasks.trigger_feature_state_change_webhooks"
+    )
+
+    # When
+    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+
+    # Then
+    mock_trigger_webhooks.assert_called_once()
+
+
+def test_trigger_feature_state_webhooks__versioned_environment__skips_webhook(
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment_v2_versioning,
+        feature=feature,
+        feature_segment__isnull=True,
+    )
+
+    audit_log = AuditLog.objects.create(
+        environment=environment_v2_versioning,
+        related_object_id=feature_state.id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state.history.first().history_id,
+        history_record_class_path=feature_state.history_record_class_path,
+    )
+
+    mock_trigger_webhooks = mocker.patch(
+        "features.tasks.trigger_feature_state_change_webhooks"
+    )
+
+    # When
+    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+
+    # Then
+    mock_trigger_webhooks.assert_not_called()
+
+
+def test_trigger_feature_state_webhooks__deleted_feature_state__skips_webhook(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+    feature_state.deleted_at = feature_state.updated_at
+    feature_state.save()
+
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state.id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state.history.first().history_id,
+        history_record_class_path=feature_state.history_record_class_path,
+    )
+
+    mock_trigger_webhooks = mocker.patch(
+        "features.tasks.trigger_feature_state_change_webhooks"
+    )
+
+    # When
+    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+
+    # Then
+    mock_trigger_webhooks.assert_not_called()
+
+
+def test_trigger_feature_state_webhooks__feature_state_value_update__triggers_webhook(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that webhook is triggered for FeatureStateValue changes.
+
+    This is important for issue #6050 where updating a segment override
+    creates an AuditLog for the FeatureStateValue, not the FeatureState.
+    """
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+    feature_state_value = feature_state.feature_state_value
+
+    # Create an AuditLog as if it was created for a FeatureStateValue update
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state.id,  # Note: still points to FeatureState
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state_value.history.first().history_id,
+        history_record_class_path=feature_state_value.history_record_class_path,
+    )
+
+    mock_trigger_webhooks = mocker.patch(
+        "features.tasks.trigger_feature_state_change_webhooks"
+    )
+
+    # When
+    trigger_feature_state_webhooks(sender=audit_log, feature_state=feature_state)
+
+    # Then
+    mock_trigger_webhooks.assert_called_once()
+    called_feature_state = mock_trigger_webhooks.call_args[0][0]
+    assert called_feature_state.id == feature_state.id
+
+
+def test_trigger_feature_state_webhooks__feature_state_does_not_exist__skips_webhook(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that webhook is skipped when the FeatureState no longer exists.
+    """
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+    feature_state_id = feature_state.id
+    history_record = feature_state.history.first()
+
+    # Create audit log before deleting the feature state
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state_id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=history_record.history_id,
+        history_record_class_path=feature_state.history_record_class_path,
+    )
+
+    # Hard delete the feature state (not soft delete)
+    # Keep a reference to the stale object to pass to the function
+    stale_feature_state = feature_state
+    FeatureState.objects.filter(id=feature_state_id).delete()
+
+    mock_trigger_webhooks = mocker.patch(
+        "features.tasks.trigger_feature_state_change_webhooks"
+    )
+
+    # When
+    # Pass the stale feature_state - the function will try to fetch fresh and fail
+    trigger_feature_state_webhooks(sender=audit_log, feature_state=stale_feature_state)
+
+    # Then
+    mock_trigger_webhooks.assert_not_called()
+
+
+def test_send_feature_flag_went_live_signal__feature_state__sends_signal(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state.id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state.history.first().history_id,
+        history_record_class_path=feature_state.history_record_class_path,
+    )
+
+    mock_signal_send = mocker.patch("audit.signals.feature_state_change_went_live.send")
+
+    # When
+    send_feature_flag_went_live_signal(sender=AuditLog, instance=audit_log)
+
+    # Then
+    mock_signal_send.assert_called_once_with(audit_log, feature_state=feature_state)
+
+
+def test_send_feature_flag_went_live_signal__feature_state_value__sends_signal(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+    feature_state_value = feature_state.feature_state_value
+
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state.id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state_value.history.first().history_id,
+        history_record_class_path=feature_state_value.history_record_class_path,
+    )
+
+    mock_signal_send = mocker.patch("audit.signals.feature_state_change_went_live.send")
+
+    # When
+    send_feature_flag_went_live_signal(sender=AuditLog, instance=audit_log)
+
+    # Then
+    # The signal should be called with the parent FeatureState extracted from FeatureStateValue
+    mock_signal_send.assert_called_once_with(audit_log, feature_state=feature_state)
+
+
+def test_send_feature_flag_went_live_signal__scheduled_feature_state__skips_signal(
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment__isnull=True
+    )
+    # Make the feature state scheduled (live_from in the future)
+    feature_state.live_from = timezone.now() + timedelta(days=1)
+    feature_state.save()
+
+    audit_log = AuditLog.objects.create(
+        environment=environment,
+        related_object_id=feature_state.id,
+        related_object_type=RelatedObjectType.FEATURE_STATE.name,
+        history_record_id=feature_state.history.first().history_id,
+        history_record_class_path=feature_state.history_record_class_path,
+    )
+
+    mock_signal_send = mocker.patch("audit.signals.feature_state_change_went_live.send")
+
+    # When
+    send_feature_flag_went_live_signal(sender=AuditLog, instance=audit_log)
+
+    # Then
+    mock_signal_send.assert_not_called()
+
+
+def test_send_feature_flag_went_live_signal__non_feature_state_instance__skips_signal(
+    project: Project,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    # Create an audit log for a Feature (not FeatureState)
+    audit_log = AuditLog.objects.create(
+        project=project,
+        related_object_id=feature.id,
+        related_object_type=RelatedObjectType.FEATURE.name,
+        history_record_id=feature.history.first().history_id,
+        history_record_class_path=feature.history_record_class_path,
+    )
+
+    mock_signal_send = mocker.patch("audit.signals.feature_state_change_went_live.send")
+
+    # When
+    send_feature_flag_went_live_signal(sender=AuditLog, instance=audit_log)
+
+    # Then
+    mock_signal_send.assert_not_called()

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -486,42 +486,6 @@ def test_trigger_feature_state_webhooks__feature_state_value_update__triggers_we
     assert called_feature_state.id == feature_state.id
 
 
-def test_trigger_feature_state_webhooks__feature_state_does_not_exist__skips_webhook(
-    environment: Environment,
-    feature: Feature,
-    mocker: MockerFixture,
-) -> None:
-    """
-    Test that webhook is skipped when the FeatureState no longer exists.
-    """
-    # Given
-    feature_state = FeatureState.objects.get(
-        environment=environment, feature=feature, feature_segment__isnull=True
-    )
-
-    audit_log = AuditLog.objects.create(
-        environment=environment,
-        related_object_id=feature_state.id,
-        related_object_type=RelatedObjectType.FEATURE_STATE.name,
-        history_record_id=feature_state.history.first().history_id,
-        history_record_class_path=feature_state.history_record_class_path,
-    )
-
-    # Hard delete the feature state so it's fully removed from the database
-    stale_feature_state = feature_state
-    feature_state.hard_delete()
-
-    mock_trigger_webhooks = mocker.patch(
-        "features.tasks.trigger_feature_state_change_webhooks"
-    )
-
-    # When
-    trigger_feature_state_webhooks(sender=stale_feature_state, audit_log=audit_log)
-
-    # Then
-    mock_trigger_webhooks.assert_not_called()
-
-
 def test_send_feature_flag_went_live_signal__feature_state__sends_signal(
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/features/conftest.py
+++ b/api/tests/unit/features/conftest.py
@@ -1,6 +1,10 @@
+from typing import Generator
+
 import pytest
+from pytest_mock import MockerFixture
 
 from features.models import FeatureState
+from users.models import FFAdminUser
 
 
 @pytest.fixture()
@@ -26,3 +30,22 @@ def feature_state_version_generator(environment, feature, request):  # type: ign
         ),
         expected_result,
     )
+
+
+@pytest.fixture
+def admin_history(
+    admin_user: FFAdminUser,
+    mocker: MockerFixture,
+) -> Generator[None, None, None]:
+    """
+    Fixture to patch `simple_history` to set the user on historical records to an admin user.
+    """
+
+    historical_records_thread_mock = mocker.MagicMock()
+    historical_records_thread_mock.request.user = admin_user
+
+    with mocker.patch(
+        "simple_history.models.HistoricalRecords.thread",
+        historical_records_thread_mock,
+    ):
+        yield

--- a/api/tests/unit/features/conftest.py
+++ b/api/tests/unit/features/conftest.py
@@ -1,5 +1,3 @@
-from typing import Generator
-
 import pytest
 from pytest_mock import MockerFixture
 
@@ -36,7 +34,7 @@ def feature_state_version_generator(environment, feature, request):  # type: ign
 def admin_history(
     admin_user: FFAdminUser,
     mocker: MockerFixture,
-) -> Generator[None, None, None]:
+) -> None:
     """
     Fixture to patch `simple_history` to set the user on historical records to an admin user.
     """
@@ -44,8 +42,7 @@ def admin_history(
     historical_records_thread_mock = mocker.MagicMock()
     historical_records_thread_mock.request.user = admin_user
 
-    with mocker.patch(
+    mocker.patch(
         "simple_history.models.HistoricalRecords.thread",
         historical_records_thread_mock,
-    ):
-        yield
+    )

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -73,14 +73,6 @@ if typing.TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
 
 
-# patch this function as it's triggering extra threads and causing errors
-# Use a module-scoped autouse fixture to properly clean up after the module
-@pytest.fixture(autouse=True, scope="module")
-def _mock_trigger_webhooks() -> typing.Generator[None, None, None]:
-    with mock.patch("features.tasks.trigger_feature_state_change_webhooks"):
-        yield
-
-
 now = timezone.now()
 two_hours_ago = now - timedelta(hours=2)
 one_hour_ago = now - timedelta(hours=1)

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -72,8 +72,14 @@ from webhooks.webhooks import WebhookEventType
 if typing.TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
 
+
 # patch this function as it's triggering extra threads and causing errors
-mock.patch("features.signals.trigger_feature_state_change_webhooks").start()
+# Use a module-scoped autouse fixture to properly clean up after the module
+@pytest.fixture(autouse=True, scope="module")
+def _mock_trigger_webhooks() -> typing.Generator[None, None, None]:
+    with mock.patch("features.tasks.trigger_feature_state_change_webhooks"):
+        yield
+
 
 now = timezone.now()
 two_hours_ago = now - timedelta(hours=2)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #6050, #5790.

In this PR, we fix incorrect webhook payloads when updating segment overrides (#6050). The root cause was that `drf-writable-nested` saves `FeatureState` before `FeatureStateValue`, so webhooks triggered on `post_save` captured stale values.

This is a step toward #5790 (centralising webhook logic), but further work remains. The webhook infrastructure still has multiple layers (`webhooks/webhooks.py`, `features/tasks.py`, `audit/signals.py`) that could be unified into a single, consistent system.    
                                                                                                           
- Remove the `post_save` signal handler from `FeatureState` that triggered webhooks prematurely
- Dispatch `FLAG_UPDATED` webhooks via the `feature_state_change_went_live` signal, which fires after AuditLog creation when all nested objects are saved
- Handle both `FeatureState` and `FeatureStateValue` audit logs, since value-only changes also need to trigger webhooks
- Refactor signal semantics: `FeatureState` is now the sender (matching the signal name), with `AuditLog` as a supplemental kwarg


## How did you test this code?

Added an integration test reproducing #6050, and various unit tests supporting the fix.
