### PR TITLE
fix(Hackathon): Platform Hub usage trends timing out

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -33,7 +33,7 @@ read_bucket = settings.INFLUXDB_BUCKET + "_downsampled_15m"
 retries = Retry(connect=3, read=3, redirect=3)
 # Set a timeout to prevent threads being potentially stuck open due to network weirdness
 influxdb_client = InfluxDBClient(
-    url=url, token=token, org=influx_org, retries=retries, timeout=3000
+    url=url, token=token, org=influx_org, retries=retries, timeout=30000
 )
 
 DEFAULT_DROP_COLUMNS = (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Prevent the heavy Influx query from Platform Hub from timing out too early.

## How did you test this code?

We'll test in production.