### PR TITLE
fix(Hackathon): Platform Hub: inverted stale counts

### DIFF
--- a/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import { StaleFlagsPerProject } from 'common/types/responses'
 import { SortOrder } from 'common/types/requests'
 import PanelSearch from 'components/PanelSearch'
@@ -8,18 +8,6 @@ interface StaleFlagsTableProps {
 }
 
 const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
-  // TODO: The backend returns non-stale (active) flag counts in the stale_flags
-  // field. This should be fixed in the backend (platform_hub/services.py) to
-  // return the actual stale count, and this inversion removed.
-  const items = useMemo(
-    () =>
-      data.map((row) => ({
-        ...row,
-        stale_flags: row.total_flags - row.stale_flags,
-      })),
-    [data],
-  )
-
   return (
     <PanelSearch
       className='no-pad'
@@ -44,8 +32,8 @@ const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
         </div>
       }
       id='stale-flags-table'
-      items={items}
-      paging={items.length > 10 ? { goToPage: 1, pageSize: 10 } : undefined}
+      items={data}
+      paging={data.length > 10 ? { goToPage: 1, pageSize: 10 } : undefined}
       renderRow={(row: StaleFlagsPerProject) => (
         <div
           className='flex-row list-item'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Makes stale flag counters not inverted.

## How did you test this code?

Unit tests.