### PR TITLE
fix(Platform Hub): Invert stale flags count in admin dashboard

### DIFF
--- a/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { StaleFlagsPerProject } from 'common/types/responses'
 import { SortOrder } from 'common/types/requests'
 import PanelSearch from 'components/PanelSearch'
@@ -8,6 +8,18 @@ interface StaleFlagsTableProps {
 }
 
 const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
+  // TODO: The backend returns non-stale (active) flag counts in the stale_flags
+  // field. This should be fixed in the backend (platform_hub/services.py) to
+  // return the actual stale count, and this inversion removed.
+  const items = useMemo(
+    () =>
+      data.map((row) => ({
+        ...row,
+        stale_flags: row.total_flags - row.stale_flags,
+      })),
+    [data],
+  )
+
   return (
     <PanelSearch
       className='no-pad'
@@ -32,8 +44,8 @@ const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
         </div>
       }
       id='stale-flags-table'
-      items={data}
-      paging={data.length > 10 ? { goToPage: 1, pageSize: 10 } : undefined}
+      items={items}
+      paging={items.length > 10 ? { goToPage: 1, pageSize: 10 } : undefined}
       renderRow={(row: StaleFlagsPerProject) => (
         <div
           className='flex-row list-item'


### PR DESCRIPTION
## Summary
- The backend returns the count of non-stale (active) flags in the `stale_flags` field, causing the "Stale Flags per Project" table in the admin dashboard to display inverted values
- Applies `total_flags - stale_flags` transformation on the frontend using `useMemo` so both display and sorting reflect the correct stale count

<img width="1082" height="713" alt="image" src="https://github.com/user-attachments/assets/dc0ce74f-334e-45d8-a9d7-ed5b455356a9" />

## Test plan
- [ ] Verify the "Stale Flags per Project" table on the Platform Hub admin dashboard shows correct stale counts
- [ ] Verify sorting by "Stale Flags" column orders correctly
- [ ] Verify the "% Stale" column percentages are accurate