### PR TITLE
fix(Logging): Omit org name from logging

### DIFF
--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -260,7 +260,7 @@ def charge_for_api_call_count_overages():  # type: ignore[no-untyped-def]
                 case _:
                     logger.error(
                         "Unknown subscription plan when trying to bill for overages"
-                        f" {organisation.id=} {organisation.name=} {organisation.subscription.plan=}"
+                        f" {organisation.id=} {organisation.subscription.plan=}"
                     )
                     continue
         except Exception:

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -1429,7 +1429,6 @@ def test_charge_for_api_call_count_overages_non_standard(
     assert inspecting_handler.messages == [  # type: ignore[attr-defined]
         "Unknown subscription plan when trying to bill for overages "
         f"organisation.id={organisation.id} "
-        f"organisation.name='{organisation.name}' "
         "organisation.subscription.plan='nonstandard-v2'"
     ]
 


### PR DESCRIPTION
Remove an occurrence of organisation names in logging, because it should not be exposed.