### PR TITLE
fix: Identity overrides empty in SDK document with v2 versioning

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -618,6 +618,8 @@ class FeatureState(
     @property
     def is_live(self) -> bool:
         if self.environment.use_v2_feature_versioning:  # type: ignore[union-attr]
+            if self.identity_id is not None:
+                return True
             return (
                 self.environment_feature_version_id is not None
                 and self.environment_feature_version.is_live  # type: ignore[union-attr]

--- a/api/tests/integration/sdk/test_sdk_environment_document.py
+++ b/api/tests/integration/sdk/test_sdk_environment_document.py
@@ -1,0 +1,34 @@
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from features.versioning.tasks import enable_v2_versioning
+
+
+def test_get_environment_document__v2_versioning_with_identity_override__identity_features_populated(
+    server_side_sdk_client: APIClient,
+    feature: int,
+    identity_featurestate: int,
+    environment: int,
+) -> None:
+    """Reproduce https://github.com/Flagsmith/flagsmith/issues/6839
+
+    When Feature Versioning v2 is enabled, identity overrides should still
+    appear in the SDK document with their identity_features populated.
+    """
+
+    # Given - v2 feature versioning is enabled after identity override exists
+    enable_v2_versioning(environment)
+
+    # When
+    url = "/api/v1/environment-document/"
+    response = server_side_sdk_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    identity_overrides = response.json()["identity_overrides"]
+    assert len(identity_overrides) == 1
+
+    identity_override = identity_overrides[0]
+    assert len(identity_override["identity_features"]) > 0
+    assert identity_override["identity_features"][0]["feature"]["id"] == feature

--- a/api/tests/integration/sdk/test_sdk_environment_document.py
+++ b/api/tests/integration/sdk/test_sdk_environment_document.py
@@ -1,3 +1,6 @@
+import json
+
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -5,10 +8,12 @@ from features.versioning.tasks import enable_v2_versioning
 
 
 def test_get_environment_document__v2_versioning_with_identity_override__identity_features_populated(
+    admin_client: APIClient,
     server_side_sdk_client: APIClient,
     feature: int,
     identity_featurestate: int,
     environment: int,
+    environment_api_key: str,
 ) -> None:
     """Reproduce https://github.com/Flagsmith/flagsmith/issues/6839
 
@@ -16,12 +21,25 @@ def test_get_environment_document__v2_versioning_with_identity_override__identit
     appear in the SDK document with their identity_features populated.
     """
 
-    # Given - v2 feature versioning is enabled after identity override exists
+    # Given - identity overrides are enabled in local eval
+    url = reverse(
+        "api-v1:environments:environment-detail",
+        args=[environment_api_key],
+    )
+    response = admin_client.get(url)
+    environment_data = response.json()
+    environment_data["use_identity_overrides_in_local_eval"] = True
+    admin_client.put(
+        url,
+        data=json.dumps(environment_data),
+        content_type="application/json",
+    )
+
+    # and v2 feature versioning is enabled after identity override exists
     enable_v2_versioning(environment)
 
     # When
-    url = "/api/v1/environment-document/"
-    response = server_side_sdk_client.get(url)
+    response = server_side_sdk_client.get("/api/v1/environment-document/")
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
+++ b/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
@@ -1,10 +1,12 @@
 import time
 from typing import TYPE_CHECKING
+from unittest.mock import ANY
 
 import pytest
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import http_date
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -118,6 +120,105 @@ def test_get_environment_document(
     assert len(response.data["identity_overrides"]) == 10
     assert response.headers[FLAGSMITH_UPDATED_AT_HEADER] == str(
         environment.updated_at.timestamp()
+    )
+
+
+@pytest.mark.parametrize(
+    "environment_",
+    (
+        lazy_fixture("environment"),
+        lazy_fixture("environment_v2_versioning"),
+    ),
+)
+def test_get_environment_document__identity_overrides(
+    project: Project,
+    environment_: Environment,
+) -> None:
+    # Given
+    api_key = EnvironmentAPIKey.objects.create(environment=environment_)
+    client = APIClient()
+    client.credentials(HTTP_X_ENVIRONMENT_KEY=api_key.key)
+
+    feature = Feature.objects.create(name="test_feature", project=project)
+    for i in range(2):
+        identity = Identity.objects.create(
+            environment=environment_,
+            identifier=f"identity_{i}",
+        )
+        identity_feature_state = FeatureState.objects.create(
+            identity=identity,
+            feature=feature,
+            environment=environment_,
+        )
+        FeatureStateValue.objects.filter(feature_state=identity_feature_state).update(
+            string_value="overridden",
+            type=STRING,
+        )
+
+    url = reverse("api-v1:environment-document")
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert sorted(
+        response.data["identity_overrides"],
+        key=lambda x: x["identifier"],
+    ) == [
+        {
+            "composite_key": ANY,
+            "created_date": ANY,
+            "django_id": ANY,
+            "environment_api_key": environment_.api_key,
+            "identifier": "identity_0",
+            "dashboard_alias": None,
+            "identity_features": [
+                {
+                    "django_id": ANY,
+                    "enabled": False,
+                    "feature": {
+                        "id": feature.id,
+                        "name": "test_feature",
+                        "type": "STANDARD",
+                    },
+                    "feature_segment": None,
+                    "feature_state_value": "overridden",
+                    "featurestate_uuid": ANY,
+                    "multivariate_feature_state_values": [],
+                }
+            ],
+            "identity_traits": [],
+            "identity_uuid": ANY,
+        },
+        {
+            "composite_key": ANY,
+            "created_date": ANY,
+            "django_id": ANY,
+            "environment_api_key": environment_.api_key,
+            "identifier": "identity_1",
+            "dashboard_alias": None,
+            "identity_features": [
+                {
+                    "django_id": ANY,
+                    "enabled": False,
+                    "feature": {
+                        "id": feature.id,
+                        "name": "test_feature",
+                        "type": "STANDARD",
+                    },
+                    "feature_segment": None,
+                    "feature_state_value": "overridden",
+                    "featurestate_uuid": ANY,
+                    "multivariate_feature_state_values": [],
+                }
+            ],
+            "identity_traits": [],
+            "identity_uuid": ANY,
+        },
+    ]
+    assert response.headers[FLAGSMITH_UPDATED_AT_HEADER] == str(
+        environment_.updated_at.timestamp()
     )
 
 

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -720,6 +720,22 @@ def test_feature_state_is_live(version, live_from, expected_is_live, environment
     )
 
 
+def test_feature_state_is_live__identity_override_v2_versioning__returns_true(
+    environment_v2_versioning: Environment,
+    identity: Identity,
+    feature: Feature,
+) -> None:
+    # Given
+    feature_state = FeatureState.objects.create(
+        identity=identity,
+        feature=feature,
+        environment=environment_v2_versioning,
+    )
+
+    # When / Then
+    assert feature_state.is_live is True
+
+
 def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(  # type: ignore[no-untyped-def]
     project, environment
 ):


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6839.

In this PR, we fix a bug where identity overrides in the SDK environment document have empty `identity_features` when Feature Versioning v2 is enabled.

## How did you test this code?

- Added an integration test reproducing the issue.
- Added `test_feature_state_is_live__identity_override_v2_versioning__returns_true` unit test targeting the model property directly.
- Added `test_get_environment_document__identity_overrides` parametrised over both v1 and v2 environments, asserting the full structure of identity overrides in the SDK document response (including non-empty `identity_features`).