### PR TITLE
fix(Segments): Fix project reference in segment creation

### DIFF
--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import Any
 
 import structlog
@@ -114,30 +113,23 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
             "rules",
             "metadata",
         ]
-        read_only_fields = ["project"]
-
-    @cached_property
-    def project(self) -> Project:
-        """Resolve the project from the view's URL kwargs"""
-        if self.instance:
-            return self.instance.project
-        try:
-            pk = int(self.context["view"].kwargs["project_pk"])
-        except KeyError as error:
-            raise RuntimeError(
-                "The serializer context is missing a view with project_pk in its URL."
-            ) from error
-        return Project.objects.get(pk=pk)  # type: ignore[no-any-return]
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         attrs = super().validate(attrs)
-        organisation = self.project.organisation
+        project = (
+            self.instance.project
+            if self.instance
+            else Project.objects.get(
+                pk=int(self.context["view"].kwargs["project_pk"]),
+            )
+        )
+        organisation = project.organisation
 
         self._validate_required_metadata(
-            organisation, attrs.get("metadata", []), project=self.project
+            organisation, attrs.get("metadata", []), project=project
         )
         self._validate_segment_rules_conditions_limit(attrs["rules"])
-        self._validate_project_segment_limit(self.project)
+        self._validate_project_segment_limit(project)
         return attrs
 
     def create(self, validated_data: dict[str, Any]):  # type: ignore[no-untyped-def]

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -115,15 +115,14 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         attrs = super().validate(attrs)
-        project: Project = self.context["project"]
-        organisation = project.organisation
+        metadata = attrs.get("metadata", [])
 
         # TODO: Make "project" read-only — https://github.com/Flagsmith/flagsmith-workflows/issues/102
-        attrs["project"] = project
+        project_pk = self.context["view"].kwargs["project_pk"]
+        project = attrs["project"] = Project.objects.get(pk=project_pk)
+        organisation = project.organisation
 
-        self._validate_required_metadata(
-            organisation, attrs.get("metadata", []), project=project
-        )
+        self._validate_required_metadata(organisation, metadata, project)
         self._validate_segment_rules_conditions_limit(attrs["rules"])
         self._validate_project_segment_limit(project)
         return attrs

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -79,7 +79,6 @@ class SegmentRuleSerializer(_BaseSegmentRuleSerializer):
 
 
 class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
-    instance: Segment | None
     rules = SegmentRuleSerializer(many=True, required=True, allow_empty=False)
     metadata = MetadataSerializer(required=False, many=True)
 

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Any
 
 import structlog
@@ -79,6 +80,7 @@ class SegmentRuleSerializer(_BaseSegmentRuleSerializer):
 
 
 class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
+    instance: Segment | None
     rules = SegmentRuleSerializer(many=True, required=True, allow_empty=False)
     metadata = MetadataSerializer(required=False, many=True)
 
@@ -112,17 +114,30 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
             "rules",
             "metadata",
         ]
+        read_only_fields = ["project"]
+
+    @cached_property
+    def project(self) -> Project:
+        """Resolve the project from the view's URL kwargs"""
+        if self.instance:
+            return self.instance.project
+        try:
+            pk = int(self.context["view"].kwargs["project_pk"])
+        except KeyError as error:
+            raise RuntimeError(
+                "The serializer context is missing a view with project_pk in its URL."
+            ) from error
+        return Project.objects.get(pk=pk)  # type: ignore[no-any-return]
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         attrs = super().validate(attrs)
-        project = self.instance.project if self.instance else attrs["project"]  # type: ignore[union-attr]
-        organisation = project.organisation
+        organisation = self.project.organisation
 
         self._validate_required_metadata(
-            organisation, attrs.get("metadata", []), project=project
+            organisation, attrs.get("metadata", []), project=self.project
         )
         self._validate_segment_rules_conditions_limit(attrs["rules"])
-        self._validate_project_segment_limit(project)
+        self._validate_project_segment_limit(self.project)
         return attrs
 
     def create(self, validated_data: dict[str, Any]):  # type: ignore[no-untyped-def]

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -116,14 +116,11 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         attrs = super().validate(attrs)
-        project = (
-            self.instance.project
-            if self.instance
-            else Project.objects.get(
-                pk=int(self.context["view"].kwargs["project_pk"]),
-            )
-        )
+        project: Project = self.context["project"]
         organisation = project.organisation
+
+        # TODO: Make "project" read-only — https://github.com/Flagsmith/flagsmith-workflows/issues/102
+        attrs["project"] = project
 
         self._validate_required_metadata(
             organisation, attrs.get("metadata", []), project=project

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any
+from functools import cache
+from typing import TYPE_CHECKING, Any
 
 from common.projects.permissions import VIEW_PROJECT
 from django.utils.decorators import method_decorator
@@ -21,6 +22,7 @@ from features.serializers import (
     SegmentAssociatedFeatureStateSerializer,
 )
 from features.versioning.models import EnvironmentFeatureVersion
+from projects.models import Project
 
 from .models import Segment
 from .permissions import SegmentPermissions
@@ -30,6 +32,9 @@ from .serializers import (
     SegmentSerializer,
 )
 from .services import delete_segment
+
+if TYPE_CHECKING:
+    from users.models import FFAdminUser
 
 logger = logging.getLogger()
 
@@ -88,15 +93,23 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     permission_classes = [SegmentPermissions]
     pagination_class = CustomPagination
 
+    @cache
+    def get_project(self) -> Project:
+        user: "FFAdminUser" = self.request.user  # type: ignore[assignment]
+        projects = user.get_permitted_projects(permission_key=VIEW_PROJECT)
+        return get_object_or_404(projects, pk=self.kwargs["project_pk"])
+
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        if not getattr(self, "swagger_fake_view", False):
+            context["project"] = self.get_project()
+        return context
+
     def get_queryset(self):  # type: ignore[no-untyped-def]
         if getattr(self, "swagger_fake_view", False):
             return Segment.objects.none()
 
-        permitted_projects = self.request.user.get_permitted_projects(  # type: ignore[union-attr]
-            permission_key=VIEW_PROJECT
-        )
-        project = get_object_or_404(permitted_projects, pk=self.kwargs["project_pk"])
-
+        project = self.get_project()
         queryset = Segment.live_objects.filter(project=project, is_system_segment=False)
 
         if self.action == "list":
@@ -134,9 +147,6 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             queryset = queryset.filter(feature__isnull=True)
 
         return queryset
-
-    def perform_create(self, serializer: SegmentSerializer) -> None:  # type: ignore[override]
-        serializer.save(project_id=int(self.kwargs["project_pk"]))  # type: ignore[no-untyped-call]
 
     @extend_schema(parameters=[AssociatedFeaturesQuerySerializer])
     @action(

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -135,6 +135,9 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
 
         return queryset
 
+    def perform_create(self, serializer: SegmentSerializer) -> None:  # type: ignore[override]
+        serializer.save(project_id=self.kwargs["project_pk"])  # type: ignore[no-untyped-call]
+
     @extend_schema(parameters=[AssociatedFeaturesQuerySerializer])
     @action(
         detail=True,

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -1,5 +1,4 @@
 import logging
-from functools import cache
 from typing import TYPE_CHECKING, Any
 
 from common.projects.permissions import VIEW_PROJECT
@@ -93,17 +92,10 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     permission_classes = [SegmentPermissions]
     pagination_class = CustomPagination
 
-    @cache
     def get_project(self) -> Project:
         user: "FFAdminUser" = self.request.user  # type: ignore[assignment]
         projects = user.get_permitted_projects(permission_key=VIEW_PROJECT)
         return get_object_or_404(projects, pk=self.kwargs["project_pk"])
-
-    def get_serializer_context(self) -> dict[str, Any]:
-        context = super().get_serializer_context()
-        if not getattr(self, "swagger_fake_view", False):
-            context["project"] = self.get_project()
-        return context
 
     def get_queryset(self):  # type: ignore[no-untyped-def]
         if getattr(self, "swagger_fake_view", False):

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -136,7 +136,7 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         return queryset
 
     def perform_create(self, serializer: SegmentSerializer) -> None:  # type: ignore[override]
-        serializer.save(project_id=self.kwargs["project_pk"])  # type: ignore[no-untyped-call]
+        serializer.save(project_id=int(self.kwargs["project_pk"]))  # type: ignore[no-untyped-call]
 
     @extend_schema(parameters=[AssociatedFeaturesQuerySerializer])
     @action(

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -1895,7 +1895,7 @@ def test_create_segment__body_project_differs_from_url__does_not_create_in_other
     other_project = Project.objects.create(name="Other Project", organisation=other_org)
 
     # When
-    admin_client.post(
+    response = admin_client.post(
         f"/api/v1/projects/{project.id}/segments/",
         data={
             "name": "a_wild_pokemon",
@@ -1906,4 +1906,6 @@ def test_create_segment__body_project_differs_from_url__does_not_create_in_other
     )
 
     # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["project"] == project.id
     assert not Segment.objects.filter(project=other_project).exists()

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -1884,3 +1884,26 @@ def test_create_segment__required_metadata_on_other_project__returns_201(
 
     # Then
     assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_create_segment__body_project_differs_from_url__does_not_create_in_other_project(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    other_org = Organisation.objects.create(name="Other Org")
+    other_project = Project.objects.create(name="Other Project", organisation=other_org)
+
+    # When
+    admin_client.post(
+        f"/api/v1/projects/{project.id}/segments/",
+        data={
+            "name": "a_wild_pokemon",
+            "project": other_project.id,
+            "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+        },
+        format="json",
+    )
+
+    # Then
+    assert not Segment.objects.filter(project=other_project).exists()

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -205,7 +205,7 @@ def test_segments_limit_ignores_old_segment_versions(
     with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
     # Given
-    with_project_permissions([MANAGE_SEGMENTS])  # type: ignore[call-arg]
+    with_project_permissions([MANAGE_SEGMENTS, VIEW_PROJECT])  # type: ignore[call-arg]
 
     # let's reduce the max segments allowed to 2
     project.max_segments_allowed = 2


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6914.

This patch prevents referencing **any** project when creating a segment, restricting to the one referenced in the URL, which has its association with the user validated.

## How did you test this code?

Included unit tests.