### PR TITLE
refactor(e2e): Replace arbitrary waits with state-based waiting in flag tests

### DIFF
--- a/frontend/e2e/tests/flag-tests.ts
+++ b/frontend/e2e/tests/flag-tests.ts
@@ -48,7 +48,7 @@ export default async function () {
   log('Try it')
   await t.wait(2000)
   await click('#try-it-btn')
-  await t.wait(500)
+  await waitForElementVisible('#try-it-results')
   let json = await parseTryItResults()
   await t.expect(json.header_size.value).eql('big')
   await t.expect(json.mv_flag.value).eql('big')
@@ -58,9 +58,8 @@ export default async function () {
   await editRemoteConfig(1,12)
 
   log('Try it again')
-  await t.wait(500)
   await click('#try-it-btn')
-  await t.wait(500)
+  await waitForElementVisible('#try-it-results')
   json = await parseTryItResults()
   await t.expect(json.header_size.value).eql(12)
 
@@ -68,9 +67,8 @@ export default async function () {
   await editRemoteConfig(1,false)
 
   log('Try it again 2')
-  await t.wait(500)
   await click('#try-it-btn')
-  await t.wait(500)
+  await waitForElementVisible('#try-it-results')
   json = await parseTryItResults()
   await t.expect(json.header_size.value).eql(false)
 


### PR DESCRIPTION
## Summary

Improves E2E test reliability and speed by replacing arbitrary timeout waits with proper state-based waiting in flag-tests.

## Changes

Replace fixed `t.wait(500)` timeouts with `waitForElementVisible('#try-it-results')` in three locations within flag-tests.ts.

## Why This Approach is Better

**Fixed timeouts:**
```typescript
await t.wait(500)  // Hope this is enough
```
- Too short = flaky tests
- Too long = slow tests  
- Doesn't adapt to different environments (local vs staging vs CI)

**State-based waiting:**
```typescript
await waitForElementVisible('#try-it-results')  // Wait for actual state
```
- Fast when API responds quickly (no artificial delays)
- Reliable when API is slow (uses 40s timeout)
- Works consistently across all environments

## Technical Details

The `#try-it-results` element only receives its ID when `!this.state.isLoading` ([TryIt.js:82](https://github.com/Flagsmith/flagsmith/blob/main/frontend/web/components/TryIt.js#L82)), guaranteeing:
- API request completed
- State updated  
- Results rendered and ready to parse

This is the standard pattern already used throughout our E2E test suite.

## Test Plan

- [ ] Run E2E tests locally: `make test`
- [ ] Verify all E2E tests pass in CI