### PR TITLE
fix: sidebar link hover and icon colour in dark mode

### DIFF
--- a/frontend/web/components/navigation/SidebarLink.tsx
+++ b/frontend/web/components/navigation/SidebarLink.tsx
@@ -21,25 +21,29 @@ const SidebarLink: FC<SidebarLinkType> = ({
   const Tag = (to ? NavLink : 'div') as any
   const activeClassName =
     'text-primary fw-semibold bg-primary-opacity-5 fill-primary'
-  const inactiveClassName = 'text-body fill-body fw-semibold'
+  const inactiveClassName = 'text-body fw-semibold'
 
   return (
     <Tag
       {...rest}
       to={to}
       activeClassName={activeClassName}
-      inactiveClassName={activeClassName}
+      inactiveClassName={inactiveClassName}
       exact={true}
       className={classNames(
         rest.className,
-        'd-flex hover-fill-primary hover-bg-primary gap-2 cursor-pointer align-items-center p-2 rounded',
+        'd-flex hover-color-primary gap-2 cursor-pointer align-items-center p-2 rounded',
         {
           [activeClassName]: !to && active,
           [inactiveClassName]: !to && !active,
         },
       )}
     >
-      {!!icon && <Icon width={18} name={icon} fill={'#767D85'} />}
+      {!!icon && (
+        <span className='text-muted'>
+          <Icon width={18} name={icon} />
+        </span>
+      )}
       {children}
     </Tag>
   )


### PR DESCRIPTION
## Summary
- Fix sidebar link hover not working in dark mode
- Fix copy-paste bug where inactive links used the active class name
- Replace non-existent CSS hover classes with working ones

## What changed

**`web/components/navigation/SidebarLink.tsx`** — 3 bugs fixed:

| Bug | Before | After |
|-----|--------|-------|
| Icon colour not controllable by CSS | `<Icon fill='#767D85' />` (inline fill beats CSS) | `<span className='text-muted'><Icon /></span>` (uses `currentColor` via CSS) |
| Inactive links styled as active | `inactiveClassName={activeClassName}` | `inactiveClassName={inactiveClassName}` |
| Hover classes don't exist | `hover-fill-primary hover-bg-primary` | `hover-color-primary` (defined in `_utils.scss`) |



//Before
<img width="231" height="276" alt="image" src="https://github.com/user-attachments/assets/1ba0d020-961b-4eb9-8b59-d89edad19814" />

// After 
<img width="220" height="267" alt="image" src="https://github.com/user-attachments/assets/6bc1d56b-5ffc-4e46-ab87-cfa3f794a55c" />

## How it works

- Icon uses `currentColor` (from QW-1 fix) which inherits the parent's text colour
- `text-muted` sets `color: $text-icon-grey` → icon is grey by default
- `hover-color-primary` sets `>* { color: $primary }` on hover → overrides the span's colour → icon turns purple
- No magic colour numbers — uses existing SCSS variables and CSS utility classes

## Test plan
- [x] `npx eslint --fix` — passes clean
- [ ] Light mode: grey icons, dark text, hover turns both purple
- [ ] Dark mode: grey icons, light text, hover turns both purple
- [ ] Active link shows purple icon and text with light purple background

**Depends on:** #6870 (icon currentColor defaults)

Closes #6868