### PR TITLE
test: fix flaky tests

### DIFF
--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -126,7 +126,7 @@ def test_get_feature_states_for_identity(  # type: ignore[no-untyped-def]
 
     # now let's amend the data so that all identities should receive variant 2
     for mv_value in feature_state_data["multivariate_feature_state_values"]:
-        if mv_value["id"] == variant_2_mvfo_id:
+        if mv_value["multivariate_feature_option"] == variant_2_mvfo_id:
             mv_value["percentage_allocation"] = 100
         else:
             mv_value["percentage_allocation"] = 0

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -75,7 +75,7 @@ def test_get_feature_states_for_identity(  # type: ignore[no-untyped-def]
         variant_1_percentage_allocation,
         variant_1_value,
     )
-    create_mv_option_with_api(
+    variant_2_mvfo_id = create_mv_option_with_api(
         admin_client,
         project,
         multivariate_feature_id,  # type: ignore[arg-type]
@@ -125,9 +125,11 @@ def test_get_feature_states_for_identity(  # type: ignore[no-untyped-def]
     feature_state_data = retrieve_feature_state_response.json()
 
     # now let's amend the data so that all identities should receive variant 2
-    mv_values = feature_state_data["multivariate_feature_state_values"]
-    mv_values[0]["percentage_allocation"] = 0
-    mv_values[1]["percentage_allocation"] = 100
+    for mv_value in feature_state_data["multivariate_feature_state_values"]:
+        if mv_value["id"] == variant_2_mvfo_id:
+            mv_value["percentage_allocation"] = 100
+        else:
+            mv_value["percentage_allocation"] = 0
 
     # and PUT the data back
     update_feature_state_response = admin_client.put(

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import urllib
 from typing import Any
 from unittest import mock
@@ -37,6 +38,9 @@ from organisations.models import Organisation
 from permissions.models import PermissionModel
 from projects.models import Project, UserProjectPermission
 from segments.models import Condition, Segment, SegmentRule
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def test_should_return_identities_list_when_requested(
@@ -598,14 +602,9 @@ def test_identities_endpoint_returns_value_for_segment_if_rule_type_percentage_s
         segment=segment, type=SegmentRule.ALL_RULE
     )
 
-    identity_percentage_value = get_hashed_percentage_for_object_ids(
-        [segment.id, identity.id]
-    )
     Condition.objects.create(
         operator=PERCENTAGE_SPLIT,
-        value=int(
-            (identity_percentage_value + (1 - identity_percentage_value) / 2) * 100.0
-        ),
+        value=100,
         rule=segment_rule,
     )
     feature_segment = FeatureSegment.objects.create(

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import urllib
 from typing import Any
 from unittest import mock
@@ -38,9 +37,6 @@ from organisations.models import Organisation
 from permissions.models import PermissionModel
 from projects.models import Project, UserProjectPermission
 from segments.models import Condition, Segment, SegmentRule
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def test_should_return_identities_list_when_requested(


### PR DESCRIPTION
## Changes

Fixes 2 flaky unit tests: 

1. `test_get_feature_states_for_identity` - this test failed when the multivariate feature values were returned in reverse order since the test assumed they were returned in the order they were created.
2. `test_identities_endpoint_returns_value_for_segment_if_rule_type_percentage_split_and_identity_in_segment` - this test failed if the returned value from `get_hashed_percentage_value` was between 0.99 and 0.995. The maths when creating the Condition then meant that the percentage value was 99, and hence the user was deemed outside of the segment. Since the logic for actually determining segment membership is covered elsewhere, I just set the percentage to 100 to guarantee that the identity will be in the segment. 

## How did you test this code?

Ran the tests 100 times consecutively (using `pytest.mark.parametrise`) to verify that the tests consistently passed. 
