### PR TITLE
fix: Enforce seat limit self hosted

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -305,6 +305,7 @@ def xero_subscription(organisation):  # type: ignore[no-untyped-def]
     return subscription
 
 
+@pytest.mark.saas_mode
 @pytest.fixture()
 def chargebee_subscription(organisation: Organisation) -> Subscription:
     subscription = Subscription.objects.get(organisation=organisation)
@@ -330,7 +331,6 @@ def system_tag(project: Project) -> Tag:
     )
 
 
-@pytest.mark.enterprise_mode
 @pytest.fixture()
 def enterprise_subscription(organisation: Organisation) -> Subscription:
     Subscription.objects.filter(organisation=organisation).update(

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -330,6 +330,7 @@ def system_tag(project: Project) -> Tag:
     )
 
 
+@pytest.mark.enterprise_mode
 @pytest.fixture()
 def enterprise_subscription(organisation: Organisation) -> Subscription:
     Subscription.objects.filter(organisation=organisation).update(

--- a/api/organisations/subscriptions/exceptions.py
+++ b/api/organisations/subscriptions/exceptions.py
@@ -36,4 +36,4 @@ class UpgradeAPIUsagePaymentFailure(APIException):
 
 class SubscriptionDoesNotSupportSeatUpgrade(APIException):
     status_code = 400
-    default_detail = "Please Upgrade your plan to add additional seats/users"
+    default_detail = "Please upgrade your plan to add additional seats/users"

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -159,7 +159,7 @@ def test_update_invite_link_returns_405(invite_link, admin_client, organisation)
 def test_join_organisation_with_permission_groups(
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
-    subscription: Subscription,
+    enterprise_subscription: Subscription,
     api_client: APIClient,
 ) -> None:
     # Given
@@ -172,8 +172,9 @@ def test_join_organisation_with_permission_groups(
     invite.permission_groups.add(user_permission_group)
 
     # update subscription to add another seat
-    subscription.max_seats = 2
-    subscription.save()
+    current_seats = organisation.users.count()
+    enterprise_subscription.max_seats += current_seats + 1
+    enterprise_subscription.save()
 
     url = reverse("api-v1:users:user-join-organisation", args=[invite.hash])
     data = {"hubspotutk": "somehubspotdata"}

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -330,6 +330,7 @@ def test_update_invite_returns_405(  # type: ignore[no-untyped-def]
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
+@pytest.mark.saas_mode
 @pytest.mark.parametrize(
     "invite_object, url",
     [
@@ -346,35 +347,6 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit_for_saas(
     # Given
     settings.ENABLE_CHARGEBEE = True
     url = reverse(url, args=[invite_object.hash])
-    # When
-    response = staff_client.post(url)
-
-    # Then
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert (
-        response.json()["detail"]
-        == "Please upgrade your plan to add additional seats/users"
-    )
-
-
-@pytest.mark.parametrize(
-    "invite_object, url",
-    [
-        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
-        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
-    ],
-)
-def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_free(
-    staff_client: APIClient,
-    invite_object: Invite | InviteLink,
-    url: str,
-    organisation: Organisation,
-) -> None:
-    # Given
-    url = reverse(url, args=[invite_object.hash])
-
-    assert organisation.subscription.is_free_plan
-
     # When
     response = staff_client.post(url)
 

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -336,7 +336,7 @@ def test_update_invite_returns_405(  # type: ignore[no-untyped-def]
         (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
-def test_join_organisation_returns_400_if_exceeds_plan_limit(
+def test_join_organisation_returns_400_if_exceeds_plan_limit_for_saas(
     staff_client: APIClient,
     invite_object: Invite | InviteLink,
     url: str,
@@ -345,6 +345,67 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit(
     # Given
     settings.ENABLE_CHARGEBEE = True
     url = reverse(url, args=[invite_object.hash])
+    # When
+    response = staff_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["detail"]
+        == "Please Upgrade your plan to add additional seats/users"
+    )
+
+
+@pytest.mark.parametrize(
+    "invite_object, url",
+    [
+        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
+        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
+    ],
+)
+def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_free(
+    staff_client: APIClient,
+    invite_object: Invite | InviteLink,
+    url: str,
+    organisation: Organisation,
+) -> None:
+    # Given
+    url = reverse(url, args=[invite_object.hash])
+
+    assert organisation.subscription.is_free_plan
+
+    # When
+    response = staff_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["detail"]
+        == "Please Upgrade your plan to add additional seats/users"
+    )
+
+
+@pytest.mark.enterprise_mode
+@pytest.mark.parametrize(
+    "invite_object, url",
+    [
+        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
+        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
+    ],
+)
+def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_enterprise(
+    staff_client: APIClient,
+    invite_object: Invite | InviteLink,
+    url: str,
+    organisation: Organisation,
+    enterprise_subscription: Subscription,
+) -> None:
+    # Given
+    url = reverse(url, args=[invite_object.hash])
+
+    enterprise_subscription.max_seats = 1
+    enterprise_subscription.save()
+
     # When
     response = staff_client.post(url)
 

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -285,7 +285,7 @@ def test_create_invite_returns_400_if_seats_are_over(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.json()["detail"]
-        == "Please Upgrade your plan to add additional seats/users"
+        == "Please upgrade your plan to add additional seats/users"
     )
 
 
@@ -353,7 +353,7 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit_for_saas(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.json()["detail"]
-        == "Please Upgrade your plan to add additional seats/users"
+        == "Please upgrade your plan to add additional seats/users"
     )
 
 
@@ -382,7 +382,7 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_fre
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.json()["detail"]
-        == "Please Upgrade your plan to add additional seats/users"
+        == "Please upgrade your plan to add additional seats/users"
     )
 
 
@@ -414,7 +414,7 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_ent
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.json()["detail"]
-        == "Please Upgrade your plan to add additional seats/users"
+        == "Please upgrade your plan to add additional seats/users"
     )
 
 

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -173,7 +173,7 @@ def test_join_organisation_with_permission_groups(
 
     # update subscription to add another seat
     current_seats = organisation.users.count()
-    enterprise_subscription.max_seats += current_seats + 1
+    enterprise_subscription.max_seats = current_seats + 1
     enterprise_subscription.save()
 
     url = reverse("api-v1:users:user-join-organisation", args=[invite.hash])

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -237,9 +237,7 @@ class FFAdminUser(LifecycleModel, AbstractUser):  # type: ignore[django-manager-
     def join_organisation_from_invite(self, invite: "AbstractBaseInviteModel"):  # type: ignore[no-untyped-def]
         organisation = invite.organisation
 
-        if settings.ENABLE_CHARGEBEE and organisation.over_plan_seats_limit(
-            additional_seats=1
-        ):
+        if organisation.over_plan_seats_limit(additional_seats=1):
             if organisation.is_auto_seat_upgrade_available():
                 organisation.subscription.add_single_seat()  # type: ignore[no-untyped-call]
             else:

--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -470,6 +470,9 @@ const Constants = {
       : apiUrl
   },
   getUpgradeUrl: (feature?: string) => {
+    // TODO: deprecate usages of this helper function without
+    //  providing feature since the billing page self hosted
+    //  has links to the pricing page anyway.
     return Utils.isSaas()
       ? '/organisation-settings?tab=billing'
       : `https://www.flagsmith.com/pricing${

--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -25,7 +25,7 @@ const controller = {
           error.status === 400
         ) {
           API.ajaxHandler(store, error)
-          return
+          throw error
         }
         return data.post(`${Project.api}users/join/${id}/`)
       })

--- a/frontend/web/components/pages/InvitePage.js
+++ b/frontend/web/components/pages/InvitePage.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import Constants from 'common/constants'
 import { withRouter } from 'react-router-dom'
-import AccountProvider from 'common/providers/AccountProvider';
+import AccountProvider from 'common/providers/AccountProvider'
 const InvitePage = class extends Component {
   static displayName = 'InvitePage'
 

--- a/frontend/web/components/pages/InvitePage.js
+++ b/frontend/web/components/pages/InvitePage.js
@@ -20,14 +20,15 @@ const InvitePage = class extends Component {
     this.props.history.replace(Utils.getOrganisationHomePage(id))
   }
 
-  getErrorMessage(detail) {
-    switch (detail) {
+  getErrorMessage(error) {
+    switch (error) {
+      case 'No Invite matches the given query.':
       case 'Not found.':
         return 'We could not validate your invite, please check the invite URL and email address you have entered is correct.'
       case 'Please upgrade your plan to add additional seats/users':
         return 'The organisation you have been invited to has no seats available. Please contact the organisation administrator to resolve this before trying again.'
       default:
-        return detail
+        return error
     }
   }
 
@@ -41,7 +42,7 @@ const InvitePage = class extends Component {
                 {error ? (
                   <div>
                     <h3 className='pt-5'>Oops</h3>
-                    <p>{this.getErrorMessage(error.detail)}</p>
+                    <p>{this.getErrorMessage(error)}</p>
                   </div>
                 ) : (
                   <Loader />

--- a/frontend/web/components/pages/InvitePage.js
+++ b/frontend/web/components/pages/InvitePage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import Constants from 'common/constants'
 import { withRouter } from 'react-router-dom'
+import AccountProvider from 'common/providers/AccountProvider';
 const InvitePage = class extends Component {
   static displayName = 'InvitePage'
 
@@ -19,6 +20,17 @@ const InvitePage = class extends Component {
     this.props.history.replace(Utils.getOrganisationHomePage(id))
   }
 
+  getErrorMessage(detail) {
+    switch (detail) {
+      case 'Not found.':
+        return 'We could not validate your invite, please check the invite URL and email address you have entered is correct.'
+      case 'Please upgrade your plan to add additional seats/users':
+        return 'The organisation you have been invited to has no seats available. Please contact the organisation administrator to resolve this before trying again.'
+      default:
+        return detail
+    }
+  }
+
   render() {
     return (
       <div className='app-container'>
@@ -29,11 +41,7 @@ const InvitePage = class extends Component {
                 {error ? (
                   <div>
                     <h3 className='pt-5'>Oops</h3>
-                    <p>
-                      {error.detail === 'Not found.'
-                        ? 'We could not validate your invite, please check the invite URL and email address you have entered is correct.'
-                        : error.detail}
-                    </p>
+                    <p>{this.getErrorMessage(error.detail)}</p>
                   </div>
                 ) : (
                   <Loader />

--- a/frontend/web/components/pages/UsersAndPermissionsPage.tsx
+++ b/frontend/web/components/pages/UsersAndPermissionsPage.tsx
@@ -239,11 +239,24 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                                     <strong>
                                       If you wish to invite any additional
                                       members, please{' '}
-                                      {
-                                        <a href='#' onClick={openChat}>
-                                          Contact us
+                                      {Utils.isSaas() ? (
+                                        <a
+                                          href='#'
+                                          onClick={(e) => {
+                                            e.stopPropagation()
+                                            openChat()
+                                          }}
+                                        >
+                                          contact us
                                         </a>
-                                      }
+                                      ) : (
+                                        <a
+                                          href='mailto:support@flagsmith.com'
+                                          onClick={(e) => e.stopPropagation()}
+                                        >
+                                          contact us
+                                        </a>
+                                      )}
                                       .
                                     </strong>
                                   ) : needsUpgradeForAdditionalSeats ? (
@@ -255,7 +268,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                                           href='#'
                                           onClick={() => {
                                             history.replace(
-                                              Constants.getUpgradeUrl(),
+                                              '/organisation-settings?tab=billing',
                                             )
                                           }}
                                         >

--- a/frontend/web/components/pages/UsersAndPermissionsPage.tsx
+++ b/frontend/web/components/pages/UsersAndPermissionsPage.tsx
@@ -121,9 +121,10 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
   const meta = subscriptionMeta || organisation.subscription || { max_seats: 1 }
   const max_seats = meta.max_seats || 1
   const isAWS = AccountStore.getPaymentMethod() === 'AWS_MARKETPLACE'
-  const autoSeats = !isAWS && Utils.getPlansPermission('AUTO_SEATS')
-  const usedSeats = paymentsEnabled && organisation.num_seats >= max_seats
-  const overSeats = paymentsEnabled && organisation.num_seats > max_seats
+  const autoSeats =
+    paymentsEnabled && !isAWS && Utils.getPlansPermission('AUTO_SEATS')
+  const usedSeats = organisation.num_seats >= max_seats
+  const overSeats = organisation.num_seats > max_seats
   const [role, setRole] = useState<'ADMIN' | 'USER'>('ADMIN')
 
   const deleteInvite = (id: number) => {
@@ -218,7 +219,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                         )}
                       </Row>
                       <FormGroup className='mt-2'>
-                        {paymentsEnabled && !isLoading && (
+                        {!isLoading && (
                           <div className='col-md-6 mt-3 mb-4'>
                             <InfoMessage>
                               {'You are currently using '}

--- a/frontend/web/components/pages/UsersAndPermissionsPage.tsx
+++ b/frontend/web/components/pages/UsersAndPermissionsPage.tsx
@@ -80,7 +80,6 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
   const [resendUserInvite] = useResendUserInviteMutation()
 
   const invites = userInvitesData?.results
-  const paymentsEnabled = Utils.getFlagsmithHasFeature('payments_enabled')
   const verifySeatsLimit = Utils.getFlagsmithHasFeature(
     'verify_seats_limit_for_invite_links',
   )
@@ -122,9 +121,10 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
   const max_seats = meta.max_seats || 1
   const isAWS = AccountStore.getPaymentMethod() === 'AWS_MARKETPLACE'
   const autoSeats =
-    paymentsEnabled && !isAWS && Utils.getPlansPermission('AUTO_SEATS')
-  const usedSeats = organisation.num_seats >= max_seats
-  const overSeats = organisation.num_seats > max_seats
+    Utils.isSaas() && !isAWS && Utils.getPlansPermission('AUTO_SEATS')
+  const isSaasOrEnterprise = Utils.isSaas() || Utils.isEnterpriseImage()
+  const usedSeats = isSaasOrEnterprise && organisation.num_seats >= max_seats
+  const overSeats = isSaasOrEnterprise && organisation.num_seats > max_seats
   const [role, setRole] = useState<'ADMIN' | 'USER'>('ADMIN')
 
   const deleteInvite = (id: number) => {
@@ -219,7 +219,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                         )}
                       </Row>
                       <FormGroup className='mt-2'>
-                        {!isLoading && (
+                        {!isLoading && isSaasOrEnterprise && (
                           <div className='col-md-6 mt-3 mb-4'>
                             <InfoMessage>
                               {'You are currently using '}


### PR DESCRIPTION
## Changes

Enforces seat limits for self-hosted deployments. 

Required changes: 

 - [x] API should prevent users joining organisations when organisation is already at or over seat limit
 - [x] FE should show information on the number of seats available / being used in the users settings page
 - [x] FE should gracefully handle an invite failing due to there not being enough seats available

Contributes to flagsmith/flagsmith-private#105 and https://github.com/Flagsmith/infrastructure/issues/267

## How did you test this code?

Ran the FE locally to verify the FE changes. Added / updated unit tests to verify API changes. 
