### PR TITLE
fix: remove dead feature prop and store dependency from Button

### DIFF
--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -3,8 +3,6 @@ import cn from 'classnames'
 import { ButtonHTMLAttributes, HTMLAttributeAnchorTarget } from 'react'
 import Icon, { IconName } from 'components/Icon'
 import Constants from 'common/constants'
-import Utils, { PaidFeature } from 'common/utils/utils'
-import PlanBasedBanner from 'components/PlanBasedAccess'
 
 export const themeClassNames = {
   danger: 'btn btn-danger',
@@ -32,7 +30,6 @@ export type ButtonType = ButtonHTMLAttributes<HTMLButtonElement> & {
   iconLeftColour?: keyof typeof Constants.colours
   iconLeft?: IconName
   href?: string
-  feature?: PaidFeature
   target?: HTMLAttributeAnchorTarget
   theme?: keyof typeof themeClassNames
   size?: keyof typeof sizeClassNames
@@ -47,7 +44,6 @@ export const Button = React.forwardRef<
     {
       children,
       className,
-      feature,
       href,
       iconLeft,
       iconLeftColour,
@@ -63,20 +59,17 @@ export const Button = React.forwardRef<
     },
     ref,
   ) => {
-    const hasPlan = feature ? Utils.getPlansPermission(feature) : true
-    return href || !hasPlan ? (
+    return href ? (
       <a
-        onClick={
-          hasPlan ? (rest.onClick as React.MouseEventHandler) : undefined
-        }
+        onClick={rest.onClick as React.MouseEventHandler}
         className={cn(className, themeClassNames[theme], sizeClassNames[size])}
-        target={hasPlan ? target : '_blank'}
-        href={hasPlan ? href : Constants.getUpgradeUrl()}
+        target={target}
+        href={href}
         rel='noreferrer'
         ref={ref as React.RefObject<HTMLAnchorElement>}
       >
         <div className='d-flex h-100 align-items-center justify-content-center gap-2'>
-          {!!iconLeft && !!hasPlan && (
+          {!!iconLeft && (
             <Icon
               fill={
                 iconLeftColour ? Constants.colours[iconLeftColour] : undefined
@@ -86,9 +79,6 @@ export const Button = React.forwardRef<
             />
           )}
           {children}
-          {!hasPlan && feature && (
-            <PlanBasedBanner feature={feature} theme={'badge'} />
-          )}
         </div>
         {!!iconRight && (
           <Icon


### PR DESCRIPTION
## Summary
- Remove unused `feature` prop, `Utils` import, and `PlanBasedBanner` import from `Button.tsx`
- These pulled in the entire Redux/Flux store chain at import time, solely for `Utils.getPlansPermission(feature)` — but zero consumers pass `feature` to Button
- Simplifies the `href` anchor rendering path by removing `hasPlan` conditional branching

## Test plan
- [x] `npm run typecheck` — no project source errors
- [x] `npx eslint --fix` — passes clean
- [x] Grep confirms no consumer passes `feature` to `<Button>`
- [ ] Verify button behaviour in the app (href links, icon buttons, all themes/sizes)

Closes #6866