### PR TITLE
ci: Use sticky PR comments for Playwright report summaries

### DIFF
--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -135,23 +135,32 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
 
-      - name: Comment PR with test results (success)
+      - name: Generate test report summary (success)
+        id: report-summary-success
         if: success() && github.event_name == 'pull_request'
         uses: daun/playwright-report-summary@v3
         with:
           report-file: frontend/e2e/playwright-report/results.json
           comment-title: 'Playwright Test Results (${{ steps.test-type.outputs.label }} - ${{ inputs.runs-on }})'
-          report-tag: 'playwright-${{ steps.test-type.outputs.label }}-${{ inputs.runs-on }}'
+          create-comment: false
           custom-info: |
             **🔄 Run:** [#${{ github.run_number }} (attempt ${{ github.run_attempt }})](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-      - name: Comment PR with test results (failure)
+      - name: Generate test report summary (failure)
+        id: report-summary-failure
         if: failure() && github.event_name == 'pull_request'
         uses: daun/playwright-report-summary@v3
         with:
           report-file: frontend/e2e/playwright-report/results.json
           comment-title: 'Playwright Test Results (${{ steps.test-type.outputs.label }} - ${{ inputs.runs-on }})'
-          report-tag: 'playwright-${{ steps.test-type.outputs.label }}-${{ inputs.runs-on }}'
+          create-comment: false
           custom-info: |
             **📦 Artifacts:** [View test results and HTML report](${{ steps.artifact-url.outputs.url }})
             **🔄 Run:** [#${{ github.run_number }} (attempt ${{ github.run_attempt }})](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Comment PR with test results
+        if: always() && github.event_name == 'pull_request' && (steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary)
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: playwright-${{ steps.test-type.outputs.label }}-${{ inputs.runs-on }}
+          message: ${{ steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary }}

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -162,5 +162,6 @@ jobs:
         if: always() && github.event_name == 'pull_request' && (steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary)
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: playwright-${{ steps.test-type.outputs.label }}-${{ inputs.runs-on }}
+          header: playwright-e2e-results
+          append: true
           message: ${{ steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary }}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In this PR, we migrate Playwright E2E test report PR comments from `daun/playwright-report-summary` direct commenting to `marocchino/sticky-pull-request-comment`. This ensures that on CI re-runs, the existing comment is updated in place rather than creating a new one each time, reducing notification spam.

- Use `create-comment: false` on `daun/playwright-report-summary` to generate the summary output only
- Post the summary via `marocchino/sticky-pull-request-comment@v2` with a stable `header` key per test type and runner

## How did you test this code?

Will be validated by the next PR that triggers E2E tests in CI.