### PR TITLE
fix: store-created-at-in-identity-override-v2-document

### DIFF
--- a/api/environments/dynamodb/types.py
+++ b/api/environments/dynamodb/types.py
@@ -5,7 +5,8 @@ from datetime import datetime
 
 import boto3
 from django.conf import settings
-from pydantic import BaseModel
+from django.utils import timezone
+from pydantic import BaseModel, Field
 
 from util.engine_models.features.models import FeatureStateModel
 
@@ -89,6 +90,7 @@ class IdentityOverrideV2(BaseModel):
     identifier: str
     identity_uuid: str
     feature_state: FeatureStateModel
+    created_date: datetime = Field(default_factory=timezone.now)
 
 
 @dataclass

--- a/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
+++ b/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import pytest
 from django.utils import timezone
+from freezegun import freeze_time
 from pytest_mock import MockerFixture
 
 from audit.models import AuditLog
@@ -399,6 +400,7 @@ def test_generate_audit_log_records(  # type: ignore[no-untyped-def]
     ).exists()
 
 
+@freeze_time("2023-01-01T00:00:00Z")
 def test_update_flagsmith_environments_v2_identity_overrides__call_expected(
     mocker: MockerFixture,
     environment: Environment,

--- a/api/tests/unit/environments/dynamodb/test_unit_services.py
+++ b/api/tests/unit/environments/dynamodb/test_unit_services.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+from django.utils import timezone
+from freezegun import freeze_time
 from mypy_boto3_dynamodb.service_resource import Table
 from pytest_mock import MockerFixture
 
@@ -40,23 +42,24 @@ def test_migrate_environments_to_v2__environment_with_overrides__writes_expected
     expected_environment_document = map_environment_to_environment_v2_document(
         environment
     )
-    expected_identity_override_document = (
-        map_identity_override_to_identity_override_document(
-            map_engine_feature_state_to_identity_override(
-                feature_state=engine_identity.identity_features[0],
-                identity_uuid=str(engine_identity.identity_uuid),
-                identifier=engine_identity.identifier,
-                environment_api_key=environment.api_key,
-                environment_id=environment.id,
-            ),
+    with freeze_time(timezone.now()):
+        expected_identity_override_document = (
+            map_identity_override_to_identity_override_document(
+                map_engine_feature_state_to_identity_override(
+                    feature_state=engine_identity.identity_features[0],
+                    identity_uuid=str(engine_identity.identity_uuid),
+                    identifier=engine_identity.identifier,
+                    environment_api_key=environment.api_key,
+                    environment_id=environment.id,
+                ),
+            )
         )
-    )
 
-    # When
-    migrate_environments_to_v2(
-        project_id=environment.project_id,
-        capacity_budget=float("Inf"),  # type: ignore[arg-type]
-    )
+        # When
+        migrate_environments_to_v2(
+            project_id=environment.project_id,
+            capacity_budget=float("Inf"),  # type: ignore[arg-type]
+        )
 
     # Then
     results = flagsmith_environments_v2_table.scan()["Items"]

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_environment_v2_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_environment_v2_wrapper.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from boto3.dynamodb.types import Binary
 from common.test_tools import AssertMetricFixture
+from freezegun import freeze_time
 from mypy_boto3_dynamodb.service_resource import Table
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
@@ -122,6 +123,49 @@ def test_environment_v2_wrapper__update_identity_overrides__put_expected(
     assert results[0] == map_identity_override_to_identity_override_document(
         override_document,
     )
+
+
+@freeze_time("2023-01-01T00:00:00Z")
+def test_environment_v2_wrapper__update_identity_overrides__put__stores_created_date(
+    settings: SettingsWrapper,
+    environment: Environment,
+    flagsmith_environments_v2_table: Table,
+    feature: Feature,
+    feature_state: FeatureState,
+) -> None:
+    # Given
+    settings.ENVIRONMENTS_V2_TABLE_NAME_DYNAMO = flagsmith_environments_v2_table.name
+    wrapper = DynamoEnvironmentV2Wrapper()
+
+    identity_uuid = str(uuid.uuid4())
+    override_document = IdentityOverrideV2.parse_obj(
+        {
+            "environment_id": str(environment.id),
+            "document_key": get_environments_v2_identity_override_document_key(
+                feature_id=feature.id, identity_uuid=identity_uuid
+            ),
+            "environment_api_key": environment.api_key,
+            "feature_state": map_feature_state_to_engine(feature_state),
+            "identifier": "identity1",
+            "identity_uuid": identity_uuid,
+        }
+    )
+
+    # When
+    wrapper.update_identity_overrides(
+        changeset=IdentityOverridesV2Changeset(
+            to_delete=[],
+            to_put=[override_document],
+        ),
+    )
+
+    # Then
+    results = flagsmith_environments_v2_table.scan()["Items"]
+    assert len(results) == 1
+    assert results[0] == map_identity_override_to_identity_override_document(
+        override_document,
+    )
+    assert results[0]["created_date"] == "2023-01-01T00:00:00+00:00"
 
 
 def test_environment_v2_wrapper__update_identity_overrides__delete_expected(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

Contributes to Edge-api [#568](https://github.com/Flagsmith/edge-api/issues/568)

## Changes
- Added `created_date` to `IdentityOverrideV2` with `default_factory=timezone.now`

⚠️ ⚠️ 
On update, `created_at ` is reseted to `now()`. We `put_item` and replace the full document so to preserve the original `created_date`, except if I am missing, we would need an extra Dynamo read. Which to me is not worth in the context of the snapshot tests. We just need it to be fix between 2 calls to the `environment_document` and that should ensure it


## How did you test this code?
- Updated tests mostly with `freezegun` 
- One new test
