### PR TITLE
fix(multivariate): Handled missing default_percentage_allocation in option validation

### DIFF
--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -59,10 +59,26 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
     def validate(self, attrs):  # type: ignore[no-untyped-def]
         attrs = super().validate(attrs)
 
-        # For partial updated, use existing instance value as fallback
-        feature = attrs.get("feature", self.instance.feature if self.instance else None)
+        # For partial updates or nested routes, use existing instance or URL value as fallback
+        feature = attrs.get("feature")
+        if feature is None and self.instance is not None:
+            feature = self.instance.feature
+
+        if feature is None:
+            view = self.context.get("view")
+            feature_pk = getattr(view, "kwargs", {}).get("feature_pk") if view else None
+            project_pk = getattr(view, "kwargs", {}).get("project_pk") if view else None
+            if feature_pk is not None:
+                qs = Feature.objects.filter(pk=feature_pk)
+                if project_pk is not None:
+                    qs = qs.filter(project__id=project_pk)
+                feature = qs.first()
+
         if feature is None:
             raise serializers.ValidationError({"feature": "Feature is required"})
+
+        # Ensure feature is always present in validated data (e.g. for creates via nested routes)
+        attrs["feature"] = feature
 
         default_allocation = attrs.get(
             "default_percentage_allocation",

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -55,6 +55,9 @@ class FeatureMVOptionsValuesResponseSerializer(serializers.Serializer):  # type:
 class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSerializer):
     class Meta(NestedMultivariateFeatureOptionSerializer.Meta):
         fields = NestedMultivariateFeatureOptionSerializer.Meta.fields + ("feature",)  # type: ignore[assignment]
+        extra_kwargs = {
+            "feature": {"required": False},
+        }
 
     def validate(self, attrs):  # type: ignore[no-untyped-def]
         attrs = super().validate(attrs)

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -70,9 +70,8 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
             )["total_percentage_allocation"]
             or 0
         )
-        total_percentage_allocation = (
-            total_sibling_percentage_allocation
-            + attrs.get("default_percentage_allocation", default_allocation)
+        total_percentage_allocation = total_sibling_percentage_allocation + attrs.get(
+            "default_percentage_allocation", default_allocation
         )
 
         if total_percentage_allocation > 100:

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -63,7 +63,7 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
         feature = attrs.get("feature", self.instance.feature if self.instance else None)
         default_allocation = attrs.get(
             "default_percentage_allocation",
-            self.instance.default_percentage_allocation if self.instance else 100
+            self.instance.default_percentage_allocation if self.instance else 100,
         )
 
         total_sibling_percentage_allocation = (

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -58,14 +58,21 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
 
     def validate(self, attrs):  # type: ignore[no-untyped-def]
         attrs = super().validate(attrs)
+
+        # For updates, use existing instance value; for creates, use model default
+        default_allocation = (
+            self.instance.default_percentage_allocation if self.instance else 100
+        )
+
         total_sibling_percentage_allocation = (
             self._get_siblings(attrs["feature"]).aggregate(
                 total_percentage_allocation=Sum("default_percentage_allocation")
             )["total_percentage_allocation"]
             or 0
         )
-        total_percentage_allocation = total_sibling_percentage_allocation + attrs.get(
-            "default_percentage_allocation", 100
+        total_percentage_allocation = (
+            total_sibling_percentage_allocation
+            + attrs.get("default_percentage_allocation", default_allocation)
         )
 
         if total_percentage_allocation > 100:

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -62,12 +62,8 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
         # For partial updated, use existing instance value as fallback
         feature = attrs.get("feature", self.instance.feature if self.instance else None)
         if feature is None:
-            raise serializers.ValidationError(
-                {
-                    "feature": "Feature is required"
-                }
-            )
-        
+            raise serializers.ValidationError({"feature": "Feature is required"})
+
         default_allocation = attrs.get(
             "default_percentage_allocation",
             self.instance.default_percentage_allocation if self.instance else 100,

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -80,9 +80,15 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
         # Ensure feature is always present in validated data (e.g. for creates via nested routes)
         attrs["feature"] = feature
 
+        # Handle legacy records where default_percentage_allocation may be NULL in the database.
+        if self.instance and self.instance.default_percentage_allocation is not None:
+            instance_default_allocation = self.instance.default_percentage_allocation
+        else:
+            instance_default_allocation = 100
+
         default_allocation = attrs.get(
             "default_percentage_allocation",
-            self.instance.default_percentage_allocation if self.instance else 100,
+            instance_default_allocation,
         )
 
         total_sibling_percentage_allocation = (

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -61,6 +61,13 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
 
         # For partial updated, use existing instance value as fallback
         feature = attrs.get("feature", self.instance.feature if self.instance else None)
+        if feature is None:
+            raise serializers.ValidationError(
+                {
+                    "feature": "Feature is required"
+                }
+            )
+        
         default_allocation = attrs.get(
             "default_percentage_allocation",
             self.instance.default_percentage_allocation if self.instance else 100,

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -64,9 +64,8 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
             )["total_percentage_allocation"]
             or 0
         )
-        total_percentage_allocation = (
-            total_sibling_percentage_allocation
-            + attrs.get("default_percentage_allocation", 100)
+        total_percentage_allocation = total_sibling_percentage_allocation + attrs.get(
+            "default_percentage_allocation", 100
         )
 
         if total_percentage_allocation > 100:

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -65,7 +65,8 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
             or 0
         )
         total_percentage_allocation = (
-            total_sibling_percentage_allocation + attrs["default_percentage_allocation"]
+            total_sibling_percentage_allocation
+            + attrs.get("default_percentage_allocation", 100)
         )
 
         if total_percentage_allocation > 100:

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -90,6 +90,7 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
             "default_percentage_allocation",
             instance_default_allocation,
         )
+        attrs["default_percentage_allocation"] = default_allocation
 
         total_sibling_percentage_allocation = (
             self._get_siblings(feature).aggregate(

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -59,19 +59,21 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
     def validate(self, attrs):  # type: ignore[no-untyped-def]
         attrs = super().validate(attrs)
 
-        # For updates, use existing instance value; for creates, use model default
-        default_allocation = (
+        # For partial updated, use existing instance value as fallback
+        feature = attrs.get("feature", self.instance.feature if self.instance else None)
+        default_allocation = attrs.get(
+            "default_percentage_allocation",
             self.instance.default_percentage_allocation if self.instance else 100
         )
 
         total_sibling_percentage_allocation = (
-            self._get_siblings(attrs["feature"]).aggregate(
+            self._get_siblings(feature).aggregate(
                 total_percentage_allocation=Sum("default_percentage_allocation")
             )["total_percentage_allocation"]
             or 0
         )
-        total_percentage_allocation = total_sibling_percentage_allocation + attrs.get(
-            "default_percentage_allocation", default_allocation
+        total_percentage_allocation = (
+            total_sibling_percentage_allocation + default_allocation
         )
 
         if total_percentage_allocation > 100:

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -39,6 +39,7 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
     assert response.json()["id"]
     assert set(data.items()).issubset(set(response.json().items()))
 
+
 @pytest.mark.parametrize(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -44,6 +44,40 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
+def test_create_mv_option__without_feature_in_payload__uses_feature_from_url(
+    client: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:feature-mv-options-list",
+        args=[project, feature],
+    )
+    data = {
+        "type": "unicode",
+        "string_value": "bigger",
+        "default_percentage_allocation": 50,
+    }
+    # When
+    response = client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    body = response.json()
+    assert body["id"]
+    assert body["feature"] == feature
+    assert body["string_value"] == "bigger"
+    assert body["default_percentage_allocation"] == 50
+
+
+@pytest.mark.parametrize(
+    "client",
+    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+)
 def test_create_mv_option__without_default_percentage_allocation__uses_default(
     client: APIClient,
     project: int,

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -44,7 +44,7 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_mv_option_without_default_percentage_allocation_uses_default(
+def test_create_mv_option__without_default_percentage_allocation__uses_default(
     client: APIClient,
     project: int,
     feature: int,
@@ -77,7 +77,7 @@ def test_create_mv_option_without_default_percentage_allocation_uses_default(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_mv_option_without_default_percentage_allocation_with_existing_sibling_and_total_gt_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_mv_option__without_default_percentage_allocation_with_existing_sibling_and_total_gt_100__returns_400(  # noqa: E501
     client: APIClient,
     project: int,
     feature: int,
@@ -112,7 +112,7 @@ def test_create_mv_option_without_default_percentage_allocation_with_existing_si
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_partial_update_mv_option_without_feature_and_allocation_uses_existing_values(
+def test_partial_update_mv_option__without_feature_and_allocation__uses_existing_values(
     client: APIClient,
     project: int,
     feature: int,
@@ -288,12 +288,12 @@ def test_can_update_default_percentage_allocation(  # type: ignore[no-untyped-de
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_partial_update_default_percentage_allocation_that_pushes_the_total_percentage_allocation_over_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: E501
-    project,
-    mv_option_50_percent,
-    client,
-    feature,
-):
+def test_partial_update_default_percentage_allocation__sibling_total_gt_100__returns_400(  # noqa: E501
+    project: int,
+    mv_option_50_percent: int,
+    client: APIClient,
+    feature: int,
+) -> None:
     # First let's create another mv_option with 30 percent allocation
     url = reverse(
         "api-v1:projects:feature-mv-options-list",

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 
 from features.models import Feature
 from features.multivariate.models import MultivariateFeatureOption
+from features.multivariate.serializers import MultivariateFeatureOptionSerializer
 from organisations.models import Organisation
 from projects.models import Project
 from users.models import FFAdminUser
@@ -181,37 +182,38 @@ def test_partial_update_mv_option__without_feature_and_allocation__uses_existing
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
 def test_partial_update_mv_option__handles_legacy_null_default_percentage_allocation(  # noqa: E501
-    client: APIClient,
     project: int,
     feature: int,
     mv_option_50_percent: int,
 ) -> None:
     # Given
-    # Simulate a legacy database record with a NULL default_percentage_allocation.
-    MultivariateFeatureOption.objects.filter(
-        id=mv_option_50_percent,
-    ).update(default_percentage_allocation=None)
+    # Simulate a legacy instance in memory where default_percentage_allocation is NULL.
+    mv_option = MultivariateFeatureOption.objects.get(id=mv_option_50_percent)
+    mv_option.default_percentage_allocation = None
 
-    url = reverse(
-        "api-v1:projects:feature-mv-options-detail",
-        args=[project, feature, mv_option_50_percent],
+    serializer = MultivariateFeatureOptionSerializer(
+        instance=mv_option,
+        data={"string_value": "updated_legacy_value"},
+        partial=True,
+        context={
+            "view": type(
+                "View",
+                (),
+                {
+                    "kwargs": {
+                        "project_pk": project,
+                        "feature_pk": feature,
+                    },
+                },
+            )(),
+        },
     )
-    data = {
-        "string_value": "updated_legacy_value",
-    }
+    assert serializer.is_valid(), serializer.errors
+    instance = serializer.save()
 
-    # When
-    response = client.patch(
-        url,
-        data=json.dumps(data),
-        content_type="application/json",
-    )
-    # Then
-    assert response.status_code == status.HTTP_200_OK
-    body = response.json()
-    assert body["string_value"] == "updated_legacy_value"
-    assert body["default_percentage_allocation"] == 100
-    assert body["feature"] == feature
+    assert instance.string_value == "updated_legacy_value"
+    assert instance.default_percentage_allocation == 100
+    assert instance.feature_id == feature
 
 
 @pytest.mark.parametrize(

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -310,6 +310,7 @@ def test_partial_update_default_percentage_allocation_that_pushes_the_total_perc
         data=json.dumps(data),
         content_type="application/json",
     )
+    assert response.status_code == status.HTTP_201_CREATED
     mv_option_30_percent = response.json()["id"]
 
     # Next, let's partially update the 30 percent mv option to 51 percent

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -73,6 +73,7 @@ def test_create_mv_option_without_default_percentage_allocation_uses_default(
     assert response.json()["id"]
     assert response.json()["default_percentage_allocation"] == 100
 
+
 @pytest.mark.parametrize(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
@@ -105,6 +106,7 @@ def test_partial_update_mv_option_without_default_percentage_allocation_uses_exi
     assert response.json()["string_value"] == "updated_value"
     # Should retain original 50% allocation, not default to 100
     assert response.json()["default_percentage_allocation"] == 50
+
 
 @pytest.mark.parametrize(
     "client, feature_id",

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -73,6 +73,38 @@ def test_create_mv_option_without_default_percentage_allocation_uses_default(
     assert response.json()["id"]
     assert response.json()["default_percentage_allocation"] == 100
 
+@pytest.mark.parametrize(
+    "client",
+    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+)
+def test_partial_update_mv_option_without_default_percentage_allocation_uses_existing_value(
+    client: APIClient,
+    project: int,
+    feature: int,
+    mv_option_50_percent: int,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:feature-mv-options-detail",
+        args=[project, feature, mv_option_50_percent],
+    )
+    data = {
+        "string_value": "updated_value",
+        # Note: default_percentage_allocation is intentionally omitted
+    }
+
+    # When
+    response = client.patch(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["string_value"] == "updated_value"
+    # Should retain original 50% allocation, not default to 100
+    assert response.json()["default_percentage_allocation"] == 50
 
 @pytest.mark.parametrize(
     "client, feature_id",

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -39,6 +39,7 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
     assert response.json()["id"]
     assert set(data.items()).issubset(set(response.json().items()))
 
+
 @pytest.mark.parametrize(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
@@ -103,6 +104,7 @@ def test_partial_update_mv_option_without_feature_and_allocation_uses_existing_v
     assert response.json()["string_value"] == "updated_value"
     assert response.json()["default_percentage_allocation"] == 50
     assert response.json()["feature"] == feature
+
 
 @pytest.mark.parametrize(
     "client, feature_id",

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -182,6 +182,7 @@ def test_partial_update_mv_option__without_feature_and_allocation__uses_existing
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
 def test_partial_update_mv_option__handles_legacy_null_default_percentage_allocation(  # noqa: E501
+    client: APIClient,
     project: int,
     feature: int,
     mv_option_50_percent: int,

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -39,6 +39,39 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
     assert response.json()["id"]
     assert set(data.items()).issubset(set(response.json().items()))
 
+@pytest.mark.parametrize(
+    "client",
+    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+)
+def test_create_mv_option_without_default_percentage_allocation_uses_default(
+    client: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:feature-mv-options-list",
+        args=[project, feature],
+    )
+    data = {
+        "type": "unicode",
+        "feature": feature,
+        "string_value": "test_value",
+        # Note: default_percentage_allocation is intentionally omitted
+    }
+
+    # When
+    response = client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["id"]
+    assert response.json()["default_percentage_allocation"] == 100
+
 
 @pytest.mark.parametrize(
     "client, feature_id",

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -77,6 +77,41 @@ def test_create_mv_option_without_default_percentage_allocation_uses_default(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
+def test_create_mv_option_without_default_percentage_allocation_with_existing_sibling_and_total_gt_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: E501
+    client: APIClient,
+    project: int,
+    feature: int,
+    mv_option_50_percent: int,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:feature-mv-options-list",
+        args=[project, feature],
+    )
+    data = {
+        "type": "unicode",
+        "feature": feature,
+        "string_value": "another_value",
+    }
+
+    # When
+    response = client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["default_percentage_allocation"] == [
+        "Invalid percentage allocation"
+    ]
+
+
+@pytest.mark.parametrize(
+    "client",
+    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+)
 def test_partial_update_mv_option_without_feature_and_allocation_uses_existing_values(
     client: APIClient,
     project: int,
@@ -247,6 +282,55 @@ def test_can_update_default_percentage_allocation(  # type: ignore[no-untyped-de
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["id"] == mv_option_50_percent
     assert set(data.items()).issubset(set(response.json().items()))
+
+
+@pytest.mark.parametrize(
+    "client",
+    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+)
+def test_partial_update_default_percentage_allocation_that_pushes_the_total_percentage_allocation_over_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: E501
+    project,
+    mv_option_50_percent,
+    client,
+    feature,
+):
+    # First let's create another mv_option with 30 percent allocation
+    url = reverse(
+        "api-v1:projects:feature-mv-options-list",
+        args=[project, feature],
+    )
+    data = {
+        "type": "unicode",
+        "feature": feature,
+        "string_value": "bigger",
+        "default_percentage_allocation": 30,
+    }
+    response = client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    mv_option_30_percent = response.json()["id"]
+
+    # Next, let's partially update the 30 percent mv option to 51 percent
+    url = reverse(
+        "api-v1:projects:feature-mv-options-detail",
+        args=[project, feature, mv_option_30_percent],
+    )
+    data = {
+        "default_percentage_allocation": 51,
+    }
+    # When
+    response = client.patch(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["default_percentage_allocation"] == [
+        "Invalid percentage allocation"
+    ]
 
 
 @pytest.mark.parametrize(

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from features.models import Feature
+from features.multivariate.models import MultivariateFeatureOption
 from organisations.models import Organisation
 from projects.models import Project
 from users.models import FFAdminUser
@@ -173,6 +174,44 @@ def test_partial_update_mv_option__without_feature_and_allocation__uses_existing
     assert response.json()["string_value"] == "updated_value"
     assert response.json()["default_percentage_allocation"] == 50
     assert response.json()["feature"] == feature
+
+
+@pytest.mark.parametrize(
+    "client",
+    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+)
+def test_partial_update_mv_option__handles_legacy_null_default_percentage_allocation(  # noqa: E501
+    client: APIClient,
+    project: int,
+    feature: int,
+    mv_option_50_percent: int,
+) -> None:
+    # Given
+    # Simulate a legacy database record with a NULL default_percentage_allocation.
+    MultivariateFeatureOption.objects.filter(
+        id=mv_option_50_percent,
+    ).update(default_percentage_allocation=None)
+
+    url = reverse(
+        "api-v1:projects:feature-mv-options-detail",
+        args=[project, feature, mv_option_50_percent],
+    )
+    data = {
+        "string_value": "updated_legacy_value",
+    }
+
+    # When
+    response = client.patch(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["string_value"] == "updated_legacy_value"
+    assert body["default_percentage_allocation"] == 100
+    assert body["feature"] == feature
 
 
 @pytest.mark.parametrize(

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -39,7 +39,6 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
     assert response.json()["id"]
     assert set(data.items()).issubset(set(response.json().items()))
 
-
 @pytest.mark.parametrize(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
@@ -58,7 +57,6 @@ def test_create_mv_option_without_default_percentage_allocation_uses_default(
         "type": "unicode",
         "feature": feature,
         "string_value": "test_value",
-        # Note: default_percentage_allocation is intentionally omitted
     }
 
     # When
@@ -78,7 +76,7 @@ def test_create_mv_option_without_default_percentage_allocation_uses_default(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_partial_update_mv_option_without_default_percentage_allocation_uses_existing_value(
+def test_partial_update_mv_option_without_feature_and_allocation_uses_existing_values(
     client: APIClient,
     project: int,
     feature: int,
@@ -91,7 +89,6 @@ def test_partial_update_mv_option_without_default_percentage_allocation_uses_exi
     )
     data = {
         "string_value": "updated_value",
-        # Note: default_percentage_allocation is intentionally omitted
     }
 
     # When
@@ -104,9 +101,8 @@ def test_partial_update_mv_option_without_default_percentage_allocation_uses_exi
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["string_value"] == "updated_value"
-    # Should retain original 50% allocation, not default to 100
     assert response.json()["default_percentage_allocation"] == 50
-
+    assert response.json()["feature"] == feature
 
 @pytest.mark.parametrize(
     "client, feature_id",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6615 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

Fixes a KeyError when creating or updating multivariate options via the API without specifying optional fields.

Root cause: The `validate()` method in `MultivariateFeatureOptionSerializer` accessed `attrs["feature"]` and `attrs["default_percentage_allocation"]` directly, causing crashes on partial updates or creates when these fields were omitted.

Fixes a `KeyError` when creating or updating multivariate options via the API when optional fields are omitted.

Root cause: `MultivariateFeatureOptionSerializer.validate()` used `attrs["feature"]` and `attrs["default_percentage_allocation"]`, which raises when those keys are missing on partial updates or when creating via nested routes without sending them.

Fix:
- `feature`: Resolved with fallbacks: `attrs.get("feature")`, then for updates `self.instance.feature`, then for nested routes the feature from URL `kwargs (feature_pk / project_pk)`. The serializer marks feature as not required via `extra_kwargs` so POSTs without feature (e.g. when the feature is in the path) still reach `validate()`.
- `default_percentage_allocation`: Resolved with `attrs.get(..., instance_default_allocation)`, where `instance_default_allocation` is the instance value when present, or 100 for creates or legacy rows with NULL. The chosen value is written back into `attrs["default_percentage_allocation"]` so validation and persistence stay in sync and legacy NULL is corrected on save.

Note: No documentation changes required - this is a bug fix for the existing API behaviour, not a new feature.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- `test_create_mv_option__without_feature_in_payload__uses_feature_from_url` – Create without feature in the body (feature from URL) → 201 and correct feature / allocation.
- `test_create_mv_option__without_default_percentage_allocation__uses_default` – Create without default_percentage_allocation → 201 and value 100.
- `test_create_mv_option__without_default_percentage_allocation_with_existing_sibling_and_total_gt_100__returns_400` – Create without allocation when a sibling has 50% → 400 and "Invalid percentage allocation".
- `test_partial_update_mv_option__without_feature_and_allocation__uses_existing_values` – PATCH without feature or default_percentage_allocation → 200 and existing values kept.
- `test_partial_update_mv_option__handles_legacy_null_default_percentage_allocation` – Serializer update with an instance that has default_percentage_allocation is None in memory → validates as 100 and persists 100 (legacy NULL handling).
- `test_partial_update_default_percentage_allocation__sibling_total_gt_100__returns_400` – PATCH that would push total allocation over 100% → 400 and "Invalid percentage allocation".
