### PR TITLE
chore: Remove environment_metrics feature flag

### DIFF
--- a/frontend/web/components/pages/features/components/FeatureMetricsSection.tsx
+++ b/frontend/web/components/pages/features/components/FeatureMetricsSection.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react'
 import EnvironmentMetricsList from 'components/metrics/EnvironmentMetricsList'
-import Utils from 'common/utils/utils'
 
 type FeatureMetricsSectionProps = {
   environmentId?: string
@@ -11,11 +10,7 @@ export const FeatureMetricsSection: FC<FeatureMetricsSectionProps> = ({
   environmentId,
   projectId,
 }) => {
-  const environmentMetricsEnabled = Utils.getFlagsmithHasFeature(
-    'environment_metrics',
-  )
-
-  if (!environmentMetricsEnabled || !environmentId) {
+  if (!environmentId) {
     return null
   }
 


### PR DESCRIPTION
**The** environment_metrics flag guarded the rendering of EnvironmentMetricsList in FeatureMetricsSection. This feature is now fully rolled out, so the flag check is removed and the metrics section renders unconditionally when an environmentId is provided.

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [ ] I have filled in the "Changes" section below.
- [ ] I have filled in the "How did you test this code" section below.

## Changes

Contributes to <!-- insert issue # or URL -->

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
