### PR TITLE
fix: mask webhook secret with password field and reveal toggle

### DIFF
--- a/frontend/web/components/base/forms/Input.js
+++ b/frontend/web/components/base/forms/Input.js
@@ -176,7 +176,7 @@ const Input = class extends React.Component {
             }}
           >
             <Icon
-              name={this.state.type === 'text' ? 'eye' : 'eye-off'}
+              name={this.state.type === 'password' ? 'eye' : 'eye-off'}
               fill={invalid && '#ef4d56'}
               width={
                 size &&

--- a/frontend/web/components/modals/CreateAuditLogWebhook.tsx
+++ b/frontend/web/components/modals/CreateAuditLogWebhook.tsx
@@ -120,7 +120,7 @@ const CreateAuditLogWebhook: React.FC<Props> = ({
               setSecret(Utils.safeParseEventValue(e))
             }
             isValid={!!url && url.length > 0}
-            type='text'
+            type='password'
             className='full-width'
             placeholder='Secret'
           />

--- a/frontend/web/components/modals/CreateWebhook.tsx
+++ b/frontend/web/components/modals/CreateWebhook.tsx
@@ -117,7 +117,7 @@ const CreateWebhook: FC<CreateWebhookProps> = ({
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setSecret(Utils.safeParseEventValue(e))
             }
-            type='text'
+            type='password'
             className='full-width'
             placeholder='Secret'
           />


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6724

### Webhook secret masking

The webhook secret was displayed as plain text when editing an existing webhook. Changed the secret input from `type='text'` to `type='password'` in both environment and audit log webhook forms.

The existing `Input` component already provides a built-in eye/eye-off toggle button for password fields, so the secret is now:
- Masked by default (`•••••`)
- Revealable via the eye icon toggle

**Files changed:**
- `CreateWebhook.tsx` — environment webhook secret input
- `CreateAuditLogWebhook.tsx` — audit log webhook secret input

### Eye icon logic fix

While implementing the above, we found the eye/eye-off icon logic in `Input.js` was **inverted** — it showed `eye-off` (crossed eye) when the field was hidden, and `eye` (open eye) when visible. This affected all password fields across the app.

Fixed to follow the standard convention:
- **Hidden** → `eye` icon (click to reveal)
- **Visible** → `eye-off` icon (click to hide)

**File changed:**
- `Input.js` — swapped icon condition

## How did you test this code?

1. Go to Environment Settings > Webhooks > edit an existing webhook
2. Verify the secret field is masked with dots
3. Click the eye icon — verify it shows `eye` when masked, `eye-off` when revealed
4. Click again to hide it
5. Repeat for Organisation Settings > Audit Log Webhooks
6. Check any other password field in the app (e.g. login) — verify the icon logic is correct