### PR TITLE
fix(ci): Fix ECS deployment following attempted task definition separation

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -64,7 +64,7 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-sdk-api.json
-        container-name: flagsmith-api
+        container-name: flagsmith-sdk-api
         image: ${{ inputs.api_ecr_image_url }}
 
     - name: Render Admin API task definition
@@ -72,7 +72,7 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-admin-api.json
-        container-name: flagsmith-api
+        container-name: flagsmith-admin-api
         image: ${{ inputs.api_ecr_image_url }}
 
     # This is used in both the SQL migrations and the Dynamo Identity Migrations

--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -106,7 +106,7 @@ runs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         cluster: ${{ inputs.aws_ecs_cluster_name }}
-        service: ${{ inputs.aws_ecs_service_name }}
+        service: ${{ inputs.aws_ecs_sdk_service_name }}
         task-definition: ${{ steps.task-def-sdk-api.outputs.task-definition }}
 
     - name: Deploy Amazon ECS Admin API service
@@ -114,7 +114,7 @@ runs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         cluster: ${{ inputs.aws_ecs_cluster_name }}
-        service: ${{ inputs.aws_ecs_sdk_service_name }}
+        service: ${{ inputs.aws_ecs_service_name }}
         task-definition: ${{ steps.task-def-admin-api.outputs.task-definition }}
 
     # The DynamoDB Identity Migrator uses the same task definition as the SQL schema migrator but overrides the container definition

--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -72,7 +72,6 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-admin-api.json
-        task-definition-family: admin-api
         container-name: flagsmith-api
         image: ${{ inputs.api_ecr_image_url }}
 
@@ -82,7 +81,6 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-migration.json
-        task-definition-family: sdk-api
         container-name: flagsmith-api-migration
         image: ${{ inputs.api_ecr_image_url }}
 

--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -102,13 +102,15 @@ runs:
       shell: bash
 
     - name: Deploy Amazon ECS SDK API task definition
+      id: deploy-sdk-api-task-definition
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         cluster: ${{ inputs.aws_ecs_cluster_name }}
         service: ${{ inputs.aws_ecs_service_name }}
         task-definition: ${{ steps.task-def-sdk-api.outputs.task-definition }}
 
-    - name: Deploy Amazon ECS SDK service
+    - name: Deploy Amazon ECS Admin API service
+      id: deploy-admin-api-task-definition
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         cluster: ${{ inputs.aws_ecs_cluster_name }}
@@ -163,7 +165,8 @@ runs:
     - name: Verify correct version is running
       shell: bash
       run: |
-        EXPECTED_TASK_DEF=${{ steps.deploy-api-task-def.outputs.task-definition-arn }}
+        EXPECTED_ADMIN_API_TASK_DEF=${{ steps.deploy-admin-api-task-definition.outputs.task-definition-arn }}
+        EXPECTED_SDK_API_TASK_DEF=${{ steps.deploy-sdk-api-task-definition.outputs.task-definition-arn }}
         RUNNING_ADMIN_API_TASK_DEF=$(aws ecs describe-services \
           --cluster ${{ inputs.aws_ecs_cluster_name }} \
           --services ${{ inputs.aws_ecs_service_name }} \
@@ -174,13 +177,14 @@ runs:
           --services ${{ inputs.aws_ecs_sdk_service_name }} \
           --query 'services[0].deployments[?status==`PRIMARY`].taskDefinition' \
           --output text)
-        if [[ "$RUNNING_ADMIN_API_TASK_DEF" == "$EXPECTED_TASK_DEF" && \
-              "$RUNNING_SDK_API_TASK_DEF" == "$EXPECTED_TASK_DEF" ]]; then
+        if [[ "$RUNNING_ADMIN_API_TASK_DEF" == "$EXPECTED_ADMIN_API_TASK_DEF" && \
+              "$RUNNING_SDK_API_TASK_DEF" == "$EXPECTED_SDK_API_TASK_DEF" ]]; then
           exit 0
         else
           echo "Task definition mismatch detected"
-          echo "Expected: $EXPECTED_TASK_DEF"
+          echo "Expected Admin API: $EXPECTED_ADMIN_API_TASK_DEF"
           echo "Admin API running: $RUNNING_ADMIN_API_TASK_DEF"
+          echo "Expected SDK API: $EXPECTED_SDK_API_TASK_DEF"
           echo "SDK API running: $RUNNING_SDK_API_TASK_DEF"
           exit 1
         fi

--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -101,21 +101,21 @@ runs:
           }}'
       shell: bash
 
-    - name: Deploy Amazon ECS SDK API task definition
-      id: deploy-sdk-api-task-definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-      with:
-        cluster: ${{ inputs.aws_ecs_cluster_name }}
-        service: ${{ inputs.aws_ecs_sdk_service_name }}
-        task-definition: ${{ steps.task-def-sdk-api.outputs.task-definition }}
-
-    - name: Deploy Amazon ECS Admin API service
+    - name: Deploy new Task Definition to ECS Admin API service
       id: deploy-admin-api-task-definition
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         cluster: ${{ inputs.aws_ecs_cluster_name }}
         service: ${{ inputs.aws_ecs_service_name }}
         task-definition: ${{ steps.task-def-admin-api.outputs.task-definition }}
+
+    - name: Deploy new Task Definition to ECS SDK API service
+      id: deploy-sdk-api-task-definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        cluster: ${{ inputs.aws_ecs_cluster_name }}
+        service: ${{ inputs.aws_ecs_sdk_service_name }}
+        task-definition: ${{ steps.task-def-sdk-api.outputs.task-definition }}
 
     # The DynamoDB Identity Migrator uses the same task definition as the SQL schema migrator but overrides the container definition
     # with the new django execute target

--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -64,7 +64,7 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-sdk-api.json
-        container-name: flagsmith-sdk-api
+        container-name: flagsmith-api
         image: ${{ inputs.api_ecr_image_url }}
 
     - name: Render Admin API task definition
@@ -72,7 +72,8 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-admin-api.json
-        container-name: flagsmith-admin-api
+        task-definition-family: admin-api
+        container-name: flagsmith-api
         image: ${{ inputs.api_ecr_image_url }}
 
     # This is used in both the SQL migrations and the Dynamo Identity Migrations
@@ -81,6 +82,7 @@ runs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: ${{ inputs.aws_task_definitions_directory_path }}/ecs-task-definition-migration.json
+        task-definition-family: sdk-api
         container-name: flagsmith-api-migration
         image: ${{ inputs.api_ecr_image_url }}
 

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix(ci)/task-def-version-check-failures
     paths:
       - api/**
       - .github/**

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix(ci)/task-def-version-check-failures
     paths:
       - api/**
       - .github/**

--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -1,5 +1,5 @@
 {
-    "family": "flagsmith-api",
+    "family": "admin-api",
     "networkMode": "awsvpc",
     "executionRoleArn": "arn:aws:iam::084060095745:role/task-exec-role-741a7e3",
     "taskRoleArn": "arn:aws:iam::084060095745:role/task-exec-role-741a7e3",

--- a/infrastructure/aws/production/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-sdk-api.json
@@ -1,5 +1,5 @@
 {
-    "family": "flagsmith-api",
+    "family": "sdk-api",
     "networkMode": "awsvpc",
     "executionRoleArn": "arn:aws:iam::084060095745:role/task-exec-role-741a7e3",
     "taskRoleArn": "arn:aws:iam::084060095745:role/task-exec-role-741a7e3",

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -1,5 +1,5 @@
 {
-    "family": "flagsmith-api",
+    "family": "admin-api",
     "networkMode": "awsvpc",
     "executionRoleArn": "arn:aws:iam::302456015006:role/task-exec-role-6fb76f6",
     "taskRoleArn": "arn:aws:iam::302456015006:role/task-exec-role-6fb76f6",

--- a/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
@@ -1,5 +1,5 @@
 {
-    "family": "flagsmith-api",
+    "family": "sdk-api",
     "networkMode": "awsvpc",
     "executionRoleArn": "arn:aws:iam::302456015006:role/task-exec-role-6fb76f6",
     "taskRoleArn": "arn:aws:iam::302456015006:role/task-exec-role-6fb76f6",


### PR DESCRIPTION
## Changes

This fixes the work started in [this PR](https://github.com/Flagsmith/flagsmith/pull/6496) to use separate task definitions for the newly separated ECS services (admin API vs SDK). 

Depends on: 
- [x] https://github.com/Flagsmith/pulumi/pull/160

## How did you test this code?

Temporarily updated the workflow to deploy this branches code to staging (see [here](https://github.com/Flagsmith/flagsmith/actions/runs/22072854220/job/63781564836?pr=6719)). 
