### PR TITLE
chore: Reduce sentry sampling rate

### DIFF
--- a/api/integrations/sentry/samplers.py
+++ b/api/integrations/sentry/samplers.py
@@ -2,7 +2,7 @@ from contextlib import suppress
 
 from django.conf import settings
 
-NON_FUNCTIONAL_ENDPOINTS = ("/health", "")
+NON_FUNCTIONAL_ENDPOINTS = ("/health", "", "/api/v1/analytics/telemetry/")
 SDK_ENDPOINTS = {
     "/api/v1/flags",
     "/api/v1/identities",

--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -216,6 +216,10 @@
                 {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
+                },
+                {
+                    "name": "DASHBOARD_ENDPOINTS_SENTRY_TRACE_SAMPLE_RATE",
+                    "value": "0.5"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

In order to manage the Sentry subscription cost, this PR achieves 2 things: 

 1. Reduces the default sample rate from 100% (default) to 50%
 2. Ignores any requests to `/api/v1/analytics/telemetry` which are sent by self-hosted deployments and we don't need to monitor the performance of

## How did you test this code?

Will be tested by monitoring the usage of sentry in production. 
