### PR TITLE
fix: defer data field in feature import/export list views

### DIFF
--- a/api/features/import_export/views.py
+++ b/api/features/import_export/views.py
@@ -134,8 +134,10 @@ class FeatureExportListView(ListAPIView):  # type: ignore[type-arg]
             if user.is_environment_admin(environment):  # type: ignore[union-attr]
                 environment_ids.append(environment.id)
 
-        return FeatureExport.objects.filter(environment__in=environment_ids).order_by(
-            "-created_at"
+        return (
+            FeatureExport.objects.filter(environment__in=environment_ids)
+            .defer("data")
+            .order_by("-created_at")
         )
 
 
@@ -156,6 +158,8 @@ class FeatureImportListView(ListAPIView):  # type: ignore[type-arg]
             if user.is_environment_admin(environment):  # type: ignore[union-attr]
                 environment_ids.append(environment.id)
 
-        return FeatureImport.objects.filter(environment__in=environment_ids).order_by(
-            "-created_at"
+        return (
+            FeatureImport.objects.filter(environment__in=environment_ids)
+            .defer("data")
+            .order_by("-created_at")
         )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`FeatureExportListView` and `FeatureImportListView` inherit from `ListAPIView` and return querysets that fetch the `data` column (`TextField` holding full JSON export blobs, potentially megabytes each) from Postgres. The list serializers correctly exclude `data` from their fields, but Django still fetches the column and materialises it into Python strings for every row — only for the garbage collector to immediately discard them.

This PR adds `.defer("data")` to both `get_queryset` methods so the `data` column is excluded from the SQL `SELECT` entirely.

## How did you test this code?

Ran the existing test suite for the import/export views — all 18 tests pass with no regressions.