### PR TITLE
fix: use-proxy-api-url-version-endpoint

### DIFF
--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -139,6 +139,14 @@ if (process.env.FLAGSMITH_PROXY_API_URL) {
       xfwd: true,
     }),
   )
+  app.use(
+    '/version/',
+    createProxyMiddleware({
+      changeOrigin: true,
+      target: process.env.FLAGSMITH_PROXY_API_URL,
+      xfwd: true,
+    }),
+  )
 }
 
 if (isDev) {
@@ -179,7 +187,7 @@ app.get('/health', (req, res) => {
   res.send('OK')
 })
 
-app.get('/version', (req, res) => {
+app.get('/_frontend_version', (req, res) => {
   let commitSha = 'Unknown'
   let imageTag = 'Unknown'
 

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -139,14 +139,6 @@ if (process.env.FLAGSMITH_PROXY_API_URL) {
       xfwd: true,
     }),
   )
-  app.use(
-    '/version/',
-    createProxyMiddleware({
-      changeOrigin: true,
-      target: process.env.FLAGSMITH_PROXY_API_URL,
-      xfwd: true,
-    }),
-  )
 }
 
 if (isDev) {
@@ -187,7 +179,7 @@ app.get('/health', (req, res) => {
   res.send('OK')
 })
 
-app.get('/_frontend_version', (req, res) => {
+app.get('/version', (req, res) => {
   let commitSha = 'Unknown'
   let imageTag = 'Unknown'
 
@@ -215,6 +207,22 @@ app.get('/_frontend_version', (req, res) => {
     res.send({ 'ci_commit_sha': commitSha, 'image_tag': imageTag })
   }
 })
+
+if (process.env.FLAGSMITH_PROXY_API_URL) {
+  app.get('/_backend_version', async (req, res) => {
+    try {
+      const response = await fetch(
+        `${process.env.FLAGSMITH_PROXY_API_URL.replace(/\/?$/, '/')}version/`,
+      )
+      const data = await response.json()
+      res.json(data)
+    } catch (err) {
+      // eslint-disable-next-line
+      console.log('Unable to fetch backend version:', err)
+      res.status(502).json({})
+    }
+  })
+}
 
 app.use(bodyParser.json())
 app.use(spm)

--- a/frontend/common/services/useBuildVersion.ts
+++ b/frontend/common/services/useBuildVersion.ts
@@ -14,7 +14,7 @@ export const buildVersionService = service
         queryFn: async (args, _, _2, baseQuery) => {
           try {
             const [frontendRes, backendRes] = await Promise.all([
-              data.get(`/version/`).catch(() => ({})),
+              data.get(`/_frontend_version`).catch(() => ({})),
               data.get(`${Project.api.replace('api/v1/', '')}version/`),
             ])
 

--- a/frontend/common/services/useBuildVersion.ts
+++ b/frontend/common/services/useBuildVersion.ts
@@ -13,9 +13,13 @@ export const buildVersionService = service
         providesTags: () => [{ id: 'BuildVersion', type: 'BuildVersion' }],
         queryFn: async (args, _, _2, baseQuery) => {
           try {
+            const backendVersionUrl =
+              Project.api === '/api/v1/'
+                ? '/_backend_version'
+                : `${Project.api.replace('api/v1/', '')}version/`
             const [frontendRes, backendRes] = await Promise.all([
-              data.get(`/_frontend_version`).catch(() => ({})),
-              data.get(`${Project.api.replace('api/v1/', '')}version/`),
+              data.get(`/version`).catch(() => ({})),
+              data.get(backendVersionUrl),
             ])
 
             const frontend = (frontendRes || {}) as Version['frontend']


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6588 

Frontend was only handling `api/v1/*` when proxying traffic with `FLAGSMITH_PROXY_API_URL` while `version` lives at the root, causing the frontend to hit its own `/version`, ignoring `is_enterprise` and `is_saas` in deployments

- Add `/version` in proxied paths when `FLAGSMITH_PROXY_API_URL` is set
- Renamed FE version endpoint to `/_frontend_version` to avoid  conflicts
- Update `useBuildVersion` to use `/_frontend_version`

## How did you test this code?
- Start a flagsmith api via docker
- in `frontend` start the server `FLAGSMITH_PROXY_API_URL=http://localhost:8000 ENV=local npm run dev`
  Run:
  - `curl http://localhost:8080/_backend_version` → response includes `is_enterprise`, `is_saas` (fetched from the API)
  - `curl http://localhost:8080/version` → returns frontend version (`ci_commit_sha`, `image_tag`)

  Go to http://localhost:8080 in the browser and verify:
  - Organisation Settings correctly shows licensing tab (based on `is_enterprise`)
  - The version tag in the UI shows the API version andnot `Unknown`