### PR TITLE
ci: Increase flag-tests wait time

### DIFF
--- a/frontend/e2e/tests/flag-tests.ts
+++ b/frontend/e2e/tests/flag-tests.ts
@@ -58,9 +58,9 @@ export default async function () {
   await editRemoteConfig(1,12)
 
   log('Try it again')
-  await t.wait(500)
+  await t.wait(2000)
   await click('#try-it-btn')
-  await t.wait(500)
+  await t.wait(1500)
   json = await parseTryItResults()
   await t.expect(json.header_size.value).eql(12)
 


### PR DESCRIPTION
## Changes

Increases wait times in flag-tests after it was decreased in [this PR](https://github.com/Flagsmith/flagsmith/pull/6469). 

Context in Slack [here](https://flagsmith.slack.com/archives/CTF0THS2D/p1772478883612029).

## How did you test this code?

TODO
