### PR TITLE
fix: standardise metadata ID types to number

### DIFF
--- a/frontend/web/components/metadata/ContentTypesMetadataFieldTable.tsx
+++ b/frontend/web/components/metadata/ContentTypesMetadataFieldTable.tsx
@@ -13,7 +13,7 @@ type selectedContentType = {
 }
 
 type ContentTypesMetadataFieldTableType = {
-  organisationId: string
+  organisationId: number
   selectedContentTypes: selectedContentType[]
   onDelete: (removed: selectedContentType) => void
   isEdit: boolean

--- a/frontend/web/components/metadata/ContentTypesValues.tsx
+++ b/frontend/web/components/metadata/ContentTypesValues.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 type ContentTypesValuesType = {
   contentTypes: MetadataFieldModelField[]
-  organisationId: string
+  organisationId: number
 }
 
 const ContentTypesValues: FC<ContentTypesValuesType> = ({
@@ -13,7 +13,7 @@ const ContentTypesValues: FC<ContentTypesValuesType> = ({
   organisationId,
 }) => {
   const { data: supportedContentTypes } = useGetSupportedContentTypeQuery({
-    organisation_id: `${organisationId}`,
+    organisation_id: organisationId,
   })
 
   const combinedData = contentTypes.map((contentType) => {

--- a/frontend/web/components/metadata/MetadataPage.tsx
+++ b/frontend/web/components/metadata/MetadataPage.tsx
@@ -17,8 +17,8 @@ import RedirectCreateCustomFields from './RedirectCreateCustomFields'
 const PAGE_SIZE = 20
 const metadataWidth = [200, 150, 150, 90]
 type MetadataPageType = {
-  organisationId: string
-  projectId?: string
+  organisationId: number
+  projectId?: number
 }
 
 type MergeMetadata = {
@@ -36,7 +36,7 @@ const MetadataPage: FC<MetadataPageType> = ({ organisationId, projectId }) => {
   const [projectPage, setProjectPage] = useState(1)
 
   const { data: orgMetadataFieldList } = useGetMetadataFieldListQuery({
-    organisation: parseInt(organisationId),
+    organisation: organisationId,
     page: orgPage,
     page_size: PAGE_SIZE,
   })
@@ -46,7 +46,7 @@ const MetadataPage: FC<MetadataPageType> = ({ organisationId, projectId }) => {
       {
         page: projectPage,
         page_size: PAGE_SIZE,
-        project_id: parseInt(projectId!),
+        project_id: projectId!,
       },
       { skip: !projectId },
     )
@@ -205,7 +205,7 @@ const MetadataPage: FC<MetadataPageType> = ({ organisationId, projectId }) => {
               <div className='search-list'>
                 <Row className='list-item p-3 text-muted'>
                   <RedirectCreateCustomFields
-                    organisationId={parseInt(organisationId)}
+                    organisationId={organisationId}
                     organisationOnly
                   />
                 </Row>

--- a/frontend/web/components/metadata/SupportedContentTypesSelect.tsx
+++ b/frontend/web/components/metadata/SupportedContentTypesSelect.tsx
@@ -5,7 +5,7 @@ import InputGroup from 'components/base/forms/InputGroup'
 import ContentTypesMetadataFieldTable from './ContentTypesMetadataFieldTable'
 
 type SupportedContentTypesSelectType = {
-  organisationId: string
+  organisationId: number
   isEdit: boolean
   getMetadataContentTypes: (m: SelectContentTypesType[]) => void
   metadataModelFieldList: MetadataFieldModelField[]

--- a/frontend/web/components/modals/CreateMetadataField.tsx
+++ b/frontend/web/components/modals/CreateMetadataField.tsx
@@ -33,12 +33,12 @@ type CreateMetadataFieldType = {
   isEdit: boolean
   metadataModelFieldList?: MetadataFieldModelField[]
   onComplete?: () => void
-  organisationId: string
-  projectId?: string
+  organisationId: number
+  projectId?: number
 }
 
 type QueryBody = {
-  content_type: number | string
+  content_type: number
   field: number
   is_required_for: isRequiredFor[]
 }
@@ -46,7 +46,7 @@ type QueryBody = {
 type Query = {
   body: QueryBody
   id?: number
-  organisation_id: string
+  organisation_id: number
 }
 
 type MetadataType = {
@@ -87,7 +87,7 @@ const CreateMetadataField: FC<CreateMetadataFieldType> = ({
   )
 
   const { data: supportedContentTypes } = useGetSupportedContentTypeQuery({
-    organisation_id: `${organisationId}`,
+    organisation_id: organisationId,
   })
   const [createMetadataField, { error: errorCreating }] =
     useCreateMetadataFieldMutation()
@@ -131,7 +131,7 @@ const CreateMetadataField: FC<CreateMetadataFieldType> = ({
     useState<metadataFieldUpdatedSelectListType[]>([])
 
   const generateDataQuery = (
-    contentType: string | number,
+    contentType: number,
     field: number,
     isRequiredFor: boolean,
     id: number,
@@ -145,9 +145,7 @@ const CreateMetadataField: FC<CreateMetadataFieldType> = ({
           ? ([
               {
                 content_type: metadataContentType.id,
-                object_id: projectId
-                  ? parseInt(projectId)
-                  : parseInt(organisationId),
+                object_id: projectId ?? organisationId,
               } as isRequiredFor,
             ] as isRequiredFor[])
           : [],
@@ -172,7 +170,7 @@ const CreateMetadataField: FC<CreateMetadataFieldType> = ({
             name,
             organisation: organisationId,
             type: `${typeValue?.value}`,
-            ...(projectId ? { project: parseInt(projectId) } : {}),
+            ...(projectId ? { project: projectId } : {}),
           },
           id: id!,
         }).unwrap()
@@ -180,7 +178,7 @@ const CreateMetadataField: FC<CreateMetadataFieldType> = ({
           await Promise.all(
             metadataFieldSelectList.map(async (m) => {
               const query = generateDataQuery(
-                m.value,
+                Number(m.value),
                 parseInt(id!),
                 !!m?.isRequired,
                 0,
@@ -224,14 +222,14 @@ const CreateMetadataField: FC<CreateMetadataFieldType> = ({
             name,
             organisation: organisationId,
             type: `${typeValue?.value}`,
-            ...(projectId ? { project: parseInt(projectId) } : {}),
+            ...(projectId ? { project: projectId } : {}),
           },
         }).unwrap()
         if (res?.id) {
           await Promise.all(
             metadataFieldSelectList.map(async (m) => {
               const query = generateDataQuery(
-                m.value,
+                Number(m.value),
                 res.id,
                 !!m?.isRequired,
                 0,

--- a/frontend/web/components/pages/project-settings/tabs/CustomFieldsTab.tsx
+++ b/frontend/web/components/pages/project-settings/tabs/CustomFieldsTab.tsx
@@ -21,10 +21,7 @@ export const CustomFieldsTab = ({
 
   return (
     <div className='mt-4'>
-      <MetadataPage
-        organisationId={`${organisationId}`}
-        projectId={`${projectId}`}
-      />
+      <MetadataPage organisationId={organisationId} projectId={projectId} />
     </div>
   )
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Standardise `organisationId` and `projectId` types from `string` to `number` across the metadata component chain, aligning with the API request types in `requests.ts`.

- Replace `string` with `number` for `organisationId`/`projectId` props in `MetadataPage`, `CreateMetadataField`, `ContentTypesValues`, `ContentTypesMetadataFieldTable`, and `SupportedContentTypesSelect`
- Remove ~8 unnecessary `parseInt()` calls and template literal conversions
- Fix silent type mismatch where org-settings `CustomFieldsTab` passed `number` to `MetadataPage` which expected `string`
- Tighten `QueryBody.content_type` and `Query.organisation_id` from `string | number` to `number`

Related to #5667

## How did you test this code?

- Verified TypeScript compilation produces no new source file errors
- ESLint passed via lint-staged pre-commit hook