### PR TITLE
fix: Disabling traits persistence prevents traits to be used in segment evaluation

### DIFF
--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -193,5 +193,6 @@ class IdentifyWithTraitsSerializer(
     def validate_traits(self, traits: typing.List[dict] = None):  # type: ignore[no-untyped-def,type-arg,assignment]
         request = self.context["request"]
         if traits and not request.environment.trait_persistence_allowed(request):
-            return []
+            for trait in traits:
+                trait["transient"] = True
         return traits

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -590,3 +590,66 @@ def test_get_feature_states_for_identity__transient_identifier__empty_segment__r
     # flag is not being overridden by the segment
     assert flag_data["enabled"] is False
     assert flag_data["feature_state_value"] == default_feature_value
+
+
+@pytest.mark.xfail(reason="https://github.com/Flagsmith/flagsmith/issues/6739")
+def test_get_feature_states_for_identity__trait_persistence_disabled__segment_match_expected(
+    admin_client: APIClient,
+    sdk_client: APIClient,
+    feature: int,
+    segment: int,
+    segment_condition_property: str,
+    segment_condition_value: str,
+    segment_featurestate: int,
+    environment: int,
+    environment_api_key: str,
+) -> None:
+    # Given
+    # trait persistence is disabled for client-side SDK keys
+    admin_client.patch(
+        reverse(
+            "api-v1:environments:environment-detail",
+            args=[environment_api_key],
+        ),
+        data=json.dumps({"allow_client_traits": False}),
+        content_type="application/json",
+    )
+
+    url = reverse("api-v1:sdk-identities")
+
+    # When
+    # flags are requested for a new identity
+    # with traits matching the segment
+    response = sdk_client.post(
+        url,
+        data=json.dumps(
+            {
+                "identifier": "unseen",
+                "traits": [
+                    {
+                        "trait_key": segment_condition_property,
+                        "trait_value": segment_condition_value,
+                    },
+                ],
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Then
+    # traits should still be used for segment evaluation
+    # even though persistence is disabled
+    assert response.status_code == status.HTTP_200_OK
+    response_json = response.json()
+    assert (
+        flag_data := next(
+            (
+                flag
+                for flag in response_json["flags"]
+                if flag["feature"]["id"] == feature
+            ),
+            None,
+        )
+    )
+    assert flag_data["enabled"] is True
+    assert flag_data["feature_state_value"] == "segment override"

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -592,7 +592,6 @@ def test_get_feature_states_for_identity__transient_identifier__empty_segment__r
     assert flag_data["feature_state_value"] == default_feature_value
 
 
-@pytest.mark.xfail(reason="https://github.com/Flagsmith/flagsmith/issues/6739")
 def test_get_feature_states_for_identity__trait_persistence_disabled__segment_match_expected(
     admin_client: APIClient,
     sdk_client: APIClient,

--- a/api/tests/unit/environments/sdk/test_unit_sdk_serializers.py
+++ b/api/tests/unit/environments/sdk/test_unit_sdk_serializers.py
@@ -117,7 +117,7 @@ def test_identify_with_traits_serializer__transient__identity_and_traits_not_per
     assert not Trait.objects.filter(identity__identifier=identity_identifier).exists()
 
 
-def test_identify_with_traits_serializer_validate_traits_returns_empty_list_when_persistence_not_allowed(
+def test_identify_with_traits_serializer__persistence_not_allowed__marks_traits_transient(
     mocker: MockerFixture,
     environment: Environment,
 ) -> None:
@@ -145,8 +145,11 @@ def test_identify_with_traits_serializer_validate_traits_returns_empty_list_when
     validated_traits = serializer.validated_data.get("traits")
 
     serializer.save()  # type: ignore[no-untyped-call]
+
     # Then
-    assert validated_traits == []
+    # traits are kept but marked as transient
+    assert len(validated_traits) == 2
+    assert all(trait["transient"] is True for trait in validated_traits)
 
     assert Identity.objects.filter(identifier="test_user").exists()
     assert not Trait.objects.filter(identity__identifier="test_user").exists()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6739.

## How did you test this code?

Added an integration test and updated an existing unit test for the serializer. 