### PR TITLE
fix: enable Gunicorn worker recycling with graceful analytics flush

### DIFF
--- a/api/app_analytics/apps.py
+++ b/api/app_analytics/apps.py
@@ -1,6 +1,25 @@
+import atexit
+import logging
+
 from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
 
 
 class AppAnalyticsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "app_analytics"
+
+    def ready(self) -> None:
+        atexit.register(flush_analytics_caches)
+
+
+def flush_analytics_caches() -> None:
+    try:
+        from app_analytics.services import api_usage_cache
+        from app_analytics.views import feature_evaluation_cache
+
+        api_usage_cache.flush_on_shutdown()
+        feature_evaluation_cache.flush_on_shutdown()
+    except Exception:
+        logger.exception("Failed to flush analytics caches during shutdown")

--- a/api/app_analytics/cache.py
+++ b/api/app_analytics/cache.py
@@ -24,7 +24,7 @@ class APIUsageCache:
         self._last_flushed_at = timezone.now()
         self._lock = Lock()
 
-    def _flush(self) -> None:
+    def _flush_through_thread(self) -> None:
         for key, value in self._cache.items():
             track_request.run_in_thread(
                 kwargs={
@@ -38,6 +38,24 @@ class APIUsageCache:
 
         self._cache = {}
         self._last_flushed_at = timezone.now()
+
+    def _flush_through_task_processor(self) -> None:
+        for key, value in self._cache.items():
+            track_request.delay(
+                kwargs={
+                    "resource": key.resource.value,
+                    "host": key.host,
+                    "environment_key": key.environment_key,
+                    "count": value,
+                    "labels": dict(key.labels),
+                }
+            )
+        self._cache = {}
+        self._last_flushed_at = timezone.now()
+
+    def flush_on_shutdown(self) -> None:
+        with self._lock:
+            self._flush_through_task_processor()
 
     def track_request(
         self,
@@ -60,7 +78,7 @@ class APIUsageCache:
             if (
                 timezone.now() - self._last_flushed_at
             ).seconds > settings.API_USAGE_CACHE_SECONDS:
-                self._flush()
+                self._flush_through_thread()
 
 
 class FeatureEvaluationCache:
@@ -69,7 +87,7 @@ class FeatureEvaluationCache:
         self._last_flushed_at = timezone.now()
         self._lock = Lock()
 
-    def _flush(self) -> None:
+    def _flush_through_task_processor(self) -> None:
         for kwargs in map_feature_evaluation_cache_to_track_feature_evaluations_by_environment_kwargs(
             self._cache
         ):
@@ -77,6 +95,10 @@ class FeatureEvaluationCache:
 
         self._cache = {}
         self._last_flushed_at = timezone.now()
+
+    def flush_on_shutdown(self) -> None:
+        with self._lock:
+            self._flush_through_task_processor()
 
     def track_feature_evaluation(
         self,
@@ -99,4 +121,4 @@ class FeatureEvaluationCache:
             if (
                 timezone.now() - self._last_flushed_at
             ).seconds > settings.FEATURE_EVALUATION_CACHE_SECONDS:
-                self._flush()
+                self._flush_through_task_processor()

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -34,6 +34,8 @@ serve() {
              --keep-alive ${GUNICORN_KEEP_ALIVE:-2} \
              ${STATSD_HOST:+--statsd-host $STATSD_HOST:$STATSD_PORT} \
              ${STATSD_HOST:+--statsd-prefix $STATSD_PREFIX} \
+             --max-requests ${GUNICORN_MAX_REQUESTS:-1000} \
+             --max-requests-jitter ${GUNICORN_MAX_REQUESTS_JITTER:-100} \
              api
 }
 run_task_processor() {

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_apps.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_apps.py
@@ -1,0 +1,54 @@
+from django.apps import apps
+from pytest_mock import MockerFixture
+
+from app_analytics.apps import flush_analytics_caches
+
+
+def test_app_analytics_config__ready__registers_atexit_handler(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_atexit_register = mocker.patch("app_analytics.apps.atexit.register")
+    config = apps.get_app_config("app_analytics")
+
+    # When
+    config.ready()
+
+    # Then
+    mock_atexit_register.assert_called_once_with(flush_analytics_caches)
+
+
+def test_flush_analytics_caches__calls_flush_on_shutdown_on_both_caches(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_api_usage_cache = mocker.patch(
+        "app_analytics.services.api_usage_cache",
+    )
+    mock_feature_evaluation_cache = mocker.patch(
+        "app_analytics.views.feature_evaluation_cache",
+    )
+
+    # When
+    flush_analytics_caches()
+
+    # Then
+    mock_api_usage_cache.flush_on_shutdown.assert_called_once()
+    mock_feature_evaluation_cache.flush_on_shutdown.assert_called_once()
+
+
+def test_flush_analytics_caches__exception__logs_and_does_not_raise(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_cache = mocker.patch("app_analytics.services.api_usage_cache")
+    mock_cache.flush_on_shutdown.side_effect = RuntimeError("test error")
+    mock_logger = mocker.patch("app_analytics.apps.logger")
+
+    # When — should not raise
+    flush_analytics_caches()
+
+    # Then
+    mock_logger.exception.assert_called_once_with(
+        "Failed to flush analytics caches during shutdown"
+    )

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
@@ -95,6 +95,153 @@ def test_api_usage_cache(
         assert not mocked_track_request_task.called
 
 
+def test_api_usage_cache__flush_on_shutdown__delegates_to_delay(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    cache = APIUsageCache()
+    mocked_track_request_task = mocker.patch("app_analytics.cache.track_request")
+
+    cache.track_request(
+        resource=Resource.FLAGS,
+        host="host",
+        environment_key="env_key_1",
+        labels={},
+    )
+    cache.track_request(
+        resource=Resource.FLAGS,
+        host="host",
+        environment_key="env_key_1",
+        labels={},
+    )
+    cache.track_request(
+        resource=Resource.IDENTITIES,
+        host="host",
+        environment_key="env_key_2",
+        labels={},
+    )
+
+    # When
+    cache.flush_on_shutdown()
+
+    # Then
+    mocked_track_request_task.delay.assert_has_calls(
+        [
+            mocker.call(
+                kwargs={
+                    "resource": Resource.FLAGS.value,
+                    "host": "host",
+                    "environment_key": "env_key_1",
+                    "count": 2,
+                    "labels": {},
+                }
+            ),
+            mocker.call(
+                kwargs={
+                    "resource": Resource.IDENTITIES.value,
+                    "host": "host",
+                    "environment_key": "env_key_2",
+                    "count": 1,
+                    "labels": {},
+                }
+            ),
+        ],
+        any_order=True,
+    )
+    mocked_track_request_task.run_in_thread.assert_not_called()
+    assert cache._cache == {}
+
+
+def test_api_usage_cache__flush_on_shutdown__empty_cache__no_calls(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    cache = APIUsageCache()
+    mocked_track_request_task = mocker.patch("app_analytics.cache.track_request")
+
+    # When
+    cache.flush_on_shutdown()
+
+    # Then
+    mocked_track_request_task.delay.assert_not_called()
+    assert cache._cache == {}
+
+
+def test_feature_evaluation_cache__flush_on_shutdown__delegates_to_delay(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    cache = FeatureEvaluationCache()
+    mocked_track_evaluation_task = mocker.patch(
+        "app_analytics.cache.track_feature_evaluations_by_environment"
+    )
+
+    cache.track_feature_evaluation(
+        environment_id=1,
+        feature_name="feature_1",
+        evaluation_count=5,
+        labels={},
+    )
+    cache.track_feature_evaluation(
+        environment_id=2,
+        feature_name="feature_2",
+        evaluation_count=3,
+        labels={},
+    )
+
+    # When
+    cache.flush_on_shutdown()
+
+    # Then
+    mocked_track_evaluation_task.delay.assert_has_calls(
+        [
+            mocker.call(
+                kwargs={
+                    "environment_id": 1,
+                    "feature_evaluations": [
+                        TrackFeatureEvaluationsByEnvironmentData(
+                            feature_name="feature_1",
+                            labels={},
+                            evaluation_count=5,
+                        ),
+                    ],
+                }
+            ),
+            mocker.call(
+                kwargs={
+                    "environment_id": 2,
+                    "feature_evaluations": [
+                        TrackFeatureEvaluationsByEnvironmentData(
+                            feature_name="feature_2",
+                            labels={},
+                            evaluation_count=3,
+                        ),
+                    ],
+                }
+            ),
+        ],
+        any_order=True,
+    )
+    assert cache._cache == {}
+
+
+def test_feature_evaluation_cache__flush_on_shutdown__empty_cache__no_calls(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    cache = FeatureEvaluationCache()
+    mocked_track_evaluation_task = mocker.patch(
+        "app_analytics.cache.track_feature_evaluations_by_environment"
+    )
+
+    # When
+    cache.flush_on_shutdown()
+
+    # Then
+    mocked_track_evaluation_task.delay.assert_not_called()
+    assert cache._cache == {}
+
+
 def test_feature_evaluation_cache(
     mocker: MockerFixture,
     settings: SettingsWrapper,


### PR DESCRIPTION
Contributes to https://github.com/Flagsmith/pulumi/issues/162

---

## Summary

- Enable Gunicorn `--max-requests` (default 1000) and `--max-requests-jitter` (default 100) to recycle workers periodically, mitigating memory leaks
- Add `atexit` handler to flush in-process analytics caches (`APIUsageCache`, `FeatureEvaluationCache`) via the task processor before a worker exits, preventing data loss during recycling
- Rename internal flush methods for clarity: `_flush_through_thread` (hot path) vs `_flush_through_task_processor` (shutdown path)

## Context

Without `--max-requests`, Gunicorn workers never recycle and memory leaks accumulate indefinitely. Enabling worker recycling requires flushing any buffered analytics data before exit, otherwise counts are silently lost. The shutdown flush uses `.delay()` (task queue enqueue) rather than `.run_in_thread()` to avoid thread-safety issues during Python interpreter teardown.

Both `GUNICORN_MAX_REQUESTS` and `GUNICORN_MAX_REQUESTS_JITTER` remain configurable via environment variables. Setting `GUNICORN_MAX_REQUESTS=0` disables recycling entirely.

## Test plan

- [x] Unit tests for `flush_on_shutdown` on both cache classes (populated and empty)
- [x] Unit tests for `flush_analytics_caches` atexit handler (happy path and exception handling)
- [x] Unit test for `AppAnalyticsConfig.ready()` atexit registration
- [x] Manual verification: ran Gunicorn with `--max-requests 3`, confirmed atexit handler fires and logs flush on worker recycle