### PR TITLE
fix: parse-string-user-agents-to-int-in-mapper

### DIFF
--- a/api/app_analytics/mappers.py
+++ b/api/app_analytics/mappers.py
@@ -66,11 +66,13 @@ def map_influx_record_values_to_labels(values: dict[str, Any]) -> Labels:
     labels: Labels = {}
     for label in LABELS:
         if label == "user_agent":
-            user_agent_influx_id: int | None = values.get("user_agent")
-            if user_agent_influx_id and (
-                user_agent := SDK_USER_AGENTS_BY_INFLUX_ID.get(user_agent_influx_id)
-            ):
-                labels["user_agent"] = user_agent
+            try:
+                influx_id = int(values["user_agent"])
+            except (KeyError, ValueError, TypeError):
+                pass
+            else:
+                if user_agent := SDK_USER_AGENTS_BY_INFLUX_ID.get(influx_id):
+                    labels["user_agent"] = user_agent
             continue
         if value := values.get(label):
             labels[label] = value


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Parse user-agent to int

It assumes that we missed user agent in production at the moment because influx would return strings

## How did you test this code?
- Tests