### PR TITLE
ci: Update `pull-request-title-pattern` to match conventional commit updates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -54,5 +54,6 @@
             "section": "Other",
             "hidden": true
         }
-    ]
+    ],
+    "pull-request-title-pattern": "chore${scope}: Release${component} ${version}"
 }


### PR DESCRIPTION
## Changes

This PR exists to resolve the issue seen when merging the release please PR for `v2.214.0` (see [here](https://github.com/Flagsmith/flagsmith/actions/workflows/platform-release-please.yml), and context in slack here)

Updates the `pull-request-title-pattern` config option for release please to match the updated expectation of the new github-webhook-handler implementation of the conventional commit check (see [here](https://github.com/Flagsmith/github-webhook-handler/pull/59)). 

## How did you test this code?

Merging this PR should create the release PR with the new title. 
