### PR TITLE
fix(Hackathon): Platform Hub: Pipeline count incorrectly presented as project adoption count

### DIFF
--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -91,9 +91,11 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
     return Object.values(byOrg)
   }, [stats])
 
-  const pipelineCount = stats.length
+  const projectsWithPipelines = new Set(stats.map((s) => s.project_id)).size
   const adoptionPct =
-    totalProjects > 0 ? Math.round((pipelineCount / totalProjects) * 100) : 0
+    totalProjects > 0
+      ? Math.round((projectsWithPipelines / totalProjects) * 100)
+      : 0
 
   const renderStages = (
     stages: ReleasePipelineStageStats[],
@@ -243,8 +245,8 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
         const completionPct =
           pipeline.total_features > 0
             ? Math.round(
-                (pipeline.completed_features / pipeline.total_features) * 100,
-              )
+              (pipeline.completed_features / pipeline.total_features) * 100,
+            )
             : 0
         const inFlightTotal = pipeline.stages.reduce(
           (sum, s) => sum + s.features_in_stage,
@@ -414,8 +416,8 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
   return (
     <div>
       <div className='text-muted mb-3' style={{ fontSize: 13, paddingLeft: 4 }}>
-        {pipelineCount} of {totalProjects} projects use release pipelines (
-        {adoptionPct}%)
+        {projectsWithPipelines} of {totalProjects} projects use release
+        pipelines ({adoptionPct}%)
       </div>
 
       <PanelSearch


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes #6695

Prevents Release Pipeline adoption rates over 100%.

## How did you test this code?

N/A