### PR TITLE
fix(Platform Hub): Use STALE tag for stale flags count

### DIFF
--- a/api/platform_hub/services.py
+++ b/api/platform_hub/services.py
@@ -30,6 +30,7 @@ from platform_hub.types import (
     UsageTrendData,
 )
 from projects.models import Project
+from projects.tags.models import TagType
 from users.models import FFAdminUser
 
 logger = structlog.get_logger("platform_hub")
@@ -359,25 +360,15 @@ def _get_stale_flag_counts_by_org(
     organisations: QuerySet[Organisation],
 ) -> dict[int, int]:
     """Return a mapping of organisation_id -> stale flag count."""
-    projects = Project.objects.filter(
-        organisation__in=organisations,
-    ).values("id", "organisation_id", "stale_flags_limit_days")
-
-    result: dict[int, int] = defaultdict(int)
-    for project in projects:
-        cutoff = timezone.now() - timedelta(days=project["stale_flags_limit_days"])
-
-        stale_count = (
-            Feature.objects.filter(project_id=project["id"])
-            .exclude(
-                feature_states__updated_at__gte=cutoff,
-            )
-            .distinct()
-            .count()
+    return dict(
+        Feature.objects.filter(
+            project__organisation__in=organisations,
+            tags__type=TagType.STALE,
         )
-        result[project["organisation_id"]] += stale_count
-
-    return result
+        .values("project__organisation_id")
+        .annotate(count=Count("id"))
+        .values_list("project__organisation_id", "count")
+    )
 
 
 def _get_integration_counts_by_org(
@@ -501,19 +492,23 @@ def get_stale_flags_per_project(
         .values_list("project_id", "count")
     )
 
+    stale_counts_by_project = dict(
+        Feature.objects.filter(
+            project__organisation__in=organisations,
+            tags__type=TagType.STALE,
+        )
+        .values("project_id")
+        .annotate(count=Count("id"))
+        .values_list("project_id", "count")
+    )
+
     results: list[StaleFlagsPerProjectData] = []
     for project in projects:
         total_flags = flag_counts_by_project.get(project.id, 0)
         if total_flags == 0:
             continue
 
-        cutoff = timezone.now() - timedelta(days=project.stale_flags_limit_days)
-        stale_flags = (
-            Feature.objects.filter(project=project)
-            .exclude(feature_states__updated_at__gte=cutoff)
-            .distinct()
-            .count()
-        )
+        stale_flags = stale_counts_by_project.get(project.id, 0)
 
         results.append(
             StaleFlagsPerProjectData(

--- a/api/tests/unit/platform_hub/test_services.py
+++ b/api/tests/unit/platform_hub/test_services.py
@@ -7,13 +7,14 @@ from django.utils import timezone
 from pytest_mock import MockerFixture
 
 from environments.models import Environment
-from features.models import Feature, FeatureState
+from features.models import Feature
 from organisations.models import (
     Organisation,
     OrganisationSubscriptionInformationCache,
 )
 from platform_hub import services
 from projects.models import Project
+from projects.tags.models import Tag, TagType
 from users.models import FFAdminUser
 
 
@@ -429,7 +430,7 @@ def test_get_stale_flags_per_project__query_count_stable_across_projects(
     platform_hub_organisation: Organisation,
     platform_hub_admin_user: FFAdminUser,
 ) -> None:
-    """Flag counts use a single batched query, not one per project."""
+    """Flag and stale counts use batched queries, not one per project."""
     # Given
     project1 = Project.objects.create(
         name="Project A",
@@ -456,33 +457,36 @@ def test_get_stale_flags_per_project__query_count_stable_across_projects(
     with CaptureQueriesContext(connection) as ctx_two:
         result = services.get_stale_flags_per_project(orgs)
 
-    # Then — the flag_counts_by_project query is batched, so only +1
-    # for the additional project's stale flag query.
-    assert len(ctx_two) <= baseline + 1
+    # Then — both flag counts and stale counts are batched, so query
+    # count should not increase when adding more projects.
+    assert len(ctx_two) <= baseline
     assert len(result) == 2
 
 
-def test_get_stale_flags_per_project__different_thresholds__counts_correctly(
+def test_get_stale_flags_per_project__stale_tagged_feature__counts_correctly(
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
     platform_hub_admin_user: FFAdminUser,
 ) -> None:
-    # Given — create a feature with a feature state updated long ago
-    feature = Feature.objects.create(
+    # Given — create a feature tagged as STALE
+    stale_tag = Tag.objects.create(
+        label="Stale",
+        project=platform_hub_project,
+        is_system_tag=True,
+        type=TagType.STALE,
+    )
+    stale_feature = Feature.objects.create(
         name="stale_feature",
         project=platform_hub_project,
     )
-    fs = FeatureState.objects.get(
-        feature=feature,
-        environment=platform_hub_environment,
-    )
-    # Make the feature state old
-    old_date = timezone.now() - timedelta(days=60)
-    FeatureState.objects.filter(id=fs.id).update(updated_at=old_date)
+    stale_feature.tags.add(stale_tag)
 
-    platform_hub_project.stale_flags_limit_days = 30
-    platform_hub_project.save()
+    # Also create a non-stale feature
+    Feature.objects.create(
+        name="active_feature",
+        project=platform_hub_project,
+    )
 
     orgs = Organisation.objects.filter(id=platform_hub_organisation.id)
 
@@ -493,7 +497,7 @@ def test_get_stale_flags_per_project__different_thresholds__counts_correctly(
     assert len(result) == 1
     assert result[0]["project_id"] == platform_hub_project.id
     assert result[0]["stale_flags"] == 1
-    assert result[0]["total_flags"] == 1
+    assert result[0]["total_flags"] == 2
 
 
 def test_get_stale_flags_per_project__no_flags__skips_project(

--- a/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import { StaleFlagsPerProject } from 'common/types/responses'
 import { SortOrder } from 'common/types/requests'
 import PanelSearch from 'components/PanelSearch'
@@ -8,18 +8,6 @@ interface StaleFlagsTableProps {
 }
 
 const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
-  // TODO: The backend returns non-stale (active) flag counts in the stale_flags
-  // field. This should be fixed in the backend (platform_hub/services.py) to
-  // return the actual stale count, and this inversion removed.
-  const items = useMemo(
-    () =>
-      data.map((row) => ({
-        ...row,
-        stale_flags: row.total_flags - row.stale_flags,
-      })),
-    [data],
-  )
-
   return (
     <PanelSearch
       className='no-pad'
@@ -44,8 +32,8 @@ const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
         </div>
       }
       id='stale-flags-table'
-      items={items}
-      paging={items.length > 10 ? { goToPage: 1, pageSize: 10 } : undefined}
+      items={data}
+      paging={data.length > 10 ? { goToPage: 1, pageSize: 10 } : undefined}
       renderRow={(row: StaleFlagsPerProject) => (
         <div
           className='flex-row list-item'


### PR DESCRIPTION
## Summary
- Replace timestamp-based stale flags query with STALE tag-based counting in `get_stale_flags_per_project` and `_get_stale_flag_counts_by_org`
- Remove the frontend inversion workaround added in #6711, since the backend now returns the correct stale count
- Eliminates N+1 per-project queries (both functions now use a single batched query)

Supersedes #6715.

## Context
The backend was using `FeatureState.updated_at` timestamps to determine staleness, which was inconsistent with the Feature Lifecycle page that uses the `STALE` tag assigned by `workflows_logic.stale_flags`. The timestamp query was also affected by identity/segment override timestamps, producing incorrect counts.

## Test plan
- [ ] Run `tests/unit/platform_hub/test_services.py` — updated tests use STALE tags instead of timestamp manipulation
- [ ] Verify the Platform Hub dashboard stale flags numbers match the Feature Lifecycle page
- [ ] Verify sorting and pagination still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)