### PR TITLE
infra: Remove unnecessary throttle rate

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -126,14 +126,6 @@
                     "value": "https://eu-central-1-1.aws.cloud2.influxdata.com"
                 },
                 {
-                    "name": "DEFAULT_THROTTLE_CLASSES",
-                    "value": "core.throttling.UserRateThrottle"
-                },
-                {
-                    "name": "USER_THROTTLE_RATE",
-                    "value": "10/sec"
-                },
-                {
                     "name": "OAUTH_CLIENT_ID",
                     "value": "232959427810-br6ltnrgouktp0ngsbs04o14ueb9rch0.apps.googleusercontent.com"
                 },


### PR DESCRIPTION
## Changes

This removes throttling at the application level in production, which is protected via WAF instead. 

It seems that this was re-added erroneously when we separated the task definition files [here](https://github.com/Flagsmith/flagsmith/pull/6496). 

Relevant previous PRs:
- https://github.com/Flagsmith/flagsmith/pull/6642
- https://github.com/Flagsmith/flagsmith/pull/6513

## How did you test this code?

N/a
