### PR TITLE
fix: update-env-state-on-metadata-update

### DIFF
--- a/frontend/web/components/metadata/AddMetadataToEntity.tsx
+++ b/frontend/web/components/metadata/AddMetadataToEntity.tsx
@@ -6,11 +6,7 @@ import { Metadata } from 'common/types/responses'
 import Utils from 'common/utils/utils'
 import Switch from 'components/Switch'
 import InputGroup from 'components/base/forms/InputGroup'
-import {
-  metadataService,
-  useGetEntityMetadataFieldsQuery,
-} from 'common/services/useMetadataField'
-import { getStore } from 'common/store'
+import { useGetEntityMetadataFieldsQuery } from 'common/services/useMetadataField'
 import { CustomMetadataField } from 'common/types/metadata-field'
 import { useGlobalMetadataValidation } from 'common/utils/metadataValidation'
 import RedirectCreateCustomFields from './RedirectCreateCustomFields'
@@ -26,6 +22,7 @@ type AddMetadataToEntityProps = {
   entity: string
   envName?: string
   onChange?: (metadata: Metadata[]) => void
+  onMetadataSave?: (metadata: Metadata[]) => void
   setHasMetadataRequired?: (b: boolean) => void
 }
 
@@ -61,6 +58,7 @@ const AddMetadataToEntity: FC<AddMetadataToEntityProps> = ({
   envName,
   isCloningEnvironment,
   onChange,
+  onMetadataSave,
   organisationId,
   projectId,
   setHasMetadataRequired,
@@ -137,9 +135,7 @@ const AddMetadataToEntity: FC<AddMetadataToEntityProps> = ({
       toast(errorMessage || 'Failed to update custom fields', 'danger')
     } else {
       toast('Environment Field Updated')
-      getStore().dispatch(
-        metadataService.util.invalidateTags([{ type: 'Metadata' }]),
-      )
+      onMetadataSave?.(formatMetadataToApi(metadataFields))
     }
   }
 

--- a/frontend/web/components/pages/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.tsx
@@ -920,6 +920,11 @@ const EnvironmentSettingsPage: React.FC = () => {
                               envName={currentEnv?.name}
                               entityContentType={environmentContentType?.id}
                               entity={environmentContentType.model}
+                              onMetadataSave={(metadata) => {
+                                setCurrentEnv((prev) =>
+                                  prev ? { ...prev, metadata } : null,
+                                )
+                              }}
                             />
                           }
                         />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Updating custom fields did not update the local env state that is used in the general page. It forced user to refresh after having updated the fields to be able to correctly save the general data.

- Update local env state after custom fields successful update

## How did you test this code?
- In dashboard

Steps to reproduce:
1. Create a custom fields required on environment
2. Toggle change requests (will fail)
3. Go to Custom fields and update the value
4. Go back to toggle change requests (would still fail until refresh)