### PR TITLE
docs: Clarify `allow_client_traits` toggle name and behaviour

### DIFF
--- a/docs/docs/administration-and-security/governance-and-compliance/security.md
+++ b/docs/docs/administration-and-security/governance-and-compliance/security.md
@@ -4,13 +4,18 @@ sidebar_label: Security
 sidebar_position: 40
 ---
 
-## Preventing Client SDKS from setting Traits
+## Preventing Client SDKs from setting Traits
 
 There may be use-cases where you want to prevent client-side SDKs from setting traits of users. For example, if you are
 setting `plan=silver` as a trait, and then enabling/disabling features based on that plan, a malicious user could, with
 a client-side SDK, update their trait to `plan=gold` and unlock features they have not paid for.
 
-You can prevent this by disabling the "Persist traits when using client-side SDK keys" option. This option defaults to "On". Turning it "Off" will not allow client-side SDKs to write traits to Flagsmith. In order to write traits, you will need to use a [server-side SDK and server-side Key](/integrating-with-flagsmith/integration-overview).
+You can prevent this by disabling the "Allow client-side SDKs to set traits" option. This option defaults to "On".
+Turning it "Off" means any traits sent by client-side SDKs will be completely ignored — they will not be persisted,
+and they will not be used for segment evaluation.
+In order to set traits, you will need to use a
+[server-side SDK and server-side Key](/integrating-with-flagsmith/integration-overview). You can still use client-side
+SDKs to read flags for an identity whose traits have been set server-side.
 
 This is a per-Environment setting.
 

--- a/docs/docs/flagsmith-concepts/segments/index.md
+++ b/docs/docs/flagsmith-concepts/segments/index.md
@@ -23,7 +23,7 @@ Segments and segment overrides can be used to implement many scenarios. For exam
 
 ## Security and privacy
 
-The Flagsmith API to set user traits, e.g. the `setTraits` method from the JavaScript SDK, does not require authentication or credentials. This means that users can change their own traits, which could be a security problem if you are using segments for authorisation or access control. If you must use segments for access control, make sure to disable the ["Persist traits when using client-side SDK keys" option](/administration-and-security/governance-and-compliance/security) on every environment that needs it, and use server-side SDKs to set traits instead. You can still use client-side SDKs to read traits and flags derived from segments in this case.
+The Flagsmith API to set user traits, e.g. the `setTraits` method from the JavaScript SDK, does not require authentication or credentials. This means that users can change their own traits, which could be a security problem if you are using segments for authorisation or access control. If you must use segments for access control, make sure to disable the ["Allow client-side SDKs to set traits" option](/administration-and-security/governance-and-compliance/security) on every environment that needs it, and use server-side SDKs to set traits instead. You can still use client-side SDKs to read flags for identities whose traits have been set server-side.
 
 Segment names and definitions might include sensitive or proprietary information that you do not wish to expose to your users. Because of this, segments are transparent to applications and are not included in API responses when using [remote evaluation mode](/integrating-with-flagsmith/sdks/server-side#when-running-in-remote-evaluation-mode).
 

--- a/frontend/web/components/pages/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.tsx
@@ -688,9 +688,9 @@ const EnvironmentSettingsPage: React.FC = () => {
                         </div>
                         <div className='mt-4'>
                           <Setting
-                            title='Persist traits when using client-side SDK keys'
+                            title='Allow client-side SDKs to set traits'
                             description={
-                              'If enabled, Flagsmith will persist any non-transient traits sent by SDKs using client-side keys when remotely evaluating flags.'
+                              'If disabled, any traits sent by SDKs using client-side environment keys will be ignored. Traits will only be accepted from server-side SDK keys. This prevents untrusted clients from setting traits that could influence segment evaluation.'
                             }
                             checked={currentEnv?.allow_client_traits}
                             onChange={(value) => {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith/issues/6739

The `allow_client_traits` toggle was labelled "Persist traits when using client-side SDK keys", which implied traits would still be used for evaluation but simply not saved. In reality, when this setting is off, traits from client-side SDKs are completely ignored — they are neither persisted nor used for segment evaluation. This is intentional: it's a security boundary that prevents untrusted clients from sending arbitrary traits to gain access to segments they shouldn't match.

This PR clarifies the toggle name and documentation to match the actual behaviour:

- **Frontend**: Renamed toggle to "Allow client-side SDKs to set traits" with a description explaining that traits are fully ignored and why.
- **Security docs**: Updated the toggle name reference and expanded the explanation to clarify that traits are not used for evaluation either, not just not persisted.
- **Segments docs**: Updated the toggle name reference and wording.

## How did you test this code?

Verified the changes visually.