### PR TITLE
fix: restore Prevent Flag Defaults UI enforcement in create feature modal

### DIFF
--- a/frontend/web/components/modals/create-feature/FeatureUpdateSummary.tsx
+++ b/frontend/web/components/modals/create-feature/FeatureUpdateSummary.tsx
@@ -2,9 +2,11 @@ import React, { FC } from 'react'
 import InfoMessage from 'components/InfoMessage'
 import Button from 'components/base/forms/Button'
 import ModalHR from 'components/modals/ModalHR'
+import { useGetProjectQuery } from 'common/services/useProject'
 
 type FeatureUpdateSummaryProps = {
   identity?: string
+  projectId: number | string
   onCreateFeature: () => void
   isSaving: boolean
   name: string
@@ -22,18 +24,24 @@ const FeatureUpdateSummary: FC<FeatureUpdateSummaryProps> = ({
   isSaving,
   name,
   onCreateFeature,
+  projectId,
   regexValid,
 }) => {
+  const { data: project } = useGetProjectQuery({ id: projectId })
+  const preventFlagDefaults = !!project?.prevent_flag_defaults
+
   return (
     <>
       <ModalHR className={`my-4 ${identity ? 'mx-3' : ''}`} />
       {!identity && (
         <div className='text-right mb-3'>
-          <InfoMessage collapseId={'create-flag'}>
-            This will create the feature for <strong>all environments</strong>,
-            you can edit this feature per environment once the feature is
-            created.
-          </InfoMessage>
+          {!preventFlagDefaults && (
+            <InfoMessage collapseId={'create-flag'}>
+              This will create the feature for <strong>all environments</strong>
+              , you can edit this feature per environment once the feature is
+              created.
+            </InfoMessage>
+          )}
 
           <Button
             onClick={onCreateFeature}

--- a/frontend/web/components/modals/create-feature/index.js
+++ b/frontend/web/components/modals/create-feature/index.js
@@ -1843,6 +1843,7 @@ const Index = class extends Component {
                                 />
                                 <FeatureUpdateSummary
                                   identity={identity}
+                                  projectId={this.props.projectId}
                                   onCreateFeature={onCreateFeature}
                                   isSaving={isSaving}
                                   name={projectFlag.name}

--- a/frontend/web/components/modals/create-feature/tabs/CreateFeature.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/CreateFeature.tsx
@@ -8,6 +8,8 @@ import { useHasPermission } from 'common/providers/Permission'
 import Switch from 'components/Switch'
 import Tooltip from 'components/Tooltip'
 import Icon from 'components/Icon'
+import InfoMessage from 'components/InfoMessage'
+import { useGetProjectQuery } from 'common/services/useProject'
 import { useCreateTagMutation, useGetTagsQuery } from 'common/services/useTag'
 
 type CreateFeatureTabProps = {
@@ -54,6 +56,9 @@ const CreateFeature: FC<CreateFeatureTabProps> = ({
     level: 'project',
     permission: 'ADMIN',
   })
+
+  const { data: project } = useGetProjectQuery({ id: projectId })
+  const preventFlagDefaults = !!project?.prevent_flag_defaults && !identity
 
   const noPermissions = !createFeature && !projectAdmin
 
@@ -134,10 +139,17 @@ const CreateFeature: FC<CreateFeatureTabProps> = ({
       <WarningMessage warningMessage={featureWarning} />
       {!!projectFlag && (
         <>
+          {preventFlagDefaults && (
+            <InfoMessage collapseId='create-flag'>
+              This will create the feature for <strong>all environments</strong>
+              , you can edit the feature's enabled state and value per
+              environment once the feature is created.
+            </InfoMessage>
+          )}
           <FeatureValue
             error={error}
             createFeature={createFeature}
-            hideValue={false}
+            hideValue={preventFlagDefaults}
             isEdit={!!identity}
             identity={identity}
             noPermissions={noPermissions}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6930

The `prevent_flag_defaults` project setting was no longer hiding the value and enabled fields when creating a feature flag. This regression was introduced in #6356 where `hideValue` was hardcoded to `false` and the `prevent_flag_defaults` check was dropped.

### What changed

- **`CreateFeature.tsx`**: Fetches `prevent_flag_defaults` via RTK Query (`useGetProjectQuery`) and conditionally hides the enabled toggle and value editor, showing an info message instead.
- **`FeatureUpdateSummary.tsx`**: Also fetches via RTK Query to conditionally hide the duplicate info message when `prevent_flag_defaults` is active.
- **`index.js`**: Passes `projectId` to `FeatureUpdateSummary` (no longer uses stale Flux `ProjectStore.model`).

### Why RTK Query instead of Flux

The previous `ProjectStore.model` data was stale — toggling the setting in Project Settings didn't update the create feature modal without a full page reload. Using `useGetProjectQuery` ensures the data is always fresh via RTK Query's cache invalidation.

## How did you test this code?

1. Enable "Prevent Flag Defaults" in Project Settings > Additional Settings
2. Open the "New Feature" modal — verify the enabled toggle and value editor are **hidden**, replaced by an info message
3. Disable "Prevent Flag Defaults" in Project Settings
4. Open the "New Feature" modal again — verify the enabled toggle and value editor are **visible**, with the standard info message at the bottom
5. Edit an existing feature — verify the Value tab always shows enabled toggle and value editor regardless of the setting