### PR TITLE
fix: only apply bold font-weight to active sidebar link

### DIFF
--- a/frontend/web/styles/project/_sidebar.scss
+++ b/frontend/web/styles/project/_sidebar.scss
@@ -1,6 +1,5 @@
 .sidebar-link {
   color: $body-color;
-  font-weight: 600;
   transition: background-color 0.15s ease, color 0.15s ease;
 
   svg path {
@@ -22,6 +21,7 @@
   }
 
   &--active {
+    font-weight: 600;
     background-color: transparentize($primary, 0.95);
   }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes regression from #6870

PR #6870 moved sidebar link styles to a dedicated `_sidebar.scss` file but placed `font-weight: 600` on the `.sidebar-link` base class, making all sidebar links bold. This moves it to `.sidebar-link--active` so only the active link is bold.

Before
<img width="226" height="406" alt="image" src="https://github.com/user-attachments/assets/50e14f3e-ec08-43fd-b65f-bbe0adc04df2" />

After

<img width="231" height="411" alt="image" src="https://github.com/user-attachments/assets/e860a7d0-05e5-446d-8e92-92804d181e27" />


## How did you test this code?

- Verified in the running app that inactive sidebar links use normal font weight
- Verified the active sidebar link remains bold (font-weight: 600)
- Checked both light and dark mode