### PR TITLE
fix(6905): replace dynamic serializer with SDKAnalyticsFlagsV1Serializer

### DIFF
--- a/api/app_analytics/serializers.py
+++ b/api/app_analytics/serializers.py
@@ -137,7 +137,7 @@ class SDKAnalyticsFlagsV1Serializer(serializers.Serializer):  # type: ignore[typ
         return {
             name: count
             for name, count in data.items()
-            if isinstance(name, str) and isinstance(count, int)
+            if isinstance(name, str) and type(count) is int
         }
 
     def validate(self, attrs: dict[str, int]) -> dict[str, int]:

--- a/api/app_analytics/serializers.py
+++ b/api/app_analytics/serializers.py
@@ -4,7 +4,9 @@ from common.core.utils import using_database_replica
 from django.conf import settings
 from rest_framework import serializers
 
+from app_analytics.cache import FeatureEvaluationCache
 from app_analytics.constants import LABELS
+from app_analytics.mappers import map_request_to_labels
 from app_analytics.tasks import (
     track_feature_evaluation_influxdb_v2,
     track_feature_evaluation_v2,
@@ -117,6 +119,55 @@ class SDKAnalyticsFlagsSerializer(serializers.Serializer):  # type: ignore[type-
                     environment.id,
                     self.validated_data["evaluations"],
                 )
+            )
+
+
+class SDKAnalyticsFlagsV1Serializer(serializers.Serializer):  # type: ignore[type-arg]
+    """Serializer for the V1 SDK analytics flags endpoint.
+
+    Accepts a flat ``{feature_name: evaluation_count}`` dict.
+    Unknown feature names and non-integer counts are silently skipped.
+    """
+
+    def to_internal_value(self, data: Any) -> dict[str, int]:
+        if not isinstance(data, dict):
+            raise serializers.ValidationError(
+                {"non_field_errors": ["Expected a JSON object."]}
+            )
+        return {
+            name: count
+            for name, count in data.items()
+            if isinstance(name, str) and isinstance(count, int)
+        }
+
+    def validate(self, attrs: dict[str, int]) -> dict[str, int]:
+        request = self.context["request"]
+        environment_feature_names = set(
+            using_database_replica(FeatureState.objects)
+            .filter(
+                environment=request.environment,
+                feature_segment=None,
+                identity=None,
+            )
+            .values_list("feature__name", flat=True)
+        )
+        return {
+            name: count
+            for name, count in attrs.items()
+            if name in environment_feature_names
+        }
+
+    def save(self, **kwargs: Any) -> None:
+        environment: Environment = kwargs["environment"]
+        cache: FeatureEvaluationCache = kwargs["cache"]
+        request = self.context["request"]
+        labels = map_request_to_labels(request)
+        for feature_name, evaluation_count in self.validated_data.items():
+            cache.track_feature_evaluation(
+                environment_id=environment.id,
+                feature_name=feature_name,
+                evaluation_count=evaluation_count,
+                labels=labels,
             )
 
 

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -65,7 +65,9 @@ class SDKAnalyticsFlags(CreateAPIView):  # type: ignore[type-arg]
         request=SDKAnalyticsFlagsSerializer,
         responses={200: None},
     )
-    def create(self, request: Request, *args: typing.Any, **kwargs: typing.Any) -> Response:
+    def create(
+        self, request: Request, *args: typing.Any, **kwargs: typing.Any
+    ) -> Response:
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(environment=request.environment, cache=feature_evaluation_cache)

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -5,31 +5,26 @@ from common.core.utils import using_database_replica
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
-from rest_framework.fields import IntegerField
 from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import Serializer
 
 from app_analytics.analytics_db_service import (
     get_total_events_count,
     get_usage_data,
 )
 from app_analytics.cache import FeatureEvaluationCache
-from app_analytics.mappers import (
-    map_request_to_labels,
-)
 from app_analytics.throttles import InfluxQueryThrottle
 from environments.authentication import EnvironmentKeyAuthentication
 from environments.permissions.permissions import EnvironmentKeyPermissions
-from features.models import FeatureState
 from organisations.models import Organisation
 from telemetry.serializers import TelemetrySerializer
 
 from .permissions import UsageDataPermission
 from .serializers import (
     SDKAnalyticsFlagsSerializer,
+    SDKAnalyticsFlagsV1Serializer,
     UsageDataQuerySerializer,
     UsageDataSerializer,
     UsageTotalCountSerializer,
@@ -63,55 +58,17 @@ class SDKAnalyticsFlags(CreateAPIView):  # type: ignore[type-arg]
 
     permission_classes = (EnvironmentKeyPermissions,)
     authentication_classes = (EnvironmentKeyAuthentication,)
+    serializer_class = SDKAnalyticsFlagsV1Serializer
     throttle_classes = []
-    format_kwarg = None
-
-    def get_serializer_class(self):  # type: ignore[no-untyped-def]
-        environment_feature_names = set(
-            using_database_replica(FeatureState.objects)
-            .filter(
-                environment=self.request.environment,
-                feature_segment=None,
-                identity=None,
-            )
-            .values_list("feature__name", flat=True)
-        )
-
-        class _AnalyticsSerializer(Serializer):  # type: ignore[type-arg]
-            def get_fields(self):  # type: ignore[no-untyped-def]
-                return {
-                    feature_name: IntegerField(required=False)
-                    for feature_name in environment_feature_names
-                }
-
-            def save(self, **kwargs: typing.Any) -> None:
-                request = self.context["request"]
-                for feature_name, evaluation_count in self.validated_data.items():
-                    feature_evaluation_cache.track_feature_evaluation(
-                        environment_id=request.environment.id,
-                        feature_name=feature_name,
-                        evaluation_count=evaluation_count,
-                        labels=map_request_to_labels(request),
-                    )
-
-        return _AnalyticsSerializer
 
     @extend_schema(
         request=SDKAnalyticsFlagsSerializer,
         responses={200: None},
     )
-    def create(
-        self, request: Request, *args: typing.Any, **kwargs: typing.Any
-    ) -> Response:
-        """
-        Send flag evaluation events from the SDK back to the API for reporting.
-
-        TODO: Eventually replace this with the v2 version of
-              this endpoint once SDKs have been updated.
-        """
+    def create(self, request: Request, *args: typing.Any, **kwargs: typing.Any) -> Response:
         serializer = self.get_serializer(data=request.data)
-        serializer.is_valid()
-        serializer.save(environment=self.request.environment)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(environment=request.environment, cache=feature_evaluation_cache)
         return Response(status=status.HTTP_200_OK)
 
 

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -77,6 +77,31 @@ def test_sdk_analytics_flags_v1__non_dict_payload__returns_400(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_sdk_analytics_flags_v1__boolean_count__is_skipped(
+    mocker: MockerFixture,
+    environment: Environment,
+    feature: Feature,
+    api_client: APIClient,
+) -> None:
+    # Given
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    data = {feature.name: True}
+    mocked_feature_eval_cache = mocker.patch(
+        "app_analytics.views.feature_evaluation_cache"
+    )
+
+    url = reverse("api-v1:analytics-flags")
+
+    # When
+    response = api_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    mocked_feature_eval_cache.track_feature_evaluation.assert_not_called()
+
+
 def test_sdk_analytics_ignores_bad_data(
     mocker: MockerFixture,
     environment: Environment,

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -23,7 +23,58 @@ from organisations.models import (
     Organisation,
     OrganisationSubscriptionInformationCache,
 )
+from projects.models import Project
 from tests.types import EnableFeaturesFixture
+
+
+def test_sdk_analytics_flags_v1__feature_name_with_dots__tracks_correctly(
+    mocker: MockerFixture,
+    environment: Environment,
+    project: Project,
+    api_client: APIClient,
+) -> None:
+    # Given
+    dotted_name = "org.app.module:handler"
+    Feature.objects.create(name=dotted_name, project=project)
+
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    data = {dotted_name: 12}
+    mocked_feature_eval_cache = mocker.patch(
+        "app_analytics.views.feature_evaluation_cache"
+    )
+
+    url = reverse("api-v1:analytics-flags")
+
+    # When
+    response = api_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    mocked_feature_eval_cache.track_feature_evaluation.assert_called_once_with(
+        environment_id=environment.id,
+        feature_name=dotted_name,
+        evaluation_count=12,
+        labels={},
+    )
+
+
+def test_sdk_analytics_flags_v1__non_dict_payload__returns_400(
+    environment: Environment,
+    api_client: APIClient,
+) -> None:
+    # Given
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    url = reverse("api-v1:analytics-flags")
+
+    # When
+    response = api_client.post(
+        url, data=json.dumps([1, 2, 3]), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_sdk_analytics_ignores_bad_data(


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/6905, #5906 

The V1 `SDKAnalyticsFlags` view dynamically generated a DRF serializer inside `get_serializer_class`. This caused dotted feature names (e.g. `org.app.module:handler`) to be split into nested dicts by DRF's `set_value`.

This PR replaces the dynamic serializer with a proper `SDKAnalyticsFlagsV1Serializer`.

Unknown feature names were already silently dropped by the old code (only known names had fields). The new serializer preserves this behaviour explicitly in `validate`. Non-integer values are now also silently skipped — the old code would have raised an unhandled `AssertionError` in this case since `is_valid()` was called without `raise_exception=True`, leaving `validated_data` unpopulated. This never surfaced because SDKs always send integers.

## How did you test this code?

Existing and new unit tests:

```
python -m pytest tests/unit/app_analytics/test_unit_app_analytics_views.py -v
```

All 22 tests pass (20 passed, 2 skipped due to no analytics database configured).