### PR TITLE
fix: Wait for all data sources before rendering identity features

### DIFF
--- a/frontend/web/components/pages/UserPage.tsx
+++ b/frontend/web/components/pages/UserPage.tsx
@@ -82,14 +82,10 @@ const UserPage: FC = () => {
 
   useEffect(() => {
     const { search, sort } = filter
-    AppActions.searchFeatures(
-      projectId,
-      environmentId,
-      true,
-      search,
-      sort,
-      { ...getServerFilter(filter), identity: id },
-    )
+    AppActions.searchFeatures(projectId, environmentId, true, search, sort, {
+      ...getServerFilter(filter),
+      identity: id,
+    })
   }, [filter, environmentId, projectId, id])
 
   useEffect(() => {
@@ -167,8 +163,9 @@ const UserPage: FC = () => {
           }) => {
             const identityName =
               (identity && identity.identity.identifier) || id
-            return (isLoading || !projectId) &&
-              (!identityFlags || !actualFlags || !projectFlags) ? (
+            const isDataLoaded =
+              !!actualFlags && !!identityFlags && !!projectFlags && !!projectId
+            return isLoading || !isDataLoaded ? (
               <div className='text-center'>
                 <Loader />
               </div>


### PR DESCRIPTION
## Summary
- Fix race condition where the identity override edit modal opens with an empty value field when `actualFlags` hasn't loaded yet
- Replace `&&` loading guard with `||` logic so the loader stays until all 3 data sources are loaded

Fixes #6898

## Root cause

`UserPage` fires 3 parallel API requests on mount. The loading guard checked for `actualFlags` but used `&&` logic: `(isLoading || !projectId) && (!identityFlags || !actualFlags || !projectFlags)`. Once the stores finished loading (`isLoading = false`), the left side became `false`, short-circuiting the entire condition — the `!actualFlags` check was never evaluated. The loader disappeared while `actualFlags` was still in flight, and the preselect (`?flag=`) auto-opened the modal with `feature_state_value: undefined`.

## Test plan
- [ ] Navigate to an identity page with `?flag={featureName}` where the identity has an override value set
- [ ] Verify the loader stays visible until all data is loaded
- [ ] Verify the edit modal opens with the correct override value
- [ ] Verify saving preserves the value correctly