### PR TITLE
fix: Add composite index to code references to improve query performance

### DIFF
--- a/api/projects/code_references/migrations/0002_add_project_repo_created_index.py
+++ b/api/projects/code_references/migrations/0002_add_project_repo_created_index.py
@@ -18,14 +18,14 @@ class Migration(migrations.Migration):
                     model_name="featureflagcodereferencesscan",
                     index=models.Index(
                         fields=["project", "repository_url", "-created_at"],
-                        name="code_refs_project_repo_created_idx",
+                        name="code_ref_proj_repo_created_idx",
                     ),
                 ),
             ],
             database_operations=[
                 PostgresOnlyRunSQL(
-                    'CREATE INDEX CONCURRENTLY IF NOT EXISTS "code_refs_project_repo_created_idx" ON "code_references_featureflagcodereferencesscan" ("project_id", "repository_url", "created_at" DESC);',
-                    reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS "code_refs_project_repo_created_idx"',
+                    'CREATE INDEX CONCURRENTLY IF NOT EXISTS "code_ref_proj_repo_created_idx" ON "code_references_featureflagcodereferencesscan" ("project_id", "repository_url", "created_at" DESC);',
+                    reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS "code_ref_proj_repo_created_idx"',
                 ),
             ],
         ),

--- a/api/projects/code_references/migrations/0002_add_project_repo_created_index.py
+++ b/api/projects/code_references/migrations/0002_add_project_repo_created_index.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+from core.migration_helpers import PostgresOnlyRunSQL
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ("code_references", "0001_code_references"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="featureflagcodereferencesscan",
+                    index=models.Index(
+                        fields=["project", "repository_url", "-created_at"],
+                        name="code_refs_project_repo_created_idx",
+                    ),
+                ),
+            ],
+            database_operations=[
+                PostgresOnlyRunSQL(
+                    'CREATE INDEX CONCURRENTLY IF NOT EXISTS "code_refs_project_repo_created_idx" ON "code_references_featureflagcodereferencesscan" ("project_id", "repository_url", "created_at" DESC);',
+                    reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS "code_refs_project_repo_created_idx"',
+                ),
+            ],
+        ),
+    ]

--- a/api/projects/code_references/models.py
+++ b/api/projects/code_references/models.py
@@ -29,3 +29,9 @@ class FeatureFlagCodeReferencesScan(models.Model):
 
     class Meta:
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["project", "repository_url", "-created_at"],
+                name="code_refs_project_repo_created_idx",
+            ),
+        ]

--- a/api/projects/code_references/models.py
+++ b/api/projects/code_references/models.py
@@ -32,6 +32,6 @@ class FeatureFlagCodeReferencesScan(models.Model):
         indexes = [
             models.Index(
                 fields=["project", "repository_url", "-created_at"],
-                name="code_refs_project_repo_created_idx",
+                name="code_ref_proj_repo_created_idx",
             ),
         ]


### PR DESCRIPTION
## Changes

Adds a composite index on the fields used to query for code references when listing features. 

<details>
<summary>Claude Details</summary>

```
Root Cause

  The slowdown is caused by a 3-level nested correlated subquery that explodes in execution count:

  Feature queryset (45 features)                     → fast (15ms)
    └─ SubPlan 2 [ArraySubquery for code_references_counts]
         Runs: 45 loops × 303ms = ~13.6s total
         └─ SubPlan 1 [last_feature_found_at]
              Runs: 45 × 107 = 4,815 loops × 2.785ms = ~13.4s total
              Does: index scan on project_id (283 rows), then filters by
                    repository_url AND jsonb_path_exists(code_references, '$[*]?(@.feature_name == $feature_name)', ...)

  SubPlan 1 (last_feature_found_at at services.py:54) runs once for every (feature, scan) pair — even though the DISTINCT ON (repository_url) in SubPlan 2 means we ultimately only care about the latest scan per repository.

  There are two compounding problems:

  1. The correlated subquery explosion: 4,815 individual executions of SubPlan 1 at 2.785ms each.
  2. jsonb_path_exists can't use an index when called with parameters (the $feature_name variable): it must scan the entire JSON array for every one of those 283 rows per execution. There's no index PostgreSQL can use here.

...

Solutions (in order of effort vs. impact)

  Option A — Composite index on (project_id, repository_url, created_at DESC) [low effort]

  What it does: The current index is only on project_id. Adding a composite index lets SubPlan 1 jump straight to rows matching (project_id, repository_url) instead of fetching all 283 project rows and filtering. Combined with DESC ordering, Postgres can stop scanning after the first row that passes jsonb_path_exists (early exit for LIMIT 1).

  Impact: Medium. If the project has N repositories, SubPlan 1's scan shrinks from 283 rows to ~283/N per execution. It also improves SubPlan 2's outer scan. The jsonb_path_exists cost on each remaining row remains, though.

  Effort: A single migration. No code changes.
```

This PR only implements Option A. I will look into other options (which can be combined) depending on the improvements we see here. 

</details>

## How did you test this code?

Ran the migration backwards and forwards locally to confirm it does what we expect and discussed the resulting query plans with claude. 

While the data locally doesn't show much improvement, the structure of the data locally is different to production, and we still expect to see a ~40x improvement in production. 
