### PR TITLE
fix: `/api/v1/environment-document` N+1 query issue related to the number of segment overrides in a version

### DIFF
--- a/api/environments/managers.py
+++ b/api/environments/managers.py
@@ -38,7 +38,10 @@ class EnvironmentManager(SoftDeleteManager):  # type: ignore[misc]
                 Prefetch(
                     "project__segments__feature_segments__feature_states",
                     queryset=FeatureState.objects.select_related(
-                        "feature", "feature_state_value", "environment"
+                        "feature",
+                        "feature_state_value",
+                        "environment",
+                        "environment_feature_version",
                     ),
                 ),
                 Prefetch(

--- a/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
+++ b/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
@@ -109,7 +109,7 @@ def test_get_environment_document(
         enable_v2_versioning(environment.id)
 
         # create new versions of a given featurestate
-        for _ in range(10):
+        for _ in range(2):
             efv = EnvironmentFeatureVersion.objects.create(
                 environment=environment,
                 feature=feature,
@@ -128,6 +128,8 @@ def test_get_environment_document(
     assert len(response.data["project"]["segments"]) == 10
     assert len(response.data["feature_states"]) == 11
     assert len(response.data["identity_overrides"]) == 10
+
+    environment.refresh_from_db()
     assert response.headers[FLAGSMITH_UPDATED_AT_HEADER] == str(
         environment.updated_at.timestamp()
     )

--- a/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
+++ b/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
@@ -22,6 +22,7 @@ from features.models import (  # type: ignore[attr-defined]
     FeatureStateValue,
 )
 from features.multivariate.models import MultivariateFeatureOption
+from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.tasks import enable_v2_versioning
 from projects.models import Project
 from segments.models import Segment
@@ -50,8 +51,6 @@ def test_get_environment_document(
         name="Test Environment",
         project=project,
     )
-    if use_v2_feature_versioning:
-        enable_v2_versioning(environment.id)
 
     api_key = EnvironmentAPIKey.objects.create(environment=environment)
     client = APIClient()
@@ -105,6 +104,17 @@ def test_get_environment_document(
             default_percentage_allocation=10,
             string_value="option-2",
         )
+
+    if use_v2_feature_versioning:
+        enable_v2_versioning(environment.id)
+
+        # create new versions of a given featurestate
+        for _ in range(10):
+            efv = EnvironmentFeatureVersion.objects.create(
+                environment=environment,
+                feature=feature,
+            )
+            efv.publish()
 
     # and the relevant URL to get an environment document
     url = reverse("api-v1:environment-document")


### PR DESCRIPTION
## Changes

Fixes an N+1 issue in the SDK environment document endpoint. 

## How did you test this code?

Updated an existing test case. 
