### PR TITLE
ci: Add flagsmith-lint-tests pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         language: system
         entry: make -C api generate-docs
         pass_filenames: false
-        types: [python,toml]
+        types: [python, toml]
       - id: python-typecheck
         name: python-typecheck
         language: system
@@ -44,7 +44,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/Flagsmith/flagsmith-common
-    rev: feat/lint-tests-ft-rules
+    rev: v3.4.0
     hooks:
       - id: flagsmith-lint-tests
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,11 @@ repos:
         types: [python]
         stages: [pre-push]
 
+  - repo: https://github.com/Flagsmith/flagsmith-common
+    rev: feat/lint-tests-ft-rules
+    hooks:
+      - id: flagsmith-lint-tests
+
   - repo: https://github.com/python-poetry/poetry
     rev: 2.3.2
     hooks:

--- a/api/README.md
+++ b/api/README.md
@@ -11,7 +11,9 @@ To install dev dependencies, run `make install`.
 
 To run linters, run `make lint`.
 
-To run tests, run `make docker-up test`.
+To run tests, run `make test`.
+
+To run a subset of tests or an individual test, run `make test opts='<pytest args>'`. If the number of test is too low for xdist, consider adding `-n0` to pytest args.
 
 To prepare a dev database, run `make docker-up django-migrate`.
 

--- a/api/tests/integration/api_keys/test_viewset.py
+++ b/api/tests/integration/api_keys/test_viewset.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient
 from organisations.models import Organisation
 
 
-def test_create_master_api_key_returns_key_in_response(admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_create_master_api_key_returns_key_in_response(admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:organisations:organisation-master-api-keys-list",
@@ -22,7 +22,7 @@ def test_create_master_api_key_returns_key_in_response(admin_client, organisatio
     assert response.json()["is_admin"] is True
 
 
-def test_creating_non_admin_master_api_key_without_rbac_returns_400(  # type: ignore[no-untyped-def]
+def test_creating_non_admin_master_api_key_without_rbac_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, settings
 ):
     # Given
@@ -44,7 +44,7 @@ def test_creating_non_admin_master_api_key_without_rbac_returns_400(  # type: ig
     ]
 
 
-def test_delete_master_api_key(admin_client, organisation, admin_master_api_key_prefix):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_delete_master_api_key(admin_client, organisation, admin_master_api_key_prefix):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     url = reverse(
         "api-v1:organisations:organisation-master-api-keys-detail",
@@ -58,7 +58,7 @@ def test_delete_master_api_key(admin_client, organisation, admin_master_api_key_
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_list_master_api_keys(
+def test_list_master_api_keys(  # noqa: FT003
     admin_client: APIClient,
     organisation: int,
     admin_master_api_key_prefix: str,
@@ -79,7 +79,7 @@ def test_list_master_api_keys(
     assert response.json()["results"][0]["has_expired"] is False
 
 
-def test_list_master_api_keys__when_expired(
+def test_list_master_api_keys__when_expired(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     expired_api_key_prefix: str,
@@ -100,7 +100,7 @@ def test_list_master_api_keys__when_expired(
     assert response.json()["results"][0]["has_expired"] is True
 
 
-def test_retrieve_master_api_key(  # type: ignore[no-untyped-def]
+def test_retrieve_master_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, admin_master_api_key_prefix
 ):
     # Given
@@ -117,7 +117,7 @@ def test_retrieve_master_api_key(  # type: ignore[no-untyped-def]
     assert response.json()["prefix"] == admin_master_api_key_prefix
 
 
-def test_update_master_api_key(  # type: ignore[no-untyped-def]
+def test_update_master_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, admin_master_api_key_prefix, settings
 ):
     # Given
@@ -147,7 +147,7 @@ def test_update_master_api_key(  # type: ignore[no-untyped-def]
     assert response.json()["is_admin"] is False
 
 
-def test_update_master_api_key_is_admin_returns_400_if_rbac_is_not_installed(  # type: ignore[no-untyped-def]
+def test_update_master_api_key_is_admin_returns_400_if_rbac_is_not_installed(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, admin_master_api_key_prefix, settings
 ):
     # Given
@@ -175,7 +175,7 @@ def test_update_master_api_key_is_admin_returns_400_if_rbac_is_not_installed(  #
     ]
 
 
-def test_api_returns_403_if_user_is_not_the_org_admin(non_admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_api_returns_403_if_user_is_not_the_org_admin(non_admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:organisations:organisation-master-api-keys-list",
@@ -188,7 +188,7 @@ def test_api_returns_403_if_user_is_not_the_org_admin(non_admin_client, organisa
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_create_master_api_key_ignores_organisation_in_body(admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_master_api_key_ignores_organisation_in_body(admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     list_create_url = reverse(
         "api-v1:organisations:organisation-master-api-keys-list",
@@ -216,7 +216,7 @@ def test_create_master_api_key_ignores_organisation_in_body(admin_client, organi
     assert key.startswith(list_response_json["results"][0]["prefix"])
 
 
-def test_deleted_api_key_is_not_returned_in_list_and_cannot_be_used(
+def test_deleted_api_key_is_not_returned_in_list_and_cannot_be_used(  # noqa: FT003
     admin_client: APIClient,
     organisation: int,
     admin_master_api_key_client: APIClient,

--- a/api/tests/integration/app_analytics/test_influx_query_throttle.py
+++ b/api/tests/integration/app_analytics/test_influx_query_throttle.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 
-def test_influx_data_endpoint_is_throttled(
+def test_influx_data_endpoint_is_throttled(  # noqa: FT003
     admin_client: APIClient,
     organisation: int,
     mocker: MockerFixture,

--- a/api/tests/integration/audit/test_audit_logs.py
+++ b/api/tests/integration/audit/test_audit_logs.py
@@ -29,7 +29,7 @@ def _subscription_metadata(mocker: MockerFixture) -> None:
     )
 
 
-def test_get_audit_logs_makes_expected_queries(  # type: ignore[no-untyped-def]
+def test_get_audit_logs_makes_expected_queries(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client,
     project,
     environment,
@@ -46,7 +46,7 @@ def test_get_audit_logs_makes_expected_queries(  # type: ignore[no-untyped-def]
     assert res.json()["count"] == 3
 
 
-def test_retrieve_audit_log_for_environment_change(
+def test_retrieve_audit_log_for_environment_change(  # noqa: FT003,FT004
     admin_client: APIClient,
     project: int,
     environment_api_key: str,
@@ -88,7 +88,7 @@ def test_retrieve_audit_log_for_environment_change(
     assert retrieve_response_json["change_details"][0]["old"] == environment_name
 
 
-def test_retrieve_audit_log_for_feature_state_enabled_change(
+def test_retrieve_audit_log_for_feature_state_enabled_change(  # noqa: FT003
     admin_client: APIClient,
     environment_api_key: str,
     environment: int,
@@ -132,7 +132,7 @@ def test_retrieve_audit_log_for_feature_state_enabled_change(
     assert retrieve_response_json["change_details"][0]["old"] is False
 
 
-def test_creates_audit_log_for_feature_state_update(
+def test_creates_audit_log_for_feature_state_update(  # noqa: FT003
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment_api_key: str,
@@ -170,7 +170,7 @@ def test_creates_audit_log_for_feature_state_update(
         ("Asia/Tokyo", "Y年n月j日 H:i (T)", "2199年4月15日 21:30 (JST)"),
     ],
 )
-def test_creates_audit_log_for_scheduled_feature_state_update(
+def test_creates_audit_log_for_scheduled_feature_state_update(  # noqa: FT003
     admin_client: APIClient,
     admin_user: FFAdminUser,
     django_datetime_format: str,
@@ -216,7 +216,7 @@ def test_creates_audit_log_for_scheduled_feature_state_update(
     )
 
 
-def test_retrieve_audit_log_for_feature_state_value_change(
+def test_retrieve_audit_log_for_feature_state_value_change(  # noqa: FT003
     admin_client: APIClient,
     environment_api_key: str,
     environment: int,
@@ -262,7 +262,7 @@ def test_retrieve_audit_log_for_feature_state_value_change(
     assert retrieve_response_json["change_details"][0]["old"] == default_feature_value
 
 
-def test_retrieve_audit_log_does_not_include_change_details_for_non_update(
+def test_retrieve_audit_log_does_not_include_change_details_for_non_update(  # noqa: FT003
     admin_client: APIClient, project: int, environment: str
 ) -> None:
     # Given
@@ -288,7 +288,7 @@ def test_retrieve_audit_log_does_not_include_change_details_for_non_update(
     assert retrieve_response.json()["change_details"] == []
 
 
-def test_retrieve_audit_log_includes_changes_when_segment_override_created_and_deleted_for_enabled_state(
+def test_retrieve_audit_log_includes_changes_when_segment_override_created_and_deleted_for_enabled_state(  # noqa: FT003,FT004
     admin_client: APIClient,
     project: int,
     feature: int,
@@ -380,7 +380,7 @@ def test_retrieve_audit_log_includes_changes_when_segment_override_created_and_d
     assert delete_override_audit_log_details["change_details"] == []
 
 
-def test_retrieve_audit_log_includes_changes_when_segment_override_created_for_feature_value(
+def test_retrieve_audit_log_includes_changes_when_segment_override_created_for_feature_value(  # noqa: FT003,FT004
     admin_client: APIClient,
     project: int,
     feature: int,

--- a/api/tests/integration/core/test_commands.py
+++ b/api/tests/integration/core/test_commands.py
@@ -97,7 +97,7 @@ def test_bootstrap__empty_instance__creates_expected(
     )
 
 
-def test_bootstrap__empty_instance__cli_overrides__creates_expected(
+def test_bootstrap__empty_instance__cli_overrides__creates_expected(  # noqa: FT003
     settings: SettingsWrapper,
     capsys: pytest.CaptureFixture,  # type: ignore[type-arg]
 ) -> None:
@@ -156,7 +156,7 @@ def test_bootstrap__used_instance__skip_expected(
     [*Project.objects.all()] == expected_projects
 
 
-def test_bootstrap__allow_admin_initiation_via_cli__false_by_default__skip_expected(
+def test_bootstrap__allow_admin_initiation_via_cli__false_by_default__skip_expected(  # noqa: FT003,FT004
     settings: SettingsWrapper,
 ) -> None:
     # When

--- a/api/tests/integration/core/test_user_rate_throttle.py
+++ b/api/tests/integration/core/test_user_rate_throttle.py
@@ -12,7 +12,7 @@ from rest_framework.test import APIClient
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_user_throttle_can_throttle_admin_endpoints(
+def test_user_throttle_can_throttle_admin_endpoints(  # noqa: FT003,FT004
     client: APIClient, project: int, mocker: MockerFixture, reset_cache: None
 ) -> None:
     # Given
@@ -29,7 +29,7 @@ def test_user_throttle_can_throttle_admin_endpoints(
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
-def test_get_flags_is_not_throttled_by_user_throttle(
+def test_get_flags_is_not_throttled_by_user_throttle(  # noqa: FT003
     sdk_client: APIClient,
     environment: int,
     environment_api_key: str,
@@ -48,7 +48,7 @@ def test_get_flags_is_not_throttled_by_user_throttle(
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_get_environment_document_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_get_environment_document_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     server_side_sdk_client: APIClient,
     environment: int,
     environment_api_key: str,
@@ -67,7 +67,7 @@ def test_get_environment_document_is_not_throttled_by_user_throttle(  # type: ig
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_get_identities_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_get_identities_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: int,
     sdk_client: APIClient,
     mocker: MockerFixture,
@@ -88,7 +88,7 @@ def test_get_identities_is_not_throttled_by_user_throttle(  # type: ignore[no-un
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_set_trait_for_an_identity_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_set_trait_for_an_identity_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: int,
     server_side_sdk_client: APIClient,
     identity: int,
@@ -114,7 +114,7 @@ def test_set_trait_for_an_identity_is_not_throttled_by_user_throttle(  # type: i
         assert res.status_code == status.HTTP_200_OK
 
 
-def test_sdk_analytics_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_sdk_analytics_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture, environment: int, sdk_client: APIClient
 ):
     # Given
@@ -128,7 +128,7 @@ def test_sdk_analytics_is_not_throttled_by_user_throttle(  # type: ignore[no-unt
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_self_hosted_telemetry_view_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_self_hosted_telemetry_view_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
 ):
     # Given

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -21,7 +21,7 @@ from organisations.models import Organisation
 from users.models import FFAdminUser, SignUpType
 
 
-def test_register_and_login_workflows(db: None, api_client: APIClient) -> None:
+def test_register_and_login_workflows(db: None, api_client: APIClient) -> None:  # noqa: FT003,FT004
     # try to register without first_name / last_name
     email = "test@example.com"
     password = FFAdminUser.objects.make_random_password()
@@ -95,7 +95,7 @@ def test_register_and_login_workflows(db: None, api_client: APIClient) -> None:
 
 
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)  # type: ignore[misc]
-def test_cannot_register_without_invite_if_disabled(
+def test_cannot_register_without_invite_if_disabled(  # noqa: FT003
     db: None, api_client: APIClient
 ) -> None:
     # Given
@@ -117,7 +117,7 @@ def test_cannot_register_without_invite_if_disabled(
 
 
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)  # type: ignore[misc]
-def test_can_register_with_invite_if_registration_disabled_without_invite(
+def test_can_register_with_invite_if_registration_disabled_without_invite(  # noqa: FT003
     db: None,
     api_client: APIClient,
 ) -> None:
@@ -148,7 +148,7 @@ def test_can_register_with_invite_if_registration_disabled_without_invite(
         settings.DJOSER,
     )
 )
-def test_registration_and_login_with_user_activation_flow(
+def test_registration_and_login_with_user_activation_flow(  # noqa: FT003
     db: None,
     api_client: APIClient,
 ) -> None:
@@ -215,7 +215,7 @@ def test_registration_and_login_with_user_activation_flow(
     assert "key" in login_result.data
 
 
-def test_login_workflow_with_mfa_enabled(
+def test_login_workflow_with_mfa_enabled(  # noqa: FT003,FT004
     db: None,
     api_client: APIClient,
 ) -> None:
@@ -293,7 +293,7 @@ def test_login_workflow_with_mfa_enabled(
 
 
 @override_settings(COOKIE_AUTH_ENABLED=True)  # type: ignore[misc]
-def test_register_and_login_workflows__jwt_cookie(
+def test_register_and_login_workflows__jwt_cookie(  # noqa: FT003
     db: None,
     api_client: APIClient,
 ) -> None:
@@ -453,7 +453,7 @@ def test_login_workflow__jwt_cookie__cors_headers_expected(
 
 
 @override_settings(COOKIE_AUTH_ENABLED=True)  # type: ignore[misc]
-def test_login_workflow__jwt_cookie__invalid_token__no_cookies_expected(
+def test_login_workflow__jwt_cookie__invalid_token__no_cookies_expected(  # noqa: FT003
     db: None,
     api_client: APIClient,
 ) -> None:
@@ -483,7 +483,7 @@ def test_login_workflow__jwt_cookie__invalid_token__no_cookies_expected(
     assert not response.cookies.get("jwt")
 
 
-def test_throttle_login_workflows(
+def test_throttle_login_workflows(  # noqa: FT003,FT004
     api_client: APIClient,
     db: None,
     reset_cache: None,
@@ -524,7 +524,7 @@ def test_throttle_login_workflows(
     assert login_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
-def test_throttle_signup(
+def test_throttle_signup(  # noqa: FT003,FT004
     api_client: APIClient,
     user_password: str,
     db: None,
@@ -560,7 +560,7 @@ def test_throttle_signup(
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
-def test_get_user_is_not_throttled(  # type: ignore[no-untyped-def]
+def test_get_user_is_not_throttled(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, reset_cache: None, mocker: MockerFixture
 ):
     # Given
@@ -576,7 +576,7 @@ def test_get_user_is_not_throttled(  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.django_db
-def test_delete_token(api_client: APIClient, db: None) -> None:
+def test_delete_token(api_client: APIClient, db: None) -> None:  # noqa: FT003
     # Given
     register_url = reverse("api-v1:custom_auth:ffadminuser-list")
     password = FFAdminUser.objects.make_random_password()
@@ -606,7 +606,7 @@ def test_delete_token(api_client: APIClient, db: None) -> None:
     assert client.delete(delete_token_url).status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_register_with_sign_up_type(client, db, settings):  # type: ignore[no-untyped-def]
+def test_register_with_sign_up_type(client, db, settings):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     password = FFAdminUser.objects.make_random_password()
     sign_up_type = "NO_INVITE"
@@ -636,7 +636,7 @@ def test_register_with_sign_up_type(client, db, settings):  # type: ignore[no-un
     assert FFAdminUser.objects.filter(email=email, sign_up_type=sign_up_type).exists()
 
 
-def test_can_create_superuser(
+def test_can_create_superuser(  # noqa: FT003
     db: None, api_client: APIClient, mocker: MockerFixture
 ) -> None:
     # Given
@@ -664,7 +664,7 @@ def test_can_create_superuser(
     assert user.superuser is True
 
 
-def test_cannot_create_superuser_on_saas_build(
+def test_cannot_create_superuser_on_saas_build(  # noqa: FT003
     db: None, api_client: APIClient, mocker: MockerFixture
 ) -> None:
     # Given
@@ -691,7 +691,7 @@ def test_cannot_create_superuser_on_saas_build(
     assert user.superuser is False
 
 
-def test_cannot_create_superuser_if_any_user_exists(
+def test_cannot_create_superuser_if_any_user_exists(  # noqa: FT003
     admin_user: FFAdminUser, api_client: APIClient, mocker: MockerFixture
 ) -> None:
     # Given
@@ -721,7 +721,7 @@ def test_cannot_create_superuser_if_any_user_exists(
 
 
 @pytest.mark.parametrize("marketing_consent_given", [None, True, False])
-def test_marketing_consent_given_defaults_to_true(
+def test_marketing_consent_given_defaults_to_true(  # noqa: FT003
     api_client: APIClient,
     marketing_consent_given: bool | None,
     db: None,

--- a/api/tests/integration/e2etests/end_to_end/test_integration_e2e_tests.py
+++ b/api/tests/integration/e2etests/end_to_end/test_integration_e2e_tests.py
@@ -9,7 +9,7 @@ from organisations.subscriptions.constants import ENTERPRISE
 from users.models import FFAdminUser
 
 
-def test_e2e_teardown(settings, db) -> None:  # type: ignore[no-untyped-def]
+def test_e2e_teardown(settings, db) -> None:  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # TODO: tidy up this hack to fix throttle rates
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["signup"] = "1000/min"
     token = "test-token"
@@ -47,7 +47,7 @@ def test_e2e_teardown(settings, db) -> None:  # type: ignore[no-untyped-def]
         assert subscription.subscription_id == "test_subscription_id"
 
 
-def test_e2e_teardown_with_incorrect_token(settings, db):  # type: ignore[no-untyped-def]
+def test_e2e_teardown_with_incorrect_token(settings, db):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     os.environ["E2E_TEST_AUTH_TOKEN"] = "expected-token"
     url = reverse("api-v1:e2etests:teardown")

--- a/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
@@ -39,7 +39,7 @@ from util.engine_models.features.models import (
 from util.mappers.engine import map_feature_to_engine
 
 
-def test_edge_identities_feature_states_list_does_not_call_sync_identity_document_features_if_not_needed(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_edge_identities_feature_states_list_does_not_call_sync_identity_document_features_if_not_needed(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     admin_client,
     environment,
     environment_api_key,
@@ -70,7 +70,7 @@ def test_edge_identities_feature_states_list_does_not_call_sync_identity_documen
     sync_identity_document_features.delay.assert_not_called()
 
 
-def test_edge_identities_feature_states_list_calls_sync_identity_document_features_if_identity_have_deleted_feature(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_edge_identities_feature_states_list_calls_sync_identity_document_features_if_identity_have_deleted_feature(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     admin_client,
     environment,
     environment_api_key,
@@ -125,7 +125,7 @@ def test_edge_identities_feature_states_list_calls_sync_identity_document_featur
     sync_identity_document_features.delay.assert_called_once_with(args=(identity_uuid,))
 
 
-def test_edge_identities_feature_states_list_can_be_filtered_using_feature_id(  # type: ignore[no-untyped-def]
+def test_edge_identities_feature_states_list_can_be_filtered_using_feature_id(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     environment,
     environment_api_key,
@@ -155,7 +155,7 @@ def test_edge_identities_feature_states_list_can_be_filtered_using_feature_id(  
     assert response.json()[0]["feature"] == feature
 
 
-def test_edge_identities_feature_states_list_returns_404_if_identity_does_not_exists(  # type: ignore[no-untyped-def]
+def test_edge_identities_feature_states_list_returns_404_if_identity_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     environment,
     environment_api_key,
@@ -175,7 +175,7 @@ def test_edge_identities_feature_states_list_returns_404_if_identity_does_not_ex
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_edge_identities_featurestate_detail(  # type: ignore[no-untyped-def]
+def test_edge_identities_featurestate_detail(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     environment,
     environment_api_key,
@@ -203,7 +203,7 @@ def test_edge_identities_featurestate_detail(  # type: ignore[no-untyped-def]
     assert response.json()["featurestate_uuid"] == featurestate_uuid
 
 
-def test_edge_identities_featurestate_detail_calls_sync_identity_if_deleted_feature_exists(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_edge_identities_featurestate_detail_calls_sync_identity_if_deleted_feature_exists(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     admin_client,
     environment,
     environment_api_key,
@@ -251,7 +251,7 @@ def test_edge_identities_featurestate_detail_calls_sync_identity_if_deleted_feat
     sync_identity_document_features.delay.assert_called_once_with(args=(identity_uuid,))
 
 
-def test_edge_identities_featurestate_delete(  # type: ignore[no-untyped-def]
+def test_edge_identities_featurestate_delete(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2,
     admin_client,
     environment,
@@ -291,7 +291,7 @@ def test_edge_identities_featurestate_delete(  # type: ignore[no-untyped-def]
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_edge_identities_featurestate_delete_returns_404_if_featurestate_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_edge_identities_featurestate_delete_returns_404_if_featurestate_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     admin_client,
     environment,
     environment_api_key,
@@ -315,7 +315,7 @@ def test_edge_identities_featurestate_delete_returns_404_if_featurestate_does_no
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_edge_identities_create_featurestate_returns_400_if_feature_state_already_exists(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_edge_identities_create_featurestate_returns_400_if_feature_state_already_exists(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     admin_client,
     environment,
     environment_api_key,
@@ -353,7 +353,7 @@ def test_edge_identities_create_featurestate_returns_400_if_feature_state_alread
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_edge_identities_create_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_create_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     admin_client_new: APIClient,
     environment: int,
@@ -417,7 +417,7 @@ def test_edge_identities_create_featurestate(  # type: ignore[no-untyped-def]
     assert actual_feature_state["featurestate_uuid"] is not None
 
 
-def test_edge_identities_create_mv_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_create_mv_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2,
     admin_client,
     environment,
@@ -497,7 +497,7 @@ def test_edge_identities_create_mv_featurestate(  # type: ignore[no-untyped-def]
     assert actual_feature_state["featurestate_uuid"] is not None
 
 
-def test_edge_identities_update_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_update_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     admin_client: APIClient,
     environment: Environment,
@@ -561,7 +561,7 @@ def test_edge_identities_update_featurestate(  # type: ignore[no-untyped-def]
     )
 
 
-def test_edge_identities_patch_returns_405(  # type: ignore[no-untyped-def]
+def test_edge_identities_patch_returns_405(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     environment,
     environment_api_key,
@@ -586,7 +586,7 @@ def test_edge_identities_patch_returns_405(  # type: ignore[no-untyped-def]
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_edge_identities_update_mv_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_update_mv_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     admin_client: APIClient,
     environment: Environment,
@@ -675,7 +675,7 @@ def test_edge_identities_update_mv_featurestate(  # type: ignore[no-untyped-def]
     )
 
 
-def test_edge_identities_post_returns_400_for_invalid_mvfs_allocation(  # type: ignore[no-untyped-def]
+def test_edge_identities_post_returns_400_for_invalid_mvfs_allocation(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     project,
     environment,
@@ -729,7 +729,7 @@ def test_edge_identities_post_returns_400_for_invalid_mvfs_allocation(  # type: 
 @pytest.mark.parametrize(
     "lazy_feature", [(lazy_fixture("feature")), (lazy_fixture("feature_name"))]
 )
-def test_edge_identities_with_identifier_create_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_with_identifier_create_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2,
     admin_client,
     environment,
@@ -795,7 +795,7 @@ def test_edge_identities_with_identifier_create_featurestate(  # type: ignore[no
 @pytest.mark.parametrize(
     "lazy_feature", [(lazy_fixture("feature")), (lazy_fixture("feature_name"))]
 )
-def test_edge_identities_with_identifier_delete_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_with_identifier_delete_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2,
     admin_client,
     environment,
@@ -837,7 +837,7 @@ def test_edge_identities_with_identifier_delete_featurestate(  # type: ignore[no
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_edge_identities_with_identifier_update_featurestate(  # type: ignore[no-untyped-def]
+def test_edge_identities_with_identifier_update_featurestate(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     admin_client: APIClient,
     environment: Environment,
@@ -896,7 +896,7 @@ def test_edge_identities_with_identifier_update_featurestate(  # type: ignore[no
     )
 
 
-def test_put_identity_override_creates_identity_if_not_found(
+def test_put_identity_override_creates_identity_if_not_found(  # noqa: FT003
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     admin_client: APIClient,
     environment: int,
@@ -962,7 +962,7 @@ def test_put_identity_override_creates_identity_if_not_found(
         ("bool", True),
     ),
 )
-def test_get_all_feature_states_for_an_identity(  # type: ignore[no-untyped-def]
+def test_get_all_feature_states_for_an_identity(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client,
     environment,
     environment_api_key,
@@ -1118,7 +1118,7 @@ def _create_segment_override(  # type: ignore[no-untyped-def]
     assert create_segment_override_response.status_code == status.HTTP_201_CREATED
 
 
-def test_edge_identity_clone_flag_states_from(
+def test_edge_identity_clone_flag_states_from(  # noqa: FT003
     admin_client: APIClient,
     mocker: MockerFixture,
     dynamo_enabled_environment: int,

--- a/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
@@ -19,7 +19,7 @@ from environments.dynamodb.wrappers.identity_wrapper import (
 from environments.models import Environment
 
 
-def test_get_identities_returns_bad_request_if_dynamo_is_not_enabled(  # type: ignore[no-untyped-def]
+def test_get_identities_returns_bad_request_if_dynamo_is_not_enabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, environment, environment_api_key
 ):
     # Given
@@ -35,7 +35,7 @@ def test_get_identities_returns_bad_request_if_dynamo_is_not_enabled(  # type: i
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_get_identity(  # type: ignore[no-untyped-def]
+def test_get_identity(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -62,7 +62,7 @@ def test_get_identity(  # type: ignore[no-untyped-def]
     )
 
 
-def test_get_identity_returns_404_if_identity_does_not_exists(  # type: ignore[no-untyped-def]
+def test_get_identity_returns_404_if_identity_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -82,7 +82,7 @@ def test_get_identity_returns_404_if_identity_does_not_exists(  # type: ignore[n
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_create_identity(  # type: ignore[no-untyped-def]
+def test_create_identity(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -116,7 +116,7 @@ def test_create_identity(  # type: ignore[no-untyped-def]
     assert response.json()["identity_uuid"] is not None
 
 
-def test_create_identity_returns_400_if_identity_already_exists(  # type: ignore[no-untyped-def]
+def test_create_identity_returns_400_if_identity_already_exists(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -135,7 +135,7 @@ def test_create_identity_returns_400_if_identity_already_exists(  # type: ignore
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_delete_identity(
+def test_delete_identity(  # noqa: FT003
     admin_client: APIClient,
     dynamo_enabled_environment: int,
     environment_api_key: str,
@@ -171,7 +171,7 @@ def test_delete_identity(
     )
 
 
-def test_identity_list_pagination(  # type: ignore[no-untyped-def]
+def test_identity_list_pagination(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -220,7 +220,7 @@ def test_identity_list_pagination(  # type: ignore[no-untyped-def]
     assert response.json()["last_evaluated_key"] is None
 
 
-def test_get_identities_list(  # type: ignore[no-untyped-def]
+def test_get_identities_list(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -253,7 +253,7 @@ def test_get_identities_list(  # type: ignore[no-untyped-def]
     )
 
 
-def test_search_identities_without_exact_match(  # type: ignore[no-untyped-def]
+def test_search_identities_without_exact_match(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient,
     dynamo_enabled_environment: Environment,
     environment_api_key: str,
@@ -281,7 +281,7 @@ def test_search_identities_without_exact_match(  # type: ignore[no-untyped-def]
     assert response.json()["results"][0]["identifier"] == identifier
 
 
-def test_search_for_identities_with_exact_match(  # type: ignore[no-untyped-def]
+def test_search_for_identities_with_exact_match(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient,
     dynamo_enabled_environment: Environment,
     environment_api_key: str,
@@ -310,7 +310,7 @@ def test_search_for_identities_with_exact_match(  # type: ignore[no-untyped-def]
     assert response.json()["results"][0]["identifier"] == identifier
 
 
-def test_search_for_identities_by_dashboard_alias_prefix(
+def test_search_for_identities_by_dashboard_alias_prefix(  # noqa: FT003
     admin_client: APIClient,
     dynamo_enabled_environment: Environment,
     environment_api_key: str,
@@ -349,7 +349,7 @@ def test_search_for_identities_by_dashboard_alias_prefix(
     assert response.json()["results"][0]["identifier"] == identifier
 
 
-def test_search_for_identities_by_dashboard_alias_exact(
+def test_search_for_identities_by_dashboard_alias_exact(  # noqa: FT003
     admin_client: APIClient,
     dynamo_enabled_environment: Environment,
     environment_api_key: str,
@@ -382,7 +382,7 @@ def test_search_for_identities_by_dashboard_alias_exact(
     assert response.json()["results"][0]["identifier"] == identifier
 
 
-def test_search_for_identities_by_dashboard_alias_casts_search_to_lower(
+def test_search_for_identities_by_dashboard_alias_casts_search_to_lower(  # noqa: FT003
     admin_client: APIClient,
     dynamo_enabled_environment: Environment,
     environment_api_key: str,
@@ -415,7 +415,7 @@ def test_search_for_identities_by_dashboard_alias_casts_search_to_lower(
     assert response.json()["results"][0]["identifier"] == identifier
 
 
-def test_update_edge_identity(
+def test_update_edge_identity(  # noqa: FT003
     admin_client_new: APIClient,
     dynamo_enabled_environment: Environment,
     environment_api_key: str,
@@ -462,7 +462,7 @@ def test_update_edge_identity(
     } == identity_from_db
 
 
-def test_edge_identities_traits_list(  # type: ignore[no-untyped-def]
+def test_edge_identities_traits_list(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     environment_api_key,
     identity_document,
@@ -492,7 +492,7 @@ def test_edge_identities_traits_list(  # type: ignore[no-untyped-def]
     )
 
 
-def test_edge_identities_trait_delete(  # type: ignore[no-untyped-def]
+def test_edge_identities_trait_delete(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     environment_api_key,
     dynamo_enabled_environment,
@@ -535,7 +535,7 @@ def test_edge_identities_trait_delete(  # type: ignore[no-untyped-def]
     )
 
 
-def test_edge_identities_create_trait(  # type: ignore[no-untyped-def]
+def test_edge_identities_create_trait(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -577,7 +577,7 @@ def test_edge_identities_create_trait(  # type: ignore[no-untyped-def]
     )
 
 
-def test_edge_identities_update_trait(  # type: ignore[no-untyped-def]
+def test_edge_identities_update_trait(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -626,7 +626,7 @@ def test_edge_identities_update_trait(  # type: ignore[no-untyped-def]
     )
 
 
-def test_edge_identities_update_trait_with_same_value(  # type: ignore[no-untyped-def]
+def test_edge_identities_update_trait_with_same_value(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,
@@ -661,7 +661,7 @@ def test_edge_identities_update_trait_with_same_value(  # type: ignore[no-untype
     edge_identity_dynamo_wrapper_mock.put_item.assert_not_called()
 
 
-def test_edge_identities_update_traits_returns_400_if_persist_trait_data_is_false(  # type: ignore[no-untyped-def]
+def test_edge_identities_update_traits_returns_400_if_persist_trait_data_is_false(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     dynamo_enabled_environment,
     environment_api_key,

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -37,7 +37,7 @@ total_variance_percentage = (
     ),
 )
 @mock.patch("features.models.get_hashed_percentage_for_object_ids")
-def test_get_feature_states_for_identity(  # type: ignore[no-untyped-def]
+def test_get_feature_states_for_identity(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mock_get_hashed_percentage_value,
     hashed_percentage,
     expected_mv_value,
@@ -149,7 +149,7 @@ def test_get_feature_states_for_identity(  # type: ignore[no-untyped-def]
     assert values_dict[multivariate_feature_id] == variant_2_value
 
 
-def test_get_feature_states_for_identity_only_makes_one_query_to_get_mv_feature_states(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_feature_states_for_identity_only_makes_one_query_to_get_mv_feature_states(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     sdk_client,
     admin_client,
     project,
@@ -286,7 +286,7 @@ def transient_identifier(
         pytest.param({}, lazy_fixture("transient_identifier"), id="missing-identifier"),
     ],
 )
-def test_get_feature_states_for_identity__segment_match_expected(
+def test_get_feature_states_for_identity__segment_match_expected(  # noqa: FT003
     sdk_client: APIClient,
     feature: int,
     segment: int,
@@ -430,7 +430,7 @@ def test_get_feature_states_for_identity__transient_trait__segment_match_expecte
     assert flag_data["feature_state_value"] == "segment override"
 
 
-def test_get_feature_states_for_identity__transient_trait__existing_identity__return_expected(
+def test_get_feature_states_for_identity__transient_trait__existing_identity__return_expected(  # noqa: FT003
     sdk_client: APIClient,
     identity_identifier: str,
     identity: int,
@@ -481,7 +481,7 @@ def test_get_feature_states_for_identity__transient_trait__existing_identity__re
     ]
 
 
-def test_get_feature_states_for_identity__transient_identifier__empty_segment__return_expected(
+def test_get_feature_states_for_identity__transient_identifier__empty_segment__return_expected(  # noqa: FT003
     admin_client: APIClient,
     sdk_client: APIClient,
     default_feature_value: str,

--- a/api/tests/integration/environments/identities/test_integration_identities_feature_states.py
+++ b/api/tests/integration/environments/identities/test_integration_identities_feature_states.py
@@ -17,7 +17,7 @@ from core.constants import BOOLEAN, INTEGER, STRING
         ("bool", True),
     ),
 )
-def test_get_all_feature_states_for_an_identity(  # type: ignore[no-untyped-def]
+def test_get_all_feature_states_for_an_identity(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client,
     environment,
     environment_api_key,

--- a/api/tests/integration/environments/test_integration_environments.py
+++ b/api/tests/integration/environments/test_integration_environments.py
@@ -18,7 +18,7 @@ from tests.integration.helpers import (
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_clone_environment_clones_feature_states_with_value(  # type: ignore[no-untyped-def]
+def test_clone_environment_clones_feature_states_with_value(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     client: APIClient,
     project: int,
     environment: int,
@@ -88,7 +88,7 @@ def test_clone_environment_clones_feature_states_with_value(  # type: ignore[no-
     )
 
 
-def test_clone_environment_creates_admin_permission_with_the_current_user(  # type: ignore[no-untyped-def]
+def test_clone_environment_creates_admin_permission_with_the_current_user(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_user, admin_client, environment, environment_api_key
 ):
     # Firstly, let's create the clone of the environment
@@ -108,7 +108,7 @@ def test_clone_environment_creates_admin_permission_with_the_current_user(  # ty
     assert response.json()[0]["admin"] is True
 
 
-def test_env_clone_creates_feature_segment(  # type: ignore[no-untyped-def]
+def test_env_clone_creates_feature_segment(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client: APIClient,
     environment: int,
     environment_api_key: str,
@@ -136,7 +136,7 @@ def test_env_clone_creates_feature_segment(  # type: ignore[no-untyped-def]
     assert json_response["results"][0]["id"] != feature_segment
 
 
-def test_env_clone_clones_segments_overrides(  # type: ignore[no-untyped-def]
+def test_env_clone_clones_segments_overrides(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client, environment, environment_api_key, feature, feature_segment, segment
 ):
     # Firstly, let's override the segment in source environment
@@ -221,7 +221,7 @@ def test_env_clone_clones_segments_overrides(  # type: ignore[no-untyped-def]
     assert clone_feature_segment_id != source_feature_segment_id
 
 
-def test_get_environment_document_using_persistent_cache(
+def test_get_environment_document_using_persistent_cache(  # noqa: FT003
     persistent_environment_document_cache: MagicMock,
     environment: int,
     environment_api_key: str,

--- a/api/tests/integration/features/feature_health/test_views.py
+++ b/api/tests/integration/features/feature_health/test_views.py
@@ -86,7 +86,7 @@ def test_feature_health_providers__delete__expected_response(
     assert response.json() == []
 
 
-def test_feature_health_events__dismiss__unauthorized__expected_response(
+def test_feature_health_events__dismiss__unauthorized__expected_response(  # noqa: FT003
     project: int,
     unhealthy_feature_health_event: int,
     staff_client: APIClient,
@@ -164,7 +164,7 @@ def test_webhook__invalid_path__expected_response(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_webhook__sample_provider__post__expected_feature_health_event_created__expected_tag_added(
+def test_webhook__sample_provider__post__expected_feature_health_event_created__expected_tag_added(  # noqa: FT003
     feature: int,
     project: int,
     feature_name: str,
@@ -268,7 +268,7 @@ def test_webhook__sample_provider__post_with_environment_expected_feature_health
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_webhook__unhealthy_feature__post__expected_feature_health_event_created__expected_tag_removed(
+def test_webhook__unhealthy_feature__post__expected_feature_health_event_created__expected_tag_removed(  # noqa: FT003
     unhealthy_feature: int,
     project: int,
     feature_name: str,
@@ -330,7 +330,7 @@ def test_webhook__unhealthy_feature__post__expected_feature_health_event_created
 @pytest.mark.parametrize(
     "body", ["invalid", json.dumps({"status": "unhealthy", "feature": "non_existent"})]
 )
-def test_webhook__webhook_provider__post__invalid_payload__expected_response(
+def test_webhook__webhook_provider__post__invalid_payload__expected_response(  # noqa: FT003,FT004
     webhook_feature_health_provider_webhook_url: str,
     api_client: APIClient,
     body: str,
@@ -346,7 +346,7 @@ def test_webhook__webhook_provider__post__invalid_payload__expected_response(
     assert response.status_code == 400
 
 
-def test_webhook__grafana_provider__post__expected_feature_health_event_created(
+def test_webhook__grafana_provider__post__expected_feature_health_event_created(  # noqa: FT003
     project: int,
     feature: int,
     feature_name: str,
@@ -427,7 +427,7 @@ def test_webhook__grafana_provider__post__expected_feature_health_event_created(
     ]
 
 
-def test_webhook__grafana_provider__post__multiple__expected_feature_health_events(
+def test_webhook__grafana_provider__post__multiple__expected_feature_health_events(  # noqa: FT003
     project: int,
     environment: int,
     environment_name: str,

--- a/api/tests/integration/features/featurestate/test_environment_featurestate_viewset.py
+++ b/api/tests/integration/features/featurestate/test_environment_featurestate_viewset.py
@@ -10,7 +10,7 @@ from rest_framework import status
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_update_feature_state_value_updates_feature_state_value(  # type: ignore[no-untyped-def]
+def test_update_feature_state_value_updates_feature_state_value(  # type: ignore[no-untyped-def]  # noqa: FT003
     client, environment, environment_api_key, feature, feature_state
 ):
     # Given

--- a/api/tests/integration/features/featurestate/test_simple_featurestate_viewset.py
+++ b/api/tests/integration/features/featurestate/test_simple_featurestate_viewset.py
@@ -10,7 +10,7 @@ from rest_framework import status
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_create_feature_state_for_identity_override(  # type: ignore[no-untyped-def]
+def test_create_feature_state_for_identity_override(  # type: ignore[no-untyped-def]  # noqa: FT003
     client, environment, identity, feature
 ):
     # Given
@@ -36,7 +36,7 @@ def test_create_feature_state_for_identity_override(  # type: ignore[no-untyped-
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_create_feature_state_for_identity_with_identifier(  # type: ignore[no-untyped-def]
+def test_create_feature_state_for_identity_with_identifier(  # type: ignore[no-untyped-def]  # noqa: FT003
     client, environment, identity, feature, identity_identifier
 ):
     # Given
@@ -62,7 +62,7 @@ def test_create_feature_state_for_identity_with_identifier(  # type: ignore[no-u
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_list_feature_states_for_environment(client, environment, feature):  # type: ignore[no-untyped-def]
+def test_list_feature_states_for_environment(client, environment, feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     base_url = reverse("api-v1:features:featurestates-list")
     url = f"{base_url}?environment={environment}"
@@ -82,7 +82,7 @@ def test_list_feature_states_for_environment(client, environment, feature):  # t
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_update_feature_state(client, environment, feature_state, feature, identity):  # type: ignore[no-untyped-def]
+def test_update_feature_state(client, environment, feature_state, feature, identity):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
 
     url = reverse("api-v1:features:featurestates-detail", args=[feature_state])
@@ -107,7 +107,7 @@ def test_update_feature_state(client, environment, feature_state, feature, ident
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_update_feature_state_for_identity_with_identifier(  # type: ignore[no-untyped-def]
+def test_update_feature_state_for_identity_with_identifier(  # type: ignore[no-untyped-def]  # noqa: FT003
     client, environment, identity_featurestate, feature, identity, identity_identifier
 ):
     # Given

--- a/api/tests/integration/features/featurestate/test_webhooks.py
+++ b/api/tests/integration/features/featurestate/test_webhooks.py
@@ -64,7 +64,7 @@ def organisation_webhook(
 
 
 @responses.activate
-def test_update_segment_override__webhook_payload_has_correct_previous_and_new_values(
+def test_update_segment_override__webhook_payload_has_correct_previous_and_new_values(  # noqa: FT003
     admin_client: APIClient,
     environment: int,
     feature: int,
@@ -150,7 +150,7 @@ def test_update_segment_override__webhook_payload_has_correct_previous_and_new_v
     [lazy_fixture("environment_webhook"), lazy_fixture("organisation_webhook")],
 )
 @responses.activate
-def test_update_multivariate_percentage__webhook_payload_includes_multivariate_values(
+def test_update_multivariate_percentage__webhook_payload_includes_multivariate_values(  # noqa: FT003
     admin_client: APIClient,
     environment: int,
     feature: int,

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -16,7 +16,7 @@ from users.models import FFAdminUser
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  # type: ignore[no-untyped-def]
+def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:projects:feature-mv-options-list",
@@ -47,7 +47,7 @@ def test_can_create_mv_option(client, project, mv_option_50_percent, feature):  
         (lazy_fixture("admin_client"), "89809"),
     ],
 )
-def test_cannot_create_mv_option_when_feature_id_invalid(client, feature_id, project):  # type: ignore[no-untyped-def]
+def test_cannot_create_mv_option_when_feature_id_invalid(client, feature_id, project):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:projects:feature-mv-options-list",
@@ -70,7 +70,7 @@ def test_cannot_create_mv_option_when_feature_id_invalid(client, feature_id, pro
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_cannot_create_mv_option_when_user_is_not_owner_of_the_feature(project):  # type: ignore[no-untyped-def]
+def test_cannot_create_mv_option_when_user_is_not_owner_of_the_feature(project):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     new_user = FFAdminUser.objects.create(email="testuser@mail.com")
     organisation = Organisation.objects.create(name="Test Org")
@@ -106,7 +106,7 @@ def test_cannot_create_mv_option_when_user_is_not_owner_of_the_feature(project):
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_list_mv_option(project, mv_option_50_percent, client, feature):  # type: ignore[no-untyped-def]
+def test_can_list_mv_option(project, mv_option_50_percent, client, feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:projects:feature-mv-options-list",
@@ -127,7 +127,7 @@ def test_can_list_mv_option(project, mv_option_50_percent, client, feature):  # 
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_creating_mv_options_with_accumulated_total_gt_100_returns_400(  # type: ignore[no-untyped-def]
+def test_creating_mv_options_with_accumulated_total_gt_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project, mv_option_50_percent, client, feature
 ):
     url = reverse(
@@ -157,7 +157,7 @@ def test_creating_mv_options_with_accumulated_total_gt_100_returns_400(  # type:
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_update_default_percentage_allocation(  # type: ignore[no-untyped-def]
+def test_can_update_default_percentage_allocation(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project, mv_option_50_percent, client, feature
 ):
     url = reverse(
@@ -187,7 +187,7 @@ def test_can_update_default_percentage_allocation(  # type: ignore[no-untyped-de
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_updating_default_percentage_allocation_that_pushes_the_total_percentage_allocation_over_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_updating_default_percentage_allocation_that_pushes_the_total_percentage_allocation_over_100_returns_400(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     project, mv_option_50_percent, client, feature
 ):
     # First let's create another mv_option with 30 percent allocation
@@ -237,7 +237,7 @@ def test_updating_default_percentage_allocation_that_pushes_the_total_percentage
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_remove_mv_option(project, mv_option_50_percent, client, feature):  # type: ignore[no-untyped-def]
+def test_can_remove_mv_option(project, mv_option_50_percent, client, feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mv_option_url = reverse(
         "api-v1:projects:feature-mv-options-detail",
@@ -269,7 +269,7 @@ def test_can_remove_mv_option(project, mv_option_50_percent, client, feature):  
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_and_update_multivariate_feature_with_2_variations_50_percent(  # type: ignore[no-untyped-def]
+def test_create_and_update_multivariate_feature_with_2_variations_50_percent(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project, environment, environment_api_key, client, feature
 ):
     """
@@ -364,7 +364,7 @@ def test_create_and_update_multivariate_feature_with_2_variations_50_percent(  #
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_modify_weight_of_2_variations_in_single_request(  # type: ignore[no-untyped-def]
+def test_modify_weight_of_2_variations_in_single_request(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project, environment, environment_api_key, client, feature
 ):
     """

--- a/api/tests/integration/features/test_integration_features.py
+++ b/api/tests/integration/features/test_integration_features.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from rest_framework import status
 
 
-def test_search_features(admin_client, feature, project):  # type: ignore[no-untyped-def]
+def test_search_features(admin_client, feature, project):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # First get the features without searching
     feature_list_url = reverse("api-v1:projects:project-features-list", args=[project])
     response = admin_client.get(feature_list_url)
@@ -27,7 +27,7 @@ def test_search_features(admin_client, feature, project):  # type: ignore[no-unt
     assert invalid_search_response.json()["count"] == 0
 
 
-def test_sort_features(admin_client, project):  # type: ignore[no-untyped-def]
+def test_sort_features(admin_client, project):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # first, we need to create 2 features
     feature_1_data = {"name": "feature_a"}
     feature_2_data = {"name": "feature_b"}
@@ -74,7 +74,7 @@ def test_sort_features(admin_client, project):  # type: ignore[no-untyped-def]
     assert name_desc_response_json["results"][1]["id"] == feature_1_id
 
 
-def test_filter_features_by_tags(admin_client, project):  # type: ignore[no-untyped-def]
+def test_filter_features_by_tags(admin_client, project):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # first lets create some tags
     tag_labels = ("tag_1", "tag_2")
 
@@ -134,7 +134,7 @@ def test_filter_features_by_tags(admin_client, project):  # type: ignore[no-unty
     assert all_tags_features_response_json["count"] == 0
 
 
-def test_filter_features_by_archived_status(admin_client, project):  # type: ignore[no-untyped-def]
+def test_filter_features_by_archived_status(admin_client, project):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # First let's create 2 new features, one which is archived and one which isn't
     features_url = reverse("api-v1:projects:project-features-list", args=[project])
     create_archived_feature_response = admin_client.post(

--- a/api/tests/integration/features/versioning/test_integration_v2_versioning.py
+++ b/api/tests/integration/features/versioning/test_integration_v2_versioning.py
@@ -72,7 +72,7 @@ def environment_v2_versioning(
     return environment
 
 
-def test_v2_versioning(  # type: ignore[no-untyped-def]
+def test_v2_versioning(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client: "APIClient",
     environment: int,
     environment_api_key: str,
@@ -277,7 +277,7 @@ def test_v2_versioning(  # type: ignore[no-untyped-def]
     assert identity_flag_tuples_pre_revert == identity_flag_tuples_post_revert
 
 
-def test_v2_versioning_mv_feature(  # type: ignore[no-untyped-def]
+def test_v2_versioning_mv_feature(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client: "APIClient",
     environment_v2_versioning: int,
     environment_api_key: str,
@@ -385,7 +385,7 @@ def test_v2_versioning_mv_feature(  # type: ignore[no-untyped-def]
     assert mv_flag["feature_state_value"] == mv_feature_option_value
 
 
-def test_v2_versioning_multiple_segment_overrides(  # type: ignore[no-untyped-def]
+def test_v2_versioning_multiple_segment_overrides(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_client: "APIClient",
     environment_v2_versioning: int,
     environment_api_key: str,
@@ -555,7 +555,7 @@ def test_v2_versioning_multiple_segment_overrides(  # type: ignore[no-untyped-de
     )
 
 
-def test_v2_versioning_carries_existing_segment_overrides_across(
+def test_v2_versioning_carries_existing_segment_overrides_across(  # noqa: FT003,FT004
     environment: int,
     environment_api_key: str,
     admin_client: "APIClient",
@@ -614,7 +614,7 @@ def test_v2_versioning_carries_existing_segment_overrides_across(
     )
 
 
-def test_identities_should_return_default_environment_values_after_deleting_segment_override(
+def test_identities_should_return_default_environment_values_after_deleting_segment_override(  # noqa: FT003
     feature: int,
     default_feature_value: str,
     segment_featurestate: int,

--- a/api/tests/integration/projects/test_integration_projects.py
+++ b/api/tests/integration/projects/test_integration_projects.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from rest_framework import status
 
 
-def test_get_all_user_permissions(project, admin_user, admin_client):  # type: ignore[no-untyped-def]
+def test_get_all_user_permissions(project, admin_user, admin_client):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     """Basic integration test to verify that endpoint works"""
     url = reverse("api-v1:projects:all-user-permissions", args=(project, admin_user.id))
     response = admin_client.get(url)

--- a/api/tests/integration/sales_dashboard/test_integration_sales_dashboard.py
+++ b/api/tests/integration/sales_dashboard/test_integration_sales_dashboard.py
@@ -5,7 +5,7 @@ from environments.dynamodb.migrator import IdentityMigrator
 from organisations.models import Organisation
 
 
-def test_sales_dashboard_index(  # type: ignore[no-untyped-def]
+def test_sales_dashboard_index(  # type: ignore[no-untyped-def]  # noqa: FT003
     superuser_authenticated_client, django_assert_num_queries
 ):
     """
@@ -27,7 +27,7 @@ def test_sales_dashboard_index(  # type: ignore[no-untyped-def]
     assert response.status_code == 200
 
 
-def test_migrate_identities_to_edge_calls_identity_migrator_with_correct_arguments_if_migration_is_not_done(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_migrate_identities_to_edge_calls_identity_migrator_with_correct_arguments_if_migration_is_not_done(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     superuser_authenticated_client, mocker, project, settings
 ):
     # Given
@@ -49,7 +49,7 @@ def test_migrate_identities_to_edge_calls_identity_migrator_with_correct_argumen
     mocked_identity_migrator.return_value.trigger_migration.assert_called_once_with()
 
 
-def test_migrate_identities_to_edge_does_not_call_migrate_if_migration_is_already_done(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_migrate_identities_to_edge_does_not_call_migrate_if_migration_is_already_done(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     superuser_authenticated_client, mocker, project, settings
 ):
     # Given
@@ -71,7 +71,7 @@ def test_migrate_identities_to_edge_does_not_call_migrate_if_migration_is_alread
     mocked_identity_migrator.return_value.trigger_migration.assert_not_called()
 
 
-def test_migrate_identities_to_edge_returns_400_if_dynamodb_is_not_enabled(  # type: ignore[no-untyped-def]
+def test_migrate_identities_to_edge_returns_400_if_dynamodb_is_not_enabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     superuser_authenticated_client, mocker, project, settings
 ):
     # Given
@@ -85,7 +85,7 @@ def test_migrate_identities_to_edge_returns_400_if_dynamodb_is_not_enabled(  # t
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_migrate_identities_to_edge_calls_send_migration_event_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_migrate_identities_to_edge_calls_send_migration_event_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     superuser_authenticated_client, mocker, project, settings, identity
 ):
     # Given

--- a/api/tests/integration/slack/test_slack_environment_viewset.py
+++ b/api/tests/integration/slack/test_slack_environment_viewset.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from integrations.slack.exceptions import SlackChannelJoinError
 
 
-def test_posting_env_config_return_400_when_slack_project_config_does_not_exist(  # type: ignore[no-untyped-def]
+def test_posting_env_config_return_400_when_slack_project_config_does_not_exist(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, environment, environment_api_key
 ):
     # Given
@@ -25,7 +25,7 @@ def test_posting_env_config_return_400_when_slack_project_config_does_not_exist(
     assert "Slack api token not found" in response.json()[0]
 
 
-def test_posting_env_config_calls_join_channel(  # type: ignore[no-untyped-def]
+def test_posting_env_config_calls_join_channel(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     admin_client,
     environment,
@@ -57,7 +57,7 @@ def test_posting_env_config_calls_join_channel(  # type: ignore[no-untyped-def]
     assert response.json()["channel_id"] == env_config["channel_id"]
 
 
-def test_update_environment_config_calls_join_channel(  # type: ignore[no-untyped-def]
+def test_update_environment_config_calls_join_channel(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     admin_client,
     environment,
@@ -92,7 +92,7 @@ def test_update_environment_config_calls_join_channel(  # type: ignore[no-untype
     assert response.json()["channel_id"] == env_config["channel_id"]
 
 
-def test_update_environment_config_returns_400_if_join_channel_raises_slack_channel_join_error(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_update_environment_config_returns_400_if_join_channel_raises_slack_channel_join_error(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker,
     admin_client,
     environment,
@@ -128,7 +128,7 @@ def test_update_environment_config_returns_400_if_join_channel_raises_slack_chan
     assert response.json()[0] == slack_error_code
 
 
-def test_get_environment_config_list_returns_200(  # type: ignore[no-untyped-def]
+def test_get_environment_config_list_returns_200(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, environment, environment_api_key, slack_environment_config
 ):
     # Given
@@ -145,7 +145,7 @@ def test_get_environment_config_list_returns_200(  # type: ignore[no-untyped-def
     assert response.json()[0]["id"] == slack_environment_config
 
 
-def test_get_environment_config_returns_200(  # type: ignore[no-untyped-def]
+def test_get_environment_config_returns_200(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, environment, environment_api_key, slack_environment_config
 ):
     # Given

--- a/api/tests/integration/slack/test_slack_get_channels.py
+++ b/api/tests/integration/slack/test_slack_get_channels.py
@@ -7,7 +7,7 @@ from rest_framework.test import APIClient
 from environments.models import Environment
 
 
-def test_get_channels_fails_if_user_has_no_permission(
+def test_get_channels_fails_if_user_has_no_permission(  # noqa: FT003
     staff_client: APIClient, environment: Environment, environment_api_key: str
 ) -> None:
     # Given
@@ -23,7 +23,7 @@ def test_get_channels_fails_if_user_has_no_permission(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_get_channels_returns_400_when_slack_project_config_does_not_exist(  # type: ignore[no-untyped-def]
+def test_get_channels_returns_400_when_slack_project_config_does_not_exist(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, environment, environment_api_key
 ):
     # Given
@@ -43,7 +43,7 @@ def test_get_channels_returns_400_when_slack_project_config_does_not_exist(  # t
     )
 
 
-def test_get_channels_pagination(  # type: ignore[no-untyped-def]
+def test_get_channels_pagination(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker,
     admin_client,
     environment_api_key,
@@ -85,7 +85,7 @@ def test_get_channels_pagination(  # type: ignore[no-untyped-def]
     mocked_slack_wrapper.assert_called_with(api_token=slack_bot_token)
 
 
-def test_get_channels_response_structure(  # type: ignore[no-untyped-def]
+def test_get_channels_response_structure(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     admin_client,
     environment_api_key,

--- a/api/tests/integration/slack/test_slack_token_flow.py
+++ b/api/tests/integration/slack/test_slack_token_flow.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from rest_framework import status
 
 
-def test_slack_oauth_flow_returns_401_if_secret_is_invalid(  # type: ignore[no-untyped-def]
+def test_slack_oauth_flow_returns_401_if_secret_is_invalid(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment_api_key, api_client
 ):
     # Given
@@ -18,7 +18,7 @@ def test_slack_oauth_flow_returns_401_if_secret_is_invalid(  # type: ignore[no-u
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_slack_oauth_flow(  # type: ignore[no-untyped-def]
+def test_slack_oauth_flow(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, settings, api_client, admin_client, environment_api_key, environment
 ):
     # Given
@@ -64,7 +64,7 @@ def test_slack_oauth_flow(  # type: ignore[no-untyped-def]
     mocked_get_bot_token.assert_called_with(code, callback_url)
 
 
-def test_slack_oauth_callback_returns_400_if_redirect_url_is_not_found_in_session(  # type: ignore[no-untyped-def]
+def test_slack_oauth_callback_returns_400_if_redirect_url_is_not_found_in_session(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, django_client, environment, environment_api_key, slack_bot_token
 ):
     url = reverse(
@@ -82,7 +82,7 @@ def test_slack_oauth_callback_returns_400_if_redirect_url_is_not_found_in_sessio
     assert response.json()["detail"] == "Redirect URL not found in request session"
 
 
-def test_slack_oauth_init_returns_401_for_user_that_does_not_have_access_to_the_environment(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_slack_oauth_init_returns_401_for_user_that_does_not_have_access_to_the_environment(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     environment, environment_api_key, settings, django_user_model, api_client
 ):
     # Given

--- a/api/tests/integration/test_api_documentation.py
+++ b/api/tests/integration/test_api_documentation.py
@@ -1,7 +1,7 @@
 from django.test import Client
 
 
-def test_api_documentation_specification_loads(
+def test_api_documentation_specification_loads(  # noqa: FT003,FT004
     client: Client,
 ) -> None:
     # When

--- a/api/tests/integration/test_integration_api_version_header.py
+++ b/api/tests/integration/test_integration_api_version_header.py
@@ -26,7 +26,7 @@ def clear_lru_caches() -> None:
         ("", "unknown"),
     ],
 )
-def test_api_version_is_added_to_success_response_headers(
+def test_api_version_is_added_to_success_response_headers(  # noqa: FT003,FT004
     admin_client: APIClient,
     expected_version: str,
     fs: FakeFilesystem,
@@ -48,7 +48,7 @@ def test_api_version_is_added_to_success_response_headers(
         ("", "unknown"),
     ],
 )
-def test_api_version_is_added_to_error_response_headers(
+def test_api_version_is_added_to_error_response_headers(  # noqa: FT003,FT004
     client: APIClient,
     expected_version: str,
     fs: FakeFilesystem,

--- a/api/tests/integration/users/test_init_config.py
+++ b/api/tests/integration/users/test_init_config.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from users.models import FFAdminUser
 
 
-def test_returns_404_when_user_exists(admin_user, django_client):  # type: ignore[no-untyped-def]
+def test_returns_404_when_user_exists(admin_user, django_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:users:config-init")
 
@@ -20,7 +20,7 @@ def test_returns_404_when_user_exists(admin_user, django_client):  # type: ignor
 
 
 @pytest.mark.django_db()
-def test_returns_200_when_no_user_exists(django_client):  # type: ignore[no-untyped-def]
+def test_returns_200_when_no_user_exists(django_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:users:config-init")
 
@@ -31,7 +31,7 @@ def test_returns_200_when_no_user_exists(django_client):  # type: ignore[no-unty
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_valid_request_creates_admin_and_updates_site(db, django_client):  # type: ignore[no-untyped-def]
+def test_valid_request_creates_admin_and_updates_site(db, django_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:users:config-init")
     form_data = {
@@ -51,7 +51,7 @@ def test_valid_request_creates_admin_and_updates_site(db, django_client):  # typ
     assert Site.objects.filter(name=form_data.get("site_name")).count() == 1
 
 
-def test_invalid_form_does_not_change_anything(db, django_client):  # type: ignore[no-untyped-def]
+def test_invalid_form_does_not_change_anything(db, django_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:users:config-init")
     form_data = {

--- a/api/tests/unit/api/test_mcp_openapi.py
+++ b/api/tests/unit/api/test_mcp_openapi.py
@@ -7,7 +7,7 @@ from api.openapi import MCPSchemaGenerator, SchemaGenerator
 from api.openapi_views import CustomSpectacularJSONAPIView, CustomSpectacularYAMLAPIView
 
 
-def test_mcp_filter_paths__includes_operations_with_mcp_tag() -> None:
+def test_mcp_filter_paths__includes_operations_with_mcp_tag() -> None:  # noqa: FT003
     # Given
     paths: dict[str, Any] = {
         "/api/v1/organisations/": {
@@ -28,7 +28,7 @@ def test_mcp_filter_paths__includes_operations_with_mcp_tag() -> None:
     assert "get" in filtered["/api/v1/organisations/"]
 
 
-def test_mcp_filter_paths__excludes_operations_without_mcp_tag() -> None:
+def test_mcp_filter_paths__excludes_operations_without_mcp_tag() -> None:  # noqa: FT003
     # Given
     paths: dict[str, Any] = {
         "/api/v1/users/": {
@@ -48,7 +48,7 @@ def test_mcp_filter_paths__excludes_operations_without_mcp_tag() -> None:
     assert "/api/v1/users/" not in filtered
 
 
-def test_mcp_filter_paths__mixed_operations() -> None:
+def test_mcp_filter_paths__mixed_operations() -> None:  # noqa: FT003
     # Given
     paths: dict[str, Any] = {
         "/api/v1/organisations/{id}/": {
@@ -80,7 +80,7 @@ def test_mcp_filter_paths__mixed_operations() -> None:
     ]
 
 
-def test_mcp_transform_for_mcp__preserves_x_gram_extension() -> None:
+def test_mcp_transform_for_mcp__preserves_x_gram_extension() -> None:  # noqa: FT003
     # Given
     operation: dict[str, Any] = {
         "operationId": "organisations_list",
@@ -105,7 +105,7 @@ def test_mcp_transform_for_mcp__preserves_x_gram_extension() -> None:
     assert transformed["description"] == "Original description"
 
 
-def test_mcp_transform_for_mcp__preserves_original_when_no_extensions() -> None:
+def test_mcp_transform_for_mcp__preserves_original_when_no_extensions() -> None:  # noqa: FT003
     # Given
     operation: dict[str, Any] = {
         "operationId": "organisations_list",
@@ -122,7 +122,7 @@ def test_mcp_transform_for_mcp__preserves_original_when_no_extensions() -> None:
     assert transformed["description"] == "Original description"
 
 
-def test_mcp_transform_for_mcp__removes_operation_level_security() -> None:
+def test_mcp_transform_for_mcp__removes_operation_level_security() -> None:  # noqa: FT003
     # Given
     operation: dict[str, Any] = {
         "operationId": "organisations_list",
@@ -139,7 +139,7 @@ def test_mcp_transform_for_mcp__removes_operation_level_security() -> None:
     assert "security" not in transformed
 
 
-def test_mcp_update_security_for_mcp__sets_api_key_security_scheme() -> None:
+def test_mcp_update_security_for_mcp__sets_api_key_security_scheme() -> None:  # noqa: FT003
     # Given
     schema: dict[str, Any] = {
         "components": {
@@ -164,7 +164,7 @@ def test_mcp_update_security_for_mcp__sets_api_key_security_scheme() -> None:
     "view_class",
     [CustomSpectacularJSONAPIView, CustomSpectacularYAMLAPIView],
 )
-def test_custom_view__returns_mcp_generator_when_mcp_param_is_true(
+def test_custom_view__returns_mcp_generator_when_mcp_param_is_true(  # noqa: FT003
     view_class: type,
 ) -> None:
     # Given
@@ -183,7 +183,7 @@ def test_custom_view__returns_mcp_generator_when_mcp_param_is_true(
     "view_class",
     [CustomSpectacularJSONAPIView, CustomSpectacularYAMLAPIView],
 )
-def test_custom_view__returns_schema_generator_when_mcp_param_is_false(
+def test_custom_view__returns_schema_generator_when_mcp_param_is_false(  # noqa: FT003
     view_class: type,
 ) -> None:
     # Given
@@ -202,7 +202,7 @@ def test_custom_view__returns_schema_generator_when_mcp_param_is_false(
     "view_class",
     [CustomSpectacularJSONAPIView, CustomSpectacularYAMLAPIView],
 )
-def test_custom_view__returns_schema_generator_when_no_mcp_param(
+def test_custom_view__returns_schema_generator_when_no_mcp_param(  # noqa: FT003
     view_class: type,
 ) -> None:
     # Given
@@ -221,7 +221,7 @@ def test_custom_view__returns_schema_generator_when_no_mcp_param(
     "view_class",
     [CustomSpectacularJSONAPIView, CustomSpectacularYAMLAPIView],
 )
-def test_custom_view__case_insensitive_mcp_param(view_class: type) -> None:
+def test_custom_view__case_insensitive_mcp_param(view_class: type) -> None:  # noqa: FT003
     # Given
     view = view_class()
     view.request = MagicMock()
@@ -234,7 +234,7 @@ def test_custom_view__case_insensitive_mcp_param(view_class: type) -> None:
     assert generator_class is MCPSchemaGenerator
 
 
-def test_mcp_schema__includes_expected_endpoints_and_excludes_others() -> None:
+def test_mcp_schema__includes_expected_endpoints_and_excludes_others() -> None:  # noqa: FT003
     # Given
     generator = MCPSchemaGenerator()
 
@@ -259,7 +259,7 @@ def test_mcp_schema__includes_expected_endpoints_and_excludes_others() -> None:
     assert "/api/v1/users/" not in paths
 
 
-def test_mcp_schema__includes_https_server() -> None:
+def test_mcp_schema__includes_https_server() -> None:  # noqa: FT003
     # Given
     generator = MCPSchemaGenerator()
 
@@ -270,7 +270,7 @@ def test_mcp_schema__includes_https_server() -> None:
     assert schema["servers"] == [{"url": "https://api.flagsmith.com"}]
 
 
-def test_mcp_schema__includes_token_auth_security() -> None:
+def test_mcp_schema__includes_token_auth_security() -> None:  # noqa: FT003
     # Given
     generator = MCPSchemaGenerator()
 

--- a/api/tests/unit/api/test_unit_api.py
+++ b/api/tests/unit/api/test_unit_api.py
@@ -17,6 +17,6 @@ from rest_framework.test import APIClient
     "client",
     (lazy_fixture("api_client"), lazy_fixture("admin_client")),
 )
-def test_swagger_docs_generation(url: str, client: APIClient) -> None:
+def test_swagger_docs_generation(url: str, client: APIClient) -> None:  # noqa: FT003,FT004
     response = client.get(url)
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/api/test_unit_openapi.py
+++ b/api/tests/unit/api/test_unit_openapi.py
@@ -5,7 +5,7 @@ from typing_extensions import TypedDict
 from api.openapi import TypedDictSchemaExtension
 
 
-def test_typeddict_schema_extension__renders_expected() -> None:
+def test_typeddict_schema_extension__renders_expected() -> None:  # noqa: FT003
     # Given
     class Nested(TypedDict):
         usual_str: str
@@ -44,7 +44,7 @@ def test_typeddict_schema_extension__renders_expected() -> None:
     }
 
 
-def test_typeddict_schema_extension__registers_nested_components() -> None:
+def test_typeddict_schema_extension__registers_nested_components() -> None:  # noqa: FT003
     # Given
     class Nested(TypedDict):
         usual_str: str
@@ -86,7 +86,7 @@ def test_typeddict_schema_extension__registers_nested_components() -> None:
     }
 
 
-def test_typeddict_schema_extension__get_name() -> None:
+def test_typeddict_schema_extension__get_name() -> None:  # noqa: FT003
     # Given
     class MyModel(TypedDict):
         field: str

--- a/api/tests/unit/api_keys/test_authentication.py
+++ b/api/tests/unit/api_keys/test_authentication.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from api_keys.authentication import MasterAPIKeyAuthentication
 
 
-def test_authenticate_returns_api_key_user_for_valid_key(master_api_key, rf):  # type: ignore[no-untyped-def]
+def test_authenticate_returns_api_key_user_for_valid_key(master_api_key, rf):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     master_api_key, key = master_api_key
     request = rf.get("/some-endpoint", HTTP_AUTHORIZATION="Api-Key " + key)
@@ -17,7 +17,7 @@ def test_authenticate_returns_api_key_user_for_valid_key(master_api_key, rf):  #
     assert user.key == master_api_key
 
 
-def test_authenticate_returns_none_if_no_key_provider(rf):  # type: ignore[no-untyped-def]
+def test_authenticate_returns_none_if_no_key_provider(rf):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     request = rf.get("/some-endpoint")
 
@@ -25,7 +25,7 @@ def test_authenticate_returns_none_if_no_key_provider(rf):  # type: ignore[no-un
     assert MasterAPIKeyAuthentication().authenticate(request) is None  # type: ignore[no-untyped-call]
 
 
-def test_authenticate_raises_error_for_expired_key(rf, master_api_key):  # type: ignore[no-untyped-def]
+def test_authenticate_raises_error_for_expired_key(rf, master_api_key):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     master_api_key, key = master_api_key
 
@@ -40,7 +40,7 @@ def test_authenticate_raises_error_for_expired_key(rf, master_api_key):  # type:
     # Then - exception was raised
 
 
-def test_authenticate_raises_error_for_invalid_key(rf, db):  # type: ignore[no-untyped-def]
+def test_authenticate_raises_error_for_invalid_key(rf, db):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     request = rf.get("/some-endpoint", HTTP_AUTHORIZATION="Api-Key something_random")
 
@@ -51,7 +51,7 @@ def test_authenticate_raises_error_for_invalid_key(rf, db):  # type: ignore[no-u
     # Then - exception was raised
 
 
-def test_authenticate_raises_error_for_revoked_key(rf, master_api_key):  # type: ignore[no-untyped-def]
+def test_authenticate_raises_error_for_revoked_key(rf, master_api_key):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     master_api_key, key = master_api_key
 

--- a/api/tests/unit/api_keys/test_user.py
+++ b/api/tests/unit/api_keys/test_user.py
@@ -9,7 +9,7 @@ from organisations.permissions.models import OrganisationPermissionModel
 from projects.models import ProjectPermissionModel
 
 
-def test_is_authenticated(master_api_key_object):  # type: ignore[no-untyped-def]
+def test_is_authenticated(master_api_key_object):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     user = APIKeyUser(master_api_key_object)
 
@@ -17,7 +17,7 @@ def test_is_authenticated(master_api_key_object):  # type: ignore[no-untyped-def
     assert user.is_authenticated is True
 
 
-def test__str__returns_name(master_api_key_object):  # type: ignore[no-untyped-def]
+def test__str__returns_name(master_api_key_object):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     user = APIKeyUser(master_api_key_object)
 
@@ -35,7 +35,7 @@ def test__str__returns_name(master_api_key_object):  # type: ignore[no-untyped-d
         (lazy_fixture("organisation_two"), False),
     ],
 )
-def test_belongs_to(for_organisation, expected_result, master_api_key_object):  # type: ignore[no-untyped-def]
+def test_belongs_to(for_organisation, expected_result, master_api_key_object):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     user = APIKeyUser(master_api_key_object)
 
@@ -60,7 +60,7 @@ def test_belongs_to(for_organisation, expected_result, master_api_key_object):  
         ),
     ],
 )
-def test_is_project_admin(  # type: ignore[no-untyped-def]
+def test_is_project_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_project,
     for_master_api_key,
     expected_is_admin,
@@ -95,7 +95,7 @@ def test_is_project_admin(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_is_environment_admin(  # type: ignore[no-untyped-def]
+def test_is_environment_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_environment,
     for_master_api_key,
     expected_is_admin,
@@ -125,7 +125,7 @@ def test_is_environment_admin(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_has_project_permission(  # type: ignore[no-untyped-def]
+def test_has_project_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     for_project, for_master_api_key, expected_has_permission
 ):
     # Given
@@ -163,7 +163,7 @@ def test_has_project_permission(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_has_environment_permission(  # type: ignore[no-untyped-def]
+def test_has_environment_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     for_environment, for_master_api_key, expected_has_permission
 ):
     # Given
@@ -201,7 +201,7 @@ def test_has_environment_permission(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_has_organisation_permission(  # type: ignore[no-untyped-def]
+def test_has_organisation_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     for_organisation, for_master_api_key, expected_has_permission
 ):
     # Given
@@ -238,7 +238,7 @@ def test_has_organisation_permission(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_get_permitted_projects(for_project, for_master_api_key, expected_project):  # type: ignore[no-untyped-def]
+def test_get_permitted_projects(for_project, for_master_api_key, expected_project):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     user = APIKeyUser(for_master_api_key)
 
@@ -277,7 +277,7 @@ def test_get_permitted_projects(for_project, for_master_api_key, expected_projec
         ),
     ],
 )
-def test_get_permitted_environments(  # type: ignore[no-untyped-def]
+def test_get_permitted_environments(  # type: ignore[no-untyped-def]  # noqa: FT003
     for_project,
     for_master_api_key,
     expected_environment,
@@ -301,7 +301,7 @@ def test_get_permitted_environments(  # type: ignore[no-untyped-def]
             assert environments.first() == expected_environment
 
 
-def test_is_organisation_admin_for_admin_key(
+def test_is_organisation_admin_for_admin_key(  # noqa: FT003,FT004
     admin_master_api_key_object: MasterAPIKey,
     organisation: Organisation,
     organisation_two: Organisation,
@@ -319,7 +319,7 @@ def test_is_organisation_admin_for_admin_key(
     assert user.is_organisation_admin(organisation_two.id) is False
 
 
-def test_is_organisation_admin_for_non_admin_key(
+def test_is_organisation_admin_for_non_admin_key(  # noqa: FT003,FT004
     master_api_key_object: MasterAPIKey,
     organisation: Organisation,
     organisation_two: Organisation,
@@ -335,7 +335,7 @@ def test_is_organisation_admin_for_non_admin_key(
     assert user.is_organisation_admin(organisation_two.id) is False
 
 
-def test_organisation_property(  # type: ignore[no-untyped-def]
+def test_organisation_property(  # type: ignore[no-untyped-def]  # noqa: FT003
     master_api_key_object: MasterAPIKey,
     organisation: Organisation,
 ):
@@ -350,7 +350,7 @@ def test_organisation_property(  # type: ignore[no-untyped-def]
     assert organisations.first().id == organisation.id  # type: ignore[union-attr]
 
 
-def test_get_organisation_role_for_admin_key(
+def test_get_organisation_role_for_admin_key(  # noqa: FT003
     admin_master_api_key_object: MasterAPIKey,
     organisation: Organisation,
     organisation_two: Organisation,
@@ -366,7 +366,7 @@ def test_get_organisation_role_for_admin_key(
     assert user.get_organisation_role(organisation_two) is None
 
 
-def test_get_organisation_role_for_non_admin_key(
+def test_get_organisation_role_for_non_admin_key(  # noqa: FT003
     master_api_key_object: MasterAPIKey,
     organisation: Organisation,
     organisation_two: Organisation,

--- a/api/tests/unit/app/test_unit_app_routers.py
+++ b/api/tests/unit/app/test_unit_app_routers.py
@@ -11,7 +11,7 @@ from app import routers
         ("another_app", None),
     ],
 )
-def test_AnalyticsRouter_db_for_read__returns_analytics_db_for_analytics_models(
+def test_AnalyticsRouter_db_for_read__returns_analytics_db_for_analytics_models(  # noqa: FT003
     given_app_label: str,
     expected_db: str | None,
 ) -> None:
@@ -36,7 +36,7 @@ def test_AnalyticsRouter_db_for_read__returns_analytics_db_for_analytics_models(
         ("another_app", None),
     ],
 )
-def test_AnalyticsRouter_db_for_write__returns_analytics_db_for_analytics_models(
+def test_AnalyticsRouter_db_for_write__returns_analytics_db_for_analytics_models(  # noqa: FT003
     model_app_label: str,
     expected_db: str | None,
 ) -> None:
@@ -61,7 +61,7 @@ def test_AnalyticsRouter_db_for_write__returns_analytics_db_for_analytics_models
         ("app_analytics", "another_app", None),
     ],
 )
-def test_AnalyticsRouter_allow_relation__allows_relations_between_analytics_models(
+def test_AnalyticsRouter_allow_relation__allows_relations_between_analytics_models(  # noqa: FT003
     model1_app_label: str,
     model2_app_label: str,
     expected: bool | None,
@@ -93,7 +93,7 @@ def test_AnalyticsRouter_allow_relation__allows_relations_between_analytics_mode
         ("analytics", "another_app", False),
     ],
 )
-def test_AnalyticsRouter_allow_migrate__allows_migrations_on_analytics_db(
+def test_AnalyticsRouter_allow_migrate__allows_migrations_on_analytics_db(  # noqa: FT003
     db_name: str,
     app_label: str,
     expected: bool | None,

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -3,7 +3,7 @@ import pytest
 from app.utils import get_numbered_env_vars_with_prefix
 
 
-def test_get_numbered_env_vars_with_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_numbered_env_vars_with_prefix(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: FT003
     # Given
     monkeypatch.setenv("DB_URL_0", "0")
     monkeypatch.setenv("DB_URL_1", "1")

--- a/api/tests/unit/app_analytics/test_analytics_db_service.py
+++ b/api/tests/unit/app_analytics/test_analytics_db_service.py
@@ -45,7 +45,7 @@ def cache(organisation: Organisation) -> OrganisationSubscriptionInformationCach
 
 
 @pytest.mark.use_analytics_db
-def test_get_usage_data_from_local_db(organisation, environment, settings):  # type: ignore[no-untyped-def]
+def test_get_usage_data_from_local_db(organisation, environment, settings):  # type: ignore[no-untyped-def]  # noqa: FT003
     environment_id = environment.id
     now = timezone.now()
     read_bucket_size = 15
@@ -102,7 +102,7 @@ def test_get_usage_data_from_local_db(organisation, environment, settings):  # t
 
 
 @pytest.mark.use_analytics_db
-def test_get_usage_data_from_local_db_project_id_filter(  # type: ignore[no-untyped-def]
+def test_get_usage_data_from_local_db_project_id_filter(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation: Organisation,
     project: Project,
     project_two: Project,
@@ -267,7 +267,7 @@ def test_get_usage_data_from_local_db__labels_filter__returns_expected(
 
 
 @pytest.mark.use_analytics_db
-def test_get_total_events_count(organisation, environment, settings):  # type: ignore[no-untyped-def]
+def test_get_total_events_count(organisation, environment, settings):  # type: ignore[no-untyped-def]  # noqa: FT003
     settings.USE_POSTGRES_FOR_ANALYTICS = True
     environment_id = environment.id
     now = timezone.now()
@@ -318,7 +318,7 @@ def test_get_total_events_count(organisation, environment, settings):  # type: i
 
 
 @pytest.mark.use_analytics_db
-def test_get_feature_evaluation_data_from_local_db(
+def test_get_feature_evaluation_data_from_local_db(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     settings: SettingsWrapper,
@@ -454,7 +454,7 @@ def test_get_feature_evaluation_data_from_local_db__labels_filter__returns_expec
     ]
 
 
-def test_get_usage_data_calls_get_usage_data_from_influxdb_if_postgres_not_configured(
+def test_get_usage_data_calls_get_usage_data_from_influxdb_if_postgres_not_configured(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     organisation: Organisation,
@@ -481,7 +481,7 @@ def test_get_usage_data_calls_get_usage_data_from_influxdb_if_postgres_not_confi
     )
 
 
-def test_get_usage_data_calls_get_usage_data_from_local_db_if_postgres_is_configured(
+def test_get_usage_data_calls_get_usage_data_from_local_db_if_postgres_is_configured(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     organisation: Organisation,
@@ -534,7 +534,7 @@ def test_get_usage_data__no_analytics_configured__no_calls_expected(
     mocked_get_usage_data_from_local_db.assert_not_called()
 
 
-def test_get_total_events_count_calls_influx_method_if_postgres_not_configured(  # type: ignore[no-untyped-def]
+def test_get_total_events_count_calls_influx_method_if_postgres_not_configured(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, settings, organisation
 ):
     # Given
@@ -553,7 +553,7 @@ def test_get_total_events_count_calls_influx_method_if_postgres_not_configured( 
     )
 
 
-def test_get_feature_evaluation_data_calls_influx_method_if_postgres_not_configured(
+def test_get_feature_evaluation_data_calls_influx_method_if_postgres_not_configured(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     organisation: Organisation,
@@ -612,7 +612,7 @@ def test_get_feature_evaluation_data__no_analytics_configured__no_calls_expected
     mocked_get_feature_evaluation_data_from_local_db.assert_not_called()
 
 
-def test_get_feature_evaluation_data_calls_get_feature_evaluation_data_from_local_db_if_configured(
+def test_get_feature_evaluation_data_calls_get_feature_evaluation_data_from_local_db_if_configured(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     feature: Feature,
@@ -643,7 +643,7 @@ def test_get_feature_evaluation_data_calls_get_feature_evaluation_data_from_loca
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @pytest.mark.parametrize("period", [PREVIOUS_BILLING_PERIOD, CURRENT_BILLING_PERIOD])
-def test_get_usage_data_returns_404_when_organisation_has_no_billing_periods(
+def test_get_usage_data_returns_404_when_organisation_has_no_billing_periods(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     organisation: Organisation,
@@ -665,7 +665,7 @@ def test_get_usage_data_returns_404_when_organisation_has_no_billing_periods(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_usage_data_calls_get_usage_data_from_local_db_with_set_period_starts_at_with_current_billing_period(
+def test_get_usage_data_calls_get_usage_data_from_local_db_with_set_period_starts_at_with_current_billing_period(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     organisation: Organisation,
@@ -694,7 +694,7 @@ def test_get_usage_data_calls_get_usage_data_from_local_db_with_set_period_start
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_usage_data_calls_get_usage_data_from_local_db_with_set_period_starts_at_with_previous_billing_period(
+def test_get_usage_data_calls_get_usage_data_from_local_db_with_set_period_starts_at_with_previous_billing_period(  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
     organisation: Organisation,

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -17,7 +17,7 @@ from tests.types import EnableFeaturesFixture
         ("/api/v1/environment-document", "environment-document"),
     ],
 )
-def test_api_usage_middleware__calls_expected(
+def test_api_usage_middleware__calls_expected(  # noqa: FT003
     rf: RequestFactory,
     mocker: MockerFixture,
     path: str,

--- a/api/tests/unit/app_analytics/test_migrate_to_pg.py
+++ b/api/tests/unit/app_analytics/test_migrate_to_pg.py
@@ -7,7 +7,7 @@ from app_analytics.models import FeatureEvaluationBucket
 
 
 @pytest.mark.use_analytics_db
-def test_migrate_feature_evaluations(mocker: MockerFixture) -> None:
+def test_migrate_feature_evaluations(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     feature_name = "test_feature_one"
     environment_id = "1"

--- a/api/tests/unit/app_analytics/test_models.py
+++ b/api/tests/unit/app_analytics/test_models.py
@@ -11,7 +11,7 @@ from app_analytics.models import (
 pytestmark = pytest.mark.use_analytics_db
 
 
-def test_creating_overlapping_api_usage_bucket_raises_error(db):  # type: ignore[no-untyped-def]
+def test_creating_overlapping_api_usage_bucket_raises_error(db):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     created_at = timezone.now()
     bucket_size = 15
@@ -39,7 +39,7 @@ def test_creating_overlapping_api_usage_bucket_raises_error(db):  # type: ignore
         )
 
 
-def test_creating_overlapping_feature_evaluation_bucket_raises_error(db):  # type: ignore[no-untyped-def]
+def test_creating_overlapping_feature_evaluation_bucket_raises_error(db):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     created_at = timezone.now()
     bucket_size = 15

--- a/api/tests/unit/app_analytics/test_tasks.py
+++ b/api/tests/unit/app_analytics/test_tasks.py
@@ -41,7 +41,7 @@ def _create_api_usage_event(environment_id: int, when: datetime) -> APIUsageRaw:
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @pytest.mark.use_analytics_db
-def test_populate_api_usage_bucket_multiple_runs(
+def test_populate_api_usage_bucket_multiple_runs(  # noqa: FT003,FT004
     freezer: FrozenDateTimeFactory,
 ) -> None:
     # Given
@@ -114,7 +114,7 @@ def test_populate_api_usage_bucket_multiple_runs(
 )
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @pytest.mark.use_analytics_db
-def test_populate_api_usage_bucket(
+def test_populate_api_usage_bucket(  # noqa: FT003
     freezer: FrozenDateTimeFactory,
     bucket_size: int,
     runs_every: int,
@@ -206,7 +206,7 @@ def test_track_request__influx__calls_expected(
 
 
 @pytest.mark.use_analytics_db
-def test_track_feature_evaluation(settings: SettingsWrapper) -> None:
+def test_track_feature_evaluation(settings: SettingsWrapper) -> None:  # noqa: FT003
     # Given
     settings.USE_POSTGRES_FOR_ANALYTICS = True
     environment_id = 1
@@ -288,7 +288,7 @@ def test_track_feature_evaluation__influx__calls_expected(
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @pytest.mark.use_analytics_db
-def test_populate_feature_evaluation_bucket_15m(freezer: FrozenDateTimeFactory) -> None:
+def test_populate_feature_evaluation_bucket_15m(freezer: FrozenDateTimeFactory) -> None:  # noqa: FT003,FT004
     # Given
     environment_id = 1
     bucket_size = 15
@@ -380,7 +380,7 @@ def test_populate_feature_evaluation_bucket_15m(freezer: FrozenDateTimeFactory) 
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
 @pytest.mark.use_analytics_db
-def test_populate_feature_evaluation_bucket__upserts_buckets(
+def test_populate_feature_evaluation_bucket__upserts_buckets(  # noqa: FT003
     freezer: FrozenDateTimeFactory,
 ) -> None:
     # Given
@@ -466,7 +466,7 @@ def test_populate_feature_evaluation_bucket__source_bucket_size__returns_expecte
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
 @pytest.mark.use_analytics_db
-def test_populate_api_usage_bucket__upserts_buckets(
+def test_populate_api_usage_bucket__upserts_buckets(  # noqa: FT003
     freezer: FrozenDateTimeFactory,
 ) -> None:
     # Given
@@ -502,7 +502,7 @@ def test_populate_api_usage_bucket__upserts_buckets(
 
 @pytest.mark.freeze_time("2023-01-19T09:00:00+00:00")
 @pytest.mark.use_analytics_db
-def test_populate_api_usage_bucket_using_a_bucket(
+def test_populate_api_usage_bucket_using_a_bucket(  # noqa: FT003
     freezer: FrozenDateTimeFactory,
 ) -> None:
     # Given
@@ -549,7 +549,7 @@ def _create_feature_evaluation_event(
 
 
 @pytest.mark.use_analytics_db
-def test_clean_up_old_analytics_data_does_nothing_if_no_data() -> None:
+def test_clean_up_old_analytics_data_does_nothing_if_no_data() -> None:  # noqa: FT003,FT004
     # When
     clean_up_old_analytics_data()
 
@@ -558,7 +558,7 @@ def test_clean_up_old_analytics_data_does_nothing_if_no_data() -> None:
 
 
 @pytest.mark.use_analytics_db
-def test_clean_up_old_analytics_data_removes_old_data(
+def test_clean_up_old_analytics_data_removes_old_data(  # noqa: FT003
     settings: SettingsWrapper,
 ) -> None:
     # Given

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
@@ -8,7 +8,7 @@ from app_analytics.models import Resource
 from app_analytics.types import TrackFeatureEvaluationsByEnvironmentData
 
 
-def test_api_usage_cache(
+def test_api_usage_cache(  # noqa: FT003,FT004
     mocker: MockerFixture,
     settings: SettingsWrapper,
 ) -> None:
@@ -95,7 +95,7 @@ def test_api_usage_cache(
         assert not mocked_track_request_task.called
 
 
-def test_feature_evaluation_cache(
+def test_feature_evaluation_cache(  # noqa: FT003,FT004
     mocker: MockerFixture,
     settings: SettingsWrapper,
 ) -> None:

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -55,7 +55,7 @@ def mock_write_api(mock_influxdb_client: MagicMock) -> MagicMock:
     return mock_write_api
 
 
-def test_write(mock_write_api: MagicMock) -> None:
+def test_write(mock_write_api: MagicMock) -> None:  # noqa: FT003
     # Given
     influxdb = InfluxDBWrapper("name")  # type: ignore[no-untyped-call]
     influxdb.add_data_point("field_name", "field_value")
@@ -68,7 +68,7 @@ def test_write(mock_write_api: MagicMock) -> None:
 
 
 @pytest.mark.parametrize("exception_class", [HTTPError, InfluxDBError, ApiException])
-def test_write_handles_errors(
+def test_write_handles_errors(  # noqa: FT003
     mock_write_api: MagicMock,
     exception_class: Type[Exception],
     caplog: pytest.LogCaptureFixture,
@@ -113,7 +113,7 @@ def test_influx_db_wrapper_query__http_error__logs_expected(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_influx_db_query_when_get_events_then_query_api_called(monkeypatch):  # type: ignore[no-untyped-def]
+def test_influx_db_query_when_get_events_then_query_api_called(monkeypatch):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     expected_query = (
         (
             f'from(bucket:"{read_bucket}") |> range(start: 2022-12-20T09:09:47.325132+00:00, '
@@ -148,7 +148,7 @@ def test_influx_db_query_when_get_events_then_query_api_called(monkeypatch):  # 
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_influx_db_query_when_get_events_list_then_query_api_called(
+def test_influx_db_query_when_get_events_list_then_query_api_called(  # noqa: FT003,FT004
     mocker: MockerFixture,
 ) -> None:
     query = (
@@ -214,7 +214,7 @@ def test_influx_db_query_when_get_events_list_then_query_api_called(
     ),
 )
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_multiple_event_list_for_organisation__calls_expected(
+def test_get_multiple_event_list_for_organisation__calls_expected(  # noqa: FT003,FT004
     mocker: MockerFixture,
     project_id: int | None,
     environment_id: int | None,
@@ -253,7 +253,7 @@ def test_get_multiple_event_list_for_organisation__calls_expected(
     ]
 
 
-def test_get_multiple_event_list_for_organisation__returns_expected(
+def test_get_multiple_event_list_for_organisation__returns_expected(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -365,7 +365,7 @@ def test_get_multiple_event_list_for_organisation__labels_filter__calls_expected
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_multiple_event_list_for_feature__calls_expected(
+def test_get_multiple_event_list_for_feature__calls_expected(  # noqa: FT003,FT004
     mocker: MockerFixture,
 ) -> None:
     query = (
@@ -432,7 +432,7 @@ def test_get_multiple_event_list_for_feature__labels_filter__calls_expected(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_usage_data__calls_expected(mocker: MockerFixture) -> None:
+def test_get_usage_data__calls_expected(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     mocked_get_multiple_event_list_for_organisation = mocker.patch(
         "app_analytics.influxdb_wrapper.get_multiple_event_list_for_organisation",
@@ -456,7 +456,7 @@ def test_get_usage_data__calls_expected(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_feature_evaluation_data__calls_expected(mocker: MockerFixture) -> None:
+def test_get_feature_evaluation_data__calls_expected(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     mocked_get_multiple_event_list_for_feature = mocker.patch(
         "app_analytics.influxdb_wrapper.get_multiple_event_list_for_feature",
@@ -480,7 +480,7 @@ def test_get_feature_evaluation_data__calls_expected(mocker: MockerFixture) -> N
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_event_list_for_organisation_with_date_stop_set_to_now_and_previously(
+def test_get_event_list_for_organisation_with_date_stop_set_to_now_and_previously(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
 ) -> None:
@@ -527,7 +527,7 @@ def test_get_event_list_for_organisation_with_date_stop_set_to_now_and_previousl
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @pytest.mark.parametrize("limit", ["10", ""])
-def test_get_top_organisations(
+def test_get_top_organisations(  # noqa: FT003
     limit: str,
     mocker: MockerFixture,
 ) -> None:
@@ -564,7 +564,7 @@ def test_get_top_organisations(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_top_organisations_value_error(
+def test_get_top_organisations_value_error(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -596,7 +596,7 @@ def test_get_top_organisations_value_error(
     assert dataset == {456: 43}
 
 
-def test_early_return_for_empty_range_for_influx_query_manager() -> None:
+def test_early_return_for_empty_range_for_influx_query_manager() -> None:  # noqa: FT003,FT004
     # When
     now = timezone.now()
     results = InfluxDBWrapper.influx_query_manager(
@@ -608,7 +608,7 @@ def test_early_return_for_empty_range_for_influx_query_manager() -> None:
     assert results == []
 
 
-def test_get_range_bucket_mappings_when_less_than_10_days(
+def test_get_range_bucket_mappings_when_less_than_10_days(  # noqa: FT003
     settings: SettingsWrapper,
 ) -> None:
     # Given
@@ -621,7 +621,7 @@ def test_get_range_bucket_mappings_when_less_than_10_days(
     assert result == settings.INFLUXDB_BUCKET + "_downsampled_15m"
 
 
-def test_get_range_bucket_mappings_when_more_than_10_days(
+def test_get_range_bucket_mappings_when_more_than_10_days(  # noqa: FT003
     settings: SettingsWrapper,
 ) -> None:
     # Given
@@ -634,7 +634,7 @@ def test_get_range_bucket_mappings_when_more_than_10_days(
     assert result == settings.INFLUXDB_BUCKET + "_downsampled_1h"
 
 
-def test_influx_query_manager_when_date_start_is_set_to_none(
+def test_influx_query_manager_when_date_start_is_set_to_none(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -648,7 +648,7 @@ def test_influx_query_manager_when_date_start_is_set_to_none(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_top_organisation_when_date_start_is_set_to_none(
+def test_get_top_organisation_when_date_start_is_set_to_none(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -667,7 +667,7 @@ def test_get_top_organisation_when_date_start_is_set_to_none(
     assert influx_query_call.kwargs["date_start"] == date_start
 
 
-def test_get_current_api_usage(mocker: MockerFixture) -> None:
+def test_get_current_api_usage(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     influx_mock = mocker.patch(
         "app_analytics.influxdb_wrapper.InfluxDBWrapper.influx_query_manager"

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_mappers.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_mappers.py
@@ -11,7 +11,7 @@ from app_analytics.mappers import (
 )
 
 
-def test_map_flux_tables_to_feature_evaluation_data__returns_expected() -> None:
+def test_map_flux_tables_to_feature_evaluation_data__returns_expected() -> None:  # noqa: FT003
     # Given
     flux_table = FluxTable()
     flux_table.records.append(
@@ -40,7 +40,7 @@ def test_map_flux_tables_to_feature_evaluation_data__returns_expected() -> None:
     ]
 
 
-def test_map_flux_tables_to_usage_data__returns_expected() -> None:
+def test_map_flux_tables_to_usage_data__returns_expected() -> None:  # noqa: FT003
     # Given
     flux_table = FluxTable()
     flux_table.records.append(
@@ -94,7 +94,7 @@ def test_map_flux_tables_to_usage_data__returns_expected() -> None:
         ({"user_agent": "not-a-number"}, {}),
     ],
 )
-def test_map_influx_record_values_to_labels(
+def test_map_influx_record_values_to_labels(  # noqa: FT003
     values: dict[str, str],
     expected: dict[str, str],
 ) -> None:

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
@@ -24,7 +24,7 @@ from app_analytics.types import TrackFeatureEvaluationsByEnvironmentData
 )
 @mock.patch("app_analytics.track.requests")
 @mock.patch("app_analytics.track.Environment")
-def test_track_request_googleanalytics(  # type: ignore[no-untyped-def]
+def test_track_request_googleanalytics(  # type: ignore[no-untyped-def]  # noqa: FT003
     MockEnvironment, mock_requests, request_uri, expected_ga_requests
 ):
     """
@@ -56,7 +56,7 @@ def test_track_request_googleanalytics(  # type: ignore[no-untyped-def]
         (Resource.ENVIRONMENT_DOCUMENT, "environment-document"),
     ),
 )
-def test_track_request_sends_data_to_influxdb_for_tracked_uris(  # type: ignore[no-untyped-def]
+def test_track_request_sends_data_to_influxdb_for_tracked_uris(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
     expected_resource: Resource,
     expected_influxdb_tag: str,
@@ -87,7 +87,7 @@ def test_track_request_sends_data_to_influxdb_for_tracked_uris(  # type: ignore[
     )
 
 
-def test_track_request_sends_host_data_to_influxdb(
+def test_track_request_sends_host_data_to_influxdb(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     """
@@ -113,7 +113,7 @@ def test_track_request_sends_host_data_to_influxdb(
     )
 
 
-def test_track_feature_evaluation_influxdb(mocker: MockerFixture) -> None:
+def test_track_feature_evaluation_influxdb(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     influx_db_wrapper_class_mock = mocker.patch("app_analytics.track.InfluxDBWrapper")
     influx_db_wrapper_mock = influx_db_wrapper_class_mock.return_value

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -102,7 +102,7 @@ def test_sdk_analytics_flags_v1__boolean_count__is_skipped(
     mocked_feature_eval_cache.track_feature_evaluation.assert_not_called()
 
 
-def test_sdk_analytics_ignores_bad_data(
+def test_sdk_analytics_ignores_bad_data(  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
     feature: Feature,
@@ -135,7 +135,7 @@ def test_sdk_analytics_ignores_bad_data(
     )
 
 
-def test_get_usage_data(mocker, admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_get_usage_data(mocker, admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:organisations:usage-data", args=[organisation.id])
 
@@ -175,7 +175,7 @@ def test_get_usage_data(mocker, admin_client, organisation):  # type: ignore[no-
 
 
 @pytest.mark.freeze_time("2024-04-30T09:09:47.325132+00:00")
-def test_get_usage_data__current_billing_period(
+def test_get_usage_data__current_billing_period(  # noqa: FT003
     settings: SettingsWrapper,
     mocker: MockerFixture,
     admin_client_new: APIClient,
@@ -250,7 +250,7 @@ def test_get_usage_data__current_billing_period(
 
 
 @pytest.mark.freeze_time("2024-04-30T09:09:47.325132+00:00")
-def test_get_usage_data__previous_billing_period(
+def test_get_usage_data__previous_billing_period(  # noqa: FT003
     mocker: MockerFixture,
     admin_client_new: APIClient,
     organisation: Organisation,
@@ -318,7 +318,7 @@ def test_get_usage_data__previous_billing_period(
 
 
 @pytest.mark.freeze_time("2024-04-30T09:09:47.325132+00:00")
-def test_get_usage_data__90_day_period(
+def test_get_usage_data__90_day_period(  # noqa: FT003
     settings: SettingsWrapper,
     mocker: MockerFixture,
     admin_client_new: APIClient,
@@ -435,7 +435,7 @@ def test_get_usage_data__labels_filter__returns_expected(
     )
 
 
-def test_get_usage_data_for_non_admin_user_returns_403(
+def test_get_usage_data_for_non_admin_user_returns_403(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -449,7 +449,7 @@ def test_get_usage_data_for_non_admin_user_returns_403(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_get_total_usage_count(mocker, admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_get_total_usage_count(mocker, admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:organisations:usage-data-total-count",
@@ -470,7 +470,7 @@ def test_get_total_usage_count(mocker, admin_client, organisation):  # type: ign
     mocked_get_total_events_count.assert_called_once_with(organisation)
 
 
-def test_get_total_usage_count_for_non_admin_user_returns_403(
+def test_get_total_usage_count_for_non_admin_user_returns_403(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -487,7 +487,7 @@ def test_get_total_usage_count_for_non_admin_user_returns_403(
 
 
 @pytest.mark.use_analytics_db
-def test_set_sdk_analytics_flags_with_identifier(
+def test_set_sdk_analytics_flags_with_identifier(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     feature: Feature,
@@ -528,7 +528,7 @@ def test_set_sdk_analytics_flags_with_identifier(
 
 
 @pytest.mark.use_analytics_db
-def test_set_sdk_analytics_flags_without_identifier(
+def test_set_sdk_analytics_flags_without_identifier(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     feature: Feature,
@@ -665,7 +665,7 @@ def test_set_sdk_analytics_flags_with_identifier__influx__calls_expected(
         ),
     ],
 )
-def test_sdk_analytics_flags_v1(
+def test_sdk_analytics_flags_v1(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/audit/test_unit_audit_models.py
+++ b/api/tests/unit/audit/test_unit_audit_models.py
@@ -12,7 +12,7 @@ from projects.models import Project
 from webhooks.webhooks import WebhookEventType
 
 
-def test_organisation_webhooks_are_called_when_audit_log_saved(
+def test_organisation_webhooks_are_called_when_audit_log_saved(  # noqa: FT003
     project: Project, mocker: MockerFixture, organisation: Organisation
 ) -> None:
     # Given
@@ -40,7 +40,7 @@ def test_organisation_webhooks_are_called_when_audit_log_saved(
     )
 
 
-def test_data_dog_track_event_not_called_on_audit_log_saved_when_not_configured(  # type: ignore[no-untyped-def]
+def test_data_dog_track_event_not_called_on_audit_log_saved_when_not_configured(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, mocker
 ):
     # Given Audit log and project not configured for Datadog
@@ -56,7 +56,7 @@ def test_data_dog_track_event_not_called_on_audit_log_saved_when_not_configured(
     datadog_mock.track_event_async.assert_not_called()
 
 
-def test_data_dog_track_event_not_called_on_audit_log_saved_when_wrong(mocker, project):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_data_dog_track_event_not_called_on_audit_log_saved_when_wrong(mocker, project):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given Audit log and project configured for Datadog integration
     datadog_mock = mocker.patch(
         "integrations.datadog.datadog.DataDogWrapper.track_event_async"
@@ -85,7 +85,7 @@ def test_data_dog_track_event_not_called_on_audit_log_saved_when_wrong(mocker, p
     "use_custom_source, expected_additional_data",
     [(False, {}), (True, {"source_type_name": "flagsmith"})],
 )
-def test_data_dog_track_event_called_on_audit_log_saved_when_correct_type(
+def test_data_dog_track_event_called_on_audit_log_saved_when_correct_type(  # noqa: FT003
     project: Project,
     mocker: MockerFixture,
     use_custom_source: bool,
@@ -158,7 +158,7 @@ def test_data_dog_track_event_called_on_audit_log_saved_when_correct_type(
     ]
 
 
-def test_audit_log_get_history_record_model_class(mocker):  # type: ignore[no-untyped-def]
+def test_audit_log_get_history_record_model_class(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     module_name = "module"
 
@@ -186,7 +186,7 @@ def test_audit_log_get_history_record_model_class(mocker):  # type: ignore[no-un
     assert klass == DummyHistoricalRecordModel  # type: ignore[comparison-overlap]
 
 
-def test_audit_log_history_record(mocker):  # type: ignore[no-untyped-def]
+def test_audit_log_history_record(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     module_name = "app.models"
     model_class_name = "MyModel"
@@ -217,7 +217,7 @@ def test_audit_log_history_record(mocker):  # type: ignore[no-untyped-def]
     )
 
 
-def test_audit_log_history_record_for_audit_log_record_with_no_history_record(mocker):  # type: ignore[no-untyped-def]
+def test_audit_log_history_record_for_audit_log_record_with_no_history_record(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     audit_log = AuditLog()
 
@@ -228,7 +228,7 @@ def test_audit_log_history_record_for_audit_log_record_with_no_history_record(mo
     assert record is None
 
 
-def test_audit_log_save_project_is_added_if_not_set(environment):  # type: ignore[no-untyped-def]
+def test_audit_log_save_project_is_added_if_not_set(environment):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     audit_log = AuditLog(environment=environment)
 
@@ -239,7 +239,7 @@ def test_audit_log_save_project_is_added_if_not_set(environment):  # type: ignor
     assert audit_log.project == environment.project
 
 
-def test_creating_audit_logs_creates_process_environment_update_task(  # type: ignore[no-untyped-def]
+def test_creating_audit_logs_creates_process_environment_update_task(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, mocker
 ):
     # Given
@@ -258,7 +258,7 @@ def test_creating_audit_logs_creates_process_environment_update_task(  # type: i
     assert environment.updated_at == audit_log.created_date
 
 
-def test_creating_audit_logs_for_change_request_does_not_trigger_process_environment_update(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_creating_audit_logs_for_change_request_does_not_trigger_process_environment_update(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment, mocker, project
 ):
     # Given
@@ -278,7 +278,7 @@ def test_creating_audit_logs_for_change_request_does_not_trigger_process_environ
 
 
 @pytest.mark.django_db
-def test_audit_log__organisation__empty_instance__return_expected() -> None:
+def test_audit_log__organisation__empty_instance__return_expected() -> None:  # noqa: FT003
     # Given
     audit_log = AuditLog.objects.create()
 

--- a/api/tests/unit/audit/test_unit_audit_permissions.py
+++ b/api/tests/unit/audit/test_unit_audit_permissions.py
@@ -11,7 +11,7 @@ from projects.models import Project
 from users.models import FFAdminUser
 
 
-def test_organisation_audit_log_permission_has_permission_organisation_admin(  # type: ignore[no-untyped-def]
+def test_organisation_audit_log_permission_has_permission_organisation_admin(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation: Organisation, admin_user: FFAdminUser, mocker: MockerFixture
 ):
     # Given
@@ -29,7 +29,7 @@ def test_organisation_audit_log_permission_has_permission_organisation_admin(  #
     assert result is True
 
 
-def test_organisation_audit_log_permission_has_permission_organisation_user_without_permission(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_organisation_audit_log_permission_has_permission_organisation_user_without_permission(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     organisation_one: Organisation,
     mocker: MockerFixture,
     organisation_one_user: FFAdminUser,
@@ -50,7 +50,7 @@ def test_organisation_audit_log_permission_has_permission_organisation_user_with
     assert result is False
 
 
-def test_project_audit_log_permission_has_permission_project_admin(  # type: ignore[no-untyped-def]
+def test_project_audit_log_permission_has_permission_project_admin(  # type: ignore[no-untyped-def]  # noqa: FT003
     project: Project, project_admin_user: FFAdminUser, mocker: MockerFixture
 ):
     # Given
@@ -68,7 +68,7 @@ def test_project_audit_log_permission_has_permission_project_admin(  # type: ign
     assert result is True
 
 
-def test_project_audit_log_permission_has_permission_project_user_with_permission(  # type: ignore[no-untyped-def]
+def test_project_audit_log_permission_has_permission_project_user_with_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     project: Project, mocker: MockerFixture, view_audit_log_user: FFAdminUser
 ):
     # Given
@@ -86,7 +86,7 @@ def test_project_audit_log_permission_has_permission_project_user_with_permissio
     assert result is True
 
 
-def test_project_audit_log_permission_has_permission_project_user_without_permission(  # type: ignore[no-untyped-def]
+def test_project_audit_log_permission_has_permission_project_user_without_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     project: Project, mocker: MockerFixture, project_user: FFAdminUser
 ):
     # Given

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -32,7 +32,7 @@ from users.models import FFAdminUser
 from webhooks.webhooks import WebhookEventType
 
 
-def test_call_webhooks_does_not_create_task_if_webhooks_disabled(
+def test_call_webhooks_does_not_create_task_if_webhooks_disabled(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     settings: SettingsWrapper,
@@ -53,7 +53,7 @@ def test_call_webhooks_does_not_create_task_if_webhooks_disabled(
     mocked_call_organisation_webhooks.delay.assert_not_called()
 
 
-def test_call_webhooks_does_not_create_task_if_organisation_has_no_webhooks(
+def test_call_webhooks_does_not_create_task_if_organisation_has_no_webhooks(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     settings: SettingsWrapper,
@@ -76,7 +76,7 @@ def test_call_webhooks_does_not_create_task_if_organisation_has_no_webhooks(
     mocked_call_organisation_webhooks.delay.assert_not_called()
 
 
-def test_call_webhooks_creates_task_if_organisation_has_webhooks(
+def test_call_webhooks_creates_task_if_organisation_has_webhooks(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     settings: SettingsWrapper,
@@ -172,7 +172,7 @@ def test_send_audit_log_event_to_grafana__organisation_grafana_config__calls_exp
     )
 
 
-def test_send_audit_log_event_to_grafana__organisation_grafana_config__deleted__doesnt_call(
+def test_send_audit_log_event_to_grafana__organisation_grafana_config__deleted__doesnt_call(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     project: Project,
@@ -199,7 +199,7 @@ def test_send_audit_log_event_to_grafana__organisation_grafana_config__deleted__
 
 
 @responses.activate
-def test_send_environment_feature_version_audit_log_event_to_grafana(
+def test_send_environment_feature_version_audit_log_event_to_grafana(  # noqa: FT003
     tagged_feature: Feature,
     tag_one: Tag,
     tag_two: Tag,
@@ -291,7 +291,7 @@ def test_send_audit_log_event_to_dynatrace__environment_dynatrace_config__calls_
 
 
 @responses.activate
-def test_send_environment_feature_version_audit_log_event_to_dynatrace(
+def test_send_environment_feature_version_audit_log_event_to_dynatrace(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     project: Project,

--- a/api/tests/unit/audit/test_unit_audit_tasks.py
+++ b/api/tests/unit/audit/test_unit_audit_tasks.py
@@ -27,7 +27,7 @@ from segments.models import Segment
 from users.models import FFAdminUser
 
 
-def test_create_audit_log_from_historical_record_does_nothing_if_no_user_or_api_key(  # type: ignore[no-untyped-def]
+def test_create_audit_log_from_historical_record_does_nothing_if_no_user_or_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     monkeypatch,
 ):
@@ -65,7 +65,7 @@ def test_create_audit_log_from_historical_record_does_nothing_if_no_user_or_api_
     mocked_audit_log_model_class.objects.create.assert_not_called()
 
 
-def test_create_audit_log_from_historical_record_does_nothing_if_no_log_message(  # type: ignore[no-untyped-def]
+def test_create_audit_log_from_historical_record_does_nothing_if_no_log_message(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     monkeypatch,
 ):
@@ -112,7 +112,7 @@ def test_create_audit_log_from_historical_record_does_nothing_if_no_log_message(
     mocked_audit_log_model_class.objects.create.assert_not_called()
 
 
-def test_create_audit_log_from_historical_record_does_nothing_if_get_skip_create_audit_log_true(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_audit_log_from_historical_record_does_nothing_if_get_skip_create_audit_log_true(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker,
     monkeypatch,
 ):
@@ -155,7 +155,7 @@ def test_create_audit_log_from_historical_record_does_nothing_if_get_skip_create
     mocked_audit_log_model_class.objects.create.assert_not_called()
 
 
-def test_create_audit_log_from_historical_record_creates_audit_log_with_correct_fields(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_audit_log_from_historical_record_creates_audit_log_with_correct_fields(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker,
     monkeypatch,
 ):
@@ -263,7 +263,7 @@ def test_create_audit_log_from_historical_record__cascade_deleted_feature_segmen
     assert get_update_log_message.spy_return is None
 
 
-def test_create_segment_priorities_changed_audit_log(
+def test_create_segment_priorities_changed_audit_log(  # noqa: FT003
     admin_user: FFAdminUser,
     feature_segment: FeatureSegment,
     feature: Feature,
@@ -298,7 +298,7 @@ def test_create_segment_priorities_changed_audit_log(
     ).exists()
 
 
-def test_create_segment_priorities_changed_audit_log_does_not_create_audit_log_for_versioned_feature_segments(
+def test_create_segment_priorities_changed_audit_log_does_not_create_audit_log_for_versioned_feature_segments(  # noqa: FT003
     admin_user: FFAdminUser,
     feature_segment: FeatureSegment,
     feature: Feature,
@@ -348,7 +348,7 @@ def test_create_segment_priorities_changed_audit_log_does_not_create_audit_log_f
     ).exists()
 
 
-def test_create_feature_state_went_live_audit_log(
+def test_create_feature_state_went_live_audit_log(  # noqa: FT003
     change_request_feature_state: FeatureState,
 ) -> None:
     # Given
@@ -534,7 +534,7 @@ def test_create_feature_state_went_live_audit_log__rescheduled_feature_update__s
         )
 
 
-def test_create_feature_state_updated_by_change_request_audit_log(
+def test_create_feature_state_updated_by_change_request_audit_log(  # noqa: FT003
     change_request_feature_state: FeatureState,
 ) -> None:
     # Given
@@ -559,7 +559,7 @@ def test_create_feature_state_updated_by_change_request_audit_log(
     )
 
 
-def test_create_feature_state_updated_by_change_request_audit_log_does_nothing_if_feature_state_deleted(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_feature_state_updated_by_change_request_audit_log_does_nothing_if_feature_state_deleted(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     change_request_feature_state,
 ):
     # Given
@@ -578,7 +578,7 @@ def test_create_feature_state_updated_by_change_request_audit_log_does_nothing_i
     )
 
 
-def test_create_feature_state_wen_live_audit_log_does_nothing_if_feature_state_deleted(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_feature_state_wen_live_audit_log_does_nothing_if_feature_state_deleted(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     change_request_feature_state,
 ):
     # Given

--- a/api/tests/unit/audit/test_unit_audit_views.py
+++ b/api/tests/unit/audit/test_unit_audit_views.py
@@ -33,7 +33,7 @@ def subscription_metadata(mocker: MockerFixture) -> None:
     return metadata  # type: ignore[return-value]
 
 
-def test_audit_log_can_be_filtered_by_environments(
+def test_audit_log_can_be_filtered_by_environments(  # noqa: FT003
     admin_client: APIClient, project: Project, environment: Environment
 ) -> None:
     # Given
@@ -55,7 +55,7 @@ def test_audit_log_can_be_filtered_by_environments(
     assert response.json()["results"][0]["environment"]["id"] == audit_env.id
 
 
-def test_audit_log_can_be_filtered_by_log_text(
+def test_audit_log_can_be_filtered_by_log_text(  # noqa: FT003
     admin_client: APIClient, project: Project, environment: Environment
 ) -> None:
     # Given
@@ -78,7 +78,7 @@ def test_audit_log_can_be_filtered_by_log_text(
     assert response.json()["results"][1]["log"] == flag_state_updated_log
 
 
-def test_audit_log_can_be_filtered_by_project(
+def test_audit_log_can_be_filtered_by_project(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     environment: Environment,
@@ -104,7 +104,7 @@ def test_audit_log_can_be_filtered_by_project(
     assert response.json()["results"][1]["project"]["id"] == project.id
 
 
-def test_audit_log_can_be_filtered_by_is_system_event(
+def test_audit_log_can_be_filtered_by_is_system_event(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     environment: Environment,
@@ -127,7 +127,7 @@ def test_audit_log_can_be_filtered_by_is_system_event(
     assert response.json()["results"][0]["is_system_event"] is True
 
 
-def test_regular_user_cannot_list_audit_log(
+def test_regular_user_cannot_list_audit_log(  # noqa: FT003
     project: Project,
     environment: Environment,
     organisation: Organisation,
@@ -148,7 +148,7 @@ def test_regular_user_cannot_list_audit_log(
     assert response.json()["count"] == 0
 
 
-def test_admin_user_cannot_list_audit_log_of_another_organisation(
+def test_admin_user_cannot_list_audit_log_of_another_organisation(  # noqa: FT003
     api_client: APIClient,
     organisation: Organisation,
     project: Project,
@@ -171,7 +171,7 @@ def test_admin_user_cannot_list_audit_log_of_another_organisation(
     assert response.json()["count"] == 0
 
 
-def test_retrieve_environment_feature_version_published_audit_log_record_includes_required_fields(
+def test_retrieve_environment_feature_version_published_audit_log_record_includes_required_fields(  # noqa: FT003
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
@@ -206,7 +206,7 @@ def test_retrieve_environment_feature_version_published_audit_log_record_include
     )
 
 
-def test_list_audit_log_for_project_limits_logs_returned_for_non_enterprise(
+def test_list_audit_log_for_project_limits_logs_returned_for_non_enterprise(  # noqa: FT003
     subscription_metadata: BaseSubscriptionMetadata,
     project: Project,
     admin_client: APIClient,
@@ -239,7 +239,7 @@ def test_list_audit_log_for_project_limits_logs_returned_for_non_enterprise(
     assert response_json["results"][0]["log"] == "Something that happened today"
 
 
-def test_list_audit_log_for_organisation_limits_logs_returned_for_non_enterprise(
+def test_list_audit_log_for_organisation_limits_logs_returned_for_non_enterprise(  # noqa: FT003
     subscription_metadata: BaseSubscriptionMetadata,
     organisation: Organisation,
     project: Project,

--- a/api/tests/unit/core/management/test_unit_core_management_makemigrations.py
+++ b/api/tests/unit/core/management/test_unit_core_management_makemigrations.py
@@ -5,21 +5,21 @@ from django.core.management import CommandError, call_command
 DATABASES_LIST = list(settings.DATABASES.keys())
 
 
-def test_makemigrations_without_name_raises_error() -> None:
+def test_makemigrations_without_name_raises_error() -> None:  # noqa: FT003,FT004
     with pytest.raises(CommandError, match="--name/-n is a required argument"):
         call_command("makemigrations")
 
 
 @pytest.mark.django_db(databases=DATABASES_LIST)
-def test_makemigrations_with_check_changes_runs_without_error() -> None:
+def test_makemigrations_with_check_changes_runs_without_error() -> None:  # noqa: FT003,FT004
     call_command("makemigrations", check_changes=True)
 
 
 @pytest.mark.django_db(databases=DATABASES_LIST)
-def test_makemigrations_with_dry_run_runs_without_error() -> None:
+def test_makemigrations_with_dry_run_runs_without_error() -> None:  # noqa: FT003,FT004
     call_command("makemigrations", dry_run=True)
 
 
 @pytest.mark.django_db(databases=DATABASES_LIST)
-def test_makemigrations_with_name_runs_without_error() -> None:
+def test_makemigrations_with_name_runs_without_error() -> None:  # noqa: FT003,FT004
     call_command("makemigrations", name="some_useful_name")

--- a/api/tests/unit/core/middleware/test_unit_core_middleware_admin.py
+++ b/api/tests/unit/core/middleware/test_unit_core_middleware_admin.py
@@ -11,7 +11,7 @@ not_allowed_ip_address = "11.0.0.1"
 
 
 @override_settings(ALLOWED_ADMIN_IP_ADDRESSES=[allowed_ip_address])
-def test_admin_whitelist_middleware_raises_permission_denied_for_admin_pages_if_ip_not_allowed():  # type: ignore[no-untyped-def]  # noqa: E501
+def test_admin_whitelist_middleware_raises_permission_denied_for_admin_pages_if_ip_not_allowed():  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     # Given
     mock_get_response = mock.MagicMock()
 
@@ -29,7 +29,7 @@ def test_admin_whitelist_middleware_raises_permission_denied_for_admin_pages_if_
 
 
 @override_settings(ALLOWED_ADMIN_IP_ADDRESSES=[allowed_ip_address])
-def test_admin_whitelist_middleware_returns_get_response_for_admin_pages_if_ip_allowed():  # type: ignore[no-untyped-def]  # noqa: E501
+def test_admin_whitelist_middleware_returns_get_response_for_admin_pages_if_ip_allowed():  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     mock_get_response = mock.MagicMock()
     mock_get_response_return = mock.MagicMock()
@@ -50,7 +50,7 @@ def test_admin_whitelist_middleware_returns_get_response_for_admin_pages_if_ip_a
 
 
 @override_settings(ALLOWED_ADMIN_IP_ADDRESSES=[allowed_ip_address])
-def test_admin_whitelist_middleware_returns_get_response_for_non_admin_request_if_ip_not_allowed():  # type: ignore[no-untyped-def]  # noqa: E501
+def test_admin_whitelist_middleware_returns_get_response_for_non_admin_request_if_ip_not_allowed():  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     mock_get_response = mock.MagicMock()
     mock_get_response_return = mock.MagicMock()

--- a/api/tests/unit/core/middleware/test_unit_core_middleware_cache_control.py
+++ b/api/tests/unit/core/middleware/test_unit_core_middleware_cache_control.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse
 from core.middleware.cache_control import NeverCacheMiddleware
 
 
-def test_NoCacheMiddleware_adds_cache_control_headers(mocker):  # type: ignore[no-untyped-def]
+def test_NoCacheMiddleware_adds_cache_control_headers(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     a_response = HttpResponse()
     mocked_get_response = mocker.MagicMock(return_value=a_response)

--- a/api/tests/unit/core/test_helpers.py
+++ b/api/tests/unit/core/test_helpers.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 pytestmark = pytest.mark.django_db
 
 
-def test_get_current_site_url_returns_correct_url_if_site_exists(
+def test_get_current_site_url_returns_correct_url_if_site_exists(  # noqa: FT003
     settings: "SettingsWrapper",
 ) -> None:
     # Given
@@ -27,7 +27,7 @@ def test_get_current_site_url_returns_correct_url_if_site_exists(
     assert url == f"https://{expected_domain}"
 
 
-def test_get_current_site_url_uses_default_url_if_site_does_not_exist(
+def test_get_current_site_url_uses_default_url_if_site_does_not_exist(  # noqa: FT003
     settings: "SettingsWrapper",
 ) -> None:
     # Given
@@ -71,7 +71,7 @@ def test_get_current_site_url__site_created__cached_return_expected(
     assert url_with_site == f"https://{expected_domain_with_site}"
 
 
-def test_get_current_site__domain_override__with_site__return_expected(
+def test_get_current_site__domain_override__with_site__return_expected(  # noqa: FT003
     settings: "SettingsWrapper",
 ) -> None:
     # Given
@@ -88,7 +88,7 @@ def test_get_current_site__domain_override__with_site__return_expected(
     assert url == f"https://{expected_domain}"
 
 
-def test_get_current_site__domain_override__no_site__return_expected(
+def test_get_current_site__domain_override__no_site__return_expected(  # noqa: FT003
     settings: "SettingsWrapper",
 ) -> None:
     # Given

--- a/api/tests/unit/core/test_redis_cluster.py
+++ b/api/tests/unit/core/test_redis_cluster.py
@@ -9,7 +9,7 @@ from redis.exceptions import RedisClusterException
 from core.redis_cluster import ClusterConnectionFactory, SafeRedisClusterClient
 
 
-def test_cluster_connection_factory__connect_cache(mocker: MockerFixture):  # type: ignore[no-untyped-def]
+def test_cluster_connection_factory__connect_cache(mocker: MockerFixture):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_get_connection = mocker.patch.object(
         ClusterConnectionFactory, "get_connection"
@@ -41,7 +41,7 @@ def test_cluster_connection_factory__connect_cache(mocker: MockerFixture):  # ty
     make_connection_params.assert_called_once_with(url)
 
 
-def test_cluster_connection_factory__get_connection_with_non_conflicting_params(  # type: ignore[no-untyped-def]
+def test_cluster_connection_factory__get_connection_with_non_conflicting_params(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
     settings: SettingsWrapper,
 ):
@@ -67,7 +67,7 @@ def test_cluster_connection_factory__get_connection_with_non_conflicting_params(
     )
 
 
-def test_cluster_connection_factory__get_connection_with_conflicting_params(  # type: ignore[no-untyped-def]
+def test_cluster_connection_factory__get_connection_with_conflicting_params(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
 ):
     # Given
@@ -85,7 +85,7 @@ def test_cluster_connection_factory__get_connection_with_conflicting_params(  # 
     mockRedisCluster.assert_not_called()
 
 
-def test_disconnect(mocker: MockerFixture):  # type: ignore[no-untyped-def]
+def test_disconnect(mocker: MockerFixture):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     connection_factory = ClusterConnectionFactory({})
     mock_connection = mocker.MagicMock()
@@ -99,7 +99,7 @@ def test_disconnect(mocker: MockerFixture):  # type: ignore[no-untyped-def]
     mock_disconnect_connection_pools.assert_called_once()
 
 
-def test_safe_redis_cluster__safe_methods_raise_connection_interrupted(  # type: ignore[no-untyped-def]
+def test_safe_redis_cluster__safe_methods_raise_connection_interrupted(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture, settings
 ):
     # Given

--- a/api/tests/unit/core/test_unit_core_example.py
+++ b/api/tests/unit/core/test_unit_core_example.py
@@ -1,0 +1,5 @@
+"""Example test that violates flagsmith-lint-tests rules."""
+
+
+def test_example_bad_naming() -> None:
+    assert 1 + 1 == 2

--- a/api/tests/unit/core/test_unit_core_example.py
+++ b/api/tests/unit/core/test_unit_core_example.py
@@ -1,5 +1,0 @@
-"""Example test that violates flagsmith-lint-tests rules."""
-
-
-def test_example_bad_naming() -> None:
-    assert 1 + 1 == 2

--- a/api/tests/unit/core/test_unit_core_management.py
+++ b/api/tests/unit/core/test_unit_core_management.py
@@ -12,7 +12,7 @@ class MockQuerySet(list):  # type: ignore[type-arg]
         return self.__len__() > 0
 
 
-def test_rollbackmigrationsappliedafter(mocker: MockerFixture) -> None:
+def test_rollbackmigrationsappliedafter(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     dt_string = "2024-10-24 08:23:45"
 
@@ -46,7 +46,7 @@ def test_rollbackmigrationsappliedafter(mocker: MockerFixture) -> None:
     ]
 
 
-def test_rollbackmigrationsappliedafter_invalid_date(mocker: MockerFixture) -> None:
+def test_rollbackmigrationsappliedafter_invalid_date(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     dt_string = "foo"
 
@@ -63,7 +63,7 @@ def test_rollbackmigrationsappliedafter_invalid_date(mocker: MockerFixture) -> N
     assert e.value.args == ("Date must be in ISO format",)
 
 
-def test_rollbackmigrationsappliedafter_no_migrations(
+def test_rollbackmigrationsappliedafter_no_migrations(  # noqa: FT003
     mocker: MockerFixture,
     capsys: CaptureFixture,  # type: ignore[type-arg]
 ) -> None:

--- a/api/tests/unit/core/test_unit_core_migration_helpers.py
+++ b/api/tests/unit/core/test_unit_core_migration_helpers.py
@@ -1,7 +1,7 @@
 from core.migration_helpers import AddDefaultUUIDs, PostgresOnlyRunSQL
 
 
-def test_add_default_uuids_class_correctly_sets_uuid_attribute(mocker):  # type: ignore[no-untyped-def]
+def test_add_default_uuids_class_correctly_sets_uuid_attribute(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_apps = mocker.MagicMock()
     mock_schema_editor = mocker.MagicMock()

--- a/api/tests/unit/custom_auth/jwt_cookie/test_unit_jwt_cookie_authentication.py
+++ b/api/tests/unit/custom_auth/jwt_cookie/test_unit_jwt_cookie_authentication.py
@@ -15,7 +15,7 @@ from custom_auth.jwt_cookie.constants import JWT_SLIDING_COOKIE_KEY
 from users.models import FFAdminUser
 
 
-def test_authenticate_without_cookie(mocker: MockerFixture) -> None:
+def test_authenticate_without_cookie(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     auth = JWTCookieAuthentication()
     request = mocker.MagicMock(spec=Request)
@@ -28,7 +28,7 @@ def test_authenticate_without_cookie(mocker: MockerFixture) -> None:
     assert result is None
 
 
-def test_authenticate_valid_cookie(mocker: MockerFixture) -> None:
+def test_authenticate_valid_cookie(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     auth = JWTCookieAuthentication()
     request = mocker.MagicMock(spec=Request)
@@ -56,7 +56,7 @@ def test_authenticate_valid_cookie(mocker: MockerFixture) -> None:
 @pytest.mark.parametrize(
     "exception_class", [InvalidToken, TokenError, AuthenticationFailed]
 )
-def test_authenticate_invalid_cookie(
+def test_authenticate_invalid_cookie(  # noqa: FT003
     mocker: MockerFixture,
     exception_class: Type[Exception],
 ) -> None:

--- a/api/tests/unit/custom_auth/mfa/trench/test_views.py
+++ b/api/tests/unit/custom_auth/mfa/trench/test_views.py
@@ -7,7 +7,7 @@ from custom_auth.mfa.trench.models import MFAMethod
 from users.models import FFAdminUser
 
 
-def test_list_user_active_methods(admin_client: APIClient, mfa_app_method: MFAMethod):  # type: ignore[no-untyped-def]
+def test_list_user_active_methods(admin_client: APIClient, mfa_app_method: MFAMethod):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:custom_auth:mfa-list-user-active-methods")
 
@@ -21,7 +21,7 @@ def test_list_user_active_methods(admin_client: APIClient, mfa_app_method: MFAMe
     ]
 
 
-def test_deactivate_user_active_method(  # type: ignore[no-untyped-def]
+def test_deactivate_user_active_method(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -36,7 +36,7 @@ def test_deactivate_user_active_method(  # type: ignore[no-untyped-def]
     assert mfa_app_method.is_active is False
 
 
-def test_deactivate_already_deactivated_mfa_returns_400(  # type: ignore[no-untyped-def]
+def test_deactivate_already_deactivated_mfa_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -54,7 +54,7 @@ def test_deactivate_already_deactivated_mfa_returns_400(  # type: ignore[no-unty
     assert response.json()["error"] == "2FA is not enabled."
 
 
-def test_activate_wrong_method_returns_404(admin_client: APIClient):  # type: ignore[no-untyped-def]
+def test_activate_wrong_method_returns_404(admin_client: APIClient):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:custom_auth:mfa-activate", kwargs={"method": "wrong_method"})
 
@@ -65,7 +65,7 @@ def test_activate_wrong_method_returns_404(admin_client: APIClient):  # type: ig
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_activate_mfa_with_existing_mfa_returns_400(  # type: ignore[no-untyped-def]
+def test_activate_mfa_with_existing_mfa_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -79,7 +79,7 @@ def test_activate_mfa_with_existing_mfa_returns_400(  # type: ignore[no-untyped-
     assert response.json()["error"] == "MFA method already active."
 
 
-def test_activate_confirm_with_wrong_method_returns_400(  # type: ignore[no-untyped-def]
+def test_activate_confirm_with_wrong_method_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -97,7 +97,7 @@ def test_activate_confirm_with_wrong_method_returns_400(  # type: ignore[no-unty
     assert response.json() == {"code": ["Requested MFA method does not exist."]}
 
 
-def test_activate_confirm_already_active_mfa_returns_400(  # type: ignore[no-untyped-def]
+def test_activate_confirm_already_active_mfa_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -113,7 +113,7 @@ def test_activate_confirm_already_active_mfa_returns_400(  # type: ignore[no-unt
     assert response.json() == {"code": ["MFA method already active."]}
 
 
-def test_re_activate_confirm_deactive_mfa_creates_new_backup_codes(  # type: ignore[no-untyped-def]
+def test_re_activate_confirm_deactive_mfa_creates_new_backup_codes(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, deactivated_mfa_app_method: MFAMethod
 ):
     # Given
@@ -132,7 +132,7 @@ def test_re_activate_confirm_deactive_mfa_creates_new_backup_codes(  # type: ign
         assert code not in new_backup_codes
 
 
-def test_activate_confirm_mfa_for_different_user_retuns_400(  # type: ignore[no-untyped-def]
+def test_activate_confirm_mfa_for_different_user_retuns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     staff_client: APIClient, deactivated_mfa_app_method: MFAMethod
 ):
     # Given
@@ -147,7 +147,7 @@ def test_activate_confirm_mfa_for_different_user_retuns_400(  # type: ignore[no-
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_activate_confirm_without_code_returns_400(  # type: ignore[no-untyped-def]
+def test_activate_confirm_without_code_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -164,7 +164,7 @@ def test_activate_confirm_without_code_returns_400(  # type: ignore[no-untyped-d
     assert response.json() == {"code": ["This field is required."]}
 
 
-def test_activate_confirm_with_wrong_code_returns_400(  # type: ignore[no-untyped-def]
+def test_activate_confirm_with_wrong_code_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given
@@ -185,7 +185,7 @@ def test_activate_confirm_with_wrong_code_returns_400(  # type: ignore[no-untype
     assert response.json() == {"code": ["Code invalid or expired."]}
 
 
-def test_login_with_invalid_mfa_code_returns_401(  # type: ignore[no-untyped-def]
+def test_login_with_invalid_mfa_code_returns_401(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient, admin_user: FFAdminUser, mfa_app_method: MFAMethod
 ):
     # Given
@@ -206,7 +206,7 @@ def test_login_with_invalid_mfa_code_returns_401(  # type: ignore[no-untyped-def
     assert login_confirm_response.json() == {"error": "Invalid or expired code."}
 
 
-def test_login_with_invalid_mfa_token_returns_401(  # type: ignore[no-untyped-def]
+def test_login_with_invalid_mfa_token_returns_401(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient, mfa_app_method: MFAMethod
 ):
     # Given

--- a/api/tests/unit/custom_auth/oauth/helpers/test_unit_oauth_github_helpers.py
+++ b/api/tests/unit/custom_auth/oauth/helpers/test_unit_oauth_github_helpers.py
@@ -7,7 +7,7 @@ from custom_auth.oauth.helpers.github_helpers import (
 )
 
 
-def test_convert_response_data_to_dictionary_success():  # type: ignore[no-untyped-def]
+def test_convert_response_data_to_dictionary_success():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     response_string = "key_1=value_1&key_2=value_2&key_3=value_3"
 
@@ -22,7 +22,7 @@ def test_convert_response_data_to_dictionary_success():  # type: ignore[no-untyp
     }
 
 
-def test_convert_response_data_to_dictionary_fail():  # type: ignore[no-untyped-def]
+def test_convert_response_data_to_dictionary_fail():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     response_string = "key_1value_1&key_2=value_2=value_2"
 
@@ -33,7 +33,7 @@ def test_convert_response_data_to_dictionary_fail():  # type: ignore[no-untyped-
     # Then - exception raised
 
 
-def test_get_first_and_last_name_success():  # type: ignore[no-untyped-def]
+def test_get_first_and_last_name_success():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     full_name = "tommy tester"
 
@@ -45,7 +45,7 @@ def test_get_first_and_last_name_success():  # type: ignore[no-untyped-def]
     assert last_name == "tester"
 
 
-def test_get_first_and_last_name_too_many_names():  # type: ignore[no-untyped-def]
+def test_get_first_and_last_name_too_many_names():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     full_name = "tommy tester the third king among testers"
 
@@ -57,7 +57,7 @@ def test_get_first_and_last_name_too_many_names():  # type: ignore[no-untyped-de
     assert last_name == ""
 
 
-def test_get_first_and_last_name_too_few_names():  # type: ignore[no-untyped-def]
+def test_get_first_and_last_name_too_few_names():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     full_name = "wall-e"
 

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_github.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_github.py
@@ -7,7 +7,7 @@ from custom_auth.oauth.github import NON_200_ERROR_MESSAGE, GithubUser
 
 
 @mock.patch("custom_auth.oauth.github.requests")
-def test_get_access_token_success_with_oauth_github(
+def test_get_access_token_success_with_oauth_github(  # noqa: FT003
     mock_requests: mock.MagicMock,
 ) -> None:
     # Given
@@ -37,7 +37,7 @@ def test_get_access_token_success_with_oauth_github(
 
 
 @mock.patch("custom_auth.oauth.github.requests")
-def test_get_access_token_fail_non_200_with_github_oauth(
+def test_get_access_token_fail_non_200_with_github_oauth(  # noqa: FT003
     mock_requests: mock.MagicMock,
 ) -> None:
     # Given
@@ -60,7 +60,7 @@ def test_get_access_token_fail_non_200_with_github_oauth(
 
 
 @mock.patch("custom_auth.oauth.github.requests")
-def test_get_access_token_fail_token_expired_with_github_oauth(
+def test_get_access_token_fail_token_expired_with_github_oauth(  # noqa: FT003
     mock_requests: mock.MagicMock,
 ) -> None:
     # Given
@@ -87,7 +87,7 @@ def test_get_access_token_fail_token_expired_with_github_oauth(
 
 
 @mock.patch("custom_auth.oauth.github.requests")
-def test_get_user_name_and_id_with_github_oauth(mock_requests: mock.MagicMock) -> None:
+def test_get_user_name_and_id_with_github_oauth(mock_requests: mock.MagicMock) -> None:  # noqa: FT003
     # Given
     # mock the post to get the access token
     mock_requests.post.return_value = mock.MagicMock(
@@ -118,7 +118,7 @@ def test_get_user_name_and_id_with_github_oauth(mock_requests: mock.MagicMock) -
 
 
 @mock.patch("custom_auth.oauth.github.requests")
-def test_get_primary_email_with_github_oauth(mock_requests: mock.MagicMock) -> None:
+def test_get_primary_email_with_github_oauth(mock_requests: mock.MagicMock) -> None:  # noqa: FT003
     # Given
     # mock the post to get the access token
     mock_requests.post.return_value = mock.MagicMock(

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_google.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_google.py
@@ -7,7 +7,7 @@ from custom_auth.oauth.google import USER_INFO_URL, get_user_info
 
 
 @mock.patch("custom_auth.oauth.google.requests")
-def test_get_user_info(mock_requests):  # type: ignore[no-untyped-def]
+def test_get_user_info(mock_requests):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     access_token = "access-token"
     mock_google_response_data = {
@@ -35,7 +35,7 @@ def test_get_user_info(mock_requests):  # type: ignore[no-untyped-def]
 
 
 @mock.patch("custom_auth.oauth.google.requests")
-def test_get_user_info_non_200_status_code(mock_requests):  # type: ignore[no-untyped-def]
+def test_get_user_info_non_200_status_code(mock_requests):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     access_token = "access-token"
     mock_response = mock.MagicMock(status_code=400)

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_serializers.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_serializers.py
@@ -29,7 +29,7 @@ from users.models import FFAdminUser, HubspotTracker, SignUpType
     ),
 )
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
-def test_create_oauth_login_serializer(
+def test_create_oauth_login_serializer(  # noqa: FT003
     mock_get_user_info: mock.MagicMock,
     db: None,
     settings: SettingsWrapper,
@@ -89,7 +89,7 @@ def test_create_oauth_login_serializer(
 
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
-def test_get_user_info_with_google_login(
+def test_get_user_info_with_google_login(  # noqa: FT003
     mock_get_user_info: mock.MagicMock,
 ) -> None:
     # Given
@@ -109,7 +109,7 @@ def test_get_user_info_with_google_login(
 
 
 @mock.patch("custom_auth.oauth.serializers.GithubUser")
-def test_get_user_info_with_github_login(
+def test_get_user_info_with_github_login(  # noqa: FT003
     mock_github_user_serializer: mock.MagicMock,
 ) -> None:
     # Given
@@ -132,7 +132,7 @@ def test_get_user_info_with_github_login(
     mock_github_user.get_user_info.assert_called()
 
 
-def test_OAuthLoginSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_OAuthLoginSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     settings, rf, mocker, db
 ):
     # Given
@@ -166,7 +166,7 @@ def test_OAuthLoginSerializer_calls_is_authentication_method_valid_correctly_if_
     )
 
 
-def test_OAuthLoginSerializer_allows_registration_if_sign_up_type_is_invite_link(  # type: ignore[no-untyped-def]
+def test_OAuthLoginSerializer_allows_registration_if_sign_up_type_is_invite_link(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings: SettingsWrapper,
     rf: RequestFactory,
     mocker: MockerFixture,
@@ -208,7 +208,7 @@ def test_OAuthLoginSerializer_allows_registration_if_sign_up_type_is_invite_link
 @pytest.mark.parametrize(
     "serializer_class", (GithubLoginSerializer, GithubLoginSerializer)
 )
-def test_OAuthLoginSerializer_allows_login_if_allow_registration_without_invite_is_false(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_OAuthLoginSerializer_allows_login_if_allow_registration_without_invite_is_false(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     settings: SettingsWrapper,
     rf: RequestFactory,
     mocker: MockerFixture,

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -15,7 +15,7 @@ from users.models import SignUpType
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)
-def test_cannot_register_with_google_without_invite_if_registration_disabled(  # type: ignore[no-untyped-def]
+def test_cannot_register_with_google_without_invite_if_registration_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_get_user_info, db
 ):
     # Given
@@ -34,7 +34,7 @@ def test_cannot_register_with_google_without_invite_if_registration_disabled(  #
 
 @mock.patch("custom_auth.oauth.serializers.GithubUser")
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)
-def test_cannot_register_with_github_without_invite_if_registration_disabled(  # type: ignore[no-untyped-def]
+def test_cannot_register_with_github_without_invite_if_registration_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     MockGithubUser, db
 ):
     # Given
@@ -55,7 +55,7 @@ def test_cannot_register_with_github_without_invite_if_registration_disabled(  #
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)
-def test_can_register_with_google_with_invite_if_registration_disabled(  # type: ignore[no-untyped-def]
+def test_can_register_with_google_with_invite_if_registration_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_get_user_info, db
 ):
     # Given
@@ -82,7 +82,7 @@ def test_can_register_with_google_with_invite_if_registration_disabled(  # type:
 
 @mock.patch("custom_auth.oauth.serializers.GithubUser")
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)
-def test_can_register_with_github_with_invite_if_registration_disabled(  # type: ignore[no-untyped-def]
+def test_can_register_with_github_with_invite_if_registration_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     MockGithubUser, db
 ):
     # Given
@@ -111,7 +111,7 @@ def test_can_register_with_github_with_invite_if_registration_disabled(  # type:
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
 @override_settings(ALLOW_OAUTH_REGISTRATION_WITHOUT_INVITE=False)
-def test_can_login_with_google_if_registration_disabled(  # type: ignore[no-untyped-def]
+def test_can_login_with_google_if_registration_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_get_user_info, db, django_user_model
 ):
     # Given
@@ -137,7 +137,7 @@ def test_can_login_with_google_if_registration_disabled(  # type: ignore[no-unty
 
 @mock.patch("custom_auth.oauth.serializers.GithubUser")
 @override_settings(ALLOW_OAUTH_REGISTRATION_WITHOUT_INVITE=False)
-def test_can_login_with_github_if_registration_disabled(  # type: ignore[no-untyped-def]
+def test_can_login_with_github_if_registration_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     MockGithubUser, db, django_user_model
 ):
     # Given
@@ -163,7 +163,7 @@ def test_can_login_with_github_if_registration_disabled(  # type: ignore[no-unty
     assert "key" in response.json()
 
 
-def test_login_with_google_updates_existing_user_case_insensitive(
+def test_login_with_google_updates_existing_user_case_insensitive(  # noqa: FT003
     db: None,
     django_user_model: type[Model],
     mocker: MockerFixture,
@@ -202,7 +202,7 @@ def test_login_with_google_updates_existing_user_case_insensitive(
     assert user.google_user_id == google_user_id
 
 
-def test_login_with_github_updates_existing_user_case_insensitive(
+def test_login_with_github_updates_existing_user_case_insensitive(  # noqa: FT003
     db: None,
     django_user_model: type[Model],
     mocker: MockerFixture,
@@ -242,7 +242,7 @@ def test_login_with_github_updates_existing_user_case_insensitive(
     assert user.github_user_id == github_user_id
 
 
-def test_user_with_duplicate_accounts_authenticates_as_the_correct_oauth_user(
+def test_user_with_duplicate_accounts_authenticates_as_the_correct_oauth_user(  # noqa: FT003
     db: None,
     django_user_model: type[Model],
     api_client: APIClient,
@@ -306,7 +306,7 @@ def test_user_with_duplicate_accounts_authenticates_as_the_correct_oauth_user(
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
 @override_settings(COOKIE_AUTH_ENABLED=True)
-def test_login_with_google_jwt_cookie(
+def test_login_with_google_jwt_cookie(  # noqa: FT003
     mock_get_user_info: mock.Mock,
     db: None,
     django_user_model: type[Any],
@@ -336,7 +336,7 @@ def test_login_with_google_jwt_cookie(
 
 
 @override_settings(COOKIE_AUTH_ENABLED=True)
-def test_login_with_github_jwt_cookie(
+def test_login_with_github_jwt_cookie(  # noqa: FT003
     db: None,
     django_user_model: type[Any],
     api_client: APIClient,

--- a/api/tests/unit/custom_auth/test_tasks.py
+++ b/api/tests/unit/custom_auth/test_tasks.py
@@ -9,7 +9,7 @@ from custom_auth.tasks import clean_up_user_password_reset_request
 from users.models import FFAdminUser
 
 
-def test_clean_up_user_password_reset_request(
+def test_clean_up_user_password_reset_request(  # noqa: FT003
     settings: SettingsWrapper, staff_user: FFAdminUser, freezer: FrozenDateTimeFactory
 ) -> None:
     # Given

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
@@ -23,7 +23,7 @@ user_dict = {
 }
 
 
-def test_CustomUserCreateSerializer_converts_email_to_lower_case(
+def test_CustomUserCreateSerializer_converts_email_to_lower_case(  # noqa: FT003
     db: None, rf: RequestFactory
 ) -> None:
     # Given
@@ -37,7 +37,7 @@ def test_CustomUserCreateSerializer_converts_email_to_lower_case(
     assert serializer.validated_data["email"] == "testuser@mail.com"
 
 
-def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(
+def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(  # noqa: FT003,FT004
     db: None, rf: RequestFactory
 ) -> None:
     # Given
@@ -53,7 +53,7 @@ def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(
     assert serializer.errors["email"][0] == "Email already exists. Please log in."
 
 
-def test_CustomUserCreateSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_CustomUserCreateSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     db, settings, mocker, rf
 ):
     # Given
@@ -80,7 +80,7 @@ def test_CustomUserCreateSerializer_calls_is_authentication_method_valid_correct
     )
 
 
-def test_CustomUserCreateSerializer_allows_registration_if_sign_up_type_is_invite_link(
+def test_CustomUserCreateSerializer_allows_registration_if_sign_up_type_is_invite_link(  # noqa: FT003
     invite_link: InviteLink,
     db: None,
     settings: SettingsWrapper,
@@ -107,7 +107,7 @@ def test_CustomUserCreateSerializer_allows_registration_if_sign_up_type_is_invit
     assert user
 
 
-def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_provided(
+def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_provided(  # noqa: FT003
     settings: SettingsWrapper,
     db: None,
 ) -> None:
@@ -129,7 +129,7 @@ def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_pro
     assert exc_info.value.detail == USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
 
 
-def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_valid(
+def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_valid(  # noqa: FT003
     invite_link: InviteLink,
     settings: SettingsWrapper,
 ) -> None:

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_views.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_views.py
@@ -12,7 +12,7 @@ from rest_framework.test import APIClient
 from users.models import FFAdminUser, HubspotTracker
 
 
-def test_get_current_user(staff_user: FFAdminUser, staff_client: APIClient) -> None:
+def test_get_current_user(staff_user: FFAdminUser, staff_client: APIClient) -> None:  # noqa: FT003
     # Given
     url = reverse("api-v1:custom_auth:ffadminuser-me")
 
@@ -30,7 +30,7 @@ def test_get_current_user(staff_user: FFAdminUser, staff_client: APIClient) -> N
     assert response_json["pylon_email_signature"] is None
 
 
-def test_get_current_user_with_pylon_signature(
+def test_get_current_user_with_pylon_signature(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     settings: SettingsWrapper,
@@ -96,7 +96,7 @@ def test_get_current_user_with_pylon_signature(
     ],
 )
 @freeze_time("2025-01-01T12:00:00Z")
-def test_get_me_should_return_onboarding_object(
+def test_get_me_should_return_onboarding_object(  # noqa: FT003
     db: None, onboarding_data: dict[str, Any], expected_response: dict[str, Any]
 ) -> None:
     # Given
@@ -145,7 +145,7 @@ def test_get_me_should_return_onboarding_object(
         ),
     ],
 )
-def test_patch_user_onboarding_updates_only_nested_objects_if_provided(
+def test_patch_user_onboarding_updates_only_nested_objects_if_provided(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     data: dict[str, Any],
@@ -175,7 +175,7 @@ def test_patch_user_onboarding_updates_only_nested_objects_if_provided(
         ).get("integrations")
 
 
-def test_patch_user_onboarding_returns_error_if_preferences_tasks_and_tools_are_missing(
+def test_patch_user_onboarding_returns_error_if_preferences_tasks_and_tools_are_missing(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -194,7 +194,7 @@ def test_patch_user_onboarding_returns_error_if_preferences_tasks_and_tools_are_
     }
 
 
-def test_create_user_calls_hubspot_tracking_and_creates_hubspot_contact(
+def test_create_user_calls_hubspot_tracking_and_creates_hubspot_contact(  # noqa: FT003
     mocker: MagicMock,
     db: None,
     settings: SettingsWrapper,
@@ -231,7 +231,7 @@ def test_create_user_calls_hubspot_tracking_and_creates_hubspot_contact(
     mock_create_hubspot_contact_for_user.delay.assert_called_once_with(args=(user.id,))
 
 
-def test_create_user_does_not_create_hubspot_tracking_if_no_cookie_is_provided(
+def test_create_user_does_not_create_hubspot_tracking_if_no_cookie_is_provided(  # noqa: FT003
     mocker: MagicMock,
     db: None,
     settings: SettingsWrapper,

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -19,7 +19,7 @@ from util.mappers import map_identity_to_identity_document
 from webhooks.constants import WEBHOOK_DATETIME_FORMAT
 
 
-def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(  # type: ignore[no-untyped-def]
+def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, identity, feature, admin_user
 ):
     # Given
@@ -65,7 +65,7 @@ def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(  # t
         lazy_fixture("admin_user"),
     ],
 )
-def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_override(  # type: ignore[no-untyped-def]
+def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_override(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
     identity: Identity,
     feature: Feature,
@@ -122,7 +122,7 @@ def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_overr
     )
 
 
-def test_edge_identity_feature_state_serializer_save_calls_webhook_for_update(  # type: ignore[no-untyped-def]
+def test_edge_identity_feature_state_serializer_save_calls_webhook_for_update(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, identity, feature, admin_user
 ):
     # Given
@@ -183,7 +183,7 @@ def test_edge_identity_feature_state_serializer_save_calls_webhook_for_update(  
     )
 
 
-def test_all_feature_states_serializer_get_feature_state_value_uses_mv_values_for_edge(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_all_feature_states_serializer_get_feature_state_value_uses_mv_values_for_edge(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     identity, multivariate_feature, environment
 ):
     # Given

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_views.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_views.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
 
 
-def test_edge_identity_view_set_get_permissions() -> None:
+def test_edge_identity_view_set_get_permissions() -> None:  # noqa: FT003
     # Given
     view_set = EdgeIdentityViewSet()
 
@@ -44,7 +44,7 @@ def test_edge_identity_view_set_get_permissions() -> None:
     }
 
 
-def test_user_with_manage_identity_permission_can_delete_identity(
+def test_user_with_manage_identity_permission_can_delete_identity(  # noqa: FT003
     environment: Environment,
     identity_document_without_fs: dict[str, typing.Any],
     staff_client: APIClient,
@@ -74,7 +74,7 @@ def test_user_with_manage_identity_permission_can_delete_identity(
     assert flagsmith_identities_table.get_item(Key={"composite_key": composite_key})
 
 
-def test_edge_identity_viewset_returns_404_for_invalid_environment_key(
+def test_edge_identity_viewset_returns_404_for_invalid_environment_key(  # noqa: FT003
     admin_client: APIClient,
 ) -> None:
     # Given
@@ -90,7 +90,7 @@ def test_edge_identity_viewset_returns_404_for_invalid_environment_key(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_get_edge_identity_overrides_for_a_feature(
+def test_get_edge_identity_overrides_for_a_feature(  # noqa: FT003
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     mocker: MockerFixture,
@@ -160,7 +160,7 @@ def test_get_edge_identity_overrides_for_a_feature(
     )
 
 
-def test_user_without_manage_identities_permission_cannot_get_edge_identity_overrides_for_a_feature(
+def test_user_without_manage_identities_permission_cannot_get_edge_identity_overrides_for_a_feature(  # noqa: FT003
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     feature: Feature,
@@ -180,7 +180,7 @@ def test_user_without_manage_identities_permission_cannot_get_edge_identity_over
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_user_cannot_delete_identity_from_another_project(
+def test_user_cannot_delete_identity_from_another_project(  # noqa: FT003
     identity_document_without_fs: dict[str, typing.Any],
     flagsmith_identities_table: "Table",
     environment: Environment,

--- a/api/tests/unit/edge_api/identities/test_edge_identity_featurestate_view.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_featurestate_view.py
@@ -11,7 +11,7 @@ from features.models import Feature
 from permissions.models import PermissionModel
 
 
-def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_edge_identity(
+def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_edge_identity(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/edge_api/identities/test_edge_identity_models.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_models.py
@@ -20,7 +20,7 @@ from users.models import FFAdminUser
 from util.engine_models.features.models import FeatureModel, FeatureStateModel
 
 
-def test_get_all_feature_states_for_edge_identity_uses_segment_priorities(  # type: ignore[no-untyped-def]
+def test_get_all_feature_states_for_edge_identity_uses_segment_priorities(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, project, segment, feature, mocker
 ):
     # Given
@@ -65,7 +65,7 @@ def test_get_all_feature_states_for_edge_identity_uses_segment_priorities(  # ty
     )
 
 
-def test_edge_identity_get_all_feature_states_ignores_not_live_feature_states(  # type: ignore[no-untyped-def]
+def test_edge_identity_get_all_feature_states_ignores_not_live_feature_states(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, project, segment, feature, feature_state, admin_user, mocker
 ):
     # Given
@@ -98,7 +98,7 @@ def test_edge_identity_get_all_feature_states_ignores_not_live_feature_states(  
     assert feature_states == [feature_state]
 
 
-def test_edge_identity_from_identity_document():  # type: ignore[no-untyped-def]
+def test_edge_identity_from_identity_document():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     identifier = "identifier"
     environment_api_key = shortuuid.uuid()
@@ -125,7 +125,7 @@ def test_edge_identity_from_identity_document():  # type: ignore[no-untyped-def]
         ),
     ),
 )
-def test_edge_identity_id_property(django_id, identity_uuid, expected_id, mocker):  # type: ignore[no-untyped-def]
+def test_edge_identity_id_property(django_id, identity_uuid, expected_id, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     edge_identity = EdgeIdentity(
         mocker.MagicMock(django_id=django_id, identity_uuid=identity_uuid)
@@ -135,7 +135,7 @@ def test_edge_identity_id_property(django_id, identity_uuid, expected_id, mocker
     assert edge_identity.id == expected_id
 
 
-def test_edge_identity_get_feature_state_by_feature_name_or_id(edge_identity_model):  # type: ignore[no-untyped-def]
+def test_edge_identity_get_feature_state_by_feature_name_or_id(edge_identity_model):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     feature_state_model = FeatureStateModel(
         feature=FeatureModel(id=1, name="test_feature", type="STANDARD"),
@@ -158,7 +158,7 @@ def test_edge_identity_get_feature_state_by_feature_name_or_id(edge_identity_mod
     )
 
 
-def test_edge_identity_get_feature_state_by_featurestate_uuid(edge_identity_model):  # type: ignore[no-untyped-def]
+def test_edge_identity_get_feature_state_by_featurestate_uuid(edge_identity_model):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     feature_state_model = FeatureStateModel(
         feature=FeatureModel(id=1, name="test_feature", type="STANDARD"),
@@ -178,7 +178,7 @@ def test_edge_identity_get_feature_state_by_featurestate_uuid(edge_identity_mode
     assert edge_identity_model.get_feature_state_by_featurestate_uuid("invalid") is None
 
 
-def test_edge_identity_remove_feature_state(edge_identity_model):  # type: ignore[no-untyped-def]
+def test_edge_identity_remove_feature_state(edge_identity_model):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     feature_state_model = FeatureStateModel(
         feature=FeatureModel(id=1, name="test_feature", type="STANDARD"),
@@ -198,7 +198,7 @@ def test_edge_identity_remove_feature_state(edge_identity_model):  # type: ignor
     )
 
 
-def test_edge_identity_remove_feature_state_if_no_matching_feature_state(  # type: ignore[no-untyped-def]
+def test_edge_identity_remove_feature_state_if_no_matching_feature_state(  # type: ignore[no-untyped-def]  # noqa: FT003
     edge_identity_model,
 ):
     # Given
@@ -219,7 +219,7 @@ def test_edge_identity_remove_feature_state_if_no_matching_feature_state(  # typ
     )
 
 
-def test_edge_identity_synchronise_features(mocker, edge_identity_model):  # type: ignore[no-untyped-def]
+def test_edge_identity_synchronise_features(mocker, edge_identity_model):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_sync_identity_document_features = mocker.patch(
         "edge_api.identities.models.sync_identity_document_features"
@@ -246,7 +246,7 @@ def test_edge_identity_synchronise_features(mocker, edge_identity_model):  # typ
     )
 
 
-def test_edge_identity_save_does_not_generate_audit_records_if_no_changes(  # type: ignore[no-untyped-def]
+def test_edge_identity_save_does_not_generate_audit_records_if_no_changes(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, edge_identity_model, edge_identity_dynamo_wrapper_mock
 ):
     # Given
@@ -416,7 +416,7 @@ def test_edge_identity_save_called__feature_override_removed__expected_tasks_cal
         (False, "initial", True, "updated"),
     ),
 )
-def test_edge_identity_save_called_generate_audit_records_if_feature_override_updated(
+def test_edge_identity_save_called_generate_audit_records_if_feature_override_updated(  # noqa: FT003
     initial_enabled: bool,
     initial_value: str,
     new_enabled: bool,
@@ -498,7 +498,7 @@ def test_edge_identity_save_called_generate_audit_records_if_feature_override_up
     )
 
 
-def test_get_all_feature_states_post_v2_versioning_migration(
+def test_get_all_feature_states_post_v2_versioning_migration(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     feature_state: FeatureState,

--- a/api/tests/unit/edge_api/identities/test_edge_identity_service.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_service.py
@@ -123,7 +123,7 @@ def test_get_overridden_feature_ids_for_edge_identity__nonexistent_identity__ret
     assert result == set()
 
 
-def test_get_edge_identity_override_keys__returns_list_of_document_keys(
+def test_get_edge_identity_override_keys__returns_list_of_document_keys(  # noqa: FT003,FT004
     flagsmith_environments_v2_table: Table,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     dynamo_enabled_project: Project,

--- a/api/tests/unit/edge_api/identities/test_edge_request_forwarder.py
+++ b/api/tests/unit/edge_api/identities/test_edge_request_forwarder.py
@@ -14,7 +14,7 @@ from edge_api.identities.edge_request_forwarder import (
 @pytest.mark.parametrize(
     "forwarder_function", [forward_identity_request, forward_trait_request]
 )
-def test_forwarder_function_makes_no_request_if_migration_is_not_yet_done(  # type: ignore[no-untyped-def]
+def test_forwarder_function_makes_no_request_if_migration_is_not_yet_done(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, forwarder_mocked_requests, forwarder_mocked_migrator, forwarder_function
 ):
     # Given
@@ -33,7 +33,7 @@ def test_forwarder_function_makes_no_request_if_migration_is_not_yet_done(  # ty
     forwarder_mocked_migrator.assert_called_with(project_id)
 
 
-def test_forward_identity_request_makes_correct_get_request(  # type: ignore[no-untyped-def]
+def test_forward_identity_request_makes_correct_get_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     forward_enable_settings,
     forwarder_mocked_migrator,
@@ -64,7 +64,7 @@ def test_forward_identity_request_makes_correct_get_request(  # type: ignore[no-
     forwarder_mocked_migrator.assert_called_with(project_id)
 
 
-def test_forward_identity_request_makes_correct_post_request(  # type: ignore[no-untyped-def]
+def test_forward_identity_request_makes_correct_post_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     forward_enable_settings,
     forwarder_mocked_migrator,
@@ -96,7 +96,7 @@ def test_forward_identity_request_makes_correct_post_request(  # type: ignore[no
     forwarder_mocked_migrator.assert_called_with(project_id)
 
 
-def test_forward_trait_request_sync_makes_correct_post_request(  # type: ignore[no-untyped-def]
+def test_forward_trait_request_sync_makes_correct_post_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     forward_enable_settings,
     forwarder_mocked_migrator,
@@ -131,7 +131,7 @@ def test_forward_trait_request_sync_makes_correct_post_request(  # type: ignore[
     forwarder_mocked_migrator.assert_called_with(project_id)
 
 
-def test_forward_trait_requests__calls_expected(mocker: MockerFixture) -> None:
+def test_forward_trait_requests__calls_expected(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     mocked_forward_trait_request = mocker.patch(
         "edge_api.identities.edge_request_forwarder.forward_trait_request",

--- a/api/tests/unit/edge_api/identities/test_events.py
+++ b/api/tests/unit/edge_api/identities/test_events.py
@@ -3,7 +3,7 @@ import json
 from edge_api.identities.events import send_migration_event
 
 
-def test_send_migration_event_calls_put_events_with_correct_arguments(mocker, settings):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_send_migration_event_calls_put_events_with_correct_arguments(mocker, settings):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     project_id = 1
     mocked_client = mocker.patch("edge_api.identities.events.events_client")

--- a/api/tests/unit/edge_api/identities/test_permissions.py
+++ b/api/tests/unit/edge_api/identities/test_permissions.py
@@ -7,7 +7,7 @@ from edge_api.identities.permissions import (
 )
 
 
-def test_edge_identity_with_identifier_view_permissions_has_permissions_calls_has_environment_permission(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_edge_identity_with_identifier_view_permissions_has_permissions_calls_has_environment_permission(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment,
     mocker,
 ):

--- a/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
+++ b/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
@@ -28,7 +28,7 @@ from webhooks.webhooks import WebhookEventType
     "new_enabled_state, new_value",
     ((True, "foo"), (False, "foo"), (True, None), (False, None)),
 )
-def test_call_environment_webhook_for_feature_state_change_with_new_state_only(  # type: ignore[no-untyped-def]
+def test_call_environment_webhook_for_feature_state_change_with_new_state_only(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, environment, feature, identity, admin_user, new_value, new_enabled_state
 ):
     # Given
@@ -79,7 +79,7 @@ def test_call_environment_webhook_for_feature_state_change_with_new_state_only( 
     assert data["timestamp"] == now_isoformat
 
 
-def test_call_environment_webhook_for_feature_state_change_with_previous_state_only(  # type: ignore[no-untyped-def]
+def test_call_environment_webhook_for_feature_state_change_with_previous_state_only(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, environment, feature, identity, admin_user
 ):
     # Given
@@ -132,7 +132,7 @@ def test_call_environment_webhook_for_feature_state_change_with_previous_state_o
     assert data["timestamp"] == now_isoformat
 
 
-def test_call_environment_webhook_for_feature_state_change_with_changed_by_user_id(
+def test_call_environment_webhook_for_feature_state_change_with_changed_by_user_id(  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
     feature: Feature,
@@ -190,7 +190,7 @@ def test_call_environment_webhook_for_feature_state_change_with_changed_by_user_
         (False, None, True, None),
     ),
 )
-def test_call_environment_webhook_for_feature_state_change_with_both_states(  # type: ignore[no-untyped-def]
+def test_call_environment_webhook_for_feature_state_change_with_both_states(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     environment,
     feature,
@@ -265,7 +265,7 @@ def test_call_environment_webhook_for_feature_state_change_with_both_states(  # 
     assert data["timestamp"] == now_isoformat
 
 
-def test_call_environment_webhook_for_feature_state_change_does_nothing_if_no_webhooks(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_call_environment_webhook_for_feature_state_change_does_nothing_if_no_webhooks(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker, environment, feature, identity, admin_user
 ):
     # Given
@@ -293,7 +293,7 @@ def test_call_environment_webhook_for_feature_state_change_does_nothing_if_no_we
     mock_call_environment_webhooks.assert_not_called()
 
 
-def test_sync_identity_document_features_removes_deleted_features(  # type: ignore[no-untyped-def]
+def test_sync_identity_document_features_removes_deleted_features(  # type: ignore[no-untyped-def]  # noqa: FT003
     edge_identity_dynamo_wrapper_mock,
     identity_document_without_fs,
     environment,
@@ -376,7 +376,7 @@ def test_sync_identity_document_features_removes_deleted_features(  # type: igno
         ),
     ),
 )
-def test_generate_audit_log_records(  # type: ignore[no-untyped-def]
+def test_generate_audit_log_records(  # type: ignore[no-untyped-def]  # noqa: FT003
     changes, identifier, expected_log_message, db, environment, admin_user
 ):
     # Given
@@ -401,7 +401,7 @@ def test_generate_audit_log_records(  # type: ignore[no-untyped-def]
 
 
 @freeze_time("2023-01-01T00:00:00Z")
-def test_update_flagsmith_environments_v2_identity_overrides__call_expected(
+def test_update_flagsmith_environments_v2_identity_overrides__call_expected(  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/edge_api/test_unit_edge_api_commands.py
+++ b/api/tests/unit/edge_api/test_unit_edge_api_commands.py
@@ -88,7 +88,7 @@ def test_migrate_to_edge_v2__core_projects__dont_migrate(
     migrate_project_environments_to_v2_mock.assert_not_called()
 
 
-def test_ensure_identity_traits_blanks__calls_expected(
+def test_ensure_identity_traits_blanks__calls_expected(  # noqa: FT003
     flagsmith_identities_table: "Table",
     mocker: "MockerFixture",
 ) -> None:
@@ -148,7 +148,7 @@ def test_ensure_identity_traits_blanks__calls_expected(
     )
 
 
-def test_ensure_identity_traits_blanks__logs_expected(
+def test_ensure_identity_traits_blanks__logs_expected(  # noqa: FT003
     flagsmith_identities_table: "Table",
     log: "StructuredLogCapture",
     mocker: "MockerFixture",

--- a/api/tests/unit/environments/dynamodb/test_unit_migrator.py
+++ b/api/tests/unit/environments/dynamodb/test_unit_migrator.py
@@ -12,7 +12,7 @@ from environments.models import Environment, EnvironmentAPIKey
 from projects.models import Project
 
 
-def test_migrate_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_migrate_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, project, identity, settings, environment_api_key
 ):
     # Given
@@ -74,7 +74,7 @@ def test_migrate_calls_internal_methods_with_correct_arguments(  # type: ignore[
     assert project.enable_dynamo_db is True
 
 
-def test_trigger_migration_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_trigger_migration_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, project
 ):
     # Given
@@ -101,7 +101,7 @@ def test_trigger_migration_calls_internal_methods_with_correct_arguments(  # typ
     mocked_send_migration_event.assert_called_once_with(project.id)
 
 
-def test_is_migration_done_returns_true_if_migration_is_completed(  # type: ignore[no-untyped-def]
+def test_is_migration_done_returns_true_if_migration_is_completed(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker,
 ):
     # Given
@@ -123,7 +123,7 @@ def test_is_migration_done_returns_true_if_migration_is_completed(  # type: igno
     mocked_project_metadata.get_or_new.assert_called_with(project_id)
 
 
-def test_can_migrate_returns_true_if_migration_was_not_started(  # type: ignore[no-untyped-def]
+def test_can_migrate_returns_true_if_migration_was_not_started(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker,
 ):
     # Given
@@ -146,7 +146,7 @@ def test_can_migrate_returns_true_if_migration_was_not_started(  # type: ignore[
     mocked_project_metadata.get_or_new.assert_called_with(project_id)
 
 
-def test_get_migration_status_returns_correct_migraion_status_for_in_progress_migration(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_migration_status_returns_correct_migraion_status_for_in_progress_migration(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker,
 ):
     # Given
@@ -197,7 +197,7 @@ def test_iter_identities_in_chunks__multiple_chunks__yields_all_in_pk_order(
     assert len(result) == 5
 
 
-def test_iter_identities_in_chunks__preserves_prefetch_related(
+def test_iter_identities_in_chunks__preserves_prefetch_related(  # noqa: FT003,FT004
     project: Project,
     environment: Environment,
     django_assert_num_queries: DjangoAssertNumQueries,

--- a/api/tests/unit/environments/dynamodb/types/test_unit_dynamodb_project_metadata.py
+++ b/api/tests/unit/environments/dynamodb/types/test_unit_dynamodb_project_metadata.py
@@ -11,7 +11,7 @@ from environments.dynamodb.types import (
 )
 
 
-def test_get_or_new_returns_instance_with_default_values_if_document_does_not_exists(  # type: ignore[no-untyped-def]
+def test_get_or_new_returns_instance_with_default_values_if_document_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
 ):
     # Given
@@ -32,7 +32,7 @@ def test_get_or_new_returns_instance_with_default_values_if_document_does_not_ex
     mocked_dynamo_table.get_item.assert_called_with(Key={"id": project_id})
 
 
-def test_get_or_new_returns_instance_with_document_data_if_document_does_exists(mocker):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_or_new_returns_instance_with_document_data_if_document_does_exists(mocker):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     project_id = 1
     migration_start_time = datetime.now().isoformat()
@@ -57,7 +57,7 @@ def test_get_or_new_returns_instance_with_document_data_if_document_does_exists(
     mocked_dynamo_table.get_item.assert_called_with(Key={"id": project_id})
 
 
-def test_start_identity_migration_calls_put_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_start_identity_migration_calls_put_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     project_id = 1
 
@@ -114,11 +114,11 @@ def test_start_identity_migration_calls_put_item_with_correct_arguments(mocker):
         ),
     ),
 )
-def test_identity_migration_status(instance, status):  # type: ignore[no-untyped-def]
+def test_identity_migration_status(instance, status):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert instance.identity_migration_status == status
 
 
-def test_finish_identity_migration_calls_put_item_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_finish_identity_migration_calls_put_item_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
 ):
     # Given
@@ -150,7 +150,7 @@ def test_finish_identity_migration_calls_put_item_with_correct_arguments(  # typ
     )
 
 
-def test_delete__removes_project_metadata_document_from_dynamodb(  # type: ignore[no-untyped-def]
+def test_delete__removes_project_metadata_document_from_dynamodb(  # type: ignore[no-untyped-def]  # noqa: FT003
     flagsmith_project_metadata_table: Table, mocker: MockerFixture
 ):
     # Given

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamo_environment_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamo_environment_wrapper.py
@@ -11,7 +11,7 @@ from tests.types import EnableFeaturesFixture
 from util.mappers import map_environment_to_environment_document
 
 
-def test_write_environments_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_write_environments_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, project, environment
 ):
     # Given
@@ -82,7 +82,7 @@ def test_write_environments__compress_dynamo_documents_enabled__observes_metrics
     )
 
 
-def test_write_environments__uncompressed__observes_size_metric(
+def test_write_environments__uncompressed__observes_size_metric(  # noqa: FT004
     environment: Environment,
     dynamo_environment_wrapper: DynamoEnvironmentWrapper,
     flagsmith_environment_table: Table,
@@ -123,7 +123,7 @@ def test_write_environments__compress_dynamo_documents_enabled__logs_expected(
     ]
 
 
-def test_get_item_calls_dynamo_get_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_get_item_calls_dynamo_get_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     dynamo_environment_wrapper = DynamoEnvironmentWrapper()
     expected_document = {"key": "value"}
@@ -139,7 +139,7 @@ def test_get_item_calls_dynamo_get_item_with_correct_arguments(mocker):  # type:
     assert returned_item == expected_document
 
 
-def test_get_item_raises_object_does_not_exists_if_get_item_does_not_return_any_item(  # type: ignore[no-untyped-def]
+def test_get_item_raises_object_does_not_exists_if_get_item_does_not_return_any_item(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker,
 ):
     # Given
@@ -153,7 +153,7 @@ def test_get_item_raises_object_does_not_exists_if_get_item_does_not_return_any_
         dynamo_environment_wrapper.get_item(api_key)
 
 
-def test_delete_environment__removes_environment_document_from_dynamodb(  # type: ignore[no-untyped-def]
+def test_delete_environment__removes_environment_document_from_dynamodb(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project_environment_one_document: dict,  # type: ignore[type-arg]
     dynamo_environment_wrapper: DynamoEnvironmentWrapper,
     flagsmith_environment_table: Table,

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_environment_api_key_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_environment_api_key_wrapper.py
@@ -5,7 +5,7 @@ from util.mappers import (
 )
 
 
-def test_write_api_keys_calls_internal_methods_correctly(  # type: ignore[no-untyped-def]
+def test_write_api_keys_calls_internal_methods_correctly(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, environment, environment_api_key
 ):
     # Given
@@ -34,7 +34,7 @@ def test_write_api_keys_calls_internal_methods_correctly(  # type: ignore[no-unt
     assert actual_environment_api_key_document == expected_environment_api_key_document
 
 
-def test_write_api_key_calls_internal_methods_correctly(  # type: ignore[no-untyped-def]
+def test_write_api_key_calls_internal_methods_correctly(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, environment, environment_api_key
 ):
     # Given

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_environment_v2_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_environment_v2_wrapper.py
@@ -27,7 +27,7 @@ from util.mappers import (
 )
 
 
-def test_environment_v2_wrapper__get_identity_overrides_by_environment_id__return_expected(
+def test_environment_v2_wrapper__get_identity_overrides_by_environment_id__return_expected(  # noqa: FT004
     environment: Environment,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     feature: Feature,
@@ -44,7 +44,7 @@ def test_environment_v2_wrapper__get_identity_overrides_by_environment_id__retur
     assert results[0] == identity_override_document
 
 
-def test_environment_v2_wrapper__get_identity_overrides_by_environment_id__last_evaluated_key__call_expected(
+def test_environment_v2_wrapper__get_identity_overrides_by_environment_id__last_evaluated_key__call_expected(  # noqa: FT003
     flagsmith_environments_v2_table: Table,
     mocker: MockerFixture,
 ) -> None:
@@ -126,7 +126,7 @@ def test_environment_v2_wrapper__update_identity_overrides__put_expected(
 
 
 @freeze_time("2023-01-01T00:00:00Z")
-def test_environment_v2_wrapper__update_identity_overrides__put__stores_created_date(
+def test_environment_v2_wrapper__update_identity_overrides__put__stores_created_date(  # noqa: FT003
     settings: SettingsWrapper,
     environment: Environment,
     flagsmith_environments_v2_table: Table,
@@ -233,7 +233,7 @@ def test_environment_v2_wrapper__write_environments__put_expected(
     assert results[0] == map_environment_to_environment_v2_document(environment)
 
 
-def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_enabled__writes_compressed(
+def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_enabled__writes_compressed(  # noqa: FT003
     environment: Environment,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     flagsmith_environments_v2_table: Table,
@@ -253,7 +253,7 @@ def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_e
     assert isinstance(results[0]["feature_states"], Binary)
 
 
-def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_enabled__observes_metrics(
+def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_enabled__observes_metrics(  # noqa: FT003
     environment: Environment,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     flagsmith_environments_v2_table: Table,
@@ -279,7 +279,7 @@ def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_e
     )
 
 
-def test_environment_v2_wrapper__write_environments__uncompressed__observes_size_metric(
+def test_environment_v2_wrapper__write_environments__uncompressed__observes_size_metric(  # noqa: FT003,FT004
     environment: Environment,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     flagsmith_environments_v2_table: Table,
@@ -296,7 +296,7 @@ def test_environment_v2_wrapper__write_environments__uncompressed__observes_size
     )
 
 
-def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_enabled__logs_expected(
+def test_environment_v2_wrapper__write_environments__compress_dynamo_documents_enabled__logs_expected(  # noqa: FT003
     environment: Environment,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
     flagsmith_environments_v2_table: Table,

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -38,7 +38,7 @@ if typing.TYPE_CHECKING:
     from projects.models import Project
 
 
-def test_get_item_from_uuid_calls_query_with_correct_argument(mocker):  # type: ignore[no-untyped-def]
+def test_get_item_from_uuid_calls_query_with_correct_argument(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
     mocked_dynamo_table = mocker.patch.object(dynamo_identity_wrapper, "_table")
@@ -54,7 +54,7 @@ def test_get_item_from_uuid_calls_query_with_correct_argument(mocker):  # type: 
     )
 
 
-def test_get_item_from_uuid_raises_object_does_not_exists_if_identity_is_not_returned(  # type: ignore[no-untyped-def]
+def test_get_item_from_uuid_raises_object_does_not_exists_if_identity_is_not_returned(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker,
 ):
     # Given
@@ -66,7 +66,7 @@ def test_get_item_from_uuid_raises_object_does_not_exists_if_identity_is_not_ret
         dynamo_identity_wrapper.get_item_from_uuid("identity_uuid")
 
 
-def test_get_item_from_uuid_or_404_calls_get_item_from_uuid_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_get_item_from_uuid_or_404_calls_get_item_from_uuid_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
 ):
     # Given
@@ -85,7 +85,7 @@ def test_get_item_from_uuid_or_404_calls_get_item_from_uuid_with_correct_argumen
     mocked_get_item_from_uuid.assert_called_with(identity_uuid)
 
 
-def test_get_item_from_uuid_or_404_calls_raises_not_found_if_internal_method_raises_object_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_item_from_uuid_or_404_calls_raises_not_found_if_internal_method_raises_object_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     mocker,
 ):
     # Given
@@ -100,7 +100,7 @@ def test_get_item_from_uuid_or_404_calls_raises_not_found_if_internal_method_rai
         dynamo_identity_wrapper.get_item_from_uuid_or_404(identity_uuid)
 
 
-def test_delete_item_calls_dynamo_delete_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_delete_item_calls_dynamo_delete_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
     composite_key = "test_key"
@@ -115,7 +115,7 @@ def test_delete_item_calls_dynamo_delete_item_with_correct_arguments(mocker):  #
     )
 
 
-def test_get_item_calls_dynamo_get_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_get_item_calls_dynamo_get_item_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
     composite_key = "test_key"
@@ -130,7 +130,7 @@ def test_get_item_calls_dynamo_get_item_with_correct_arguments(mocker):  # type:
     )
 
 
-def test_get_all_items_without_start_key_calls_query_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_get_all_items_without_start_key_calls_query_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
     environment_key = "environment_key"
@@ -147,7 +147,7 @@ def test_get_all_items_without_start_key_calls_query_with_correct_arguments(mock
     )
 
 
-def test_get_all_items_with_start_key_calls_query_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_get_all_items_with_start_key_calls_query_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
 
@@ -192,7 +192,7 @@ def test_get_all_items__return_consumed_capacity_true__calls_expected(
     )
 
 
-def test_search_items_with_identifier_calls_query_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]
+def test_search_items_with_identifier_calls_query_with_correct_arguments(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     dynamo_identity_wrapper = DynamoIdentityWrapper()
     environment_key = "environment_key"
     identifier = "test_user"
@@ -222,7 +222,7 @@ def test_search_items_with_identifier_calls_query_with_correct_arguments(mocker)
     )
 
 
-def test_write_identities_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_write_identities_calls_internal_methods_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, project, identity
 ):
     # Given
@@ -251,7 +251,7 @@ def test_write_identities_calls_internal_methods_with_correct_arguments(  # type
     assert actual_identity_document == expected_identity_document
 
 
-def test_write_identities_skips_identity_if_identifier_is_too_large(  # type: ignore[no-untyped-def]
+def test_write_identities_skips_identity_if_identifier_is_too_large(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, project, identity
 ):
     # Given
@@ -272,7 +272,7 @@ def test_write_identities_skips_identity_if_identifier_is_too_large(  # type: ig
     mocked_dynamo_table.batch_writer.return_value.__enter__.return_value.put_item.assert_not_called()
 
 
-def test_is_enabled_is_false_if_dynamo_table_name_is_not_set(settings, mocker):  # type: ignore[no-untyped-def]
+def test_is_enabled_is_false_if_dynamo_table_name_is_not_set(settings, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mocker.patch(
         "environments.dynamodb.wrappers.identity_wrapper.DynamoIdentityWrapper.table_name",
@@ -289,7 +289,7 @@ def test_is_enabled_is_false_if_dynamo_table_name_is_not_set(settings, mocker): 
     mocked_boto3.resource.return_value.Table.assert_not_called()
 
 
-def test_is_enabled_is_true_if_dynamo_table_name_is_set(settings, mocker):  # type: ignore[no-untyped-def]
+def test_is_enabled_is_true_if_dynamo_table_name_is_set(settings, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     table_name = "random_table_name"
     settings.IDENTITIES_TABLE_NAME_DYNAMO = table_name
@@ -307,7 +307,7 @@ def test_is_enabled_is_true_if_dynamo_table_name_is_set(settings, mocker):  # ty
     mocked_boto3.resource.return_value.Table.assert_called_with(table_name)
 
 
-def test_get_segment_ids_returns_correct_segment_ids(  # type: ignore[no-untyped-def]
+def test_get_segment_ids_returns_correct_segment_ids(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment, identity, identity_matching_segment, mocker
 ):
     # Given - two segments (one that matches the identity and one that does not)
@@ -329,7 +329,7 @@ def test_get_segment_ids_returns_correct_segment_ids(  # type: ignore[no-untyped
     mocked_get_item_from_uuid.assert_called_with(identity_uuid)
 
 
-def test_get_segment_ids_with_segment_feature_overrides(
+def test_get_segment_ids_with_segment_feature_overrides(  # noqa: FT003
     project: "Project",
     environment: "Environment",
     feature: "Feature",
@@ -394,7 +394,7 @@ def test_get_segment_ids_with_segment_feature_overrides(
     assert segment_ids == [identity_matching_segment.id]
 
 
-def test_get_segment_ids_returns_segment_using_in_operator_for_integer_traits(
+def test_get_segment_ids_returns_segment_using_in_operator_for_integer_traits(  # noqa: FT003
     project: "Project", environment: "Environment", mocker: "MockerFixture"
 ) -> None:
     """
@@ -430,7 +430,7 @@ def test_get_segment_ids_returns_segment_using_in_operator_for_integer_traits(
     assert segment_ids == [segment.id]
 
 
-def test_get_segment_ids_returns_empty_list_if_identity_does_not_exists(  # type: ignore[no-untyped-def]
+def test_get_segment_ids_returns_empty_list_if_identity_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project, environment, identity, mocker
 ):
     # Given
@@ -448,7 +448,7 @@ def test_get_segment_ids_returns_empty_list_if_identity_does_not_exists(  # type
     assert segment_ids == []
 
 
-def test_get_segment_ids_throws_value_error_if_no_arguments():  # type: ignore[no-untyped-def]
+def test_get_segment_ids_throws_value_error_if_no_arguments():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
 
@@ -460,7 +460,7 @@ def test_get_segment_ids_throws_value_error_if_no_arguments():  # type: ignore[n
     # exception raised
 
 
-def test_get_segment_ids_throws_value_error_if_arguments_not_valid():  # type: ignore[no-untyped-def]
+def test_get_segment_ids_throws_value_error_if_arguments_not_valid():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     dynamo_identity_wrapper = DynamoIdentityWrapper()
 
@@ -472,7 +472,7 @@ def test_get_segment_ids_throws_value_error_if_arguments_not_valid():  # type: i
     # exception raised
 
 
-def test_get_segment_ids_with_identity_model(identity, environment, mocker):  # type: ignore[no-untyped-def]
+def test_get_segment_ids_with_identity_model(identity, environment, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     identity_document = map_identity_to_identity_document(identity)
     identity_model = IdentityModel.parse_obj(identity_document)
@@ -586,7 +586,7 @@ def test_identity_wrapper__iter_all_items_paginated__returns_expected(
 
 
 @pytest.mark.parametrize("capacity_budget", [Decimal("2.0"), Decimal("2.2")])
-def test_identity_wrapper__iter_all_items_paginated__capacity_budget_set__raises_expected(
+def test_identity_wrapper__iter_all_items_paginated__capacity_budget_set__raises_expected(  # noqa: FT003
     identity: "Identity",
     mocker: "MockerFixture",
     capacity_budget: Decimal,
@@ -659,7 +659,7 @@ def test_identity_wrapper__iter_all_items_paginated__capacity_budget_set__raises
     )
 
 
-def test_delete_all_identities__deletes_all_identities_documents_from_dynamodb(
+def test_delete_all_identities__deletes_all_identities_documents_from_dynamodb(  # noqa: FT003
     flagsmith_identities_table: Table,
     dynamodb_identity_wrapper: DynamoIdentityWrapper,
 ) -> None:

--- a/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
@@ -24,7 +24,7 @@ from projects.models import Project
 from tests.unit.environments.helpers import get_environment_user_client
 
 
-def test_user_without_update_feature_state_permission_cannot_create_identity_feature_state(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_user_without_update_feature_state_permission_cannot_create_identity_feature_state(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     client,
     organisation_one,
     organisation_one_project_one,
@@ -62,7 +62,7 @@ def test_user_without_update_feature_state_permission_cannot_create_identity_fea
 @pytest.mark.parametrize(
     "permission_keys, admin", (([], True), ([UPDATE_FEATURE_STATE], False))
 )
-def test_user_with_update_feature_state_permission_can_update_identity_feature_state(  # type: ignore[no-untyped-def]
+def test_user_with_update_feature_state_permission_can_update_identity_feature_state(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation_one_project_one_environment_one,
     organisation_one_project_one_feature_one,
     organisation_one_project_one,
@@ -99,7 +99,7 @@ def test_user_with_update_feature_state_permission_can_update_identity_feature_s
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_identity(
+def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_identity(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     staff_client: APIClient,
@@ -121,7 +121,7 @@ def test_user_with_view_environment_permission_can_retrieve_all_feature_states_f
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_identity_clone_flag_states_from(
+def test_identity_clone_flag_states_from(  # noqa: FT003
     project: Project,
     environment: Environment,
     admin_client: Client,

--- a/api/tests/unit/environments/identities/test_unit_identities_models.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_models.py
@@ -30,7 +30,7 @@ from .helpers import (
 )
 
 
-def test_create_identity_should_assign_relevant_attributes(
+def test_create_identity_should_assign_relevant_attributes(  # noqa: FT003,FT004
     environment: Environment,
 ) -> None:
     # When
@@ -43,7 +43,7 @@ def test_create_identity_should_assign_relevant_attributes(
     assert hasattr(identity, "created_date")
 
 
-def test_identity_str__returns_account_identifier(
+def test_identity_str__returns_account_identifier(  # noqa: FT003
     environment: Environment,
 ) -> None:
     # Given
@@ -58,7 +58,7 @@ def test_identity_str__returns_account_identifier(
     assert result == "Account test-identity"
 
 
-def test_get_all_feature_states(
+def test_get_all_feature_states(  # noqa: FT003,FT004
     project: Project,
     environment: Environment,
 ) -> None:
@@ -113,7 +113,7 @@ def test_get_all_feature_states(
     assert fs_identity_anticipated in flags
 
 
-def test_create_trait_should_assign_relevant_attributes(
+def test_create_trait_should_assign_relevant_attributes(  # noqa: FT003,FT004
     environment: Environment,
 ) -> None:
     identity = Identity.objects.create(
@@ -129,7 +129,7 @@ def test_create_trait_should_assign_relevant_attributes(
     assert hasattr(trait, "created_date") is True
 
 
-def test_create_trait_float_value_should_assign_relevant_attributes(
+def test_create_trait_float_value_should_assign_relevant_attributes(  # noqa: FT003,FT004
     environment: Environment,
 ) -> None:
     identity = Identity.objects.create(
@@ -152,7 +152,7 @@ def test_create_trait_float_value_should_assign_relevant_attributes(
     assert hasattr(trait, "created_date") is True
 
 
-def test_get_all_traits_for_identity(environment: Environment) -> None:
+def test_get_all_traits_for_identity(environment: Environment) -> None:  # noqa: FT003,FT004
     identity = Identity.objects.create(
         identifier="test-identifier", environment=environment
     )
@@ -181,7 +181,7 @@ def test_get_all_traits_for_identity(environment: Environment) -> None:
     assert len(traits_identity_two) == 1
 
 
-def test_get_all_feature_states_for_identity_returns_correct_values_for_matching_segment(
+def test_get_all_feature_states_for_identity_returns_correct_values_for_matching_segment(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -250,7 +250,7 @@ def test_get_all_feature_states_for_identity_returns_correct_values_for_matching
     assert remote_config_feature_state.get_feature_state_value() == overridden_value
 
 
-def test_get_all_feature_states_for_identity_returns_correct_values_for_identity_not_matching_segment(
+def test_get_all_feature_states_for_identity_returns_correct_values_for_identity_not_matching_segment(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -312,7 +312,7 @@ def test_get_all_feature_states_for_identity_returns_correct_values_for_identity
     assert remote_config_feature_state.get_feature_state_value() == initial_value
 
 
-def test_get_all_feature_states_for_identity_returns_correct_value_for_matching_segment_when_value_integer(
+def test_get_all_feature_states_for_identity_returns_correct_value_for_matching_segment_when_value_integer(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -362,7 +362,7 @@ def test_get_all_feature_states_for_identity_returns_correct_value_for_matching_
     assert feature_state.get_feature_state_value() == overridden_value
 
 
-def test_get_all_feature_states_for_identity_returns_correct_value_for_matching_segment_when_value_boolean(
+def test_get_all_feature_states_for_identity_returns_correct_value_for_matching_segment_when_value_boolean(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -412,7 +412,7 @@ def test_get_all_feature_states_for_identity_returns_correct_value_for_matching_
     assert not feature_state.get_feature_state_value()
 
 
-def test_get_all_feature_states_highest_value_of_highest_priority_segment(
+def test_get_all_feature_states_highest_value_of_highest_priority_segment(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -496,7 +496,7 @@ def test_get_all_feature_states_highest_value_of_highest_priority_segment(
     assert remote_config_feature_state.get_feature_state_value() == overridden_value_1
 
 
-def test_remote_config_override(
+def test_remote_config_override(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -553,7 +553,7 @@ def test_remote_config_override(
     assert overridden_feature_state.get_feature_state_value() == overridden_value_2
 
 
-def test_get_all_feature_states_returns_correct_value_when_traits_passed_manually(
+def test_get_all_feature_states_returns_correct_value_when_traits_passed_manually(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -612,7 +612,7 @@ def test_get_all_feature_states_returns_correct_value_when_traits_passed_manuall
     assert feature_states[0].enabled == enabled_for_segment
 
 
-def test_generate_traits_with_persistence(environment: Environment) -> None:
+def test_generate_traits_with_persistence(environment: Environment) -> None:  # noqa: FT003
     # Given
     identity = Identity.objects.create(identifier="identifier", environment=environment)
     trait_data_items = [
@@ -636,7 +636,7 @@ def test_generate_traits_with_persistence(environment: Environment) -> None:
     ).exists()
 
 
-def test_generate_traits_without_persistence(environment: Environment) -> None:
+def test_generate_traits_without_persistence(environment: Environment) -> None:  # noqa: FT003
     # Given
     identity = Identity.objects.create(identifier="identifier", environment=environment)
 
@@ -659,7 +659,7 @@ def test_generate_traits_without_persistence(environment: Environment) -> None:
     assert Trait.objects.filter(identity=identity).count() == 0
 
 
-def test_update_traits(environment: Environment) -> None:
+def test_update_traits(environment: Environment) -> None:  # noqa: FT003
     """
     This is quite a long test to verify the update traits functionality correctly
     handles updating and creating traits.
@@ -725,7 +725,7 @@ def test_update_traits(environment: Environment) -> None:
     assert transient_trait.trait_value == transient_trait_value
 
 
-def test_update_traits_deletes_when_nulled_out(environment: Environment) -> None:
+def test_update_traits_deletes_when_nulled_out(environment: Environment) -> None:  # noqa: FT003
     """
     This is quite a long test to verify the update traits functionality correctly
     handles updating and creating traits.
@@ -762,7 +762,7 @@ def test_update_traits_deletes_when_nulled_out(environment: Environment) -> None
     assert updated_traits[0].trait_value == trait_2_value
 
 
-def test_get_identity_segments(
+def test_get_identity_segments(  # noqa: FT003
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,
     project: Project,
@@ -816,7 +816,7 @@ def test_get_identity_segments(
     assert len(segments) == 1 and segments[0] == segment
 
 
-def test_get_segments_with_overrides_only_only_returns_segments_overridden_in_environment(
+def test_get_segments_with_overrides_only_only_returns_segments_overridden_in_environment(  # noqa: FT003
     project: Project,
     environment: Environment,
 ) -> None:
@@ -861,7 +861,7 @@ def test_get_segments_with_overrides_only_only_returns_segments_overridden_in_en
     assert identity_segments[0] == segment_1
 
 
-def test_get_all_feature_states_does_not_return_null_versions(
+def test_get_all_feature_states_does_not_return_null_versions(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,
@@ -885,7 +885,7 @@ def test_get_all_feature_states_does_not_return_null_versions(
     assert identity_feature_states[0].id == version_1_feature_state.id
 
 
-def test_update_traits_does_not_make_extra_queries_if_traits_value_do_not_change(  # type: ignore[no-untyped-def]
+def test_update_traits_does_not_make_extra_queries_if_traits_value_do_not_change(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     identity, django_assert_num_queries, trait
 ):
     # Given
@@ -913,7 +913,7 @@ def test_update_traits_does_not_make_extra_queries_if_traits_value_do_not_change
         (None, False, True),
     ),
 )
-def test_get_all_feature_hide_disabled_flags(  # type: ignore[no-untyped-def]
+def test_get_all_feature_hide_disabled_flags(  # type: ignore[no-untyped-def]  # noqa: FT003
     project,
     environment,
     identity,
@@ -961,7 +961,7 @@ def test_get_all_feature_hide_disabled_flags(  # type: ignore[no-untyped-def]
     assert bool(identity_flags) == disabled_flag_returned
 
 
-def test_identity_get_all_feature_states_gets_latest_committed_version(environment):  # type: ignore[no-untyped-def]
+def test_identity_get_all_feature_states_gets_latest_committed_version(environment):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     identity = Identity.objects.create(identifier="identity", environment=environment)
 
@@ -1008,7 +1008,7 @@ def test_identity_get_all_feature_states_gets_latest_committed_version(environme
     assert identity_feature_state.get_feature_state_value() == "v2"
 
 
-def test_get_hash_key_with_use_identity_composite_key_for_hashing_enabled(  # type: ignore[no-untyped-def]
+def test_get_hash_key_with_use_identity_composite_key_for_hashing_enabled(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     identity: Identity,
 ):
     assert (
@@ -1017,7 +1017,7 @@ def test_get_hash_key_with_use_identity_composite_key_for_hashing_enabled(  # ty
     )
 
 
-def test_get_hash_key_with_use_identity_composite_key_for_hashing_disabled(  # type: ignore[no-untyped-def]
+def test_get_hash_key_with_use_identity_composite_key_for_hashing_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     identity: Identity,
 ):
     assert identity.get_hash_key(use_identity_composite_key_for_hashing=False) == str(

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -36,7 +36,7 @@ from projects.models import Project, UserProjectPermission
 from segments.models import Condition, Segment, SegmentRule
 
 
-def test_should_return_identities_list_when_requested(
+def test_should_return_identities_list_when_requested(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     admin_client: APIClient,
@@ -57,7 +57,7 @@ def test_should_return_identities_list_when_requested(
     assert response.data["identifier"] == identity.identifier
 
 
-def test_should_create_identity_feature_when_post(
+def test_should_create_identity_feature_when_post(  # noqa: FT003
     feature: Feature,
     admin_client: APIClient,
     identity: Identity,
@@ -83,7 +83,7 @@ def test_should_create_identity_feature_when_post(
     assert identity_features.count() == 1
 
 
-def test_should_return_400_when_duplicate_identity_feature_is_posted(
+def test_should_return_400_when_duplicate_identity_feature_is_posted(  # noqa: FT003
     feature: Feature,
     admin_client: APIClient,
     identity: Identity,
@@ -113,7 +113,7 @@ def test_should_return_400_when_duplicate_identity_feature_is_posted(
     assert identity_feature.count() == 1
 
 
-def test_should_change_enabled_state_when_put(
+def test_should_change_enabled_state_when_put(  # noqa: FT003
     feature: Feature,
     admin_client: APIClient,
     identity: Identity,
@@ -144,7 +144,7 @@ def test_should_change_enabled_state_when_put(
     assert feature_state.enabled
 
 
-def test_should_remove_identity_feature_when_delete(
+def test_should_remove_identity_feature_when_delete(  # noqa: FT003
     admin_client: APIClient,
     feature: Feature,
     project: Project,
@@ -179,7 +179,7 @@ def test_should_remove_identity_feature_when_delete(
     assert identity_features.count() == 1
 
 
-def test_can_search_for_identities(
+def test_can_search_for_identities(  # noqa: FT003
     admin_client: APIClient,
     identity: Identity,
     environment: Environment,
@@ -205,7 +205,7 @@ def test_can_search_for_identities(
     assert response.data["results"][0]["identifier"] == identity.identifier
 
 
-def test_can_search_for_identities_with_exact_match(
+def test_can_search_for_identities_with_exact_match(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
 ) -> None:
@@ -235,7 +235,7 @@ def test_can_search_for_identities_with_exact_match(
     assert response.data["results"][0]["id"] == identity_to_return.id
 
 
-def test_search_identities_is_case_insensitive(
+def test_search_identities_is_case_insensitive(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     admin_client: APIClient,
@@ -258,7 +258,7 @@ def test_search_identities_is_case_insensitive(
     assert response.data["count"] == 1
 
 
-def test_no_identities_returned_if_search_matches_none(
+def test_no_identities_returned_if_search_matches_none(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
 ) -> None:
@@ -277,7 +277,7 @@ def test_no_identities_returned_if_search_matches_none(
     assert response.data["count"] == 0
 
 
-def test_search_identities_still_allows_paging(
+def test_search_identities_still_allows_paging(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
 ) -> None:
@@ -302,7 +302,7 @@ def test_search_identities_still_allows_paging(
     assert response2.data["results"]
 
 
-def test_can_delete_identity(
+def test_can_delete_identity(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
     identity: Identity,
@@ -321,7 +321,7 @@ def test_can_delete_identity(
     assert not Identity.objects.filter(id=identity.id).exists()
 
 
-def test_identities_endpoint_returns_all_feature_states_for_identity_if_feature_not_provided(
+def test_identities_endpoint_returns_all_feature_states_for_identity_if_feature_not_provided(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -341,7 +341,7 @@ def test_identities_endpoint_returns_all_feature_states_for_identity_if_feature_
     assert len(response.data["flags"]) == 2
 
 
-def test_get_flags_for_identities_with_cache(
+def test_get_flags_for_identities_with_cache(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     django_assert_num_queries: DjangoAssertNumQueries,
@@ -390,7 +390,7 @@ def test_get_flags_for_identities_with_cache(
 
 
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
-def test_identities_endpoint_get_all_feature_amplitude_called(
+def test_identities_endpoint_get_all_feature_amplitude_called(  # noqa: FT003
     mock_amplitude_wrapper: mock.MagicMock,
     environment: Environment,
     identity: Identity,
@@ -417,7 +417,7 @@ def test_identities_endpoint_get_all_feature_amplitude_called(
 
 
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
-def test_identities_endpoint_returns_traits(
+def test_identities_endpoint_returns_traits(  # noqa: FT003
     mock_amplitude_wrapper: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -445,7 +445,7 @@ def test_identities_endpoint_returns_traits(
     mock_amplitude_wrapper.assert_not_called()
 
 
-def test_identities_endpoint_returns_single_feature_state_if_feature_provided(
+def test_identities_endpoint_returns_single_feature_state_if_feature_provided(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -469,7 +469,7 @@ def test_identities_endpoint_returns_single_feature_state_if_feature_provided(
 
 
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
-def test_identities_endpoint_returns_value_for_segment_if_identity_in_segment(
+def test_identities_endpoint_returns_value_for_segment_if_identity_in_segment(  # noqa: FT003
     mock_amplitude_wrapper: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -524,7 +524,7 @@ def test_identities_endpoint_returns_value_for_segment_if_identity_in_segment(
 
 
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
-def test_identities_endpoint_returns_value_for_segment_if_identity_in_segment_and_feature_specified(
+def test_identities_endpoint_returns_value_for_segment_if_identity_in_segment_and_feature_specified(  # noqa: FT003
     mock_amplitude_wrapper: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -579,7 +579,7 @@ def test_identities_endpoint_returns_value_for_segment_if_identity_in_segment_an
 
 
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
-def test_identities_endpoint_returns_value_for_segment_if_rule_type_percentage_split_and_identity_in_segment(
+def test_identities_endpoint_returns_value_for_segment_if_rule_type_percentage_split_and_identity_in_segment(  # noqa: FT003
     mock_amplitude_wrapper: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -627,7 +627,7 @@ def test_identities_endpoint_returns_value_for_segment_if_rule_type_percentage_s
 
 
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
-def test_identities_endpoint_returns_default_value_if_rule_type_percentage_split_and_identity_not_in_segment(
+def test_identities_endpoint_returns_default_value_if_rule_type_percentage_split_and_identity_not_in_segment(  # noqa: FT003
     mock_amplitude_wrapper: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -672,7 +672,7 @@ def test_identities_endpoint_returns_default_value_if_rule_type_percentage_split
     mock_amplitude_wrapper.assert_not_called()
 
 
-def test_post_identify_with_new_identity_work_with_null_trait_value(
+def test_post_identify_with_new_identity_work_with_null_trait_value(  # noqa: FT003
     environment: Environment,
     api_client: APIClient,
     identity: Identity,
@@ -697,7 +697,7 @@ def test_post_identify_with_new_identity_work_with_null_trait_value(
     assert identity.identity_traits.count() == 0
 
 
-def test_post_identify_deletes_a_trait_if_trait_value_is_none(  # type: ignore[no-untyped-def]
+def test_post_identify_deletes_a_trait_if_trait_value_is_none(  # type: ignore[no-untyped-def]  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -737,7 +737,7 @@ def test_post_identify_deletes_a_trait_if_trait_value_is_none(  # type: ignore[n
     assert identity.identity_traits.filter(trait_key=trait_2.trait_key).exists()
 
 
-def test_post_identify_with_persistence(
+def test_post_identify_with_persistence(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -770,7 +770,7 @@ def test_post_identify_with_persistence(
     assert identity.identity_traits.count() == 2
 
 
-def test_post_identify_without_persistence(
+def test_post_identify_without_persistence(  # noqa: FT003
     organisation: Organisation,
     identity: Identity,
     environment: Environment,
@@ -812,7 +812,7 @@ def test_post_identify_without_persistence(
 
 @override_settings(EDGE_API_URL="http://localhost")
 @mock.patch("environments.identities.views.forward_identity_request")
-def test_post_identities_calls_forward_identity_request_with_correct_arguments(
+def test_post_identities_calls_forward_identity_request_with_correct_arguments(  # noqa: FT003
     mocked_forward_identity_request: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -849,7 +849,7 @@ def test_post_identities_calls_forward_identity_request_with_correct_arguments(
 
 @override_settings(EDGE_API_URL="http://localhost")
 @mock.patch("environments.identities.views.forward_identity_request")
-def test_get_identities_calls_forward_identity_request_with_correct_arguments(
+def test_get_identities_calls_forward_identity_request_with_correct_arguments(  # noqa: FT003
     mocked_forward_identity_request: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -877,7 +877,7 @@ def test_get_identities_calls_forward_identity_request_with_correct_arguments(
     assert kwargs["kwargs"]["query_params"] == {"identifier": identity.identifier}
 
 
-def test_post_identities_returns_empty_traits_if_client_cannot_set_traits(
+def test_post_identities_returns_empty_traits_if_client_cannot_set_traits(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -905,7 +905,7 @@ def test_post_identities_returns_empty_traits_if_client_cannot_set_traits(
     assert response.json()["identifier"] == identity.identifier
 
 
-def test_post_identities_with_traits_success_if_client_cannot_set_traits_server_key(
+def test_post_identities_with_traits_success_if_client_cannot_set_traits_server_key(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -938,7 +938,7 @@ def test_post_identities_with_traits_success_if_client_cannot_set_traits_server_
     assert trait.trait_value == trait_value  # type: ignore[union-attr]
 
 
-def test_post_identities_request_includes_updated_at_header(
+def test_post_identities_request_includes_updated_at_header(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     api_client: APIClient,
@@ -963,7 +963,7 @@ def test_post_identities_request_includes_updated_at_header(
     )
 
 
-def test_get_identities_request_includes_updated_at_header(
+def test_get_identities_request_includes_updated_at_header(  # noqa: FT003
     environment: Environment,
     api_client: APIClient,
 ) -> None:
@@ -981,7 +981,7 @@ def test_get_identities_request_includes_updated_at_header(
     )
 
 
-def test_get_identities_with_hide_sensitive_data_with_feature_name(  # type: ignore[no-untyped-def]
+def test_get_identities_with_hide_sensitive_data_with_feature_name(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, feature, identity, api_client
 ):
     # Given
@@ -1013,7 +1013,7 @@ def test_get_identities_with_hide_sensitive_data_with_feature_name(  # type: ign
         assert flag["feature"][field] is None
 
 
-def test_get_identities_with_hide_sensitive_data(  # type: ignore[no-untyped-def]
+def test_get_identities_with_hide_sensitive_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, feature, identity, api_client
 ):
     # Given
@@ -1064,7 +1064,7 @@ def test_get_identities__transient__no_persistence(
     assert not Identity.objects.filter(identifier=identifier).count()
 
 
-def test_post_identities_with_hide_sensitive_data(  # type: ignore[no-untyped-def]
+def test_post_identities_with_hide_sensitive_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, feature, identity, api_client
 ):
     # Given
@@ -1130,7 +1130,7 @@ def test_post_identities__server_key_only_feature__return_expected(
     assert not response.json()["flags"]
 
 
-def test_post_identities__server_key_only_feature__server_key_auth__return_expected(
+def test_post_identities__server_key_only_feature__server_key_auth__return_expected(  # noqa: FT003
     environment_api_key: EnvironmentAPIKey,
     feature: Feature,
     identity: Identity,
@@ -1203,7 +1203,7 @@ def test_post_identities__transient__no_persistence(
         pytest.param({}, id="trait-default"),
     ],
 )
-def test_post_identities__existing__transient__no_persistence(
+def test_post_identities__existing__transient__no_persistence(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     trait: Trait,
@@ -1290,7 +1290,7 @@ def test_post_identities__transient_traits__no_persistence(
     assert not Trait.objects.filter(trait_key=transient_trait_key).exists()
 
 
-def test_user_with_view_identities_permission_can_retrieve_identity(
+def test_user_with_view_identities_permission_can_retrieve_identity(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     staff_client: APIClient,
@@ -1319,7 +1319,7 @@ def test_user_with_view_identities_permission_can_retrieve_identity(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_user_with_view_environment_permission_can_not_list_identities(
+def test_user_with_view_environment_permission_can_not_list_identities(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     staff_client: APIClient,
@@ -1346,7 +1346,7 @@ def test_user_with_view_environment_permission_can_not_list_identities(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_identity_view_set_get_permissions():  # type: ignore[no-untyped-def]
+def test_identity_view_set_get_permissions():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     view_set = views.IdentityViewSet()
 
@@ -1420,7 +1420,7 @@ def test_SDKIdentitiesDeprecated__given_identifier__retrieves_identity(
         pytest.param(True, False, True, 4, id="replica_db,old_identity,transient"),
     ],
 )
-def test_SDKIdentities_retrieves_identity_feature_states(
+def test_SDKIdentities_retrieves_identity_feature_states(  # noqa: FT003
     api_client: APIClient,
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,

--- a/api/tests/unit/environments/identities/traits/test_traits_views.py
+++ b/api/tests/unit/environments/identities/traits/test_traits_views.py
@@ -27,7 +27,7 @@ from projects.models import Project, UserProjectPermission
 from users.models import FFAdminUser
 
 
-def test_can_set_trait_for_an_identity(
+def test_can_set_trait_for_an_identity(  # noqa: FT003
     api_client: APIClient,
     identity: Identity,
     environment: Environment,
@@ -53,7 +53,7 @@ def test_can_set_trait_for_an_identity(
     assert Trait.objects.filter(identity=identity, trait_key=trait_key).exists()
 
 
-def test_cannot_set_trait_for_an_identity_for_organisations_without_persistence(
+def test_cannot_set_trait_for_an_identity_for_organisations_without_persistence(  # noqa: FT003
     api_client: APIClient,
     identity: Identity,
     organisation: Organisation,
@@ -89,7 +89,7 @@ def test_cannot_set_trait_for_an_identity_for_organisations_without_persistence(
     assert Trait.objects.count() == 0
 
 
-def test_can_set_trait_with_boolean_value_for_an_identity(
+def test_can_set_trait_with_boolean_value_for_an_identity(  # noqa: FT003
     api_client: APIClient,
     identity: Identity,
     environment: Environment,
@@ -120,7 +120,7 @@ def test_can_set_trait_with_boolean_value_for_an_identity(
     )
 
 
-def test_can_set_trait_with_identity_value_for_an_identity(
+def test_can_set_trait_with_identity_value_for_an_identity(  # noqa: FT003
     api_client: APIClient,
     identity: Identity,
     environment: Environment,
@@ -151,7 +151,7 @@ def test_can_set_trait_with_identity_value_for_an_identity(
     )
 
 
-def test_can_set_trait_with_float_value_for_an_identity(
+def test_can_set_trait_with_float_value_for_an_identity(  # noqa: FT003
     api_client: APIClient,
     identity: Identity,
     environment: Environment,
@@ -184,7 +184,7 @@ def test_can_set_trait_with_float_value_for_an_identity(
     )
 
 
-def test_add_trait_creates_identity_if_it_doesnt_exist(
+def test_add_trait_creates_identity_if_it_doesnt_exist(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -217,7 +217,7 @@ def test_add_trait_creates_identity_if_it_doesnt_exist(
     ).exists()
 
 
-def test_trait_is_updated_if_already_exists(
+def test_trait_is_updated_if_already_exists(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -252,7 +252,7 @@ def test_trait_is_updated_if_already_exists(
     assert trait.get_trait_value() == new_value  # type: ignore[no-untyped-call]
 
 
-def test_increment_value_increments_trait_value_if_value_positive_integer(
+def test_increment_value_increments_trait_value_if_value_positive_integer(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -287,7 +287,7 @@ def test_increment_value_increments_trait_value_if_value_positive_integer(
     assert trait.get_trait_value() == initial_value + increment_by  # type: ignore[no-untyped-call]
 
 
-def test_increment_value_decrements_trait_value_if_value_negative_integer(
+def test_increment_value_decrements_trait_value_if_value_negative_integer(  # noqa: FT003
     api_client: APIClient,
     identity: Identity,
     environment: Environment,
@@ -321,7 +321,7 @@ def test_increment_value_decrements_trait_value_if_value_negative_integer(
     assert trait.get_trait_value() == initial_value + increment_by  # type: ignore[no-untyped-call]
 
 
-def test_increment_value_initialises_trait_with_a_value_of_zero_if_it_doesnt_exist(
+def test_increment_value_initialises_trait_with_a_value_of_zero_if_it_doesnt_exist(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -345,7 +345,7 @@ def test_increment_value_initialises_trait_with_a_value_of_zero_if_it_doesnt_exi
     assert trait.get_trait_value() == increment_by  # type: ignore[no-untyped-call]
 
 
-def test_increment_value_returns_400_if_trait_value_not_integer(
+def test_increment_value_returns_400_if_trait_value_not_integer(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -373,7 +373,7 @@ def test_increment_value_returns_400_if_trait_value_not_integer(
     assert res.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_set_trait_with_too_long_string_value_returns_400(
+def test_set_trait_with_too_long_string_value_returns_400(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -405,7 +405,7 @@ def test_set_trait_with_too_long_string_value_returns_400(
     )
 
 
-def test_can_set_trait_with_bad_value_for_an_identity(
+def test_can_set_trait_with_bad_value_for_an_identity(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     identity: Identity,
@@ -436,7 +436,7 @@ def test_can_set_trait_with_bad_value_for_an_identity(
     ).get_trait_value() == str(bad_trait_value)
 
 
-def test_bulk_create_traits(
+def test_bulk_create_traits(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -470,7 +470,7 @@ def test_bulk_create_traits(
     )
 
 
-def test_bulk_create_traits_when_bad_trait_value_sent_then_trait_value_stringified(
+def test_bulk_create_traits_when_bad_trait_value_sent_then_trait_value_stringified(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -516,7 +516,7 @@ def test_bulk_create_traits_when_bad_trait_value_sent_then_trait_value_stringifi
     ).get_trait_value() == str(bad_trait_value)
 
 
-def test_sending_null_value_in_bulk_create_deletes_trait_for_identity(
+def test_sending_null_value_in_bulk_create_deletes_trait_for_identity(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -562,7 +562,7 @@ def test_sending_null_value_in_bulk_create_deletes_trait_for_identity(
     assert Trait.objects.filter(id=trait_to_keep.id).exists()
 
 
-def test_bulk_create_traits_when_float_value_sent_then_trait_value_correct(
+def test_bulk_create_traits_when_float_value_sent_then_trait_value_correct(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -601,7 +601,7 @@ def test_bulk_create_traits_when_float_value_sent_then_trait_value_correct(
 
 @override_settings(EDGE_API_URL="http://localhost")
 @mock.patch("environments.identities.traits.views.forward_trait_request")
-def test_post_trait_calls_forward_trait_request_with_correct_arguments(
+def test_post_trait_calls_forward_trait_request_with_correct_arguments(  # noqa: FT003
     mocked_forward_trait_request: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -636,7 +636,7 @@ def test_post_trait_calls_forward_trait_request_with_correct_arguments(
 
 @override_settings(EDGE_API_URL="http://localhost")
 @mock.patch("environments.identities.traits.views.forward_trait_request")
-def test_increment_value_calls_forward_trait_request_with_correct_arguments(
+def test_increment_value_calls_forward_trait_request_with_correct_arguments(  # noqa: FT003
     mocked_forward_trait_request: mock.MagicMock,
     identity: Identity,
     api_client: APIClient,
@@ -674,7 +674,7 @@ def test_increment_value_calls_forward_trait_request_with_correct_arguments(
 
 @override_settings(EDGE_API_URL="http://localhost")
 @mock.patch("environments.identities.traits.views.forward_trait_requests")
-def test_bulk_create_traits_calls_forward_trait_request_with_correct_arguments(
+def test_bulk_create_traits_calls_forward_trait_request_with_correct_arguments(  # noqa: FT003
     mocked_forward_trait_requests: mock.MagicMock,
     api_client: APIClient,
     environment: Environment,
@@ -711,7 +711,7 @@ def test_bulk_create_traits_calls_forward_trait_request_with_correct_arguments(
     assert kwargs["args"][3] == data
 
 
-def test_create_trait_returns_403_if_client_cannot_set_traits(
+def test_create_trait_returns_403_if_client_cannot_set_traits(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -739,7 +739,7 @@ def test_create_trait_returns_403_if_client_cannot_set_traits(
     }
 
 
-def test_server_key_can_create_trait_if_not_allow_client_traits(
+def test_server_key_can_create_trait_if_not_allow_client_traits(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -767,7 +767,7 @@ def test_server_key_can_create_trait_if_not_allow_client_traits(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_bulk_create_traits_returns_403_if_client_cannot_set_traits(
+def test_bulk_create_traits_returns_403_if_client_cannot_set_traits(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -795,7 +795,7 @@ def test_bulk_create_traits_returns_403_if_client_cannot_set_traits(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_server_key_can_bulk_create_traits_if_not_allow_client_traits(
+def test_server_key_can_bulk_create_traits_if_not_allow_client_traits(  # noqa: FT003
     identity: Identity,
     api_client: APIClient,
     environment: Environment,
@@ -826,7 +826,7 @@ def test_server_key_can_bulk_create_traits_if_not_allow_client_traits(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_delete_trait_only_deletes_single_trait_if_query_param_not_provided(
+def test_delete_trait_only_deletes_single_trait_if_query_param_not_provided(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     admin_client: APIClient,
@@ -864,7 +864,7 @@ def test_delete_trait_only_deletes_single_trait_if_query_param_not_provided(
     assert Trait.objects.filter(pk=trait_2.id).exists()
 
 
-def test_delete_trait_deletes_all_traits_if_query_param_provided(
+def test_delete_trait_deletes_all_traits_if_query_param_provided(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     admin_client: APIClient,
@@ -903,7 +903,7 @@ def test_delete_trait_deletes_all_traits_if_query_param_provided(
     assert not Trait.objects.filter(pk=trait_2.id).exists()
 
 
-def test_delete_trait_only_deletes_traits_in_current_environment(
+def test_delete_trait_only_deletes_traits_in_current_environment(  # noqa: FT003
     identity: Identity,
     environment: Environment,
     admin_client: APIClient,
@@ -944,7 +944,7 @@ def test_delete_trait_only_deletes_traits_in_current_environment(
     assert Trait.objects.filter(pk=trait_2.id).exists()
 
 
-def test_set_trait_for_an_identity_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_set_trait_for_an_identity_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings, identity, environment, api_client
 ):
     # Given
@@ -969,7 +969,7 @@ def test_set_trait_for_an_identity_is_not_throttled_by_user_throttle(  # type: i
         assert res.status_code == status.HTTP_200_OK
 
 
-def test_user_with_manage_identities_permission_can_add_trait_for_identity(
+def test_user_with_manage_identities_permission_can_add_trait_for_identity(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     staff_user: FFAdminUser,
@@ -1000,7 +1000,7 @@ def test_user_with_manage_identities_permission_can_add_trait_for_identity(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_trait_view_delete_trait(environment, admin_client, identity, trait, mocker):  # type: ignore[no-untyped-def]
+def test_trait_view_delete_trait(environment, admin_client, identity, trait, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:environments:identities-traits-detail",
@@ -1017,7 +1017,7 @@ def test_trait_view_delete_trait(environment, admin_client, identity, trait, moc
     assert not Trait.objects.filter(pk=trait.id).exists()
 
 
-def test_trait_view_set_update(environment, admin_client, identity, trait, mocker):  # type: ignore[no-untyped-def]
+def test_trait_view_set_update(environment, admin_client, identity, trait, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:environments:identities-traits-detail",
@@ -1033,7 +1033,7 @@ def test_trait_view_set_update(environment, admin_client, identity, trait, mocke
     assert response.json()["string_value"] == new_value
 
 
-def test_edge_identity_view_set_get_permissions():  # type: ignore[no-untyped-def]
+def test_edge_identity_view_set_get_permissions():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     view_set = TraitViewSet()
 

--- a/api/tests/unit/environments/identities/traits/test_unit_traits_models.py
+++ b/api/tests/unit/environments/identities/traits/test_unit_traits_models.py
@@ -14,7 +14,7 @@ from environments.identities.traits.models import Trait
         (123.4, {"value_type": "float", "float_value": 123.4}),
     ),
 )
-def test_generate_trait_value_data_for_value(value, expected_data):  # type: ignore[no-untyped-def]
+def test_generate_trait_value_data_for_value(value, expected_data):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert Trait.generate_trait_value_data(value) == expected_data
 
 
@@ -41,13 +41,13 @@ def test_generate_trait_value_data_for_value(value, expected_data):  # type: ign
         ),
     ),
 )
-def test_generate_trait_value_data_for_deserialized_data(  # type: ignore[no-untyped-def]
+def test_generate_trait_value_data_for_deserialized_data(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     deserialized_data, expected_data
 ):
     assert Trait.generate_trait_value_data(deserialized_data) == expected_data
 
 
-def test_trait_bulk_create_create_objects(identity):  # type: ignore[no-untyped-def]
+def test_trait_bulk_create_create_objects(identity):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     traits = [
         Trait(identity=identity, trait_key="key1"),
@@ -61,7 +61,7 @@ def test_trait_bulk_create_create_objects(identity):  # type: ignore[no-untyped-
     assert Trait.objects.filter(identity=identity).count() == 2
 
 
-def test_trait_bulk_delete_deletes_objects(trait):  # type: ignore[no-untyped-def]
+def test_trait_bulk_delete_deletes_objects(trait):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     Trait.objects.filter(identity=trait.identity).delete()
 

--- a/api/tests/unit/environments/identities/traits/test_unit_traits_serializers.py
+++ b/api/tests/unit/environments/identities/traits/test_unit_traits_serializers.py
@@ -3,7 +3,7 @@ from environments.identities.traits.models import Trait
 from environments.sdk.serializers import SDKBulkCreateUpdateTraitSerializer
 
 
-def test_bulk_create_update_serializer_save_many(  # type: ignore[no-untyped-def]
+def test_bulk_create_update_serializer_save_many(  # type: ignore[no-untyped-def]  # noqa: FT003
     identity, django_assert_num_queries, mocker
 ):
     # Given

--- a/api/tests/unit/environments/management/commands/test_unit_environments_management_commands_migrate_to_edge.py
+++ b/api/tests/unit/environments/management/commands/test_unit_environments_management_commands_migrate_to_edge.py
@@ -5,7 +5,7 @@ from django.core.management.base import CommandError
 from environments.dynamodb.migrator import IdentityMigrator
 
 
-def test_calling_migrate_to_edge_calls_migrate_identities_with_correct_arguments(  # type: ignore[no-untyped-def]
+def test_calling_migrate_to_edge_calls_migrate_identities_with_correct_arguments(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
 ):
     # Given
@@ -24,7 +24,7 @@ def test_calling_migrate_to_edge_calls_migrate_identities_with_correct_arguments
     mocked_identity_migrator.return_value.migrate.assert_called_with()
 
 
-def test_calling_migrate_to_edge_raises_command_error_if_identities_are_already_migrated(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_calling_migrate_to_edge_raises_command_error_if_identities_are_already_migrated(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker,
 ):
     # Given

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
@@ -28,7 +28,7 @@ nested_environment_permissions = NestedEnvironmentPermissions()
 environment_admin_permissions = EnvironmentAdminPermission()
 
 
-def test_environment_admin_permissions_has_permissions_returns_false_for_non_admin_user(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_environment_admin_permissions_has_permissions_returns_false_for_non_admin_user(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     environment, django_user_model, mocker
 ) -> None:
     # Given
@@ -46,7 +46,7 @@ def test_environment_admin_permissions_has_permissions_returns_false_for_non_adm
     assert has_permission is False
 
 
-def test_environment_admin_permissions_has_permissions_returns_true_for_admin_user(
+def test_environment_admin_permissions_has_permissions_returns_true_for_admin_user(  # noqa: FT003
     environment: Environment,
     staff_user: FFAdminUser,
     user_environment_permission: UserEnvironmentPermission,
@@ -71,7 +71,7 @@ def test_environment_admin_permissions_has_permissions_returns_true_for_admin_us
     assert has_permission is True
 
 
-def test_org_admin_can_create_environment_for_any_project(
+def test_org_admin_can_create_environment_for_any_project(  # noqa: FT003
     admin_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -88,7 +88,7 @@ def test_org_admin_can_create_environment_for_any_project(
     assert result is True
 
 
-def test_project_admin_can_create_environment_in_project(
+def test_project_admin_can_create_environment_in_project(  # noqa: FT003
     admin_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -105,7 +105,7 @@ def test_project_admin_can_create_environment_in_project(
     assert result is True
 
 
-def test_project_user_with_create_environment_permission_can_create_environment(
+def test_project_user_with_create_environment_permission_can_create_environment(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -129,7 +129,7 @@ def test_project_user_with_create_environment_permission_can_create_environment(
     assert result is True
 
 
-def test_project_user_without_create_environment_permission_cannot_create_environment(
+def test_project_user_without_create_environment_permission_cannot_create_environment(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -146,7 +146,7 @@ def test_project_user_without_create_environment_permission_cannot_create_enviro
     assert result is False
 
 
-def test_all_users_can_list_environments_for_project(
+def test_all_users_can_list_environments_for_project(  # noqa: FT003
     staff_user: FFAdminUser,
 ) -> None:
     # Given
@@ -161,7 +161,7 @@ def test_all_users_can_list_environments_for_project(
     assert result is True
 
 
-def test_organisation_admin_can_delete_environment(
+def test_organisation_admin_can_delete_environment(  # noqa: FT003
     admin_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -179,7 +179,7 @@ def test_organisation_admin_can_delete_environment(
     assert result is True
 
 
-def test_project_admin_can_delete_environment(
+def test_project_admin_can_delete_environment(  # noqa: FT003
     admin_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -197,7 +197,7 @@ def test_project_admin_can_delete_environment(
     assert result is True
 
 
-def test_environment_admin_can_delete_environment(
+def test_environment_admin_can_delete_environment(  # noqa: FT003
     admin_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -215,7 +215,7 @@ def test_environment_admin_can_delete_environment(
     assert result is True
 
 
-def test_regular_user_cannot_delete_environment(
+def test_regular_user_cannot_delete_environment(  # noqa: FT003
     staff_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -233,7 +233,7 @@ def test_regular_user_cannot_delete_environment(
     assert result is False
 
 
-def test_organisation_admin_has_create_permission(
+def test_organisation_admin_has_create_permission(  # noqa: FT003
     admin_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -250,7 +250,7 @@ def test_organisation_admin_has_create_permission(
     assert result is True
 
 
-def test_environment_admin_has_create_permission(
+def test_environment_admin_has_create_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -270,7 +270,7 @@ def test_environment_admin_has_create_permission(
     assert result is True
 
 
-def test_regular_user_does_not_have_create_permission(
+def test_regular_user_does_not_have_create_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     environment: Environment,
 ) -> None:
@@ -287,7 +287,7 @@ def test_regular_user_does_not_have_create_permission(
     assert result is False
 
 
-def test_organisation_admin_has_destroy_permission(
+def test_organisation_admin_has_destroy_permission(  # noqa: FT003
     admin_user: FFAdminUser,
     identity: Identity,
 ) -> None:
@@ -305,7 +305,7 @@ def test_organisation_admin_has_destroy_permission(
     assert result is True
 
 
-def test_environment_admin_has_destroy_permission(
+def test_environment_admin_has_destroy_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     environment: Environment,
     identity: Identity,
@@ -327,7 +327,7 @@ def test_environment_admin_has_destroy_permission(
     assert result is True
 
 
-def test_regular_user_does_not_have_destroy_permission(
+def test_regular_user_does_not_have_destroy_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     identity: Identity,
 ) -> None:

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions_migrations.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions_migrations.py
@@ -11,7 +11,7 @@ from django.db.models import Model
 from django_test_migrations.migrator import Migrator
 
 
-def test_add_change_request_permissions_adds_correct_permissions_if_user_has_update_fs(  # noqa: E501
+def test_add_change_request_permissions_adds_correct_permissions_if_user_has_update_fs(  # noqa: E501,FT003
     django_user_model: Type[Model], migrator: Migrator
 ) -> None:
     # Given
@@ -61,7 +61,7 @@ def test_add_change_request_permissions_adds_correct_permissions_if_user_has_upd
     ) == [APPROVE_CHANGE_REQUEST, CREATE_CHANGE_REQUEST, UPDATE_FEATURE_STATE]
 
 
-def test_add_change_request_permissions_does_nothing_if_user_does_not_have_update_fs(  # type: ignore[no-untyped-def]
+def test_add_change_request_permissions_does_nothing_if_user_does_not_have_update_fs(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, django_user_model, migrator
 ):
     # Given
@@ -95,7 +95,7 @@ def test_add_change_request_permissions_does_nothing_if_user_does_not_have_updat
     )
 
 
-def test_add_view_identity_permissions_adds_view_permissions_if_user_has_manage_identities(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_add_view_identity_permissions_adds_view_permissions_if_user_has_manage_identities(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment, django_user_model, migrator
 ):
     # Given
@@ -176,7 +176,7 @@ def test_add_view_identity_permissions_adds_view_permissions_if_user_has_manage_
     ]
 
 
-def test_add_view_identity_permissions_does_nothing_if_user_does_not_have_manage_identities(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_add_view_identity_permissions_does_nothing_if_user_does_not_have_manage_identities(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment, django_user_model, migrator
 ):
     # Given
@@ -225,7 +225,7 @@ def test_add_view_identity_permissions_does_nothing_if_user_does_not_have_manage
     )
 
 
-def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
+def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:  # noqa: FT003
     # Given - the migration state is at 0005 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("environment_permissions", "0005_add_view_identity_permissions")

--- a/api/tests/unit/environments/permissions/test_unit_environments_views.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_views.py
@@ -19,7 +19,7 @@ from tests.types import WithEnvironmentPermissionsCallable
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_user_can_list_all_user_permissions_for_an_environment(
+def test_user_can_list_all_user_permissions_for_an_environment(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
     staff_user: FFAdminUser,
@@ -40,7 +40,7 @@ def test_user_can_list_all_user_permissions_for_an_environment(
     assert len(response.json()) == 1
 
 
-def test_user_can_create_new_user_permission_for_an_environment(
+def test_user_can_create_new_user_permission_for_an_environment(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     organisation: Organisation,
@@ -74,7 +74,7 @@ def test_user_can_create_new_user_permission_for_an_environment(
     assert user_environment_permission.permissions.count() == 1
 
 
-def test_user_can_update_user_permission_for_a_project(
+def test_user_can_update_user_permission_for_a_project(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     environment: Environment,
@@ -105,7 +105,7 @@ def test_user_can_update_user_permission_for_a_project(
     assert uep.permissions.first().key == VIEW_ENVIRONMENT  # type: ignore[union-attr]
 
 
-def test_user_can_delete_user_permission_for_a_project(
+def test_user_can_delete_user_permission_for_a_project(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -126,7 +126,7 @@ def test_user_can_delete_user_permission_for_a_project(
         uep.refresh_from_db()
 
 
-def test_user_can_list_all_user_group_permissions_for_an_environment(
+def test_user_can_list_all_user_group_permissions_for_an_environment(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
     organisation: Organisation,
@@ -159,7 +159,7 @@ def test_user_can_list_all_user_group_permissions_for_an_environment(
     assert len(response.json()) == 1
 
 
-def test_user_can_create_new_user_group_permission_for_an_environment(
+def test_user_can_create_new_user_group_permission_for_an_environment(  # noqa: FT003
     organisation: Organisation,
     staff_user: FFAdminUser,
     admin_client: APIClient,
@@ -202,7 +202,7 @@ def test_user_can_create_new_user_group_permission_for_an_environment(
     assert user_group_environment_permission.permissions.count() == 1
 
 
-def test_user_can_update_user_group_permission_for_an_environment(
+def test_user_can_update_user_group_permission_for_an_environment(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     environment: Environment,
@@ -240,7 +240,7 @@ def test_user_can_update_user_group_permission_for_an_environment(
     assert user_group_environment_permission.permissions.count() == 0
 
 
-def test_user_can_delete_user_permission_for_a_user_group(
+def test_user_can_delete_user_permission_for_a_user_group(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     environment: Environment,

--- a/api/tests/unit/environments/sdk/test_unit_sdk_serializers.py
+++ b/api/tests/unit/environments/sdk/test_unit_sdk_serializers.py
@@ -14,7 +14,7 @@ from features.models import Feature
     "create_identity_before, persist_traits",
     ((True, True), (True, False), (False, True), (False, False)),
 )
-def test_identify_with_traits_serializer_runs_identity_integrations_on_create(
+def test_identify_with_traits_serializer_runs_identity_integrations_on_create(  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
     create_identity_before: bool,
@@ -117,7 +117,7 @@ def test_identify_with_traits_serializer__transient__identity_and_traits_not_per
     assert not Trait.objects.filter(identity__identifier=identity_identifier).exists()
 
 
-def test_identify_with_traits_serializer_validate_traits_returns_empty_list_when_persistence_not_allowed(
+def test_identify_with_traits_serializer_validate_traits_returns_empty_list_when_persistence_not_allowed(  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
 ) -> None:
@@ -152,7 +152,7 @@ def test_identify_with_traits_serializer_validate_traits_returns_empty_list_when
     assert not Trait.objects.filter(identity__identifier="test_user").exists()
 
 
-def test_identify_with_traits_serializer_does_not_erase_existing_traits_when_persistence_not_allowed(
+def test_identify_with_traits_serializer_does_not_erase_existing_traits_when_persistence_not_allowed(  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/environments/test_environment_metrics_views.py
+++ b/api/tests/unit/environments/test_environment_metrics_views.py
@@ -11,7 +11,7 @@ from tests.types import WithEnvironmentPermissionsCallable
 
 
 @pytest.mark.parametrize("with_workflows", [True, False])
-def test_get_environment_metrics_without_workflows(
+def test_get_environment_metrics_without_workflows(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -45,7 +45,7 @@ def test_get_environment_metrics_without_workflows(
         assert "total_scheduled_changes" not in names
 
 
-def test_environment_metrics_requires_permission(
+def test_environment_metrics_requires_permission(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/environments/test_unit_environments_admin.py
+++ b/api/tests/unit/environments/test_unit_environments_admin.py
@@ -5,7 +5,7 @@ from environments.admin import EnvironmentAdmin
 from environments.models import Environment
 
 
-def test_environment_admin_rebuild_environments(
+def test_environment_admin_rebuild_environments(  # noqa: FT003
     environment: Environment, mocker: MockerFixture
 ) -> None:
     # GIVEN

--- a/api/tests/unit/environments/test_unit_environments_authentication.py
+++ b/api/tests/unit/environments/test_unit_environments_authentication.py
@@ -8,7 +8,7 @@ from environments.models import Environment
 from organisations.models import Organisation
 
 
-def test_authentication_passes_if_valid_api_key_passed(
+def test_authentication_passes_if_valid_api_key_passed(  # noqa: FT003
     environment: Environment,
 ) -> None:
     # Given
@@ -20,7 +20,7 @@ def test_authentication_passes_if_valid_api_key_passed(
     authenticator.authenticate(request)  # type: ignore[no-untyped-call]
 
 
-def test_authenticate_raises_authentication_failed_if_request_missing_environment_key(
+def test_authenticate_raises_authentication_failed_if_request_missing_environment_key(  # noqa: FT003
     db: None,
 ) -> None:
     # Given
@@ -32,7 +32,7 @@ def test_authenticate_raises_authentication_failed_if_request_missing_environmen
         authenticator.authenticate(request)  # type: ignore[no-untyped-call]
 
 
-def test_authenticate_raises_authentication_failed_if_request_environment_key_not_found(
+def test_authenticate_raises_authentication_failed_if_request_environment_key_not_found(  # noqa: FT003
     db: None,
 ) -> None:
     # Given
@@ -45,7 +45,7 @@ def test_authenticate_raises_authentication_failed_if_request_environment_key_no
         authenticator.authenticate(request)  # type: ignore[no-untyped-call]
 
 
-def test_authenticate_raises_authentication_failed_if_organisation_set_to_stop_serving_flags(
+def test_authenticate_raises_authentication_failed_if_organisation_set_to_stop_serving_flags(  # noqa: FT003
     organisation: Organisation,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/environments/test_unit_environments_feature_states_views.py
+++ b/api/tests/unit/environments/test_unit_environments_feature_states_views.py
@@ -11,7 +11,7 @@ from rest_framework import status
 from tests.unit.environments.helpers import get_environment_user_client
 
 
-def test_user_without_update_feature_state_permission_cannot_update_feature_state(  # type: ignore[no-untyped-def]
+def test_user_without_update_feature_state_permission_cannot_update_feature_state(  # type: ignore[no-untyped-def]  # noqa: FT003
     client,
     organisation_one,
     organisation_one_project_one,
@@ -50,7 +50,7 @@ def test_user_without_update_feature_state_permission_cannot_update_feature_stat
     "permissions, admin",
     (([], True), ([VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE], False)),
 )
-def test_permitted_user_can_update_feature_state(  # type: ignore[no-untyped-def]
+def test_permitted_user_can_update_feature_state(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation_one_project_one_environment_one,
     organisation_one_project_one_feature_one,
     organisation_one_project_one,
@@ -85,7 +85,7 @@ def test_permitted_user_can_update_feature_state(  # type: ignore[no-untyped-def
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_user_with_view_environment_can_retrieve_feature_state(  # type: ignore[no-untyped-def]
+def test_user_with_view_environment_can_retrieve_feature_state(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation_one_project_one_environment_one,
     organisation_one_project_one_feature_one,
     organisation_one_user,

--- a/api/tests/unit/environments/test_unit_environments_migrations.py
+++ b/api/tests/unit/environments/test_unit_environments_migrations.py
@@ -1,7 +1,7 @@
 from django_test_migrations.migrator import Migrator
 
 
-def test_migrate_use_mv_v2_evaluation(migrator: Migrator) -> None:
+def test_migrate_use_mv_v2_evaluation(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     old_state = migrator.apply_initial_migration(
         ("environments", "0027_auto_20230106_0626")

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -47,7 +47,7 @@ if typing.TYPE_CHECKING:
     from django.db.models import Model
 
 
-def test_on_environment_create_makes_feature_states(
+def test_on_environment_create_makes_feature_states(  # noqa: FT003
     organisation: Organisation,
     feature: Feature,
     project: Project,
@@ -63,7 +63,7 @@ def test_on_environment_create_makes_feature_states(
     assert feature.feature_states.count() == 1
 
 
-def test_on_environment_update_feature_states(
+def test_on_environment_update_feature_states(  # noqa: FT003,FT004
     environment: Environment,
     feature: Feature,
 ) -> None:
@@ -76,7 +76,7 @@ def test_on_environment_update_feature_states(
     assert FeatureState.objects.count() == 1
 
 
-def test_environment_clone_does_not_modify_the_original_instance(
+def test_environment_clone_does_not_modify_the_original_instance(  # noqa: FT003,FT004
     environment: Environment,
 ) -> None:
     # When
@@ -87,7 +87,7 @@ def test_environment_clone_does_not_modify_the_original_instance(
     assert clone.api_key != environment.api_key
 
 
-def test_environment_clone_save_creates_feature_states(  # type: ignore[no-untyped-def]
+def test_environment_clone_save_creates_feature_states(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment, feature: Feature
 ):
     # Given
@@ -102,7 +102,7 @@ def test_environment_clone_save_creates_feature_states(  # type: ignore[no-untyp
     assert feature_states.count() == 1
 
 
-def test_environment_clone_does_not_modify_source_feature_state(  # type: ignore[no-untyped-def]
+def test_environment_clone_does_not_modify_source_feature_state(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment,
     feature: Feature,
 ):
@@ -119,7 +119,7 @@ def test_environment_clone_does_not_modify_source_feature_state(  # type: ignore
     assert source_feature_state_before_clone == source_feature_state_after_clone
 
 
-def test_environment_clone_does_not_create_identities(  # type: ignore[no-untyped-def]
+def test_environment_clone_does_not_create_identities(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment,
 ):
     # Given
@@ -132,7 +132,7 @@ def test_environment_clone_does_not_create_identities(  # type: ignore[no-untype
     assert clone.identities.count() == 0
 
 
-def test_environment_clone_clones_the_feature_states(
+def test_environment_clone_clones_the_feature_states(  # noqa: FT003
     environment: Environment,
     feature: Feature,
 ) -> None:
@@ -154,7 +154,7 @@ def test_environment_clone_clones_the_feature_states(
     assert clone.is_creating is False
 
 
-def test_environment_clone_clones_multivariate_feature_state_values(
+def test_environment_clone_clones_multivariate_feature_state_values(  # noqa: FT003
     environment: Environment,
     project: Project,
 ) -> None:
@@ -200,7 +200,7 @@ def test_environment_clone_clones_multivariate_feature_state_values(
 
 
 @mock.patch("environments.models.environment_cache")
-def test_environment_get_from_cache_stores_environment_in_cache_on_success(
+def test_environment_get_from_cache_stores_environment_in_cache_on_success(  # noqa: FT003
     mock_cache: MagicMock,
     environment: Environment,
 ) -> None:
@@ -215,7 +215,7 @@ def test_environment_get_from_cache_stores_environment_in_cache_on_success(
     mock_cache.set.assert_called_with(environment.api_key, environment, timeout=60)
 
 
-def test_environment_get_from_cache_returns_None_if_no_matching_environment(
+def test_environment_get_from_cache_returns_None_if_no_matching_environment(  # noqa: FT003
     environment: Environment,
 ) -> None:
     # Given
@@ -228,7 +228,7 @@ def test_environment_get_from_cache_returns_None_if_no_matching_environment(
     assert env is None
 
 
-def test_environment_get_from_cache_accepts_environment_api_key_model_key(
+def test_environment_get_from_cache_accepts_environment_api_key_model_key(  # noqa: FT003
     environment: Environment,
 ) -> None:
     # Given
@@ -241,7 +241,7 @@ def test_environment_get_from_cache_accepts_environment_api_key_model_key(
     assert environment_from_cache == environment
 
 
-def test_environment_get_from_cache_with_null_environment_key_returns_null(
+def test_environment_get_from_cache_with_null_environment_key_returns_null(  # noqa: FT003,FT004
     environment: Environment,
 ) -> None:
     # When
@@ -254,7 +254,7 @@ def test_environment_get_from_cache_with_null_environment_key_returns_null(
 @override_settings(
     CACHE_BAD_ENVIRONMENTS_SECONDS=60, CACHE_BAD_ENVIRONMENTS_AFTER_FAILURES=1
 )
-def test_environment_get_from_cache_does_not_hit_database_if_api_key_in_bad_env_cache(
+def test_environment_get_from_cache_does_not_hit_database_if_api_key_in_bad_env_cache(  # noqa: FT003,FT004
     django_assert_num_queries: DjangoAssertNumQueries,
     db: None,
 ) -> None:
@@ -266,7 +266,7 @@ def test_environment_get_from_cache_does_not_hit_database_if_api_key_in_bad_env_
         [Environment.get_from_cache(api_key) for _ in range(10)]
 
 
-def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key(  # type: ignore[no-untyped-def]
+def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment,
 ):
     assert (
@@ -279,7 +279,7 @@ def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key( 
     )
 
 
-def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key_with_expired_date_in_future(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key_with_expired_date_in_future(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     environment,
 ):
     assert (
@@ -293,7 +293,7 @@ def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key_w
     )
 
 
-def test_environment_api_key_model_is_valid_is_false_for_expired_active_key(  # type: ignore[no-untyped-def]
+def test_environment_api_key_model_is_valid_is_false_for_expired_active_key(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment,
 ):
     assert (
@@ -307,7 +307,7 @@ def test_environment_api_key_model_is_valid_is_false_for_expired_active_key(  # 
     )
 
 
-def test_environment_api_key_model_is_valid_is_false_for_non_expired_inactive_key(  # type: ignore[no-untyped-def]
+def test_environment_api_key_model_is_valid_is_false_for_non_expired_inactive_key(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment,
 ):
     assert (
@@ -318,7 +318,7 @@ def test_environment_api_key_model_is_valid_is_false_for_non_expired_inactive_ke
     )
 
 
-def test_existence_of_multiple_environment_api_keys_does_not_break_get_from_cache(  # type: ignore[no-untyped-def]
+def test_existence_of_multiple_environment_api_keys_does_not_break_get_from_cache(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment,
 ):
     # Given
@@ -343,7 +343,7 @@ def test_existence_of_multiple_environment_api_keys_does_not_break_get_from_cach
     )
 
 
-def test_get_from_cache_sets_the_cache_correctly_with_environment_api_key(  # type: ignore[no-untyped-def]
+def test_get_from_cache_sets_the_cache_correctly_with_environment_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment, environment_api_key, mocker
 ):
     # When
@@ -356,7 +356,7 @@ def test_get_from_cache_sets_the_cache_correctly_with_environment_api_key(  # ty
     assert environment == environment_cache.get(environment_api_key.key)
 
 
-def test_updated_at_gets_updated_when_environment_audit_log_created(environment):  # type: ignore[no-untyped-def]
+def test_updated_at_gets_updated_when_environment_audit_log_created(environment):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     audit_log = AuditLog.objects.create(
         environment=environment, project=environment.project, log="random_audit_log"
@@ -367,7 +367,7 @@ def test_updated_at_gets_updated_when_environment_audit_log_created(environment)
     assert environment.updated_at == audit_log.created_date
 
 
-def test_updated_at_gets_updated_when_project_audit_log_created(environment):  # type: ignore[no-untyped-def]
+def test_updated_at_gets_updated_when_project_audit_log_created(environment):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     audit_log = AuditLog.objects.create(
         project=environment.project, log="random_audit_log"
@@ -377,7 +377,7 @@ def test_updated_at_gets_updated_when_project_audit_log_created(environment):  #
     assert environment.updated_at == audit_log.created_date
 
 
-def test_change_request_audit_logs_does_not_update_updated_at(environment):  # type: ignore[no-untyped-def]
+def test_change_request_audit_logs_does_not_update_updated_at(environment):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     updated_at_before_audit_log = environment.updated_at
 
@@ -393,7 +393,7 @@ def test_change_request_audit_logs_does_not_update_updated_at(environment):  # t
     assert environment.updated_at != audit_log.created_date
 
 
-def test_save_environment_clears_environment_cache(mocker, project):  # type: ignore[no-untyped-def]
+def test_save_environment_clears_environment_cache(mocker, project):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_environment_cache = mocker.patch("environments.models.environment_cache")
     environment = Environment.objects.create(name="test environment", project=project)
@@ -425,7 +425,7 @@ def test_save_environment_clears_environment_cache(mocker, project):  # type: ig
         (False, RequestOrigin.SERVER, True),
     ),
 )
-def test_environment_trait_persistence_allowed(  # type: ignore[no-untyped-def]
+def test_environment_trait_persistence_allowed(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     allow_client_traits, request_origin, expected_result
 ):
     request = MagicMock(originated_from=request_origin)
@@ -437,7 +437,7 @@ def test_environment_trait_persistence_allowed(  # type: ignore[no-untyped-def]
     )
 
 
-def test_write_environments_to_dynamodb_with_environment(  # type: ignore[no-untyped-def]
+def test_write_environments_to_dynamodb_with_environment(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project,
     dynamo_enabled_project_environment_one,
     mock_dynamo_env_wrapper,
@@ -460,7 +460,7 @@ def test_write_environments_to_dynamodb_with_environment(  # type: ignore[no-unt
     )
 
 
-def test_write_environments_to_dynamodb_project(  # type: ignore[no-untyped-def]
+def test_write_environments_to_dynamodb_project(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project,
     dynamo_enabled_project_environment_one,
     dynamo_enabled_project_environment_two,
@@ -481,7 +481,7 @@ def test_write_environments_to_dynamodb_project(  # type: ignore[no-untyped-def]
     )
 
 
-def test_write_environments_to_dynamodb_with_environment_and_project(  # type: ignore[no-untyped-def]
+def test_write_environments_to_dynamodb_with_environment_and_project(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project,
     dynamo_enabled_project_environment_one,
     mock_dynamo_env_wrapper,
@@ -528,7 +528,7 @@ def test_write_environments_to_dynamodb__project_environments_v2_migrated__call_
     )
 
 
-def test_write_environments_to_dynamodb__project_environments_v2_migrated__wrapper_disabled__wrapper_not_called(
+def test_write_environments_to_dynamodb__project_environments_v2_migrated__wrapper_disabled__wrapper_not_called(  # noqa: FT003
     dynamo_enabled_project: Project,
     dynamo_enabled_project_environment_one: Environment,
     dynamo_enabled_project_environment_two: Environment,
@@ -584,7 +584,7 @@ def test_write_environments_to_dynamodb__project_environments_v2_not_migrated__w
         ("foo", 1, "identity-identifier"),
     ),
 )
-def test_webhook_generate_webhook_feature_state_data(  # type: ignore[no-untyped-def]
+def test_webhook_generate_webhook_feature_state_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature, environment, value, identity_id, identifier
 ):
     # Given
@@ -600,7 +600,7 @@ def test_webhook_generate_webhook_feature_state_data(  # type: ignore[no-untyped
 
 
 @pytest.mark.parametrize("identity_id, identifier", ((1, None), (None, "identifier")))
-def test_webhook_generate_webhook_feature_state_data_identity_error_conditions(  # type: ignore[no-untyped-def]
+def test_webhook_generate_webhook_feature_state_data_identity_error_conditions(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, identity_id, identifier
 ):
     # Given
@@ -624,7 +624,7 @@ def test_webhook_generate_webhook_feature_state_data_identity_error_conditions( 
     # exception raised
 
 
-def test_webhook_generate_webhook_feature_state_data_raises_error_segment_and_identity(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_webhook_generate_webhook_feature_state_data_raises_error_segment_and_identity(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     mocker,
 ):
     # Given
@@ -652,7 +652,7 @@ def test_webhook_generate_webhook_feature_state_data_raises_error_segment_and_id
     # exception raised
 
 
-def test_environment_get_environment_document(environment, django_assert_num_queries):  # type: ignore[no-untyped-def]
+def test_environment_get_environment_document(environment, django_assert_num_queries):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
 
     # When
@@ -664,7 +664,7 @@ def test_environment_get_environment_document(environment, django_assert_num_que
     assert environment_document["api_key"] == environment.api_key
 
 
-def test_environment_get_environment_document_with_caching_when_document_in_cache(  # type: ignore[no-untyped-def]
+def test_environment_get_environment_document_with_caching_when_document_in_cache(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, django_assert_num_queries, settings, mocker
 ):
     # Given
@@ -686,7 +686,7 @@ def test_environment_get_environment_document_with_caching_when_document_in_cach
     assert environment_document["api_key"] == environment.api_key
 
 
-def test_environment_get_environment_document_with_caching_when_document_not_in_cache(  # type: ignore[no-untyped-def]
+def test_environment_get_environment_document_with_caching_when_document_not_in_cache(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, django_assert_num_queries, settings, mocker
 ):
     # Given
@@ -710,7 +710,7 @@ def test_environment_get_environment_document_with_caching_when_document_not_in_
     )
 
 
-def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(project):  # type: ignore[no-untyped-def]
+def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(project):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     project.prevent_flag_defaults = True
     project.save()
@@ -735,11 +735,11 @@ def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(proj
     assert not feature_state.get_feature_state_value()
 
 
-def test_get_segments_returns_no_segments_if_no_overrides(environment, segment):  # type: ignore[no-untyped-def]
+def test_get_segments_returns_no_segments_if_no_overrides(environment, segment):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert environment.get_segments_from_cache() == []
 
 
-def test_get_segments_returns_only_segments_that_have_an_override(  # type: ignore[no-untyped-def]
+def test_get_segments_returns_only_segments_that_have_an_override(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, segment, segment_featurestate, mocker, monkeypatch
 ):
     # Given
@@ -764,7 +764,7 @@ def test_get_segments_returns_only_segments_that_have_an_override(  # type: igno
     )
 
 
-def test_get_segments_from_cache_does_not_hit_db_if_cache_hit(  # type: ignore[no-untyped-def]
+def test_get_segments_from_cache_does_not_hit_db_if_cache_hit(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment,
     segment,
     segment_featurestate,
@@ -802,7 +802,7 @@ def test_get_segments_from_cache_does_not_hit_db_if_cache_hit(  # type: ignore[n
         (None, False, False),
     ),
 )
-def test_get_hide_disabled_flags(  # type: ignore[no-untyped-def]
+def test_get_hide_disabled_flags(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project, environment, environment_value, project_value, expected_result
 ):
     # Given
@@ -816,7 +816,7 @@ def test_get_hide_disabled_flags(  # type: ignore[no-untyped-def]
     assert environment.get_hide_disabled_flags() is expected_result
 
 
-def test_saving_environment_api_key_creates_dynamo_document_if_enabled(  # type: ignore[no-untyped-def]
+def test_saving_environment_api_key_creates_dynamo_document_if_enabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project_environment_one: Environment,
     mocker: MockerFixture,
     flagsmith_environment_api_key_table: "Table",
@@ -837,7 +837,7 @@ def test_saving_environment_api_key_creates_dynamo_document_if_enabled(  # type:
     assert response["Item"]["key"] == api_key.key
 
 
-def test_deleting_environment_api_key_deletes_dynamo_document_if_enabled(  # type: ignore[no-untyped-def]
+def test_deleting_environment_api_key_deletes_dynamo_document_if_enabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project_environment_one: Environment,
     mocker: MockerFixture,
     flagsmith_environment_api_key_table: "Table",
@@ -860,7 +860,7 @@ def test_deleting_environment_api_key_deletes_dynamo_document_if_enabled(  # typ
     assert flagsmith_environment_api_key_table.scan()["Count"] == 0
 
 
-def test_deleting_environment_creates_task_to_delete_dynamo_document_if_enabled(
+def test_deleting_environment_creates_task_to_delete_dynamo_document_if_enabled(  # noqa: FT003
     dynamo_enabled_project_environment_one: Environment,
     mocker: MockerFixture,
 ) -> None:
@@ -884,7 +884,7 @@ def test_deleting_environment_creates_task_to_delete_dynamo_document_if_enabled(
     )
 
 
-def test_delete_api_key_not_called_when_deleting_environment_api_key_for_non_edge_project(
+def test_delete_api_key_not_called_when_deleting_environment_api_key_for_non_edge_project(  # noqa: FT003
     environment_api_key: EnvironmentAPIKey, mocker: MockerFixture
 ) -> None:
     # Given
@@ -898,7 +898,7 @@ def test_delete_api_key_not_called_when_deleting_environment_api_key_for_non_edg
     mocked_environment_api_key_wrapper.delete_api_key.assert_not_called()
 
 
-def test_put_item_not_called_when_saving_environment_api_key_for_non_edge_project(  # type: ignore[no-untyped-def]
+def test_put_item_not_called_when_saving_environment_api_key_for_non_edge_project(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, mocker
 ):
     # Given
@@ -912,7 +912,7 @@ def test_put_item_not_called_when_saving_environment_api_key_for_non_edge_projec
     mocked_environment_api_key_wrapper.write_api_key.assert_not_called()
 
 
-def test_delete_environment_with_committed_change_request(
+def test_delete_environment_with_committed_change_request(  # noqa: FT003
     organisation: "Organisation",
     environment: Environment,
     change_request: "ChangeRequest",
@@ -932,7 +932,7 @@ def test_delete_environment_with_committed_change_request(
     assert environment.deleted_at is not None
 
 
-def test_create_environment_creates_feature_states_in_all_environments_and_environment_feature_version(
+def test_create_environment_creates_feature_states_in_all_environments_and_environment_feature_version(  # noqa: FT003
     project: "Project",
 ) -> None:
     # Given
@@ -951,7 +951,7 @@ def test_create_environment_creates_feature_states_in_all_environments_and_envir
     assert environment.feature_states.count() == 2
 
 
-def test_clone_environment_v2_versioning(
+def test_clone_environment_v2_versioning(  # noqa: FT003
     feature: Feature,
     feature_state: FeatureState,
     segment: Segment,
@@ -1004,7 +1004,7 @@ def test_clone_environment_v2_versioning(
     )
 
 
-def test_environment_clone_async(
+def test_environment_clone_async(  # noqa: FT003
     environment: Environment, mocker: MockerFixture
 ) -> None:
     # Given
@@ -1028,7 +1028,7 @@ def test_environment_clone_async(
     )
 
 
-def test_delete_environment_removes_environment_document_cache(
+def test_delete_environment_removes_environment_document_cache(  # noqa: FT003,FT004
     environment: Environment,
     persistent_environment_document_cache: MagicMock,
 ) -> None:
@@ -1041,7 +1041,7 @@ def test_delete_environment_removes_environment_document_cache(
     )
 
 
-def test_change_api_key_updates_environment_document_cache(
+def test_change_api_key_updates_environment_document_cache(  # noqa: FT003
     environment: Environment,
     persistent_environment_document_cache: MagicMock,
 ) -> None:
@@ -1060,7 +1060,7 @@ def test_change_api_key_updates_environment_document_cache(
     )
 
 
-def test_get_environment_document_from_cache_triggers_correct_metrics__cache_hit(
+def test_get_environment_document_from_cache_triggers_correct_metrics__cache_hit(  # noqa: FT003,FT004
     environment: Environment,
     persistent_environment_document_cache: MagicMock,
     populate_environment_document_cache: None,
@@ -1079,7 +1079,7 @@ def test_get_environment_document_from_cache_triggers_correct_metrics__cache_hit
     )
 
 
-def test_get_environment_document_from_cache_triggers_correct_metrics__cache_miss(
+def test_get_environment_document_from_cache_triggers_correct_metrics__cache_miss(  # noqa: FT003
     environment: Environment,
     persistent_environment_document_cache: MagicMock,
     assert_metric: AssertMetricFixture,
@@ -1108,7 +1108,7 @@ def test_get_environment_document_from_cache_triggers_correct_metrics__cache_mis
         (21, 14, 8, 13, 2),
     ],
 )
-def test_environment_metric_query_helpers_match_expected_counts(
+def test_environment_metric_query_helpers_match_expected_counts(  # noqa: FT003
     project: Project,
     admin_user: FFAdminUser,
     total_features: int,
@@ -1209,7 +1209,7 @@ def test_environment_metric_query_helpers_match_expected_counts(
     assert identity_override_count == 0
 
 
-def test_environment_create_with_use_v2_feature_versioning_true(
+def test_environment_create_with_use_v2_feature_versioning_true(  # noqa: FT003
     project: Project,
     feature: Feature,
     enable_features: EnableFeaturesFixture,
@@ -1230,7 +1230,7 @@ def test_environment_create_with_use_v2_feature_versioning_true(
     assert new_environment.use_v2_feature_versioning
 
 
-def test_environment_clone_from_versioned_environment_with_use_v2_feature_versioning_true(
+def test_environment_clone_from_versioned_environment_with_use_v2_feature_versioning_true(  # noqa: FT003
     project: Project,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -1249,7 +1249,7 @@ def test_environment_clone_from_versioned_environment_with_use_v2_feature_versio
     assert new_environment.use_v2_feature_versioning
 
 
-def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_versioning_true(
+def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_versioning_true(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/environments/test_unit_environments_permissions.py
+++ b/api/tests/unit/environments/test_unit_environments_permissions.py
@@ -8,7 +8,7 @@ from permissions.models import ENVIRONMENT_PERMISSION_TYPE, PermissionModel
 from users.models import FFAdminUser
 
 
-def test_nested_environment_permissions_has_permission_false_if_no_env_key(  # type: ignore[no-untyped-def]
+def test_nested_environment_permissions_has_permission_false_if_no_env_key(  # type: ignore[no-untyped-def]  # noqa: FT003
     rf, mocker, db
 ):
     # Given
@@ -24,7 +24,7 @@ def test_nested_environment_permissions_has_permission_false_if_no_env_key(  # t
     assert result is False
 
 
-def test_nested_environment_permissions_has_permission_true_if_action_in_map(
+def test_nested_environment_permissions_has_permission_true_if_action_in_map(  # noqa: FT003
     rf: RequestFactory,
     mocker: MockerFixture,
     environment: Environment,
@@ -56,7 +56,7 @@ def test_nested_environment_permissions_has_permission_true_if_action_in_map(
     assert has_permission is True
 
 
-def test_nested_environment_permissions_has_permission_if_create_and_user_is_admin(
+def test_nested_environment_permissions_has_permission_if_create_and_user_is_admin(  # noqa: FT003
     rf: RequestFactory,
     mocker: MockerFixture,
     environment: Environment,
@@ -82,7 +82,7 @@ def test_nested_environment_permissions_has_permission_if_create_and_user_is_adm
     assert has_permission is True
 
 
-def test_nested_environment_permissions_has_object_permission_true_if_action_in_map(
+def test_nested_environment_permissions_has_object_permission_true_if_action_in_map(  # noqa: FT003
     rf: RequestFactory,
     mocker: MockerFixture,
     environment: Environment,
@@ -117,7 +117,7 @@ def test_nested_environment_permissions_has_object_permission_true_if_action_in_
     assert has_object_permission is True
 
 
-def test_nested_environment_permissions_has_object_permission_true_if_user_is_admin(
+def test_nested_environment_permissions_has_object_permission_true_if_user_is_admin(  # noqa: FT003
     rf: RequestFactory,
     mocker: MockerFixture,
     environment: Environment,

--- a/api/tests/unit/environments/test_unit_environments_tasks.py
+++ b/api/tests/unit/environments/test_unit_environments_tasks.py
@@ -9,7 +9,7 @@ from environments.tasks import (
 )
 
 
-def test_rebuild_environment_document(
+def test_rebuild_environment_document(  # noqa: FT003
     environment: Environment,
     mocker: MockerFixture,
 ) -> None:
@@ -27,7 +27,7 @@ def test_rebuild_environment_document(
     )
 
 
-def test_process_environment_update_with_environment_audit_log(environment, mocker):  # type: ignore[no-untyped-def]
+def test_process_environment_update_with_environment_audit_log(environment, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     audit_log = AuditLog.objects.create(
         project=environment.project, environment=environment
@@ -57,7 +57,7 @@ def test_process_environment_update_with_environment_audit_log(environment, mock
     mock_send_environment_update_message_for_project.assert_not_called()
 
 
-def test_process_environment_update_with_project_audit_log(environment, mocker):  # type: ignore[no-untyped-def]
+def test_process_environment_update_with_project_audit_log(environment, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     audit_log = AuditLog.objects.create(project=environment.project)
     mock_environment_model_class = mocker.patch(
@@ -85,7 +85,7 @@ def test_process_environment_update_with_project_audit_log(environment, mocker):
     )
 
 
-def test_delete_environment__calls_internal_methods_correctly(
+def test_delete_environment__calls_internal_methods_correctly(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -38,7 +38,7 @@ from tests.types import WithEnvironmentPermissionsCallable
 from users.models import FFAdminUser
 
 
-def test_retrieve_environment(
+def test_retrieve_environment(  # noqa: FT003
     admin_client_new: APIClient, environment: Environment
 ) -> None:
     # Given
@@ -80,7 +80,7 @@ def test_retrieve_environment(
     )
 
 
-def test_get_by_uuid_returns_environment(
+def test_get_by_uuid_returns_environment(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -101,7 +101,7 @@ def test_get_by_uuid_returns_environment(
     assert response.json()["uuid"] == str(environment.uuid)
 
 
-def test_get_by_uuid_returns_403_for_user_without_permission(
+def test_get_by_uuid_returns_403_for_user_without_permission(  # noqa: FT003
     staff_client: APIClient, environment: Environment
 ) -> None:
     # Given
@@ -117,7 +117,7 @@ def test_get_by_uuid_returns_403_for_user_without_permission(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_user_with_view_environment_permission_can_retrieve_environment(
+def test_user_with_view_environment_permission_can_retrieve_environment(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -134,7 +134,7 @@ def test_user_with_view_environment_permission_can_retrieve_environment(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_can_clone_environment_with_create_environment_permission(
+def test_can_clone_environment_with_create_environment_permission(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
     user_project_permission: UserProjectPermission,
@@ -153,7 +153,7 @@ def test_can_clone_environment_with_create_environment_permission(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_should_return_identities_for_an_environment(
+def test_should_return_identities_for_an_environment(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     identity: Identity,
@@ -174,7 +174,7 @@ def test_should_return_identities_for_an_environment(
     assert response.data["results"][1]["identifier"] == identifier_two
 
 
-def test_audit_log_entry_created_when_new_environment_created(
+def test_audit_log_entry_created_when_new_environment_created(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
 ) -> None:
@@ -205,7 +205,7 @@ def test_audit_log_entry_created_when_new_environment_created(
         (lazy_fixture("admin_client_original"), None, lazy_fixture("admin_user")),
     ],
 )
-def test_audit_log_created_when_feature_state_updated(
+def test_audit_log_created_when_feature_state_updated(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     client: APIClient,
@@ -234,7 +234,7 @@ def test_audit_log_created_when_feature_state_updated(
     assert AuditLog.objects.first().master_api_key == master_api_key
 
 
-def test_delete_trait_keys_deletes_trait_for_all_users_in_that_environment(
+def test_delete_trait_keys_deletes_trait_for_all_users_in_that_environment(  # noqa: FT003
     environment: Environment,
     identity: Identity,
     admin_client_new: APIClient,
@@ -278,7 +278,7 @@ def test_delete_trait_keys_deletes_trait_for_all_users_in_that_environment(
     assert Trait.objects.filter(identity=identity2, trait_key=trait_key).exists()
 
 
-def test_environment_user_can_get_their_permissions(
+def test_environment_user_can_get_their_permissions(  # noqa: FT003
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
@@ -298,7 +298,7 @@ def test_environment_user_can_get_their_permissions(
     assert "VIEW_ENVIRONMENT" in response.json()["permissions"]
 
 
-def test_environment_user_can_get_their_detailed_permissions(
+def test_environment_user_can_get_their_detailed_permissions(  # noqa: FT003
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
@@ -328,7 +328,7 @@ def test_environment_user_can_get_their_detailed_permissions(
     ]
 
 
-def test_environment_user_can_not_get_detailed_permissions_of_other_user(
+def test_environment_user_can_not_get_detailed_permissions_of_other_user(  # noqa: FT003
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
@@ -348,7 +348,7 @@ def test_environment_user_can_not_get_detailed_permissions_of_other_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_environment_admin_can_get_detailed_permissions_of_other_user(
+def test_environment_admin_can_get_detailed_permissions_of_other_user(  # noqa: FT003
     admin_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
@@ -379,7 +379,7 @@ def test_environment_admin_can_get_detailed_permissions_of_other_user(
     ]
 
 
-def test_can_create_webhook_for_an_environment(
+def test_can_create_webhook_for_an_environment(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -399,7 +399,7 @@ def test_can_create_webhook_for_an_environment(
     assert Webhook.objects.filter(environment=environment, **data).exists()
 
 
-def test_can_update_webhook_for_an_environment(
+def test_can_update_webhook_for_an_environment(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -423,7 +423,7 @@ def test_can_update_webhook_for_an_environment(
     assert webhook.url == data["url"] and not webhook.enabled
 
 
-def test_can_update_webhook_secret(
+def test_can_update_webhook_secret(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -447,7 +447,7 @@ def test_can_update_webhook_secret(
     assert webhook.secret == data["secret"]
 
 
-def test_can_delete_webhook_for_an_environment(
+def test_can_delete_webhook_for_an_environment(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -467,7 +467,7 @@ def test_can_delete_webhook_for_an_environment(
     assert not Webhook.objects.filter(id=webhook.id).exists()
 
 
-def test_can_list_webhooks_for_an_environment(
+def test_can_list_webhooks_for_an_environment(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -487,7 +487,7 @@ def test_can_list_webhooks_for_an_environment(
     assert response.json()[0]["id"] == webhook.id
 
 
-def test_cannot_delete_webhooks_for_environment_user_does_not_belong_to(
+def test_cannot_delete_webhooks_for_environment_user_does_not_belong_to(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -514,7 +514,7 @@ def test_cannot_delete_webhooks_for_environment_user_does_not_belong_to(
     assert Webhook.objects.filter(id=webhook.id).exists()
 
 
-def test_list_api_keys(
+def test_list_api_keys(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -542,7 +542,7 @@ def test_list_api_keys(
     }
 
 
-def test_create_api_key(
+def test_create_api_key(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
 ) -> None:
@@ -564,7 +564,7 @@ def test_create_api_key(
     assert response.data["active"] is True
 
 
-def test_update_api_key(
+def test_update_api_key(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -592,7 +592,7 @@ def test_update_api_key(
     assert api_key.key != new_key
 
 
-def test_delete_api_key(
+def test_delete_api_key(  # noqa: FT003
     environment: Environment,
     admin_client_new: APIClient,
 ) -> None:
@@ -618,7 +618,7 @@ def test_delete_api_key(
         (lazy_fixture("admin_client_original"), False),
     ],
 )
-def test_should_create_environments(  # type: ignore[no-untyped-def]
+def test_should_create_environments(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, client, admin_user, is_admin_master_api_key_client
 ) -> None:
     # Given
@@ -647,7 +647,7 @@ def test_should_create_environments(  # type: ignore[no-untyped-def]
         ).exists()
 
 
-def test_environment_matches_existing_environment_name(
+def test_environment_matches_existing_environment_name(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
 ) -> None:
@@ -674,7 +674,7 @@ def test_environment_matches_existing_environment_name(
     }
 
 
-def test_create_environment_without_required_metadata_returns_400(  # type: ignore[no-untyped-def]
+def test_create_environment_without_required_metadata_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     project,
     admin_client_new,
     required_a_environment_metadata_field,
@@ -701,7 +701,7 @@ def test_create_environment_without_required_metadata_returns_400(  # type: igno
     settings.IS_RBAC_INSTALLED is True,
     reason="Skip this test if RBAC is installed",
 )
-def test_view_environment_with_staff__query_count_is_expected_without_rbac(
+def test_view_environment_with_staff__query_count_is_expected_without_rbac(  # noqa: FT003,FT004
     staff_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -730,7 +730,7 @@ def test_view_environment_with_staff__query_count_is_expected_without_rbac(
     settings.IS_RBAC_INSTALLED is False,
     reason="Skip this test if RBAC is not installed",
 )
-def test_view_environment_with_staff__query_count_is_expected_with_rbac(
+def test_view_environment_with_staff__query_count_is_expected_with_rbac(  # noqa: FT003,FT004
     staff_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -803,7 +803,7 @@ def _assert_view_environment_with_staff__query_count(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_view_environment_with_admin__query_count_is_expected(
+def test_view_environment_with_admin__query_count_is_expected(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     project: Project,
@@ -842,7 +842,7 @@ def test_view_environment_with_admin__query_count_is_expected(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_create_environment_with_required_metadata_returns_201(  # type: ignore[no-untyped-def]
+def test_create_environment_with_required_metadata_returns_201(  # type: ignore[no-untyped-def]  # noqa: FT003
     project,
     admin_client_new,
     required_a_environment_metadata_field,
@@ -878,7 +878,7 @@ def test_create_environment_with_required_metadata_returns_201(  # type: ignore[
     assert response.json()["metadata"][0]["field_value"] == str(field_value)
 
 
-def test_update_environment_metadata(  # type: ignore[no-untyped-def]
+def test_update_environment_metadata(  # type: ignore[no-untyped-def]  # noqa: FT003
     project,
     admin_client_new,
     environment,
@@ -919,7 +919,7 @@ def test_update_environment_metadata(  # type: ignore[no-untyped-def]
     ]
 
 
-def test_create_multiple_environments_with_metadata_keeps_metadata_isolated(
+def test_create_multiple_environments_with_metadata_keeps_metadata_isolated(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     optional_b_environment_metadata_field: MetadataModelField,
@@ -1013,7 +1013,7 @@ def test_create_multiple_environments_with_metadata_keeps_metadata_isolated(
     assert second_environment_metadata_after[0]["id"] != first_metadata_id
 
 
-def test_audit_log_entry_created_when_environment_updated(
+def test_audit_log_entry_created_when_environment_updated(  # noqa: FT003
     environment: Environment, project: Project, admin_client_new: APIClient
 ) -> None:
     # Given
@@ -1064,7 +1064,7 @@ def test_audit_log_entry_created_when_environment_updated(
     )
 
 
-def test_environment_update_cannot_change_is_creating(
+def test_environment_update_cannot_change_is_creating(  # noqa: FT003
     environment: Environment, project: Project, admin_client_new: APIClient
 ) -> None:
     # Given
@@ -1088,7 +1088,7 @@ def test_environment_update_cannot_change_is_creating(
     assert response.json()["is_creating"] is False
 
 
-def test_environment_update_cannot_change_project(
+def test_environment_update_cannot_change_project(  # noqa: FT003
     environment: Environment,
     project: Project,
     organisation: Organisation,
@@ -1120,7 +1120,7 @@ def test_environment_update_cannot_change_project(
     assert response.json()["project"] == original_project.id
 
 
-def test_get_document(
+def test_get_document(  # noqa: FT003
     environment: Environment,
     project: Project,
     staff_client: APIClient,
@@ -1152,7 +1152,7 @@ def test_get_document(
     assert response.json()
 
 
-def test_cannot_get_environment_document_without_permission(
+def test_cannot_get_environment_document_without_permission(  # noqa: FT003
     staff_client: APIClient, environment: Environment
 ) -> None:
     # Given
@@ -1167,7 +1167,7 @@ def test_cannot_get_environment_document_without_permission(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(
+def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(  # noqa: FT003
     identity: Identity,
     admin_client_new: APIClient,
     trait: Trait,
@@ -1208,7 +1208,7 @@ def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(
     assert len(res.json().get("keys")) == 2
 
 
-def test_user_with_view_environment_can_get_trait_keys(
+def test_user_with_view_environment_can_get_trait_keys(  # noqa: FT003
     identity: Identity,
     staff_client: APIClient,
     trait: Trait,
@@ -1229,7 +1229,7 @@ def test_user_with_view_environment_can_get_trait_keys(
     assert res.status_code == status.HTTP_200_OK
 
 
-def test_delete_trait_keys_deletes_traits_matching_provided_key_only(
+def test_delete_trait_keys_deletes_traits_matching_provided_key_only(  # noqa: FT003
     identity: Identity,
     admin_client_new: APIClient,
     trait: Trait,
@@ -1261,7 +1261,7 @@ def test_delete_trait_keys_deletes_traits_matching_provided_key_only(
     assert Trait.objects.filter(identity=identity, trait_key=trait_to_persist).exists()
 
 
-def test_user_can_list_environment_permission(
+def test_user_can_list_environment_permission(  # noqa: FT003
     admin_client_new: APIClient, environment: Environment
 ) -> None:
     # Given
@@ -1282,7 +1282,7 @@ def test_user_can_list_environment_permission(
     assert set(returned_supported_permissions) == set(TAG_SUPPORTED_PERMISSIONS)
 
 
-def test_environment_my_permissions_reruns_400_for_master_api_key(
+def test_environment_my_permissions_reruns_400_for_master_api_key(  # noqa: FT003
     admin_master_api_key_client: APIClient, environment: Environment
 ) -> None:
     # Given
@@ -1301,7 +1301,7 @@ def test_environment_my_permissions_reruns_400_for_master_api_key(
     )
 
 
-def test_partial_environment_update(
+def test_partial_environment_update(  # noqa: FT003
     admin_client: APIClient, environment: "Environment"
 ) -> None:
     # Given
@@ -1317,7 +1317,7 @@ def test_partial_environment_update(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_cannot_enable_v2_versioning_for_environment_already_enabled(
+def test_cannot_enable_v2_versioning_for_environment_already_enabled(  # noqa: FT003
     environment_v2_versioning: Environment,
     admin_client_new: APIClient,
     mocker: MockerFixture,
@@ -1340,7 +1340,7 @@ def test_cannot_enable_v2_versioning_for_environment_already_enabled(
     mock_enable_v2_versioning.delay.assert_not_called()
 
 
-def test_total_segment_overrides_correctly_ignores_old_versions(
+def test_total_segment_overrides_correctly_ignores_old_versions(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     environment_v2_versioning: Environment,

--- a/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
+++ b/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     "use_v2_feature_versioning, total_queries", [(True, 12), (False, 11)]
 )
-def test_get_environment_document(
+def test_get_environment_document(  # noqa: FT003
     organisation_one: "Organisation",
     organisation_two: "Organisation",
     organisation_one_project_one: "Project",
@@ -142,7 +142,7 @@ def test_get_environment_document(
         lazy_fixture("environment_v2_versioning"),
     ),
 )
-def test_get_environment_document__identity_overrides(
+def test_get_environment_document__identity_overrides(  # noqa: FT003
     project: Project,
     environment_: Environment,
 ) -> None:
@@ -234,7 +234,7 @@ def test_get_environment_document__identity_overrides(
     )
 
 
-def test_get_environment_document_fails_with_invalid_key(
+def test_get_environment_document_fails_with_invalid_key(  # noqa: FT003
     organisation_one: "Organisation",
     organisation_one_project_one: "Project",
 ) -> None:
@@ -260,7 +260,7 @@ def test_get_environment_document_fails_with_invalid_key(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_environment_document_if_modified_since(
+def test_environment_document_if_modified_since(  # noqa: FT003
     organisation_one: "Organisation",
     organisation_one_project_one: "Project",
 ) -> None:

--- a/api/tests/unit/features/feature_health/test_models.py
+++ b/api/tests/unit/features/feature_health/test_models.py
@@ -17,7 +17,7 @@ from users.models import FFAdminUser
 now = datetime.datetime.now()
 
 
-def test_feature_health_provider__get_create_log_message__return_expected(
+def test_feature_health_provider__get_create_log_message__return_expected(  # noqa: FT004
     feature_health_provider: FeatureHealthProvider,
     mocker: MockerFixture,
 ) -> None:
@@ -28,7 +28,7 @@ def test_feature_health_provider__get_create_log_message__return_expected(
     assert log_message == "Health provider Webhook set up for project Test Project."
 
 
-def test_feature_health_provider__get_delete_log_message__return_expected(
+def test_feature_health_provider__get_delete_log_message__return_expected(  # noqa: FT004
     feature_health_provider: FeatureHealthProvider,
     mocker: MockerFixture,
 ) -> None:
@@ -39,7 +39,7 @@ def test_feature_health_provider__get_delete_log_message__return_expected(
     assert log_message == "Health provider Webhook removed from project Test Project."
 
 
-def test_feature_health_provider__get_audit_log_author__return_expected(
+def test_feature_health_provider__get_audit_log_author__return_expected(  # noqa: FT004
     feature_health_provider: FeatureHealthProvider,
     mocker: MockerFixture,
     staff_user: FFAdminUser,
@@ -203,7 +203,7 @@ def test_feature_health_event__get_create_log_message__return_expected(
     )
 
 
-def test_feature_health_event__get_create_log_message__environment__return_expected(
+def test_feature_health_event__get_create_log_message__environment__return_expected(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     mocker: MockerFixture,

--- a/api/tests/unit/features/feature_health/test_services.py
+++ b/api/tests/unit/features/feature_health/test_services.py
@@ -12,7 +12,7 @@ from features.feature_health.services import (
 from features.models import Feature
 
 
-def test_get_provider_response__invalid_provider__return_none__log_expected(
+def test_get_provider_response__invalid_provider__return_none__log_expected(  # noqa: FT003
     mocker: MockerFixture,
     log: "StructuredLogCapture",
 ) -> None:

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_limits.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_limits.py
@@ -5,7 +5,7 @@ from projects.models import Project
 from segments.models import Segment
 
 
-def test_segment_override_limit_does_not_exclude_invalid_overrides_being_deleted(
+def test_segment_override_limit_does_not_exclude_invalid_overrides_being_deleted(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     another_segment: Segment,

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_models.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_models.py
@@ -4,7 +4,7 @@ from projects.models import Project
 from segments.models import Segment
 
 
-def test_feature_segment_is_less_than_other_if_priority_lower(
+def test_feature_segment_is_less_than_other_if_priority_lower(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     segment: Segment,
@@ -33,7 +33,7 @@ def test_feature_segment_is_less_than_other_if_priority_lower(
     assert result is True
 
 
-def test_feature_segments_are_created_with_correct_priority(
+def test_feature_segments_are_created_with_correct_priority(  # noqa: FT003,FT004
     feature: Feature,
     environment: Environment,
     segment: Segment,
@@ -89,7 +89,7 @@ def test_feature_segments_are_created_with_correct_priority(
     assert feature_segment_5.priority == 0
 
 
-def test_clone_creates_a_new_object(
+def test_clone_creates_a_new_object(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     segment: Segment,

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_serializers.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_serializers.py
@@ -14,7 +14,7 @@ from segments.models import Segment
 from users.models import FFAdminUser
 
 
-def test_feature_segment_change_priorities_serializer_validate_fails_if_non_unique_version(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_feature_segment_change_priorities_serializer_validate_fails_if_non_unique_version(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -64,7 +64,7 @@ def test_feature_segment_change_priorities_serializer_validate_fails_if_non_uniq
     assert serializer.errors
 
 
-def test_feature_segment_serializer_save_new_feature_segment_sets_lowest_priority_if_none_given(
+def test_feature_segment_serializer_save_new_feature_segment_sets_lowest_priority_if_none_given(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -86,7 +86,7 @@ def test_feature_segment_serializer_save_new_feature_segment_sets_lowest_priorit
     assert new_feature_segment.priority == 1
 
 
-def test_feature_segment_serializer_save_new_feature_segment_sets_highest_priority_if_0_given(
+def test_feature_segment_serializer_save_new_feature_segment_sets_highest_priority_if_0_given(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -108,7 +108,7 @@ def test_feature_segment_serializer_save_new_feature_segment_sets_highest_priori
     assert new_feature_segment.priority == 0
 
 
-def test_feature_segment_serializer_save_new_feature_segment_moves_others_if_needed(
+def test_feature_segment_serializer_save_new_feature_segment_moves_others_if_needed(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -132,7 +132,7 @@ def test_feature_segment_serializer_save_new_feature_segment_moves_others_if_nee
     assert new_feature_segment.priority == 1
 
 
-def test_feature_segment_serializer_save_existing_feature_segment_does_nothing_if_no_priority_given(
+def test_feature_segment_serializer_save_existing_feature_segment_does_nothing_if_no_priority_given(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -161,7 +161,7 @@ def test_feature_segment_serializer_save_existing_feature_segment_does_nothing_i
     assert updated_feature_segment.priority == 1
 
 
-def test_feature_segment_serializer_save_existing_feature_segment_sets_highest_priority_if_0_given(
+def test_feature_segment_serializer_save_existing_feature_segment_sets_highest_priority_if_0_given(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -191,7 +191,7 @@ def test_feature_segment_serializer_save_existing_feature_segment_sets_highest_p
     assert updated_feature_segment.priority == 0
 
 
-def test_feature_segment_serializer_save_existing_feature_segment_moves_others_if_needed(
+def test_feature_segment_serializer_save_existing_feature_segment_moves_others_if_needed(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -222,7 +222,7 @@ def test_feature_segment_serializer_save_existing_feature_segment_moves_others_i
     assert updated_feature_segment.priority == 1
 
 
-def test_feature_segment_serializer_save_new_feature_segment_does_nothing_on_error(
+def test_feature_segment_serializer_save_new_feature_segment_does_nothing_on_error(  # noqa: FT003
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -46,7 +46,7 @@ from users.models import FFAdminUser
         ),  # one for each for master_api_key
     ],
 )
-def test_list_feature_segments_without_rbac(
+def test_list_feature_segments_without_rbac(  # noqa: FT003
     segment: Segment,
     feature: Feature,
     environment: Environment,
@@ -93,7 +93,7 @@ def test_list_feature_segments_without_rbac(
         ),  # one for each for master_api_key
     ],
 )
-def test_list_feature_segments_with_rbac(
+def test_list_feature_segments_with_rbac(  # noqa: FT003
     segment: Segment,
     feature: Feature,
     environment: Environment,
@@ -147,7 +147,7 @@ def _list_feature_segment_setup_data(
     "client",
     [lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")],
 )
-def test_list_feature_segments_is_feature_specific(  # type: ignore[no-untyped-def]
+def test_list_feature_segments_is_feature_specific(  # type: ignore[no-untyped-def]  # noqa: FT003
     segment,
     feature,
     environment,
@@ -179,7 +179,7 @@ def test_list_feature_segments_is_feature_specific(  # type: ignore[no-untyped-d
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_feature_segment(segment, feature, environment, client):  # type: ignore[no-untyped-def]
+def test_create_feature_segment(segment, feature, environment, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     data = {
         "feature": feature.id,
@@ -197,7 +197,7 @@ def test_create_feature_segment(segment, feature, environment, client):  # type:
     assert response_json["id"]
 
 
-def test_create_feature_segment_without_permission_returns_403(
+def test_create_feature_segment_without_permission_returns_403(  # noqa: FT003
     segment: Segment,
     feature: Feature,
     environment: Environment,
@@ -220,7 +220,7 @@ def test_create_feature_segment_without_permission_returns_403(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_create_feature_segment_staff_with_permission(
+def test_create_feature_segment_staff_with_permission(  # noqa: FT003
     segment: Segment,
     feature: Feature,
     environment: Environment,
@@ -246,7 +246,7 @@ def test_create_feature_segment_staff_with_permission(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_create_feature_segment_staff_wrong_permission(  # type: ignore[no-untyped-def]
+def test_create_feature_segment_staff_wrong_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     segment: Segment,
     feature: Feature,
     environment: Environment,
@@ -277,7 +277,7 @@ def test_create_feature_segment_staff_wrong_permission(  # type: ignore[no-untyp
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_delete_feature_segment(segment, feature, environment, client):  # type: ignore[no-untyped-def]
+def test_delete_feature_segment(segment, feature, environment, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     feature_segment = FeatureSegment.objects.create(
         feature=feature, environment=environment, segment=segment
@@ -296,7 +296,7 @@ def test_delete_feature_segment(segment, feature, environment, client):  # type:
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_update_priority_of_multiple_feature_segments(  # type: ignore[no-untyped-def]
+def test_update_priority_of_multiple_feature_segments(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature_segment,
     project,
     client,
@@ -332,7 +332,7 @@ def test_update_priority_of_multiple_feature_segments(  # type: ignore[no-untype
     assert json_response[1]["id"] == another_feature_segment.id
 
 
-def test_update_priority_for_staff(
+def test_update_priority_for_staff(  # noqa: FT003
     feature_segment: FeatureSegment,
     project: Project,
     environment: Environment,
@@ -359,7 +359,7 @@ def test_update_priority_for_staff(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_update_priority_returns_403_if_user_does_not_have_permission(  # type: ignore[no-untyped-def]
+def test_update_priority_returns_403_if_user_does_not_have_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature_segment: FeatureSegment,
     project: Project,
     environment: Environment,
@@ -386,7 +386,7 @@ def test_update_priority_returns_403_if_user_does_not_have_permission(  # type: 
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_update_priorities_empty_list(client):  # type: ignore[no-untyped-def]
+def test_update_priorities_empty_list(client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:features:feature-segment-update-priorities")
 
@@ -402,7 +402,7 @@ def test_update_priorities_empty_list(client):  # type: ignore[no-untyped-def]
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_get_feature_segment_by_uuid(  # type: ignore[no-untyped-def]
+def test_get_feature_segment_by_uuid(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature_segment, project, client, environment, feature
 ):
     # Given
@@ -420,7 +420,7 @@ def test_get_feature_segment_by_uuid(  # type: ignore[no-untyped-def]
     assert json_response["uuid"] == str(feature_segment.uuid)
 
 
-def test_get_feature_segment_by_uuid_for_staff(
+def test_get_feature_segment_by_uuid_for_staff(  # noqa: FT003
     feature_segment: FeatureSegment,
     project: Project,
     staff_client: FFAdminUser,
@@ -447,7 +447,7 @@ def test_get_feature_segment_by_uuid_for_staff(
     assert json_response["uuid"] == str(feature_segment.uuid)
 
 
-def test_get_feature_segment_by_uuid_returns_404_if_user_does_not_have_access(
+def test_get_feature_segment_by_uuid_returns_404_if_user_does_not_have_access(  # noqa: FT003
     feature_segment: FeatureSegment,
     project: Project,
     staff_client: APIClient,
@@ -470,7 +470,7 @@ def test_get_feature_segment_by_uuid_returns_404_if_user_does_not_have_access(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_get_feature_segment_by_id(  # type: ignore[no-untyped-def]
+def test_get_feature_segment_by_id(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature_segment, project, client, environment, feature
 ):
     # Given
@@ -486,7 +486,7 @@ def test_get_feature_segment_by_id(  # type: ignore[no-untyped-def]
     assert json_response["uuid"] == str(feature_segment.uuid)
 
 
-def test_get_feature_segment_by_id_for_staff(  # type: ignore[no-untyped-def]
+def test_get_feature_segment_by_id_for_staff(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature_segment: FeatureSegment,
     project: Project,
     staff_client: FFAdminUser,
@@ -518,7 +518,7 @@ def test_get_feature_segment_by_id_for_staff(  # type: ignore[no-untyped-def]
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_creating_segment_override_for_feature_based_segment_returns_400_for_wrong_feature(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_creating_segment_override_for_feature_based_segment_returns_400_for_wrong_feature(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     client, feature_based_segment, project, environment
 ):
     # Given - A different feature
@@ -546,7 +546,7 @@ def test_creating_segment_override_for_feature_based_segment_returns_400_for_wro
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_creating_segment_override_for_feature_based_segment_returns_201_for_correct_feature(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_creating_segment_override_for_feature_based_segment_returns_201_for_correct_feature(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     client, feature_based_segment, project, environment, feature
 ):
     # Given
@@ -567,7 +567,7 @@ def test_creating_segment_override_for_feature_based_segment_returns_201_for_cor
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_creating_segment_override_reaching_max_limit(  # type: ignore[no-untyped-def]
+def test_creating_segment_override_reaching_max_limit(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     client, segment, environment, project, feature, feature_based_segment
 ):
     # Given
@@ -599,7 +599,7 @@ def test_creating_segment_override_reaching_max_limit(  # type: ignore[no-untype
     assert environment.feature_segments.count() == 1
 
 
-def test_get_feature_segments_only_returns_latest_version(
+def test_get_feature_segments_only_returns_latest_version(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -667,7 +667,7 @@ def test_get_feature_segments_only_returns_latest_version(
     assert response_json["results"][0]["id"] == feature_segment_v2.id
 
 
-def test_delete_feature_segment_does_not_create_audit_log_for_versioning_v2(
+def test_delete_feature_segment_does_not_create_audit_log_for_versioning_v2(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     feature_segment: FeatureSegment,

--- a/api/tests/unit/features/feature_states/test_models.py
+++ b/api/tests/unit/features/feature_states/test_models.py
@@ -17,7 +17,7 @@ from features.value_types import BOOLEAN, INTEGER, STRING
         ("TRUE", "boolean", True, BOOLEAN),
     ],
 )
-def test_set_value(
+def test_set_value(  # noqa: FT003
     feature_state: FeatureState,
     value: str,
     type_: FeatureValueType,
@@ -43,7 +43,7 @@ def test_set_value(
         ("hello", "invalid", "'invalid' is not a valid type"),
     ],
 )
-def test_set_value_invalid_raises_error(
+def test_set_value_invalid_raises_error(  # noqa: FT003
     feature_state: FeatureState,
     value: str,
     type_: str,
@@ -59,7 +59,7 @@ def test_set_value_invalid_raises_error(
     assert expected_error in str(exc_info.value)
 
 
-def test_set_value_clears_old_fields_when_changing_type(
+def test_set_value_clears_old_fields_when_changing_type(  # noqa: FT003
     feature_state: FeatureState,
 ) -> None:
     # Given
@@ -87,7 +87,7 @@ def test_set_value_clears_old_fields_when_changing_type(
         ("hello", "invalid_type"),
     ],
 )
-def test_set_value_preserves_original_value_on_error(
+def test_set_value_preserves_original_value_on_error(  # noqa: FT003
     feature_state: FeatureState,
     invalid_value: str,
     invalid_type: str,

--- a/api/tests/unit/features/feature_states/test_serializers.py
+++ b/api/tests/unit/features/feature_states/test_serializers.py
@@ -14,7 +14,7 @@ from projects.models import Project
 from segments.models import Segment
 
 
-def test_get_feature_raises_error_when_environment_not_in_context(
+def test_get_feature_raises_error_when_environment_not_in_context(  # noqa: FT003
     feature: Feature,
 ) -> None:
     # Given
@@ -36,7 +36,7 @@ def test_get_feature_raises_error_when_environment_not_in_context(
     assert "Environment context is required" in str(exc_info.value)
 
 
-def test_validate_segment_overrides_returns_empty_list() -> None:
+def test_validate_segment_overrides_returns_empty_list() -> None:  # noqa: FT003
     # Given
     serializer = UpdateFlagV2Serializer()
 
@@ -47,7 +47,7 @@ def test_validate_segment_overrides_returns_empty_list() -> None:
     assert result == []
 
 
-def test_feature_value_serializer_rejects_invalid_integer() -> None:
+def test_feature_value_serializer_rejects_invalid_integer() -> None:  # noqa: FT003
     # Given
     serializer = FeatureValueSerializer(
         data={"type": "integer", "value": "not_a_number"}
@@ -61,7 +61,7 @@ def test_feature_value_serializer_rejects_invalid_integer() -> None:
     assert "not a valid integer" in str(serializer.errors)
 
 
-def test_feature_value_serializer_rejects_invalid_boolean() -> None:
+def test_feature_value_serializer_rejects_invalid_boolean() -> None:  # noqa: FT003
     # Given
     serializer = FeatureValueSerializer(data={"type": "boolean", "value": "yes"})
 
@@ -104,7 +104,7 @@ def test_feature_value_serializer_rejects_invalid_boolean() -> None:
         ),
     ],
 )
-def test_serializer_rejects_nonexistent_segment(
+def test_serializer_rejects_nonexistent_segment(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     serializer_class: type,
@@ -155,7 +155,7 @@ def test_serializer_rejects_nonexistent_segment(
         ),
     ],
 )
-def test_serializer_rejects_cross_project_segment(
+def test_serializer_rejects_cross_project_segment(  # noqa: FT003
     feature: Feature,
     environment: Environment,
     organisation: object,

--- a/api/tests/unit/features/feature_states/test_unit_feature_states_views.py
+++ b/api/tests/unit/features/feature_states/test_unit_feature_states_views.py
@@ -31,7 +31,7 @@ from tests.types import WithEnvironmentPermissionsCallable
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_by_name(
+def test_update_flag_by_name(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -73,7 +73,7 @@ def test_update_flag_by_name(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_by_id(
+def test_update_flag_by_id(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -112,7 +112,7 @@ def test_update_flag_by_id(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_error_when_both_name_and_id_provided(
+def test_update_flag_error_when_both_name_and_id_provided(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -147,7 +147,7 @@ def test_update_flag_error_when_both_name_and_id_provided(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_error_when_both_name_and_id_provided_for_different_features(
+def test_update_flag_error_when_both_name_and_id_provided_for_different_features(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -189,7 +189,7 @@ def test_update_flag_error_when_both_name_and_id_provided_for_different_features
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_error_when_neither_name_nor_id_provided(
+def test_update_flag_error_when_neither_name_nor_id_provided(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -224,7 +224,7 @@ def test_update_flag_error_when_neither_name_nor_id_provided(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_error_when_feature_not_found_by_name(
+def test_update_flag_error_when_feature_not_found_by_name(  # noqa: FT003
     staff_client: APIClient,
     environment_: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -256,7 +256,7 @@ def test_update_flag_error_when_feature_not_found_by_name(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_error_when_feature_not_found_by_id(
+def test_update_flag_error_when_feature_not_found_by_id(  # noqa: FT003
     staff_client: APIClient,
     environment_: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -288,7 +288,7 @@ def test_update_flag_error_when_feature_not_found_by_id(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_segment_override_by_name(
+def test_update_flag_segment_override_by_name(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -339,7 +339,7 @@ def test_update_flag_segment_override_by_name(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_flag_segment_override_creates_feature_segment_if_not_exists(
+def test_update_flag_segment_override_creates_feature_segment_if_not_exists(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -395,7 +395,7 @@ def test_update_flag_segment_override_creates_feature_segment_if_not_exists(
     assert segment_override.feature_segment.priority == 10
 
 
-def test_create_new_segment_override_reorders_priorities_v1(
+def test_create_new_segment_override_reorders_priorities_v1(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -459,7 +459,7 @@ def test_create_new_segment_override_reorders_priorities_v1(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_feature_states_creates_new_segment_overrides(
+def test_update_feature_states_creates_new_segment_overrides(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -547,7 +547,7 @@ def test_update_feature_states_creates_new_segment_overrides(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_feature_states_environment_default_only(
+def test_update_feature_states_environment_default_only(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -588,7 +588,7 @@ def test_update_feature_states_environment_default_only(
     assert env_default.get_feature_state_value() == 100
 
 
-def test_update_feature_states_rejects_duplicate_segment_ids(
+def test_update_feature_states_rejects_duplicate_segment_ids(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -640,7 +640,7 @@ def test_update_feature_states_rejects_duplicate_segment_ids(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_existing_segment_override_with_priority_v1(
+def test_update_existing_segment_override_with_priority_v1(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -702,7 +702,7 @@ def test_update_existing_segment_override_with_priority_v1(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_update_existing_segment_override_with_priority_v2(
+def test_update_existing_segment_override_with_priority_v2(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -768,7 +768,7 @@ def test_update_existing_segment_override_with_priority_v2(
     assert feature_segment.priority == 2
 
 
-def test_create_new_segment_override_reorders_priorities_v2(
+def test_create_new_segment_override_reorders_priorities_v2(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -834,7 +834,7 @@ def test_create_new_segment_override_reorders_priorities_v2(
     assert feature_segment1.priority == 1
 
 
-def test_update_flag_v1_returns_403_when_workflow_enabled(
+def test_update_flag_v1_returns_403_when_workflow_enabled(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -866,7 +866,7 @@ def test_update_flag_v1_returns_403_when_workflow_enabled(
     assert "change requests are enabled" in str(response.json())
 
 
-def test_update_flag_v2_returns_403_when_workflow_enabled(
+def test_update_flag_v2_returns_403_when_workflow_enabled(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -900,7 +900,7 @@ def test_update_flag_v2_returns_403_when_workflow_enabled(
     assert "change requests are enabled" in str(response.json())
 
 
-def test_update_existing_segment_override_v2_versioning(
+def test_update_existing_segment_override_v2_versioning(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_v2_versioning: Environment,
@@ -974,7 +974,7 @@ def test_update_existing_segment_override_v2_versioning(
     assert segment_override.feature_segment.priority == 1
 
 
-def test_update_flag_v1_returns_403_without_permission(
+def test_update_flag_v1_returns_403_without_permission(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -1000,7 +1000,7 @@ def test_update_flag_v1_returns_403_without_permission(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_update_flag_v2_returns_403_without_permission(
+def test_update_flag_v2_returns_403_without_permission(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment: Environment,
@@ -1028,7 +1028,7 @@ def test_update_flag_v2_returns_403_without_permission(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_update_flag_v1_returns_403_for_nonexistent_environment(
+def test_update_flag_v1_returns_403_for_nonexistent_environment(  # noqa: FT003
     staff_client: APIClient,
 ) -> None:
     # Given
@@ -1056,7 +1056,7 @@ def test_update_flag_v1_returns_403_for_nonexistent_environment(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_success(
+def test_delete_segment_override_success(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -1121,7 +1121,7 @@ def test_delete_segment_override_success(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_by_feature_id(
+def test_delete_segment_override_by_feature_id(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -1176,7 +1176,7 @@ def test_delete_segment_override_by_feature_id(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_feature_not_found(
+def test_delete_segment_override_feature_not_found(  # noqa: FT003
     staff_client: APIClient,
     environment_: Environment,
     project: Project,
@@ -1211,7 +1211,7 @@ def test_delete_segment_override_feature_not_found(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_segment_not_in_project(
+def test_delete_segment_override_segment_not_in_project(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -1245,7 +1245,7 @@ def test_delete_segment_override_segment_not_in_project(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_not_found(
+def test_delete_segment_override_not_found(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -1282,7 +1282,7 @@ def test_delete_segment_override_not_found(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_403_without_permission(
+def test_delete_segment_override_403_without_permission(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -1314,7 +1314,7 @@ def test_delete_segment_override_403_without_permission(
     "environment_",
     (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
 )
-def test_delete_segment_override_403_when_workflow_enabled(
+def test_delete_segment_override_403_when_workflow_enabled(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_: Environment,
@@ -1348,7 +1348,7 @@ def test_delete_segment_override_403_when_workflow_enabled(
     assert "change requests are enabled" in str(response.json())
 
 
-def test_delete_segment_override_v2_versioning_creates_new_version(
+def test_delete_segment_override_v2_versioning_creates_new_version(  # noqa: FT003
     staff_client: APIClient,
     feature: Feature,
     environment_v2_versioning: Environment,

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_tasks.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_tasks.py
@@ -36,7 +36,7 @@ from projects.models import Project
 from projects.tags.models import Tag
 
 
-def test_clear_stale_feature_imports_and_exports(  # type: ignore[no-untyped-def]
+def test_clear_stale_feature_imports_and_exports(  # type: ignore[no-untyped-def]  # noqa: FT003
     db: None, environment: Environment, freezer: FrozenDateTimeFactory
 ):
     # Given
@@ -74,7 +74,7 @@ def test_clear_stale_feature_imports_and_exports(  # type: ignore[no-untyped-def
     kept_feature_export.refresh_from_db()
 
 
-def test_retire_stalled_feature_imports_and_exports(  # type: ignore[no-untyped-def]
+def test_retire_stalled_feature_imports_and_exports(  # type: ignore[no-untyped-def]  # noqa: FT003
     db: None, environment: Environment, freezer: FrozenDateTimeFactory
 ):
     # Given
@@ -118,7 +118,7 @@ def test_retire_stalled_feature_imports_and_exports(  # type: ignore[no-untyped-
     assert keep_processing_feature_export.status == PROCESSING
 
 
-def test_export_and_import_features_for_environment_with_skip(
+def test_export_and_import_features_for_environment_with_skip(  # noqa: FT003
     db: None,
     environment: Environment,
     project: Project,
@@ -201,7 +201,7 @@ def test_export_and_import_features_for_environment_with_skip(
     assert new_feature2.default_enabled is False
 
 
-def test_export_and_import_features_for_environment_with_overwrite_destructive(
+def test_export_and_import_features_for_environment_with_overwrite_destructive(  # noqa: FT003
     db: None,
     environment: Environment,
     project: Project,
@@ -373,7 +373,7 @@ def test_export_and_import_features_for_environment_with_overwrite_destructive(
     assert new_feature_state3.feature_state_value.value == "changed"
 
 
-def test_create_flagsmith_on_flagsmith_feature_export(
+def test_create_flagsmith_on_flagsmith_feature_export(  # noqa: FT003
     db: None,
     settings: SettingsWrapper,
     environment: Environment,

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -27,7 +27,7 @@ from tests.types import WithProjectPermissionsCallable
 from users.models import FFAdminUser
 
 
-def test_list_feature_exports(
+def test_list_feature_exports(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     environment: Environment,
@@ -66,7 +66,7 @@ def test_list_feature_exports(
     assert response.data["results"][1]["name"].startswith(f"{environment.name} | ")
 
 
-def test_list_feature_export_with_filtered_environments(
+def test_list_feature_export_with_filtered_environments(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     project: Project,
@@ -110,7 +110,7 @@ def test_list_feature_export_with_filtered_environments(
     assert response.data["results"][0]["id"] == feature_export2.id
 
 
-def test_list_feature_exports_unauthorized(
+def test_list_feature_exports_unauthorized(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     environment: Environment,
@@ -133,7 +133,7 @@ def test_list_feature_exports_unauthorized(
     assert response.status_code == 403
 
 
-def test_download_feature_export(
+def test_download_feature_export(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -155,7 +155,7 @@ def test_download_feature_export(
     assert response.json() == [{"feature": "data"}]
 
 
-def test_download_feature_export_unauthorized(
+def test_download_feature_export_unauthorized(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -173,7 +173,7 @@ def test_download_feature_export_unauthorized(
 
 
 @pytest.mark.parametrize("status", (PROCESSING, FAILED))
-def test_cannot_download_non_success_feature_export(
+def test_cannot_download_non_success_feature_export(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     status: str,
@@ -195,7 +195,7 @@ def test_cannot_download_non_success_feature_export(
     }
 
 
-def test_feature_import(
+def test_feature_import(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -220,7 +220,7 @@ def test_feature_import(
     assert feature_import.strategy == OVERWRITE_DESTRUCTIVE  # type: ignore[union-attr]
 
 
-def test_feature_import_already_processing(
+def test_feature_import_already_processing(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -254,7 +254,7 @@ def test_feature_import_already_processing(
     ]
 
 
-def test_feature_import_unauthorized(
+def test_feature_import_unauthorized(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -278,7 +278,7 @@ def test_feature_import_unauthorized(
 
 
 @pytest.mark.freeze_time("2023-12-08T06:05:47.320000+00:00")
-def test_create_feature_export(
+def test_create_feature_export(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
     mocker: MockerFixture,
@@ -323,7 +323,7 @@ def test_create_feature_export(
     )
 
 
-def test_create_feature_export_unauthorized(
+def test_create_feature_export_unauthorized(  # noqa: FT003
     staff_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -348,7 +348,7 @@ def test_create_feature_export_unauthorized(
     }
 
 
-def test_download_flagsmith_on_flagsmith_when_none(
+def test_download_flagsmith_on_flagsmith_when_none(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     settings: SettingsWrapper,
@@ -372,7 +372,7 @@ def test_download_flagsmith_on_flagsmith_when_none(
     assert response.status_code == 404
 
 
-def test_download_flagsmith_on_flagsmith_when_success(
+def test_download_flagsmith_on_flagsmith_when_success(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     settings: SettingsWrapper,
@@ -404,7 +404,7 @@ def test_download_flagsmith_on_flagsmith_when_success(
     assert response.data == [{"feature": "data"}]
 
 
-def test_list_feature_import_with_filtered_environments(
+def test_list_feature_import_with_filtered_environments(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     project: Project,
@@ -459,7 +459,7 @@ def test_list_feature_import_with_filtered_environments(
     assert response.data["results"][0]["strategy"] == OVERWRITE_DESTRUCTIVE
 
 
-def test_list_feature_import_unauthorized(
+def test_list_feature_import_unauthorized(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     environment: Environment,

--- a/api/tests/unit/features/multivariate/test_migrations.py
+++ b/api/tests/unit/features/multivariate/test_migrations.py
@@ -5,7 +5,7 @@ from django_test_migrations.migrator import Migrator
 from core.constants import STRING
 
 
-def test_remove_duplicate_mv_feature_state_values(migrator: Migrator) -> None:
+def test_remove_duplicate_mv_feature_state_values(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     # We set the DB to be in the state prior to the migration we want to test
     old_state = migrator.apply_initial_migration(("multivariate", "0001_initial"))

--- a/api/tests/unit/features/multivariate/test_unit_multivariate_models.py
+++ b/api/tests/unit/features/multivariate/test_unit_multivariate_models.py
@@ -11,7 +11,7 @@ from features.multivariate.models import (
 from segments.models import Segment
 
 
-def test_multivariate_feature_option_get_create_log_message(feature):  # type: ignore[no-untyped-def]
+def test_multivariate_feature_option_get_create_log_message(feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mvfo = MultivariateFeatureOption.objects.create(feature=feature, string_value="foo")
 
@@ -24,7 +24,7 @@ def test_multivariate_feature_option_get_create_log_message(feature):  # type: i
     assert msg == f"Multivariate option added to feature '{feature.name}'."
 
 
-def test_multivariate_feature_option_get_delete_log_message_for_valid_feature(feature):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_multivariate_feature_option_get_delete_log_message_for_valid_feature(feature):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     mvfo = MultivariateFeatureOption.objects.create(feature=feature, string_value="foo")
 
@@ -37,7 +37,7 @@ def test_multivariate_feature_option_get_delete_log_message_for_valid_feature(fe
     assert msg == f"Multivariate option removed from feature '{feature.name}'."
 
 
-def test_multivariate_feature_option_get_delete_log_message_for_deleted_feature(  # type: ignore[no-untyped-def]
+def test_multivariate_feature_option_get_delete_log_message_for_deleted_feature(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature,
 ):
     # Given
@@ -58,7 +58,7 @@ def test_multivariate_feature_option_get_delete_log_message_for_deleted_feature(
     assert msg is None
 
 
-def test_multivariate_feature_state_value_get_update_log_message_environment_default(  # type: ignore[no-untyped-def]
+def test_multivariate_feature_state_value_get_update_log_message_environment_default(  # type: ignore[no-untyped-def]  # noqa: FT003
     multivariate_feature, environment
 ):
     # Given
@@ -77,7 +77,7 @@ def test_multivariate_feature_state_value_get_update_log_message_environment_def
     )
 
 
-def test_multivariate_feature_state_value_get_update_log_message_identity_override(  # type: ignore[no-untyped-def]
+def test_multivariate_feature_state_value_get_update_log_message_identity_override(  # type: ignore[no-untyped-def]  # noqa: FT003
     multivariate_feature, environment, identity
 ):
     # Given
@@ -101,7 +101,7 @@ def test_multivariate_feature_state_value_get_update_log_message_identity_overri
     )
 
 
-def test_multivariate_feature_state_value_get_update_log_message_segment_override(  # type: ignore[no-untyped-def]
+def test_multivariate_feature_state_value_get_update_log_message_segment_override(  # type: ignore[no-untyped-def]  # noqa: FT003
     multivariate_feature, environment, segment
 ):
     # Given
@@ -130,7 +130,7 @@ def test_multivariate_feature_state_value_get_update_log_message_segment_overrid
     )
 
 
-def test_deleting_last_mv_option_of_mulitvariate_feature_converts_it_into_standard(  # type: ignore[no-untyped-def]
+def test_deleting_last_mv_option_of_mulitvariate_feature_converts_it_into_standard(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     multivariate_feature,
 ):
     # Given
@@ -153,7 +153,7 @@ def test_deleting_last_mv_option_of_mulitvariate_feature_converts_it_into_standa
     assert multivariate_feature.type == STANDARD
 
 
-def test_adding_mv_option_to_standard_feature_converts_it_into_multivariate(feature):  # type: ignore[no-untyped-def]
+def test_adding_mv_option_to_standard_feature_converts_it_into_multivariate(feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     assert feature.type == STANDARD
 
@@ -165,7 +165,7 @@ def test_adding_mv_option_to_standard_feature_converts_it_into_multivariate(feat
     assert feature.type == MULTIVARIATE
 
 
-def test_multivariate_feature_state_value__get_skip_create_audit_log_for_identity_delete(
+def test_multivariate_feature_state_value__get_skip_create_audit_log_for_identity_delete(  # noqa: FT003
     multivariate_feature: MultivariateFeatureOption,
     environment: Environment,
     identity: Identity,
@@ -190,7 +190,7 @@ def test_multivariate_feature_state_value__get_skip_create_audit_log_for_identit
     assert mvfsv_history_instance.instance.get_skip_create_audit_log() is True
 
 
-def test_multivariate_feature_state_value__get_skip_create_audit_log_for_segment_delete(
+def test_multivariate_feature_state_value__get_skip_create_audit_log_for_segment_delete(  # noqa: FT003
     multivariate_feature: MultivariateFeatureOption,
     environment: Environment,
     segment: Segment,
@@ -220,7 +220,7 @@ def test_multivariate_feature_state_value__get_skip_create_audit_log_for_segment
     assert mvfsv_history_instance.instance.get_skip_create_audit_log() is True
 
 
-def test_multivariate_feature_state_value__get_skip_create_audit_log_for_feature_delete(
+def test_multivariate_feature_state_value__get_skip_create_audit_log_for_feature_delete(  # noqa: FT003
     multivariate_feature: MultivariateFeatureOption,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
+++ b/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
@@ -13,7 +13,7 @@ from features.multivariate.views import MultivariateFeatureOptionViewSet
 from projects.permissions import NestedProjectPermissions
 
 
-def test_multivariate_feature_options_view_set_get_permissions():  # type: ignore[no-untyped-def]
+def test_multivariate_feature_options_view_set_get_permissions():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     view_set = MultivariateFeatureOptionViewSet()
 
@@ -37,7 +37,7 @@ def test_multivariate_feature_options_view_set_get_permissions():  # type: ignor
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_get_mv_feature_option_by_uuid(client, project, multivariate_feature):  # type: ignore[no-untyped-def]
+def test_get_mv_feature_option_by_uuid(client, project, multivariate_feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mv_option_uuid = multivariate_feature.multivariate_options.first().uuid
     url = reverse(
@@ -57,7 +57,7 @@ def test_get_mv_feature_option_by_uuid(client, project, multivariate_feature):  
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_get_mv_feature_option_by_uuid_returns_404_if_mv_option_does_not_exists(  # type: ignore[no-untyped-def]
+def test_get_mv_feature_option_by_uuid_returns_404_if_mv_option_does_not_exists(  # type: ignore[no-untyped-def]  # noqa: FT003
     client, project
 ):
     # Given

--- a/api/tests/unit/features/release_pipeline/core/test_unit_release_pipeline_models.py
+++ b/api/tests/unit/features/release_pipeline/core/test_unit_release_pipeline_models.py
@@ -21,7 +21,7 @@ from segments.models import Segment
 from users.models import FFAdminUser
 
 
-def test_release_pipeline_publish_raises_error_if_pipeline_is_already_published(
+def test_release_pipeline_publish_raises_error_if_pipeline_is_already_published(  # noqa: FT003
     release_pipeline: ReleasePipeline, admin_user: FFAdminUser
 ) -> None:
     # Given - the pipeline is already published
@@ -34,7 +34,7 @@ def test_release_pipeline_publish_raises_error_if_pipeline_is_already_published(
         release_pipeline.publish(admin_user)
 
 
-def test_release_pipeline_get_first_stage_returns_none_if_pipeline_has_no_stages(
+def test_release_pipeline_get_first_stage_returns_none_if_pipeline_has_no_stages(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
 ) -> None:
     # When
@@ -44,7 +44,7 @@ def test_release_pipeline_get_first_stage_returns_none_if_pipeline_has_no_stages
     assert first_stage is None
 
 
-def test_release_pipeline_get_first_stage_returns_correct_stage(
+def test_release_pipeline_get_first_stage_returns_correct_stage(  # noqa: FT003
     release_pipeline: ReleasePipeline, environment: Environment
 ) -> None:
     # Given
@@ -63,7 +63,7 @@ def test_release_pipeline_get_first_stage_returns_correct_stage(
     assert first_stage.order == 0  # type: ignore[union-attr]
 
 
-def test_release_pipeline_get_last_stage_returns_none_if_pipeline_has_no_stages(
+def test_release_pipeline_get_last_stage_returns_none_if_pipeline_has_no_stages(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
 ) -> None:
     # When
@@ -73,7 +73,7 @@ def test_release_pipeline_get_last_stage_returns_none_if_pipeline_has_no_stages(
     assert last_stage is None
 
 
-def test_release_pipeline_get_last_stage_returns_correct_stage(
+def test_release_pipeline_get_last_stage_returns_correct_stage(  # noqa: FT003
     release_pipeline: ReleasePipeline, environment: Environment
 ) -> None:
     # Given
@@ -92,7 +92,7 @@ def test_release_pipeline_get_last_stage_returns_correct_stage(
     assert last_stage.order == 2  # type: ignore[union-attr]
 
 
-def test_release_pipeline_get_next_stage(
+def test_release_pipeline_get_next_stage(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline, environment: Environment
 ) -> None:
     # Given
@@ -121,7 +121,7 @@ def test_release_pipeline_get_next_stage(
     assert stage3.get_next_stage() is None
 
 
-def test_release_pipeline_get_create_log_message(
+def test_release_pipeline_get_create_log_message(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
 ) -> None:
     # When
@@ -131,7 +131,7 @@ def test_release_pipeline_get_create_log_message(
     assert release_pipeline.get_create_log_message(release_pipeline) == expected_message
 
 
-def test_release_pipeline_get_delete_log_message(
+def test_release_pipeline_get_delete_log_message(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
 ) -> None:
     # When
@@ -141,7 +141,7 @@ def test_release_pipeline_get_delete_log_message(
     assert release_pipeline.get_delete_log_message(release_pipeline) == expected_message
 
 
-def test_release_pipeline_unpublish(
+def test_release_pipeline_unpublish(  # noqa: FT003
     release_pipeline: ReleasePipeline, admin_user: FFAdminUser
 ) -> None:
     # Given - the pipeline is already published
@@ -155,7 +155,7 @@ def test_release_pipeline_unpublish(
     assert release_pipeline.published_by is None
 
 
-def test_should_raise_error_when_unpublishing_unpublished_pipeline(
+def test_should_raise_error_when_unpublishing_unpublished_pipeline(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline, admin_user: FFAdminUser
 ) -> None:
     # When/ Then
@@ -163,7 +163,7 @@ def test_should_raise_error_when_unpublishing_unpublished_pipeline(
         release_pipeline.unpublish()
 
 
-def test_release_pipeline_has_feature_in_flight(
+def test_release_pipeline_has_feature_in_flight(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
     environment: Environment,
     pipeline_stage_enable_feature_on_enter: PipelineStage,
@@ -190,7 +190,7 @@ def test_release_pipeline_has_feature_in_flight(
     assert release_pipeline.has_feature_in_flight() is False
 
 
-def test_phased_rollout_state_increase_split_does_not_exceed_100(
+def test_phased_rollout_state_increase_split_does_not_exceed_100(  # noqa: FT003
     phased_rollout_state: PhasedRolloutState,
 ) -> None:
     # Given
@@ -219,7 +219,7 @@ def test_phased_rollout_state_increase_split_does_not_exceed_100(
     )
 
 
-def test_phased_rollout_complete_rollout(
+def test_phased_rollout_complete_rollout(  # noqa: FT003,FT004
     phased_rollout_state: PhasedRolloutState,
     rollout_segment: Segment,
 ) -> None:
@@ -230,7 +230,7 @@ def test_phased_rollout_complete_rollout(
     assert Segment.objects.filter(id=rollout_segment.id).exists() is False
 
 
-def test_get_phased_rollout_action_returns_none_if_no_phased_rollout_action(
+def test_get_phased_rollout_action_returns_none_if_no_phased_rollout_action(  # noqa: FT003,FT004
     pipeline_stage_enable_feature_on_enter: PipelineStage,
 ) -> None:
     # When
@@ -242,7 +242,7 @@ def test_get_phased_rollout_action_returns_none_if_no_phased_rollout_action(
     assert phased_rollout_action is None
 
 
-def test_get_phased_rollout_action_returns_phased_rollout_action_if_exists(
+def test_get_phased_rollout_action_returns_phased_rollout_action_if_exists(  # noqa: FT003,FT004
     pipeline_stage_phased_rollout: PipelineStage,
 ) -> None:
     # When
@@ -253,7 +253,7 @@ def test_get_phased_rollout_action_returns_phased_rollout_action_if_exists(
     assert phased_rollout_action.action_type == StageActionType.PHASED_ROLLOUT.value
 
 
-def test_pipeline_stage_on_enter_get_completed_feature_versions_qs(
+def test_pipeline_stage_on_enter_get_completed_feature_versions_qs(  # noqa: FT003,FT004
     pipeline_stage_enable_feature_on_enter: PipelineStage,
     feature_in_pipeline_stage_enable_feature_on_enter: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -279,7 +279,7 @@ def test_pipeline_stage_on_enter_get_completed_feature_versions_qs(
     )
 
 
-def test_pipeline_stage_on_enter_get_completed_feature_versions_qs_with_completed_after(
+def test_pipeline_stage_on_enter_get_completed_feature_versions_qs_with_completed_after(  # noqa: FT003
     pipeline_stage_enable_feature_on_enter: PipelineStage,
     feature_in_pipeline_stage_enable_feature_on_enter: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -315,7 +315,7 @@ def test_pipeline_stage_on_enter_get_completed_feature_versions_qs_with_complete
     )
 
 
-def test_pipeline_stage_on_enter_get_in_stage_feature_versions_qs(
+def test_pipeline_stage_on_enter_get_in_stage_feature_versions_qs(  # noqa: FT003,FT004
     pipeline_stage_enable_feature_on_enter: PipelineStage,
     feature_in_pipeline_stage_enable_feature_on_enter: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -340,7 +340,7 @@ def test_pipeline_stage_on_enter_get_in_stage_feature_versions_qs(
     assert in_stage_feature_versions.count() == 0
 
 
-def test_pipeline_stage_wait_for_get_completed_feature_versions_qs(
+def test_pipeline_stage_wait_for_get_completed_feature_versions_qs(  # noqa: FT003,FT004
     pipeline_stage_update_feature_value_on_wait_for: PipelineStage,
     feature_in_pipeline_stage_update_feature_value_on_wait_for: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -363,7 +363,7 @@ def test_pipeline_stage_wait_for_get_completed_feature_versions_qs(
     )
 
 
-def test_pipeline_stage_wait_for_get_in_stage_feature_versions_qs(
+def test_pipeline_stage_wait_for_get_in_stage_feature_versions_qs(  # noqa: FT003,FT004
     pipeline_stage_update_feature_value_on_wait_for: PipelineStage,
     feature_in_pipeline_stage_update_feature_value_on_wait_for: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -386,7 +386,7 @@ def test_pipeline_stage_wait_for_get_in_stage_feature_versions_qs(
     assert in_stage_feature_versions.count() == 0
 
 
-def test_pipeline_stage_phased_rollout_get_completed_feature_versions_qs(
+def test_pipeline_stage_phased_rollout_get_completed_feature_versions_qs(  # noqa: FT003,FT004
     pipeline_stage_phased_rollout: PipelineStage,
     feature_in_pipeline_stage_phased_rollout: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -404,7 +404,7 @@ def test_pipeline_stage_phased_rollout_get_completed_feature_versions_qs(
     )
 
 
-def test_pipeline_stage_phased_rollout_get_completed_feature_versions_qs_with_completed_after(
+def test_pipeline_stage_phased_rollout_get_completed_feature_versions_qs_with_completed_after(  # noqa: FT003
     pipeline_stage_phased_rollout: PipelineStage,
     feature_in_pipeline_stage_phased_rollout: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -445,7 +445,7 @@ def test_pipeline_stage_phased_rollout_get_completed_feature_versions_qs_with_co
     )
 
 
-def test_pipeline_stage_phased_rollout_get_in_stage_feature_versions_qs(
+def test_pipeline_stage_phased_rollout_get_in_stage_feature_versions_qs(  # noqa: FT003,FT004
     pipeline_stage_phased_rollout: PipelineStage,
     feature_in_pipeline_stage_phased_rollout: Feature,
     feature_completed_pipeline_phased_rollout: Feature,
@@ -463,7 +463,7 @@ def test_pipeline_stage_phased_rollout_get_in_stage_feature_versions_qs(
     )
 
 
-def test_release_pipeline_get_feature_versions_in_pipeline_qs(
+def test_release_pipeline_get_feature_versions_in_pipeline_qs(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
     feature_in_pipeline_stage_enable_feature_on_enter: Feature,
     feature_in_pipeline_stage_phased_rollout: Feature,
@@ -496,7 +496,7 @@ def test_release_pipeline_get_feature_versions_in_pipeline_qs(
     )
 
 
-def test_release_pipeline_url(release_pipeline: ReleasePipeline) -> None:
+def test_release_pipeline_url(release_pipeline: ReleasePipeline) -> None:  # noqa: FT003,FT004
     # When
     url = release_pipeline.url
     # Then
@@ -506,7 +506,7 @@ def test_release_pipeline_url(release_pipeline: ReleasePipeline) -> None:
     )
 
 
-def test_release_pipeline_url_raises_error_if_pipeline_is_not_saved(
+def test_release_pipeline_url_raises_error_if_pipeline_is_not_saved(  # noqa: FT003,FT004
     release_pipeline: ReleasePipeline,
 ) -> None:
     # When/ Then

--- a/api/tests/unit/features/test_migrations.py
+++ b/api/tests/unit/features/test_migrations.py
@@ -6,7 +6,7 @@ from django_test_migrations.migrator import Migrator
 from features.feature_types import MULTIVARIATE, STANDARD
 
 
-def test_migrate_feature_segments_forward(migrator: Migrator) -> None:
+def test_migrate_feature_segments_forward(migrator: Migrator) -> None:  # noqa: FT003
     # Given - the migration state is at 0017 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("features", "0017_auto_20200607_1005")
@@ -82,7 +82,7 @@ def test_migrate_feature_segments_forward(migrator: Migrator) -> None:
     assert NewFeatureState.objects.values("feature_segment").distinct().count() == 4
 
 
-def test_migrate_feature_segments_reverse(migrator: Migrator) -> None:
+def test_migrate_feature_segments_reverse(migrator: Migrator) -> None:  # noqa: FT003
     # Given - migration state is at 0018, after the migration we want to test in reverse
     old_state = migrator.apply_initial_migration(
         ("features", "0018_auto_20200607_1057")
@@ -136,7 +136,7 @@ def test_migrate_feature_segments_reverse(migrator: Migrator) -> None:
     assert NewFeatureSegment.objects.first().segment.pk == segment.pk
 
 
-def test_revert_feature_state_versioning_migrations(migrator: Migrator) -> None:
+def test_revert_feature_state_versioning_migrations(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     old_state = migrator.apply_initial_migration(
         ("features", "0038_remove_old_versions_and_drafts")
@@ -183,7 +183,7 @@ def test_revert_feature_state_versioning_migrations(migrator: Migrator) -> None:
     assert NewFeatureState.objects.filter(id=v2.id).exists()
 
 
-def test_fix_feature_type_migration(migrator: Migrator) -> None:
+def test_fix_feature_type_migration(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     old_state = migrator.apply_initial_migration(
         ("features", "0058_alter_boolean_values")
@@ -274,7 +274,7 @@ def test_constrain_feature_type__invalid_types__fixes_to_standard_or_multivariat
     assert NewFeature.objects.get(id=bad_type_mv_feature.id).type == MULTIVARIATE
 
 
-def test_migrate_sample_to_webhook_forward(migrator: Migrator) -> None:
+def test_migrate_sample_to_webhook_forward(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     old_state = migrator.apply_initial_migration(
         ("feature_health", "0002_featurehealthevent_add_external_id_alter_created_at")
@@ -318,7 +318,7 @@ def test_migrate_sample_to_webhook_forward(migrator: Migrator) -> None:
     assert not NewFeatureHealthEvent.objects.filter(provider_name="Sample").exists()
 
 
-def test_migrate_sample_to_webhook_reverse(migrator: Migrator) -> None:
+def test_migrate_sample_to_webhook_reverse(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     old_state = migrator.apply_initial_migration(
         ("feature_health", "0003_migrate_sample_to_webhook")

--- a/api/tests/unit/features/test_unit_feature_external_resources_views.py
+++ b/api/tests/unit/features/test_unit_feature_external_resources_views.py
@@ -69,7 +69,7 @@ def expected_segment_comment_body(
 
 
 @responses.activate
-def test_create_feature_external_resource(
+def test_create_feature_external_resource(  # noqa: FT003
     admin_client_new: APIClient,
     feature_with_value: Feature,
     segment_override_for_feature_with_value: FeatureState,
@@ -185,7 +185,7 @@ def test_create_feature_external_resource(
 
 
 @responses.activate
-def test_create_feature_external_resource_missing_tags(
+def test_create_feature_external_resource_missing_tags(  # noqa: FT003
     admin_client_new: APIClient,
     feature_with_value: Feature,
     segment_override_for_feature_with_value: FeatureState,
@@ -226,7 +226,7 @@ def test_create_feature_external_resource_missing_tags(
     assert tag.label == "Issue Open"  # type: ignore[union-attr]
 
 
-def test_cannot_create_feature_external_resource_with_an_invalid_gh_url(
+def test_cannot_create_feature_external_resource_with_an_invalid_gh_url(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -256,7 +256,7 @@ def test_cannot_create_feature_external_resource_with_an_invalid_gh_url(
     assert response.json()["detail"] == "Invalid GitHub Issue/PR URL"
 
 
-def test_cannot_create_feature_external_resource_with_an_incorrect_gh_type(
+def test_cannot_create_feature_external_resource_with_an_incorrect_gh_type(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -286,7 +286,7 @@ def test_cannot_create_feature_external_resource_with_an_incorrect_gh_type(
     assert response.json()["detail"] == "Incorrect GitHub type"
 
 
-def test_cannot_create_feature_external_resource_when_doesnt_have_a_valid_github_integration(
+def test_cannot_create_feature_external_resource_when_doesnt_have_a_valid_github_integration(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -311,7 +311,7 @@ def test_cannot_create_feature_external_resource_when_doesnt_have_a_valid_github
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_cannot_create_feature_external_resource_when_doesnt_have_permissions(
+def test_cannot_create_feature_external_resource_when_doesnt_have_permissions(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
 ) -> None:
@@ -335,7 +335,7 @@ def test_cannot_create_feature_external_resource_when_doesnt_have_permissions(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_cannot_create_feature_external_resource_when_the_type_is_incorrect(
+def test_cannot_create_feature_external_resource_when_the_type_is_incorrect(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -356,7 +356,7 @@ def test_cannot_create_feature_external_resource_when_the_type_is_incorrect(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_cannot_create_feature_external_resource_due_to_unique_constraint(
+def test_cannot_create_feature_external_resource_due_to_unique_constraint(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -385,7 +385,7 @@ def test_cannot_create_feature_external_resource_due_to_unique_constraint(
     )
 
 
-def test_update_feature_external_resource(
+def test_update_feature_external_resource(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     feature_external_resource: FeatureExternalResource,
@@ -418,7 +418,7 @@ def test_update_feature_external_resource(
     assert response.json()["url"] == feature_external_resource_data["url"]
 
 
-def test_delete_feature_external_resource(
+def test_delete_feature_external_resource(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -457,7 +457,7 @@ def test_delete_feature_external_resource(
 
 
 @responses.activate
-def test_get_feature_external_resources(
+def test_get_feature_external_resources(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -486,7 +486,7 @@ def test_get_feature_external_resources(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_get_feature_external_resource(
+def test_get_feature_external_resource(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -510,7 +510,7 @@ def test_get_feature_external_resource(
     assert response.data["url"] == feature_external_resource.url
 
 
-def test_create_github_comment_on_feature_state_updated(
+def test_create_github_comment_on_feature_state_updated(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -571,7 +571,7 @@ def test_create_github_comment_on_feature_state_updated(
     )
 
 
-def test_create_github_comment_on_feature_was_deleted(
+def test_create_github_comment_on_feature_was_deleted(  # noqa: FT003
     admin_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     feature: Feature,
@@ -606,7 +606,7 @@ def test_create_github_comment_on_feature_was_deleted(
     )
 
 
-def test_create_github_comment_on_segment_override_updated(
+def test_create_github_comment_on_segment_override_updated(  # noqa: FT003
     feature_with_value: Feature,
     segment_override_for_feature_with_value: FeatureState,
     project: Project,
@@ -665,7 +665,7 @@ def test_create_github_comment_on_segment_override_updated(
     )
 
 
-def test_create_github_comment_on_segment_override_deleted(
+def test_create_github_comment_on_segment_override_deleted(  # noqa: FT003
     segment_override_for_feature_with_value: FeatureState,
     feature_with_value_segment: FeatureSegment,
     github_configuration: GithubConfiguration,
@@ -702,7 +702,7 @@ def test_create_github_comment_on_segment_override_deleted(
     )
 
 
-def test_create_github_comment_using_v2(
+def test_create_github_comment_using_v2(  # noqa: FT003
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -775,7 +775,7 @@ def test_create_github_comment_using_v2(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_create_github_comment_using_v2_fails_on_wrong_params(
+def test_create_github_comment_using_v2_fails_on_wrong_params(  # noqa: FT003
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -821,7 +821,7 @@ def test_create_github_comment_using_v2_fails_on_wrong_params(
 
 @responses.activate
 @pytest.mark.freeze_time("2024-05-28T09:09:47.325132+00:00")
-def test_create_feature_external_resource_on_environment_with_v2(
+def test_create_feature_external_resource_on_environment_with_v2(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     github_configuration: GithubConfiguration,
@@ -897,7 +897,7 @@ def test_create_feature_external_resource_on_environment_with_v2(
     )
 
 
-def test_cannot_create_feature_external_resource_for_the_same_feature_and_resource_uri(
+def test_cannot_create_feature_external_resource_for_the_same_feature_and_resource_uri(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,

--- a/api/tests/unit/features/test_unit_features_audit_helpers.py
+++ b/api/tests/unit/features/test_unit_features_audit_helpers.py
@@ -50,7 +50,7 @@ with _frozen_time:
         ),
     ),
 )
-def test_get_identity_override_created_audit_message(  # type: ignore[no-untyped-def]
+def test_get_identity_override_created_audit_message(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, live_from, feature_name, environment_name, identifier, expected_message
 ):
     # Given
@@ -88,7 +88,7 @@ def test_get_identity_override_created_audit_message(  # type: ignore[no-untyped
         ),
     ),
 )
-def test_get_segment_override_created_audit_message(  # type: ignore[no-untyped-def]
+def test_get_segment_override_created_audit_message(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, live_from, feature_name, environment_name, segment_name, expected_message
 ):
     # Given
@@ -130,7 +130,7 @@ def test_get_segment_override_created_audit_message(  # type: ignore[no-untyped-
         ),
     ),
 )
-def test_get_environment_feature_state_created_audit_message(  # type: ignore[no-untyped-def]
+def test_get_environment_feature_state_created_audit_message(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, live_from, feature_name, environment_name, expected_message
 ):
     # Given

--- a/api/tests/unit/features/test_unit_features_features_service.py
+++ b/api/tests/unit/features/test_unit_features_features_service.py
@@ -93,7 +93,7 @@ def distinct_identity_featurestate(
         ),
     ],
 )
-def test_feature_get_overrides_data__call_expected(
+def test_feature_get_overrides_data__call_expected(  # noqa: FT003
     mocker: "MockerFixture",
     environment: "Environment",
     enable_dynamo_db: bool,
@@ -168,7 +168,7 @@ def test_feature_get_overrides_data__edge_project_not_migrated_to_v2__return_exp
     )
 
 
-def test_feature_get_core_overrides_data(
+def test_feature_get_core_overrides_data(  # noqa: FT003
     feature: Feature,
     environment: "Environment",
     identity: Identity,
@@ -216,7 +216,7 @@ def test_feature_get_core_overrides_data(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_feature_get_edge_overrides_data(
+def test_feature_get_edge_overrides_data(  # noqa: FT003
     feature: Feature,
     environment: "Environment",
     identity: Identity,
@@ -268,7 +268,7 @@ def test_feature_get_edge_overrides_data(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_get_edge_overrides_data_skips_deleted_features(  # type: ignore[no-untyped-def]
+def test_get_edge_overrides_data_skips_deleted_features(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature: Feature,
     environment: "Environment",
     identity: Identity,

--- a/api/tests/unit/features/test_unit_features_helpers.py
+++ b/api/tests/unit/features/test_unit_features_helpers.py
@@ -15,5 +15,5 @@ from features.value_types import BOOLEAN, INTEGER, STRING
         (STRING, "False", "False"),
     ),
 )
-def test_get_correctly_typed_value(value_type, string_value, expected_value):  # type: ignore[no-untyped-def]
+def test_get_correctly_typed_value(value_type, string_value, expected_value):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert get_correctly_typed_value(value_type, string_value) == expected_value

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -30,7 +30,7 @@ yesterday = now - timedelta(days=1)
 tomorrow = now + timedelta(days=1)
 
 
-def test_feature_should_create_feature_states_for_environments(
+def test_feature_should_create_feature_states_for_environments(  # noqa: FT003
     db: None,
     environment: Environment,
     project: Project,
@@ -46,7 +46,7 @@ def test_feature_should_create_feature_states_for_environments(
     assert feature_states.count() == 2
 
 
-def test_save_existing_feature_should_not_change_feature_state_enabled(
+def test_save_existing_feature_should_not_change_feature_state_enabled(  # noqa: FT003
     db: None,
     project: Project,
 ) -> None:
@@ -66,7 +66,7 @@ def test_save_existing_feature_should_not_change_feature_state_enabled(
     assert all(fs.enabled == default_enabled for fs in feature.feature_states.all())
 
 
-def test_creating_feature_with_initial_value_should_set_value_for_all_feature_states(
+def test_creating_feature_with_initial_value_should_set_value_for_all_feature_states(  # noqa: FT003
     project: Project,
     environment: Environment,
 ) -> None:
@@ -87,7 +87,7 @@ def test_creating_feature_with_initial_value_should_set_value_for_all_feature_st
         feature_state.get_feature_state_value() == value
 
 
-def test_creating_feature_with_integer_initial_value_should_set_integer_value_for_all_feature_states(
+def test_creating_feature_with_integer_initial_value_should_set_integer_value_for_all_feature_states(  # noqa: FT003
     project: Project,
     environment: Environment,
 ) -> None:
@@ -110,7 +110,7 @@ def test_creating_feature_with_integer_initial_value_should_set_integer_value_fo
         assert feature_state.get_feature_state_value() == initial_value
 
 
-def test_creating_feature_with_boolean_initial_value_should_set_boolean_value_for_all_feature_states(
+def test_creating_feature_with_boolean_initial_value_should_set_boolean_value_for_all_feature_states(  # noqa: FT003
     project: Project,
     environment: Environment,
 ) -> None:
@@ -133,7 +133,7 @@ def test_creating_feature_with_boolean_initial_value_should_set_boolean_value_fo
         assert feature_state.get_feature_state_value() == initial_value
 
 
-def test_cannot_create_feature_with_same_case_insensitive_name(
+def test_cannot_create_feature_with_same_case_insensitive_name(  # noqa: FT003
     project: Project,
 ) -> None:
     # Given
@@ -150,7 +150,7 @@ def test_cannot_create_feature_with_same_case_insensitive_name(
         feature_two.save()
 
 
-def test_updating_feature_name_should_update_feature_states(
+def test_updating_feature_name_should_update_feature_states(  # noqa: FT003
     project: Project,
 ) -> None:
     # Given
@@ -167,7 +167,7 @@ def test_updating_feature_name_should_update_feature_states(
     FeatureState.objects.filter(feature__name=new_feature_name).exists()
 
 
-def test_full_clean_fails_when_duplicate_case_insensitive_name(
+def test_full_clean_fails_when_duplicate_case_insensitive_name(  # noqa: FT003,FT004
     project: Project,
 ) -> None:
     # unit test to validate validate_unique() method
@@ -186,7 +186,7 @@ def test_full_clean_fails_when_duplicate_case_insensitive_name(
         feature_two.full_clean()
 
 
-def test_updating_feature_should_allow_case_insensitive_name(project: Project) -> None:
+def test_updating_feature_should_allow_case_insensitive_name(project: Project) -> None:  # noqa: FT003,FT004
     # Given
     feature_name = "Test Feature"
     feature = Feature.objects.create(
@@ -199,7 +199,7 @@ def test_updating_feature_should_allow_case_insensitive_name(project: Project) -
     feature.full_clean()
 
 
-def test_when_create_feature_with_tags_then_success(project: Project) -> None:
+def test_when_create_feature_with_tags_then_success(project: Project) -> None:  # noqa: FT003,FT004
     # Given
     tag1 = Tag.objects.create(
         label="Test Tag 1",
@@ -223,7 +223,7 @@ def test_when_create_feature_with_tags_then_success(project: Project) -> None:
     assert list(feature.tags.all()) == [tag1, tag2]
 
 
-def test_cannot_create_duplicate_feature_state_in_an_environment(
+def test_cannot_create_duplicate_feature_state_in_an_environment(  # noqa: FT003
     feature: Feature,
     environment: Environment,
 ) -> None:
@@ -243,7 +243,7 @@ def test_cannot_create_duplicate_feature_state_in_an_environment(
     )
 
 
-def test_cannot_create_duplicate_feature_state_in_an_environment_for_segment(
+def test_cannot_create_duplicate_feature_state_in_an_environment_for_segment(  # noqa: FT003
     project: Project,
     feature: Feature,
     environment: Environment,
@@ -281,7 +281,7 @@ def test_cannot_create_duplicate_feature_state_in_an_environment_for_segment(
     )
 
 
-def test_cannot_create_duplicate_feature_state_in_an_environment_for_identity(
+def test_cannot_create_duplicate_feature_state_in_an_environment_for_identity(  # noqa: FT003
     project: Project,
     feature: Feature,
     environment: Environment,
@@ -312,7 +312,7 @@ def test_cannot_create_duplicate_feature_state_in_an_environment_for_identity(
     )
 
 
-def test_feature_state_gt_operator_order(
+def test_feature_state_gt_operator_order(  # noqa: FT003
     identity: Identity,
     feature: Feature,
     environment: Environment,
@@ -367,7 +367,7 @@ def test_feature_state_gt_operator_order(
     assert segment_2_state > default_env_state
 
 
-def test_feature_state_gt_operator_order_when_environment_feature_version_is_none(
+def test_feature_state_gt_operator_order_when_environment_feature_version_is_none(  # noqa: FT003
     identity: Identity,
     feature: Feature,
     feature_state: FeatureState,
@@ -397,7 +397,7 @@ def test_feature_state_gt_operator_order_when_environment_feature_version_is_non
     )
 
 
-def test_feature_state_gt_operator_throws_value_error_if_different_environments(
+def test_feature_state_gt_operator_throws_value_error_if_different_environments(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,
@@ -416,7 +416,7 @@ def test_feature_state_gt_operator_throws_value_error_if_different_environments(
         feature_state_env_1 > feature_state_env_2
 
 
-def test_feature_state_gt_operator_throws_value_error_if_different_features(
+def test_feature_state_gt_operator_throws_value_error_if_different_features(  # noqa: FT003
     project: Project,
     feature: Feature,
     environment: Environment,
@@ -431,7 +431,7 @@ def test_feature_state_gt_operator_throws_value_error_if_different_features(
         feature_state_env_1 > feature_state_env_2
 
 
-def test_feature_state_gt_operator_throws_value_error_if_different_identities(
+def test_feature_state_gt_operator_throws_value_error_if_different_identities(  # noqa: FT003
     environment: Environment,
     feature: Feature,
 ) -> None:
@@ -455,7 +455,7 @@ def test_feature_state_gt_operator_throws_value_error_if_different_identities(
         feature_state_identity_1 > feature_state_identity_2
 
 
-def test_feature_state_gt_operator__environment_default__returns_expected(
+def test_feature_state_gt_operator__environment_default__returns_expected(  # noqa: FT004
     environment: Environment,
     feature: Feature,
     identity: Identity,
@@ -490,7 +490,7 @@ def test_feature_state_gt_operator__environment_default__returns_expected(
         ),
     ],
 )
-def test_feature_state_str__returns_expected(
+def test_feature_state_str__returns_expected(  # noqa: FT003
     feature_state: FeatureState,
     feature_identity: Identity | None,
     expected_result: str,
@@ -503,7 +503,7 @@ def test_feature_state_str__returns_expected(
 
 
 @mock.patch("features.tasks.trigger_feature_state_change_webhooks")
-def test_feature_state_save_calls_trigger_webhooks(
+def test_feature_state_save_calls_trigger_webhooks(  # noqa: FT003
     mock_trigger_webhooks: mock.MagicMock,
     feature: Feature,
     environment: Environment,
@@ -524,7 +524,7 @@ def test_feature_state_save_calls_trigger_webhooks(
     assert called_feature_state.id == feature_state.id
 
 
-def test_delete_feature_should_not_trigger_fs_change_webhooks(
+def test_delete_feature_should_not_trigger_fs_change_webhooks(  # noqa: FT003
     mocker: MockerFixture,
     feature: Feature,
     environment: Environment,
@@ -541,7 +541,7 @@ def test_delete_feature_should_not_trigger_fs_change_webhooks(
     mock_trigger_webhooks.assert_not_called()
 
 
-def test_feature_state_type_environment(
+def test_feature_state_type_environment(  # noqa: FT003,FT004
     feature: Feature,
     environment: Environment,
 ) -> None:
@@ -557,7 +557,7 @@ def test_feature_state_type_environment(
     assert feature_state.type == ENVIRONMENT
 
 
-def test_feature_state_type_identity(
+def test_feature_state_type_identity(  # noqa: FT003,FT004
     identity: Identity,
     feature: Feature,
     environment: Environment,
@@ -574,7 +574,7 @@ def test_feature_state_type_identity(
     assert feature_state.type == IDENTITY
 
 
-def test_feature_state_type_feature_segment(
+def test_feature_state_type_feature_segment(  # noqa: FT003,FT004
     segment: Segment,
     feature: Feature,
     environment: Environment,
@@ -596,7 +596,7 @@ def test_feature_state_type_feature_segment(
 
 @pytest.mark.parametrize("hashed_percentage", (0.0, 30.0, 50.0, 80.0, 99.9999))
 @mock.patch("features.models.get_hashed_percentage_for_object_ids")
-def test_get_multivariate_value_returns_correct_value_when_we_pass_identity(  # type: ignore[no-untyped-def]
+def test_get_multivariate_value_returns_correct_value_when_we_pass_identity(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_get_hashed_percentage,
     hashed_percentage,
     multivariate_feature,
@@ -627,7 +627,7 @@ def test_get_multivariate_value_returns_correct_value_when_we_pass_identity(  # 
 
 
 @mock.patch.object(FeatureState, "get_multivariate_feature_state_value")
-def test_get_feature_state_value_for_multivariate_features(  # type: ignore[no-untyped-def]
+def test_get_feature_state_value_for_multivariate_features(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_get_mv_feature_state_value, environment, multivariate_feature, identity
 ):
     # Given
@@ -656,7 +656,7 @@ def test_get_feature_state_value_for_multivariate_features(  # type: ignore[no-u
 
 
 @mock.patch.object(FeatureState, "get_multivariate_feature_state_value")
-def test_get_feature_state_value_for_multivariate_features_mv_v2_evaluation(  # type: ignore[no-untyped-def]
+def test_get_feature_state_value_for_multivariate_features_mv_v2_evaluation(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_get_mv_feature_state_value, environment, multivariate_feature, identity
 ):
     # Given
@@ -696,7 +696,7 @@ def test_get_feature_state_value_for_multivariate_features_mv_v2_evaluation(  # 
     ),
     indirect=True,
 )
-def test_feature_state_gt_operator(feature_state_version_generator):  # type: ignore[no-untyped-def]
+def test_feature_state_gt_operator(feature_state_version_generator):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     first, second, expected_result = feature_state_version_generator
     assert (first > second) is expected_result
 
@@ -711,7 +711,7 @@ def test_feature_state_gt_operator(feature_state_version_generator):  # type: ig
         (1, tomorrow, False),
     ),
 )
-def test_feature_state_is_live(version, live_from, expected_is_live, environment):  # type: ignore[no-untyped-def]
+def test_feature_state_is_live(version, live_from, expected_is_live, environment):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert (
         FeatureState(
             version=version, live_from=live_from, environment=environment
@@ -736,7 +736,7 @@ def test_feature_state_is_live__identity_override_v2_versioning__returns_true(
     assert feature_state.is_live is True
 
 
-def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(  # type: ignore[no-untyped-def]
+def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment
 ):
     # Given
@@ -762,7 +762,7 @@ def test_creating_a_feature_with_defaults_does_not_set_defaults_if_disabled(  # 
     assert not feature_state.get_feature_state_value()
 
 
-def test_feature_state_get_skip_create_audit_log_if_uncommitted_change_request(  # type: ignore[no-untyped-def]
+def test_feature_state_get_skip_create_audit_log_if_uncommitted_change_request(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment, feature, admin_user
 ):
     # Given
@@ -780,7 +780,7 @@ def test_feature_state_get_skip_create_audit_log_if_uncommitted_change_request( 
     assert feature_state.get_skip_create_audit_log() is True
 
 
-def test_feature_state_get_skip_create_audit_log_if_environment_feature_version(  # type: ignore[no-untyped-def]
+def test_feature_state_get_skip_create_audit_log_if_environment_feature_version(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment_v2_versioning: Environment, feature: Feature
 ):
     # Given
@@ -797,7 +797,7 @@ def test_feature_state_get_skip_create_audit_log_if_environment_feature_version(
     assert feature_state.get_skip_create_audit_log() is True
 
 
-def test_feature_state_value_get_skip_create_audit_log_if_environment_feature_version(  # type: ignore[no-untyped-def]
+def test_feature_state_value_get_skip_create_audit_log_if_environment_feature_version(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment_v2_versioning: Environment, feature: Feature
 ):
     # Given
@@ -814,7 +814,7 @@ def test_feature_state_value_get_skip_create_audit_log_if_environment_feature_ve
     assert feature_state.feature_state_value.get_skip_create_audit_log() is True
 
 
-def test_feature_state_value__get_skip_create_audit_log_for_feature_segment_delete(
+def test_feature_state_value__get_skip_create_audit_log_for_feature_segment_delete(  # noqa: FT003,FT004
     feature: Feature, feature_segment: FeatureSegment, environment: Environment
 ) -> None:
     # Give
@@ -836,7 +836,7 @@ def test_feature_state_value__get_skip_create_audit_log_for_feature_segment_dele
     assert fsv_history_instance.instance.get_skip_create_audit_log() is True
 
 
-def test_feature_state_value__get_skip_create_audit_log_for_identity_delete(
+def test_feature_state_value__get_skip_create_audit_log_for_identity_delete(  # noqa: FT003,FT004
     feature: Feature,
     environment: Environment,
     identity: Identity,
@@ -860,7 +860,7 @@ def test_feature_state_value__get_skip_create_audit_log_for_identity_delete(
     assert fsv_history_instance.instance.get_skip_create_audit_log() is True
 
 
-def test_feature_state_value__get_skip_create_audit_log_for_feature_delete(
+def test_feature_state_value__get_skip_create_audit_log_for_feature_delete(  # noqa: FT003,FT004
     feature: Feature,
     environment: Environment,
     identity: Identity,
@@ -888,7 +888,7 @@ def test_feature_state_value__get_skip_create_audit_log_for_feature_delete(
         (None, None, "get_environment_feature_state_created_audit_message"),
     ),
 )
-def test_feature_state_get_create_log_message_calls_correct_helper_function(  # type: ignore[no-untyped-def]
+def test_feature_state_get_create_log_message_calls_correct_helper_function(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     feature_segment_id,
     identity_id,
@@ -915,7 +915,7 @@ def test_feature_state_get_create_log_message_calls_correct_helper_function(  # 
     expected_function.assert_called_once_with(feature_state)
 
 
-def test_feature_state_get_create_log_message_returns_null_if_environment_created_after_feature(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_feature_state_get_create_log_message_returns_null_if_environment_created_after_feature(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     feature, mocker
 ):
     # Given
@@ -931,7 +931,7 @@ def test_feature_state_get_create_log_message_returns_null_if_environment_create
     assert log is None
 
 
-def test_feature_state_get_create_log_message_returns_value_if_environment_created_after_feature_for_override(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_feature_state_get_create_log_message_returns_value_if_environment_created_after_feature_for_override(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     feature, mocker, identity
 ):
     # Given
@@ -949,7 +949,7 @@ def test_feature_state_get_create_log_message_returns_value_if_environment_creat
     assert log is not None
 
 
-def test_feature_state_get_create_log_message_returns_message_if_environment_created_before_feature(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_feature_state_get_create_log_message_returns_message_if_environment_created_before_feature(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment, mocker
 ):
     # Given
@@ -963,7 +963,7 @@ def test_feature_state_get_create_log_message_returns_message_if_environment_cre
     assert log is not None
 
 
-def test_feature_segment_update_priorities_when_no_changes(  # type: ignore[no-untyped-def]
+def test_feature_segment_update_priorities_when_no_changes(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment, feature, feature_segment, admin_user, mocker
 ):
     # Given
@@ -997,7 +997,7 @@ def test_feature_segment_update_priorities_when_no_changes(  # type: ignore[no-u
     mocked_create_segment_priorities_changed_audit_log.delay.assert_not_called()
 
 
-def test_feature_segment_update_priorities_when_changes(  # type: ignore[no-untyped-def]
+def test_feature_segment_update_priorities_when_changes(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment, feature, feature_segment, admin_user, mocker
 ):
     # Given
@@ -1044,7 +1044,7 @@ def test_feature_segment_update_priorities_when_changes(  # type: ignore[no-unty
     )
 
 
-def test_feature_state_gt_operator_for_multiple_versions_of_segment_overrides(  # type: ignore[no-untyped-def]
+def test_feature_state_gt_operator_for_multiple_versions_of_segment_overrides(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     feature, segment, feature_segment, environment
 ):
     # Given
@@ -1062,7 +1062,7 @@ def test_feature_state_gt_operator_for_multiple_versions_of_segment_overrides(  
     assert v2_segment_override > v1_segment_override
 
 
-def test_feature_state_gt_operator_for_segment_overrides_and_environment_default(  # type: ignore[no-untyped-def]
+def test_feature_state_gt_operator_for_segment_overrides_and_environment_default(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     feature, segment, feature_segment, environment
 ):
     # Given
@@ -1080,7 +1080,7 @@ def test_feature_state_gt_operator_for_segment_overrides_and_environment_default
     assert segment_override > environment_default
 
 
-def test_feature_state_clone_for_segment_override_clones_feature_segment(
+def test_feature_state_clone_for_segment_override_clones_feature_segment(  # noqa: FT003,FT004
     feature: Feature,
     segment_featurestate: FeatureState,
     environment: Environment,
@@ -1102,7 +1102,7 @@ def test_feature_state_clone_for_segment_override_clones_feature_segment(
     )
 
 
-def test_feature_segment_clone(
+def test_feature_segment_clone(  # noqa: FT003,FT004
     feature_segment: FeatureSegment,
     environment: Environment,
     environment_two: Environment,
@@ -1119,7 +1119,7 @@ def test_feature_segment_clone(
     assert cloned_feature_segment.environment == environment_two
 
 
-def test_create_feature_creates_feature_states_in_all_environments_and_environment_feature_version(
+def test_create_feature_creates_feature_states_in_all_environments_and_environment_feature_version(  # noqa: FT003
     project: "Project",
 ) -> None:
     # Given
@@ -1138,7 +1138,7 @@ def test_create_feature_creates_feature_states_in_all_environments_and_environme
     assert feature.feature_states.count() == 2
 
 
-def test_webhooks_are_called_when_feature_state_is_updated(
+def test_webhooks_are_called_when_feature_state_is_updated(  # noqa: FT003
     mocker: MockerFixture,
     feature_state: FeatureState,
     admin_history: None,
@@ -1159,7 +1159,7 @@ def test_webhooks_are_called_when_feature_state_is_updated(
     assert called_feature_state.id == feature_state.id
 
 
-def test_webhooks_are_called_when_feature_state_is_created(
+def test_webhooks_are_called_when_feature_state_is_created(  # noqa: FT003
     mocker: MockerFixture,
     feature: Feature,
     environment: Environment,
@@ -1193,7 +1193,7 @@ def test_webhooks_are_called_when_feature_state_is_created(
     assert called_feature_state.id == feature_state.id
 
 
-def test_webhooks_are_not_called_for_feature_state_with_environment_feature_version(
+def test_webhooks_are_not_called_for_feature_state_with_environment_feature_version(  # noqa: FT003
     mocker: MockerFixture,
     feature: Feature,
     environment_v2_versioning: Environment,

--- a/api/tests/unit/features/test_unit_features_permissions.py
+++ b/api/tests/unit/features/test_unit_features_permissions.py
@@ -22,7 +22,7 @@ from tests.types import WithProjectPermissionsCallable
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_organisation_admin_can_list_features(
+def test_organisation_admin_can_list_features(  # noqa: FT003
     admin_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -42,7 +42,7 @@ def test_organisation_admin_can_list_features(
     assert result is True
 
 
-def test_project_admin_can_list_features(
+def test_project_admin_can_list_features(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -63,7 +63,7 @@ def test_project_admin_can_list_features(
     assert result is True
 
 
-def test_project_user_with_read_access_can_list_features(
+def test_project_user_with_read_access_can_list_features(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -85,7 +85,7 @@ def test_project_user_with_read_access_can_list_features(
     assert result is True
 
 
-def test_organisation_admin_can_create_feature(
+def test_organisation_admin_can_create_feature(  # noqa: FT003
     admin_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -107,7 +107,7 @@ def test_organisation_admin_can_create_feature(
     assert result is True
 
 
-def test_project_admin_can_create_feature(
+def test_project_admin_can_create_feature(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     staff_user: FFAdminUser,
@@ -139,7 +139,7 @@ def test_project_admin_can_create_feature(
     assert result is True
 
 
-def test_project_user_with_create_feature_permission_can_create_feature(
+def test_project_user_with_create_feature_permission_can_create_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     organisation: Organisation,
@@ -172,7 +172,7 @@ def test_project_user_with_create_feature_permission_can_create_feature(
     assert result is True
 
 
-def test_project_user_without_create_feature_permission_cannot_create_feature(
+def test_project_user_without_create_feature_permission_cannot_create_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -194,7 +194,7 @@ def test_project_user_without_create_feature_permission_cannot_create_feature(
     assert result is False
 
 
-def test_organisation_admin_can_view_feature(
+def test_organisation_admin_can_view_feature(  # noqa: FT003
     admin_user: FFAdminUser,
     feature: Feature,
 ) -> None:
@@ -213,7 +213,7 @@ def test_organisation_admin_can_view_feature(
     assert result is True
 
 
-def test_project_admin_can_view_feature(
+def test_project_admin_can_view_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     feature: Feature,
@@ -235,7 +235,7 @@ def test_project_admin_can_view_feature(
     assert result is True
 
 
-def test_project_user_with_view_project_permission_can_view_feature(
+def test_project_user_with_view_project_permission_can_view_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -258,7 +258,7 @@ def test_project_user_with_view_project_permission_can_view_feature(
     assert result is True
 
 
-def test_project_user_without_view_project_permission_cannot_view_feature(
+def test_project_user_without_view_project_permission_cannot_view_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     feature: Feature,
 ) -> None:
@@ -279,7 +279,7 @@ def test_project_user_without_view_project_permission_cannot_view_feature(
 
 
 @pytest.mark.parametrize("action", (("update"), ("partial_update")))
-def test_organisation_admin_can_edit_feature(
+def test_organisation_admin_can_edit_feature(  # noqa: FT003
     action: str,
     admin_user: FFAdminUser,
     feature: Feature,
@@ -301,7 +301,7 @@ def test_organisation_admin_can_edit_feature(
 
 
 @pytest.mark.parametrize("action", (("update"), ("partial_update")))
-def test_project_admin_can_edit_feature(
+def test_project_admin_can_edit_feature(  # noqa: FT003
     action: str,
     staff_user: FFAdminUser,
     project: Project,
@@ -321,7 +321,7 @@ def test_project_admin_can_edit_feature(
 
 
 @pytest.mark.parametrize("action", (("update"), ("partial_update")))
-def test_project_user_cannot_edit_feature(
+def test_project_user_cannot_edit_feature(  # noqa: FT003
     action: str,
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -342,7 +342,7 @@ def test_project_user_cannot_edit_feature(
     assert result is False
 
 
-def test_organisation_admin_can_delete_feature(
+def test_organisation_admin_can_delete_feature(  # noqa: FT003
     admin_user: FFAdminUser,
     feature: Feature,
 ) -> None:
@@ -358,7 +358,7 @@ def test_organisation_admin_can_delete_feature(
     assert result is True
 
 
-def test_project_admin_can_delete_feature(
+def test_project_admin_can_delete_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     feature: Feature,
     project: Project,
@@ -376,7 +376,7 @@ def test_project_admin_can_delete_feature(
     assert result is True
 
 
-def test_project_user_with_delete_feature_permission_can_delete_feature(
+def test_project_user_with_delete_feature_permission_can_delete_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
     feature: Feature,
@@ -395,7 +395,7 @@ def test_project_user_with_delete_feature_permission_can_delete_feature(
     assert result is True
 
 
-def test_project_user_without_delete_feature_permission_cannot_delete_feature(
+def test_project_user_without_delete_feature_permission_cannot_delete_feature(  # noqa: FT003
     staff_user: FFAdminUser,
     feature: Feature,
 ) -> None:
@@ -411,7 +411,7 @@ def test_project_user_without_delete_feature_permission_cannot_delete_feature(
     assert result is False
 
 
-def test_organisation_admin_can_update_feature_segments(
+def test_organisation_admin_can_update_feature_segments(  # noqa: FT003
     admin_user: FFAdminUser,
     feature: Feature,
 ) -> None:
@@ -427,7 +427,7 @@ def test_organisation_admin_can_update_feature_segments(
     assert result is True
 
 
-def test_project_admin_can_update_feature_segments(
+def test_project_admin_can_update_feature_segments(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     feature: Feature,
@@ -445,7 +445,7 @@ def test_project_admin_can_update_feature_segments(
     assert result is True
 
 
-def test_project_user_cannot_update_feature_segments(
+def test_project_user_cannot_update_feature_segments(  # noqa: FT003
     staff_user: FFAdminUser,
     feature: Feature,
 ) -> None:
@@ -470,7 +470,7 @@ def test_project_user_cannot_update_feature_segments(
         ({"create": CREATE_FEATURE}, "create", CREATE_FEATURE, True),
     ),
 )
-def test_nested_project_permissions_has_permission(  # type: ignore[no-untyped-def]
+def test_nested_project_permissions_has_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     action_permission_map,
     action,
     user_permission,
@@ -512,7 +512,7 @@ def test_nested_project_permissions_has_permission(  # type: ignore[no-untyped-d
         ({"update": CREATE_FEATURE}, "update", CREATE_FEATURE, True),
     ),
 )
-def test_nested_project_permissions_has_object_permission(  # type: ignore[no-untyped-def]
+def test_nested_project_permissions_has_object_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     action_permission_map,
     action,
     user_permission,

--- a/api/tests/unit/features/test_unit_features_serializers.py
+++ b/api/tests/unit/features/test_unit_features_serializers.py
@@ -17,7 +17,7 @@ from features.serializers import FeatureStateSerializerBasic
 @pytest.mark.parametrize(
     "percentage_value, expected_is_valid", ((90, True), (100, True), (110, False))
 )
-def test_feature_state_serializer_basic_validates_mv_percentage_values(  # type: ignore[no-untyped-def]
+def test_feature_state_serializer_basic_validates_mv_percentage_values(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature, environment, percentage_value, expected_is_valid
 ):
     # Given
@@ -54,7 +54,7 @@ def test_feature_state_serializer_basic_validates_mv_percentage_values(  # type:
     assert is_valid == expected_is_valid
 
 
-def test_multivariate_option_values_serializer_with_string_value(
+def test_multivariate_option_values_serializer_with_string_value(  # noqa: FT003
     multivariate_feature: MultivariateFeatureOption,
 ) -> None:
     # Given
@@ -67,7 +67,7 @@ def test_multivariate_option_values_serializer_with_string_value(
     assert serializer.data["value"] == option.string_value
 
 
-def test_multivariate_option_values_serializer_with_boolean_value(
+def test_multivariate_option_values_serializer_with_boolean_value(  # noqa: FT003
     feature: Feature,
 ) -> None:
     # Given
@@ -85,7 +85,7 @@ def test_multivariate_option_values_serializer_with_boolean_value(
     assert serializer.data["value"] is True
 
 
-def test_multivariate_option_values_serializer_with_integer_value(
+def test_multivariate_option_values_serializer_with_integer_value(  # noqa: FT003
     feature: Feature,
 ) -> None:
     # Given
@@ -103,7 +103,7 @@ def test_multivariate_option_values_serializer_with_integer_value(
     assert serializer.data["value"] == 42
 
 
-def test_feature_mv_options_values_response_serializer_with_feature_state(
+def test_feature_mv_options_values_response_serializer_with_feature_state(  # noqa: FT003
     multivariate_feature: Feature,
     environment: Environment,
 ) -> None:
@@ -128,7 +128,7 @@ def test_feature_mv_options_values_response_serializer_with_feature_state(
     assert len(serializer.data["options"]) == 3
 
 
-def test_feature_mv_options_values_response_serializer_without_feature_state(
+def test_feature_mv_options_values_response_serializer_without_feature_state(  # noqa: FT003
     multivariate_feature: Feature,
 ) -> None:
     # Given

--- a/api/tests/unit/features/test_unit_features_tasks.py
+++ b/api/tests/unit/features/test_unit_features_tasks.py
@@ -24,7 +24,7 @@ from webhooks.webhooks import WebhookEventType
     ],
 )
 @pytest.mark.django_db
-def test_trigger_feature_state_change_webhooks(
+def test_trigger_feature_state_change_webhooks(  # noqa: FT003
     mocker: MockerFixture,
     user: FFAdminUser | None,
     api_key: MasterAPIKey | None,
@@ -85,7 +85,7 @@ def test_trigger_feature_state_change_webhooks(
 
 
 @pytest.mark.django_db
-def test_trigger_feature_state_change_webhooks_for_deleted_flag(  # type: ignore[no-untyped-def]
+def test_trigger_feature_state_change_webhooks_for_deleted_flag(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, organisation, project, environment, feature
 ):
     # Given
@@ -125,7 +125,7 @@ def test_trigger_feature_state_change_webhooks_for_deleted_flag(  # type: ignore
 
 
 @pytest.mark.django_db
-def test_trigger_feature_state_change_webhooks_for_deleted_flag_uses_fs_instance(  # type: ignore[no-untyped-def]
+def test_trigger_feature_state_change_webhooks_for_deleted_flag_uses_fs_instance(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker: MockerFixture,
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/features/test_unit_features_utils.py
+++ b/api/tests/unit/features/test_unit_features_utils.py
@@ -19,5 +19,5 @@ from features.value_types import BOOLEAN, INTEGER, STRING
         ('{"some_other": "data_type"}', STRING),
     ),
 )
-def test_get_value_type(value, expected_type):  # type: ignore[no-untyped-def]
+def test_get_value_type(value, expected_type):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert get_value_type(value) == expected_type

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -83,7 +83,7 @@ two_hours_ago = now - timedelta(hours=2)
 one_hour_ago = now - timedelta(hours=1)
 
 
-def test_project_owners_is_read_only_for_feature_create(
+def test_project_owners_is_read_only_for_feature_create(  # noqa: FT003
     project: Project,
     admin_client_original: APIClient,
     admin_user: FFAdminUser,
@@ -118,7 +118,7 @@ def test_project_owners_is_read_only_for_feature_create(
 
 
 @mock.patch("features.views.trigger_feature_state_change_webhooks")
-def test_feature_state_webhook_triggered_when_feature_deleted(
+def test_feature_state_webhook_triggered_when_feature_deleted(  # noqa: FT003
     mocked_trigger_fs_change_webhook: mock.MagicMock,
     project: Project,
     feature: Feature,
@@ -138,7 +138,7 @@ def test_feature_state_webhook_triggered_when_feature_deleted(
     mocked_trigger_fs_change_webhook.assert_has_calls(mock_calls)
 
 
-def test_remove_owners_only_remove_specified_owners(
+def test_remove_owners_only_remove_specified_owners(  # noqa: FT003,FT004
     feature: Feature,
     project: Project,
     admin_client_new: APIClient,
@@ -169,7 +169,7 @@ def test_remove_owners_only_remove_specified_owners(
     }
 
 
-def test_audit_log_created_when_feature_state_created_for_identity(
+def test_audit_log_created_when_feature_state_created_for_identity(  # noqa: FT003
     feature: Feature,
     project: Project,
     identity: Identity,
@@ -204,7 +204,7 @@ def test_audit_log_created_when_feature_state_created_for_identity(
     assert audit_log.log == expected_log_message
 
 
-def test_audit_log_created_when_feature_state_updated_for_identity(
+def test_audit_log_created_when_feature_state_updated_for_identity(  # noqa: FT003
     feature: Feature,
     project: Project,
     environment: Environment,
@@ -245,7 +245,7 @@ def test_audit_log_created_when_feature_state_updated_for_identity(
     assert audit_log.log == expected_log_message
 
 
-def test_audit_log_created_when_feature_state_deleted_for_identity(
+def test_audit_log_created_when_feature_state_deleted_for_identity(  # noqa: FT003
     feature: Feature,
     project: Project,
     environment: Environment,
@@ -280,7 +280,7 @@ def test_audit_log_created_when_feature_state_deleted_for_identity(
     )
 
 
-def test_when_add_tags_from_different_project_on_feature_create_then_failed(
+def test_when_add_tags_from_different_project_on_feature_create_then_failed(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     organisation: Organisation,
@@ -316,7 +316,7 @@ def test_when_add_tags_from_different_project_on_feature_create_then_failed(
     assert Feature.objects.filter(name=feature_name, project=project.id).count() == 0
 
 
-def test_when_add_tags_on_feature_update_then_success(
+def test_when_add_tags_on_feature_update_then_success(  # noqa: FT003
     project: Project,
     feature: Feature,
     tag_one: Tag,
@@ -352,7 +352,7 @@ def test_when_add_tags_on_feature_update_then_success(
     assert check_feature.tags.count() == 1
 
 
-def test_when_add_tags_from_different_project_on_feature_update_then_failed(
+def test_when_add_tags_from_different_project_on_feature_update_then_failed(  # noqa: FT003
     feature: Feature,
     project: Project,
     admin_client_new: APIClient,
@@ -395,7 +395,7 @@ def test_when_add_tags_from_different_project_on_feature_update_then_failed(
     assert check_feature.tags.count() == 0
 
 
-def test_list_features_is_archived_filter(
+def test_list_features_is_archived_filter(  # noqa: FT003
     feature: Feature,
     project: Project,
     admin_client_new: APIClient,
@@ -424,7 +424,7 @@ def test_list_features_is_archived_filter(
     assert response.json()["results"][0]["id"] == feature.id
 
 
-def test_put_feature_does_not_update_feature_states(
+def test_put_feature_does_not_update_feature_states(  # noqa: FT003
     feature: Feature,
     project: Project,
     admin_client_new: APIClient,
@@ -453,7 +453,7 @@ def test_put_feature_does_not_update_feature_states(
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @mock.patch("features.views.get_multiple_event_list_for_feature")
-def test_get_project_features_influx_data(
+def test_get_project_features_influx_data(  # noqa: FT003
     mock_get_event_list: mock.MagicMock,
     feature: Feature,
     project: Project,
@@ -490,7 +490,7 @@ def test_get_project_features_influx_data(
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @mock.patch("features.views.get_multiple_event_list_for_feature")
-def test_get_project_features_influx_data_with_two_weeks_period(
+def test_get_project_features_influx_data_with_two_weeks_period(  # noqa: FT003
     mock_get_event_list: mock.MagicMock,
     feature: Feature,
     project: Project,
@@ -526,7 +526,7 @@ def test_get_project_features_influx_data_with_two_weeks_period(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_project_features_influx_data_with_malformed_period(
+def test_get_project_features_influx_data_with_malformed_period(  # noqa: FT003
     feature: Feature,
     project: Project,
     environment: Environment,
@@ -547,7 +547,7 @@ def test_get_project_features_influx_data_with_malformed_period(
     assert response.data[0] == "Malformed period supplied"
 
 
-def test_regular_user_cannot_create_mv_options_when_creating_feature(
+def test_regular_user_cannot_create_mv_options_when_creating_feature(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -572,7 +572,7 @@ def test_regular_user_cannot_create_mv_options_when_creating_feature(
     assert response.json()["detail"] == detail
 
 
-def test_regular_user_cannot_create_mv_options_when_updating_feature(
+def test_regular_user_cannot_create_mv_options_when_updating_feature(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -602,7 +602,7 @@ def test_regular_user_cannot_create_mv_options_when_updating_feature(
     assert response.json()["detail"] == detail
 
 
-def test_regular_user_can_update_feature_description(
+def test_regular_user_can_update_feature_description(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -637,7 +637,7 @@ def test_regular_user_can_update_feature_description(
 
 
 @mock.patch("environments.models.environment_wrapper")
-def test_create_feature_only_triggers_write_to_dynamodb_once_per_environment(
+def test_create_feature_only_triggers_write_to_dynamodb_once_per_environment(  # noqa: FT003
     mock_dynamo_environment_wrapper: mock.MagicMock,
     project: Project,
     admin_client_new: APIClient,
@@ -660,7 +660,7 @@ def test_create_feature_only_triggers_write_to_dynamodb_once_per_environment(
     mock_dynamo_environment_wrapper.write_environments.assert_called_once()
 
 
-def test_get_flags_for_environment_response(
+def test_get_flags_for_environment_response(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     project: Project,
@@ -712,7 +712,7 @@ def test_get_flags_for_environment_response(
 
 
 @pytest.mark.parametrize("cache_flags_seconds", [0, 30])
-def test_SDKFeatureStates_get__responds_200_with_feature_list(
+def test_SDKFeatureStates_get__responds_200_with_feature_list(  # noqa: FT003
     api_client: APIClient,
     cache_flags_seconds: int,
     environment: Environment,
@@ -807,7 +807,7 @@ def test_SDKFeatureStates_get__given_identifier__responds_200_with_feature_list(
         pytest.param(True, False, 7, id="replica_database,existing_identity"),
     ],
 )
-def test_SDKFeatureStates_get__given_identifier_and_feature__both_exist__responds_200_with_feature(
+def test_SDKFeatureStates_get__given_identifier_and_feature__both_exist__responds_200_with_feature(  # noqa: FT003
     api_client: APIClient,
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,
@@ -858,7 +858,7 @@ def test_SDKFeatureStates_get__given_identifier_and_feature__both_exist__respond
         pytest.param(True, False, 6, id="replica_database,existing_identity"),
     ],
 )
-def test_SDKFeatureStates_get__given_identifier_and_feature__feature_does_not_exist__responds_404(
+def test_SDKFeatureStates_get__given_identifier_and_feature__feature_does_not_exist__responds_404(  # noqa: FT003
     api_client: APIClient,
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,
@@ -882,7 +882,7 @@ def test_SDKFeatureStates_get__given_identifier_and_feature__feature_does_not_ex
     assert Identity.objects.filter(identifier=identifier).exists()
 
 
-def test_SDKFeatureStates_get__given_feature__exists__responds_200_with_feature(
+def test_SDKFeatureStates_get__given_feature__exists__responds_200_with_feature(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     feature: Feature,
@@ -908,7 +908,7 @@ def test_SDKFeatureStates_get__given_feature__exists__responds_200_with_feature(
     }
 
 
-def test_SDKFeatureStates_get__given_feature__doesnt_exist__responds_404(
+def test_SDKFeatureStates_get__given_feature__doesnt_exist__responds_404(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     mocker: MockerFixture,
@@ -934,7 +934,7 @@ def test_SDKFeatureStates_get__given_feature__doesnt_exist__responds_404(
         (None, False, True),
     ),
 )
-def test_get_flags_hide_disabled_flags(
+def test_get_flags_hide_disabled_flags(  # noqa: FT003
     environment_value: bool | None,
     project_value: bool,
     disabled_flag_returned: bool,
@@ -963,7 +963,7 @@ def test_get_flags_hide_disabled_flags(
     assert len(response.json()) == (2 if disabled_flag_returned else 1)
 
 
-def test_get_flags_hide_sensitive_data(
+def test_get_flags_hide_sensitive_data(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     feature: Feature,
@@ -1016,7 +1016,7 @@ def test_get_flags__server_key_only_feature__return_expected(
     assert not response.json()
 
 
-def test_get_flags_cache(
+def test_get_flags_cache(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     django_assert_num_queries: DjangoAssertNumQueries,
@@ -1059,7 +1059,7 @@ def test_get_flags_cache(
             )
 
 
-def test_get_flags__server_key_only_feature__server_key_auth__return_expected(
+def test_get_flags__server_key_only_feature__server_key_auth__return_expected(  # noqa: FT003
     api_client: APIClient,
     environment_api_key: EnvironmentAPIKey,
     feature: Feature,
@@ -1120,7 +1120,7 @@ def test_get_flags__server_key_only_feature__cache_isolation_between_client_and_
     assert feature.name not in client_feature_names
 
 
-def test_get_feature_states_by_uuid(
+def test_get_feature_states_by_uuid(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -1141,7 +1141,7 @@ def test_get_feature_states_by_uuid(
     assert response_json["uuid"] == str(feature_state.uuid)
 
 
-def test_deleted_features_are_not_listed(
+def test_deleted_features_are_not_listed(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -1159,7 +1159,7 @@ def test_deleted_features_are_not_listed(
     assert response.json()["count"] == 0
 
 
-def test_get_feature_evaluation_data(
+def test_get_feature_evaluation_data(  # noqa: FT003
     project: Project,
     feature: Feature,
     environment: Environment,
@@ -1267,7 +1267,7 @@ def test_get_feature_evaluation_data__labels_filter__returns_expected(
     )
 
 
-def test_create_segment_override_forbidden(
+def test_create_segment_override_forbidden(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     environment: Environment,
@@ -1301,7 +1301,7 @@ def test_create_segment_override_forbidden(
     }
 
 
-def test_create_segment_override_staff(
+def test_create_segment_override_staff(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     environment: Environment,
@@ -1334,7 +1334,7 @@ def test_create_segment_override_staff(
     assert response.data["feature_segment"]["segment"] == segment.id
 
 
-def test_create_segment_override(
+def test_create_segment_override(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     segment: Segment,
@@ -1370,7 +1370,7 @@ def test_create_segment_override(
     assert created_override.get_feature_state_value() == string_value
 
 
-def test_get_flags_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]
+def test_get_flags_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     feature: Feature,
@@ -1390,7 +1390,7 @@ def test_get_flags_is_not_throttled_by_user_throttle(  # type: ignore[no-untyped
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_list_feature_states_from_simple_view_set(
+def test_list_feature_states_from_simple_view_set(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     admin_user: FFAdminUser,
@@ -1447,7 +1447,7 @@ def test_list_feature_states_from_simple_view_set(
     assert response_json["count"] == 3
 
 
-def test_list_feature_states_nested_environment_view_set(
+def test_list_feature_states_nested_environment_view_set(  # noqa: FT003
     environment: Environment,
     project: Project,
     feature: Feature,
@@ -1494,7 +1494,7 @@ def test_list_feature_states_nested_environment_view_set(
     assert response_json["count"] == 3
 
 
-def test_environment_feature_states_filter_using_feature_name(
+def test_environment_feature_states_filter_using_feature_name(  # noqa: FT003
     environment: Environment,
     project: Project,
     feature: Feature,
@@ -1517,7 +1517,7 @@ def test_environment_feature_states_filter_using_feature_name(
     assert response.json()["results"][0]["feature"] == feature.id
 
 
-def test_environment_feature_states_filter_to_show_identity_override_only(
+def test_environment_feature_states_filter_to_show_identity_override_only(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     admin_client_new: APIClient,
@@ -1546,7 +1546,7 @@ def test_environment_feature_states_filter_to_show_identity_override_only(
     assert res.json()["results"][0]["identity"]["identifier"] == identifier
 
 
-def test_environment_feature_states_only_returns_latest_versions(
+def test_environment_feature_states_only_returns_latest_versions(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     admin_client_new: APIClient,
@@ -1573,7 +1573,7 @@ def test_environment_feature_states_only_returns_latest_versions(
     assert response_json["results"][0]["id"] == feature_state_v2.id
 
 
-def test_environment_feature_states_does_not_return_null_versions(
+def test_environment_feature_states_does_not_return_null_versions(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     admin_client_new: APIClient,
@@ -1599,7 +1599,7 @@ def test_environment_feature_states_does_not_return_null_versions(
     assert response_json["results"][0]["id"] == feature_state.id
 
 
-def test_create_feature_default_is_archived_is_false(
+def test_create_feature_default_is_archived_is_false(  # noqa: FT003
     admin_client_new: APIClient, project: Project
 ) -> None:
     # Given
@@ -1617,7 +1617,7 @@ def test_create_feature_default_is_archived_is_false(
     assert response["is_archived"] is False
 
 
-def test_update_feature_is_archived(
+def test_update_feature_is_archived(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -1637,7 +1637,7 @@ def test_update_feature_is_archived(
     assert response["is_archived"] is True
 
 
-def test_should_create_feature_states_when_feature_created(
+def test_should_create_feature_states_when_feature_created(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -1674,7 +1674,7 @@ def test_should_create_feature_states_when_feature_created(
 
 
 @pytest.mark.parametrize("default_value", [(12), (True), ("test")])
-def test_should_create_feature_states_with_value_when_feature_created(
+def test_should_create_feature_states_with_value_when_feature_created(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -1706,7 +1706,7 @@ def test_should_create_feature_states_with_value_when_feature_created(
     assert feature_state.get_feature_state_value() == default_value
 
 
-def test_should_delete_feature_states_when_feature_deleted(
+def test_should_delete_feature_states_when_feature_deleted(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -1737,7 +1737,7 @@ def test_should_delete_feature_states_when_feature_deleted(
     )
 
 
-def test_create_feature_returns_201_if_name_matches_regex(
+def test_create_feature_returns_201_if_name_matches_regex(  # noqa: FT003,FT004
     admin_client_new: APIClient, project: Project
 ) -> None:
     # Given
@@ -1755,7 +1755,7 @@ def test_create_feature_returns_201_if_name_matches_regex(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_create_feature_returns_400_if_name_does_not_matches_regex(
+def test_create_feature_returns_400_if_name_does_not_matches_regex(  # noqa: FT003,FT004
     admin_client_new: APIClient, project: Project
 ) -> None:
     # Given
@@ -1777,7 +1777,7 @@ def test_create_feature_returns_400_if_name_does_not_matches_regex(
     )
 
 
-def test_audit_log_created_when_feature_created(
+def test_audit_log_created_when_feature_created(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -1807,7 +1807,7 @@ def test_audit_log_created_when_feature_created(
     ).count() == len(project.environments.all())
 
 
-def test_audit_log_created_when_feature_updated(
+def test_audit_log_created_when_feature_updated(  # noqa: FT003
     admin_client_new: APIClient, project: Project, feature: Feature
 ) -> None:
     # Given
@@ -1833,7 +1833,7 @@ def test_audit_log_created_when_feature_updated(
     )
 
 
-def test_audit_logs_created_when_feature_deleted(
+def test_audit_logs_created_when_feature_deleted(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -1863,7 +1863,7 @@ def test_audit_logs_created_when_feature_deleted(
     ).count() == len(feature_states_ids)
 
 
-def test_should_create_tags_when_feature_created(
+def test_should_create_tags_when_feature_created(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     tag_one: Tag,
@@ -1899,7 +1899,7 @@ def test_should_create_tags_when_feature_created(
     assert list(feature.tags.all()) == [tag_one, tag_two]
 
 
-def test_add_owners_fails_if_user_not_found(
+def test_add_owners_fails_if_user_not_found(  # noqa: FT003
     admin_client_new: APIClient, project: Project
 ) -> None:
     # Given
@@ -1924,7 +1924,7 @@ def test_add_owners_fails_if_user_not_found(
     assert feature.owners.filter(id__in=[user_1.id, user_2.id]).count() == 0
 
 
-def test_add_owners_adds_owner(
+def test_add_owners_adds_owner(  # noqa: FT003
     staff_user: FFAdminUser,
     admin_user: FFAdminUser,
     admin_client_new: APIClient,
@@ -1968,7 +1968,7 @@ def test_add_owners_adds_owner(
     }
 
 
-def test_add_group_owners_adds_group_owner(
+def test_add_group_owners_adds_group_owner(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -2010,7 +2010,7 @@ def test_add_group_owners_adds_group_owner(
     }
 
 
-def test_remove_group_owners_removes_group_owner(
+def test_remove_group_owners_removes_group_owner(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -2051,7 +2051,7 @@ def test_remove_group_owners_removes_group_owner(
     }
 
 
-def test_remove_group_owners_when_nonexistent(
+def test_remove_group_owners_when_nonexistent(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -2086,7 +2086,7 @@ def test_remove_group_owners_when_nonexistent(
     assert len(json_response["group_owners"]) == 0
 
 
-def test_add_group_owners_with_wrong_org_group(
+def test_add_group_owners_with_wrong_org_group(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -2125,7 +2125,7 @@ def test_add_group_owners_with_wrong_org_group(
     response.json() == {"non_field_errors": ["Some groups not found"]}
 
 
-def test_list_features_return_tags(
+def test_list_features_return_tags(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -2146,7 +2146,7 @@ def test_list_features_return_tags(
     assert "tags" in feature
 
 
-def test_list_features_group_owners(
+def test_list_features_group_owners(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -2185,7 +2185,7 @@ def test_list_features_group_owners(
     }
 
 
-def test_project_admin_can_create_mv_options_when_creating_feature(
+def test_project_admin_can_create_mv_options_when_creating_feature(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -2209,7 +2209,7 @@ def test_project_admin_can_create_mv_options_when_creating_feature(
     assert len(response_json["multivariate_options"]) == 1
 
 
-def test_get_feature_by_uuid(
+def test_get_feature_by_uuid(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -2226,7 +2226,7 @@ def test_get_feature_by_uuid(
     assert response.json()["uuid"] == str(feature.uuid)
 
 
-def test_get_feature_by_uuid_returns_404_if_feature_does_not_exists(
+def test_get_feature_by_uuid_returns_404_if_feature_does_not_exists(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -2240,7 +2240,7 @@ def test_get_feature_by_uuid_returns_404_if_feature_does_not_exists(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_update_feature_state_value_triggers_dynamo_rebuild(
+def test_update_feature_state_value_triggers_dynamo_rebuild(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -2273,7 +2273,7 @@ def test_update_feature_state_value_triggers_dynamo_rebuild(
     mock_dynamo_environment_wrapper.write_environments.assert_called_once()
 
 
-def test_create_segment_overrides_creates_correct_audit_log_messages(
+def test_create_segment_overrides_creates_correct_audit_log_messages(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     segment: Segment,
@@ -2329,7 +2329,7 @@ def test_create_segment_overrides_creates_correct_audit_log_messages(
     )
 
 
-def test_list_features_provides_information_on_number_of_overrides(
+def test_list_features_provides_information_on_number_of_overrides(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     segment_featurestate: FeatureState,
@@ -2357,7 +2357,7 @@ def test_list_features_provides_information_on_number_of_overrides(
     assert response_json["results"][0]["num_identity_overrides"] == 1
 
 
-def test_list_features_provides_correct_information_on_number_of_overrides_based_on_version(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_list_features_provides_correct_information_on_number_of_overrides_based_on_version(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     feature: Feature,
     segment: Segment,
     project: Project,
@@ -2410,7 +2410,7 @@ def test_list_features_provides_correct_information_on_number_of_overrides_based
     assert response_json["results"][0]["num_segment_overrides"] == 0
 
 
-def test_list_features_provides_segment_overrides_for_dynamo_enabled_project(
+def test_list_features_provides_segment_overrides_for_dynamo_enabled_project(  # noqa: FT003
     dynamo_enabled_project: Project,
     dynamo_enabled_project_environment_one: Environment,
     dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
@@ -2452,7 +2452,7 @@ def test_list_features_provides_segment_overrides_for_dynamo_enabled_project(
     assert response_json["results"][0]["num_identity_overrides"] is None
 
 
-def test_list_features_calls_get_overrides_data(
+def test_list_features_calls_get_overrides_data(  # noqa: FT003
     dynamo_enabled_project: Project,
     dynamo_enabled_project_environment_one: Environment,
     admin_client_new: APIClient,
@@ -2483,7 +2483,7 @@ def test_list_features_calls_get_overrides_data(
     )
 
 
-def test_create_segment_override_reaching_max_limit(
+def test_create_segment_override_reaching_max_limit(  # noqa: FT003,FT004
     admin_client_new: APIClient,
     feature: Feature,
     segment: Segment,
@@ -2526,7 +2526,7 @@ def test_create_segment_override_reaching_max_limit(
     assert environment.feature_segments.count() == 1
 
 
-def test_create_feature_reaching_max_limit(
+def test_create_feature_reaching_max_limit(  # noqa: FT003,FT004
     admin_client_new: APIClient,
     project: Project,
     settings: SettingsWrapper,
@@ -2555,7 +2555,7 @@ def test_create_feature_reaching_max_limit(
     )
 
 
-def test_create_segment_override_using_environment_viewset(
+def test_create_segment_override_using_environment_viewset(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -2586,7 +2586,7 @@ def test_create_segment_override_using_environment_viewset(
     response.json()["feature_state_value"] == new_value
 
 
-def test_cannot_create_feature_state_for_feature_from_different_project(
+def test_cannot_create_feature_state_for_feature_from_different_project(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     project_two_feature: Feature,
@@ -2617,7 +2617,7 @@ def test_cannot_create_feature_state_for_feature_from_different_project(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_create_feature_state_environment_is_read_only(
+def test_create_feature_state_environment_is_read_only(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -2648,7 +2648,7 @@ def test_create_feature_state_environment_is_read_only(
     assert response.json()["environment"] == environment.id
 
 
-def test_cannot_create_feature_state_of_feature_from_different_project(
+def test_cannot_create_feature_state_of_feature_from_different_project(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     project_two_feature: Feature,
@@ -2678,7 +2678,7 @@ def test_cannot_create_feature_state_of_feature_from_different_project(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_create_feature_state_environment_field_is_read_only(
+def test_create_feature_state_environment_field_is_read_only(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -2709,7 +2709,7 @@ def test_create_feature_state_environment_field_is_read_only(
     assert response.json()["environment"] == environment.id
 
 
-def test_cannot_update_environment_of_a_feature_state(
+def test_cannot_update_environment_of_a_feature_state(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -2745,7 +2745,7 @@ def test_cannot_update_environment_of_a_feature_state(
     )
 
 
-def test_update_feature_state_without_history_of_fsv(
+def test_update_feature_state_without_history_of_fsv(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -2778,7 +2778,7 @@ def test_update_feature_state_without_history_of_fsv(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_cannot_update_feature_of_a_feature_state(
+def test_cannot_update_feature_of_a_feature_state(  # noqa: FT003
     admin_client_new: APIClient,
     environment: Environment,
     feature: Feature,
@@ -2817,7 +2817,7 @@ def test_cannot_update_feature_of_a_feature_state(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_feature_without_required_metadata_returns_400(
+def test_create_feature_without_required_metadata_returns_400(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_feature_metadata_field: MetadataModelField,
@@ -2841,7 +2841,7 @@ def test_create_feature_without_required_metadata_returns_400(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_feature_with_optional_metadata_returns_201(
+def test_create_feature_with_optional_metadata_returns_201(  # noqa: FT003
     project: Project,
     client: APIClient,
     optional_b_feature_metadata_field: MetadataModelField,
@@ -2877,7 +2877,7 @@ def test_create_feature_with_optional_metadata_returns_201(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_feature_with_required_metadata_returns_201(
+def test_create_feature_with_required_metadata_returns_201(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_feature_metadata_field: MetadataModelField,
@@ -2913,7 +2913,7 @@ def test_create_feature_with_required_metadata_returns_201(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_feature_with_required_metadata_using_organisation_content_typereturns_201(
+def test_create_feature_with_required_metadata_using_organisation_content_typereturns_201(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_feature_metadata_field_using_organisation_content_type: MetadataModelField,
@@ -3099,7 +3099,7 @@ def test_update_segment_override__using_simple_feature_state_viewset__denies_upd
     settings.IS_RBAC_INSTALLED is True,
     reason="Skip this test if RBAC is installed",
 )
-def test_list_features_n_plus_1_without_rbac(
+def test_list_features_n_plus_1_without_rbac(  # noqa: FT003,FT004
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3128,7 +3128,7 @@ def test_list_features_n_plus_1_without_rbac(
     settings.IS_RBAC_INSTALLED is False,
     reason="Skip this test if RBAC is not installed",
 )
-def test_list_features_n_plus_1_with_rbac(
+def test_list_features_n_plus_1_with_rbac(  # noqa: FT003,FT004
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3176,7 +3176,7 @@ def _assert_list_feature_n_plus_1(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_list_features_from_different_project_returns_404(
+def test_list_features_from_different_project_returns_404(  # noqa: FT003
     staff_client: APIClient,
     organisation_two_project_two: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -3195,7 +3195,7 @@ def test_list_features_from_different_project_returns_404(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_list_features_with_union_tag(
+def test_list_features_with_union_tag(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3247,7 +3247,7 @@ def test_list_features_with_union_tag(
     assert response.data["results"][1]["tags"] == [tag2.id]
 
 
-def test_list_features_with_intersection_tag(
+def test_list_features_with_intersection_tag(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3297,7 +3297,7 @@ def test_list_features_with_intersection_tag(
     assert response.data["results"][0]["tags"] == [tag1.id, tag2.id]
 
 
-def test_list_features_with_feature_state(
+def test_list_features_with_feature_state(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3414,7 +3414,7 @@ def test_list_features_with_feature_state(
     assert results[2]["name"] == feature3.name
 
 
-def test_list_features_with_filter_by_value_search_string_and_int(
+def test_list_features_with_filter_by_value_search_string_and_int(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     project: Project,
@@ -3512,7 +3512,7 @@ def test_list_features_with_filter_by_value_search_string_and_int(
     assert feature4.name in features
 
 
-def test_list_features_with_filter_by_search_value_boolean(
+def test_list_features_with_filter_by_search_value_boolean(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3581,7 +3581,7 @@ def test_list_features_with_filter_by_search_value_boolean(
     assert response.data["results"][0]["name"] == feature2.name
 
 
-def test_FeatureViewSet_list__includes_code_references_counts(
+def test_FeatureViewSet_list__includes_code_references_counts(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     feature: Feature,
@@ -3690,7 +3690,7 @@ def test_FeatureViewSet_list__no_scans__returns_empty_code_references_counts(
     assert results[0]["code_references_counts"] == []
 
 
-def test_simple_feature_state_returns_only_latest_versions(
+def test_simple_feature_state_returns_only_latest_versions(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -3746,7 +3746,7 @@ def test_simple_feature_state_returns_only_latest_versions(
     reason="Skip this test if RBAC is installed",
 )
 @pytest.mark.freeze_time(two_hours_ago)
-def test_feature_list_last_modified_values_without_rbac(
+def test_feature_list_last_modified_values_without_rbac(  # noqa: FT003,FT004
     staff_client: APIClient,
     staff_user: FFAdminUser,
     environment_v2_versioning: Environment,
@@ -3772,7 +3772,7 @@ def test_feature_list_last_modified_values_without_rbac(
     reason="Skip this test if RBAC is not installed",
 )
 @pytest.mark.freeze_time(two_hours_ago)
-def test_feature_list_last_modified_values_with_rbac(
+def test_feature_list_last_modified_values_with_rbac(  # noqa: FT003,FT004
     staff_client: APIClient,
     staff_user: FFAdminUser,
     environment_v2_versioning: Environment,
@@ -3856,7 +3856,7 @@ def _assert_feature_list_last_modified_values(  # type: ignore[no-untyped-def]
     )
 
 
-def test_filter_features_with_owners(
+def test_filter_features_with_owners(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     admin_user: FFAdminUser,
@@ -3899,7 +3899,7 @@ def test_filter_features_with_owners(
     assert response.data["results"][1]["id"] == feature2.id
 
 
-def test_filter_features_with_group_owners(
+def test_filter_features_with_group_owners(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     organisation: Organisation,
@@ -3945,7 +3945,7 @@ def test_filter_features_with_group_owners(
     assert response.data["results"][1]["id"] == feature2.id
 
 
-def test_filter_features_with_owners_and_group_owners_together(
+def test_filter_features_with_owners_and_group_owners_together(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     project: Project,
@@ -3989,7 +3989,7 @@ def test_filter_features_with_owners_and_group_owners_together(
     assert response.data["results"][1]["id"] == feature2.id
 
 
-def test_delete_feature_deletes_any_related_identity_overrides(
+def test_delete_feature_deletes_any_related_identity_overrides(  # noqa: FT003
     flagsmith_environments_v2_table: "Table",
     flagsmith_identities_table: "Table",
     dynamodb_identity_wrapper: DynamoIdentityWrapper,
@@ -4041,7 +4041,7 @@ def test_delete_feature_deletes_any_related_identity_overrides(
     )
 
 
-def test_get_multivariate_options_responds_200_with_control_value_and_options(
+def test_get_multivariate_options_responds_200_with_control_value_and_options(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
     multivariate_feature: Feature,
@@ -4068,7 +4068,7 @@ def test_get_multivariate_options_responds_200_with_control_value_and_options(
         assert expected_value in actual_option_values
 
 
-def test_get_multivariate_options_feature_not_found_responds_404(
+def test_get_multivariate_options_feature_not_found_responds_404(  # noqa: FT003
     api_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -4085,7 +4085,7 @@ def test_get_multivariate_options_feature_not_found_responds_404(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_list_features_segment_query_param_with_valid_segment(
+def test_list_features_segment_query_param_with_valid_segment(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -4129,7 +4129,7 @@ def test_list_features_segment_query_param_with_valid_segment(
     assert segment_state["enabled"] is True
 
 
-def test_list_features_segment_query_param_with_invalid_segment(
+def test_list_features_segment_query_param_with_invalid_segment(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     feature: Feature,
@@ -4271,7 +4271,7 @@ def test_list_features__edge_identity_query__sorts_by_field_with_overrides_first
         (True, "0"),
     ],
 )
-def test_list_features__identity_query__invalid_format__returns_400(
+def test_list_features__identity_query__invalid_format__returns_400(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -4293,7 +4293,7 @@ def test_list_features__identity_query__invalid_format__returns_400(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_list_features__edge_identity_query__nonexistent_identity__returns_features_unsorted(
+def test_list_features__edge_identity_query__nonexistent_identity__returns_features_unsorted(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -4326,7 +4326,7 @@ def test_list_features__edge_identity_query__nonexistent_identity__returns_featu
     ]
 
 
-def test_create_multiple_features_with_metadata_keeps_metadata_isolated(
+def test_create_multiple_features_with_metadata_keeps_metadata_isolated(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     optional_b_feature_metadata_field: MetadataModelField,

--- a/api/tests/unit/features/versioning/test_unit_versioning_dataclasses.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_dataclasses.py
@@ -7,13 +7,13 @@ from features.versioning.dataclasses import Conflict
 
 
 @pytest.mark.parametrize("segment_id, expected_result", ((None, True), (1, False)))
-def test_conflict_is_environment_default(
+def test_conflict_is_environment_default(  # noqa: FT003,FT004
     segment_id: int | None, expected_result: bool
 ) -> None:
     assert Conflict(segment_id=segment_id).is_environment_default is expected_result
 
 
-def test_author_data_from_request_sets_api_key_for_non_user() -> None:
+def test_author_data_from_request_sets_api_key_for_non_user() -> None:  # noqa: FT003,FT004
     mock_master_api_key = Mock(spec_set=["id", "name"])
     mock_api_key_user = Mock()
     mock_api_key_user.key = mock_master_api_key
@@ -26,7 +26,7 @@ def test_author_data_from_request_sets_api_key_for_non_user() -> None:
     assert author.user is None
 
 
-def test_author_data_from_request_raises_for_invalid_user() -> None:
+def test_author_data_from_request_raises_for_invalid_user() -> None:  # noqa: FT003,FT004
     mock_request = Mock()
     mock_request.user = object()  # No .key attribute
 

--- a/api/tests/unit/features/versioning/test_unit_versioning_migrations.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_migrations.py
@@ -10,7 +10,7 @@ from django_test_migrations.migrator import Migrator
     test_settings.SKIP_MIGRATION_TESTS is True,
     reason="Skip migration tests to speed up tests where necessary",
 )
-def test_fix_scheduled_fs_data_issue_caused_by_enabling_versioning(
+def test_fix_scheduled_fs_data_issue_caused_by_enabling_versioning(  # noqa: FT003
     migrator: Migrator,
 ) -> None:
     # Given

--- a/api/tests/unit/features/versioning/test_unit_versioning_models.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_models.py
@@ -23,7 +23,7 @@ from users.models import FFAdminUser
 now = timezone.now()
 
 
-def test_create_new_environment_feature_version_clones_feature_states_from_previous_version(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_create_new_environment_feature_version_clones_feature_states_from_previous_version(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment_v2_versioning, feature
 ):
     # Given
@@ -75,7 +75,7 @@ def test_create_new_environment_feature_version_clones_feature_states_from_previ
     )
 
 
-def test_environment_feature_version_create_initial_version_fails_for_v1_versioning_environment(
+def test_environment_feature_version_create_initial_version_fails_for_v1_versioning_environment(  # noqa: FT003
     feature: "Feature", project: "Project"
 ) -> None:
     # Given
@@ -96,7 +96,7 @@ def test_environment_feature_version_create_initial_version_fails_for_v1_version
     )
 
 
-def test_environment_feature_version_create_initial_version_fails_if_version_already_exists(
+def test_environment_feature_version_create_initial_version_fails_if_version_already_exists(  # noqa: FT003
     feature: "Feature", project: "Project"
 ) -> None:
     # Given
@@ -121,7 +121,7 @@ def test_environment_feature_version_create_initial_version_fails_if_version_alr
     )
 
 
-def test_get_previous_version(feature: "Feature", project: "Project") -> None:
+def test_get_previous_version(feature: "Feature", project: "Project") -> None:  # noqa: FT003,FT004
     # Given
     environment = Environment.objects.create(
         name="Test", project=project, use_v2_feature_versioning=True
@@ -138,7 +138,7 @@ def test_get_previous_version(feature: "Feature", project: "Project") -> None:
     assert version_2.get_previous_version() == version_1
 
 
-def test_get_previous_version_ignores_unpublished_version(
+def test_get_previous_version_ignores_unpublished_version(  # noqa: FT003,FT004
     feature: "Feature", project: "Project"
 ) -> None:
     # Given
@@ -161,7 +161,7 @@ def test_get_previous_version_ignores_unpublished_version(
     assert version_3.get_previous_version() == version_1
 
 
-def test_get_previous_version_returns_previous_version_if_there_is_a_more_recent_previous_version(
+def test_get_previous_version_returns_previous_version_if_there_is_a_more_recent_previous_version(  # noqa: FT003
     feature: "Feature",
     environment_v2_versioning: Environment,
     admin_user: "FFAdminUser",
@@ -191,7 +191,7 @@ def test_get_previous_version_returns_previous_version_if_there_is_a_more_recent
     assert previous_version == version_0
 
 
-def test_publish(
+def test_publish(  # noqa: FT003
     feature: "Feature",
     project: "Project",
     admin_user: "FFAdminUser",
@@ -226,7 +226,7 @@ def test_publish(
     )
 
 
-def test_update_version_webhooks_triggered_when_version_published(
+def test_update_version_webhooks_triggered_when_version_published(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: "Feature",
     admin_user: "FFAdminUser",
@@ -252,7 +252,7 @@ def test_update_version_webhooks_triggered_when_version_published(
     )
 
 
-def test_get_latest_versions_does_not_return_versions_scheduled_for_the_future(
+def test_get_latest_versions_does_not_return_versions_scheduled_for_the_future(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: "Feature",
     admin_user: "FFAdminUser",
@@ -280,7 +280,7 @@ def test_get_latest_versions_does_not_return_versions_scheduled_for_the_future(
     assert latest_versions.first() == version_0
 
 
-def test_version_change_set_adds_environment_on_create_with_change_request(
+def test_version_change_set_adds_environment_on_create_with_change_request(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: "Feature",
     change_request: ChangeRequest,
@@ -297,7 +297,7 @@ def test_version_change_set_adds_environment_on_create_with_change_request(
     assert version_change_set.environment == change_request.environment
 
 
-def test_version_change_set_adds_environment_on_create_with_environment_feature_version(
+def test_version_change_set_adds_environment_on_create_with_environment_feature_version(  # noqa: FT003
     environment_v2_versioning: Environment, feature: "Feature"
 ) -> None:
     # Given
@@ -315,7 +315,7 @@ def test_version_change_set_adds_environment_on_create_with_environment_feature_
     assert version_change_set.environment == version.environment
 
 
-def test_version_change_set_create_fails_if_no_related_object(
+def test_version_change_set_create_fails_if_no_related_object(  # noqa: FT003
     feature: "Feature",
 ) -> None:
     # Given
@@ -332,7 +332,7 @@ def test_version_change_set_create_fails_if_no_related_object(
     )
 
 
-def test_version_change_set_get_conflicts(
+def test_version_change_set_get_conflicts(  # noqa: FT003
     project: Project,
     segment: Segment,
     another_segment: Segment,
@@ -496,7 +496,7 @@ def test_version_change_set_get_conflicts(
     assert not conflict_dict[change_request_4.id].is_environment_default
 
 
-def test_version_change_set_publish_not_scheduled(
+def test_version_change_set_publish_not_scheduled(  # noqa: FT003
     environment_v2_versioning: Environment,
     change_request: ChangeRequest,
     feature: Feature,
@@ -522,7 +522,7 @@ def test_version_change_set_publish_not_scheduled(
     )
 
 
-def test_version_change_set_publish_scheduled(
+def test_version_change_set_publish_scheduled(  # noqa: FT003
     environment_v2_versioning: Environment,
     change_request: ChangeRequest,
     feature: Feature,
@@ -555,7 +555,7 @@ def test_version_change_set_publish_scheduled(
     )
 
 
-def test_version_change_set_get_conflicts_returns_empty_list_if_published(
+def test_version_change_set_get_conflicts_returns_empty_list_if_published(  # noqa: FT003,FT004
     feature: Feature,
     admin_user: FFAdminUser,
     segment: Segment,
@@ -594,7 +594,7 @@ def test_version_change_set_get_conflicts_returns_empty_list_if_published(
     assert all(cs.get_conflicts() == [] for cs in change_sets)
 
 
-def test_version_change_set_get_conflicts_returns_empty_list_if_no_conflicts(
+def test_version_change_set_get_conflicts_returns_empty_list_if_no_conflicts(  # noqa: FT003
     change_request: ChangeRequest,
     feature: Feature,
     segment: Segment,
@@ -656,7 +656,7 @@ def test_version_change_set_get_conflicts_returns_empty_list_if_no_conflicts(
     assert conflicts == []
 
 
-def test_version_change_set_get_conflicts_returns_empty_list_if_no_change_sets_since_creation(
+def test_version_change_set_get_conflicts_returns_empty_list_if_no_change_sets_since_creation(  # noqa: FT003
     change_request: ChangeRequest,
     feature: Feature,
 ) -> None:

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -39,7 +39,7 @@ from users.models import FFAdminUser
 from webhooks.webhooks import WebhookEventType
 
 
-def test_enable_v2_versioning(
+def test_enable_v2_versioning(  # noqa: FT003,FT004
     environment: Environment, feature: Feature, multivariate_feature: Feature
 ) -> None:
     # When
@@ -57,7 +57,7 @@ def test_enable_v2_versioning(
     assert environment.use_v2_feature_versioning is True
 
 
-def test_disable_v2_versioning(
+def test_disable_v2_versioning(  # noqa: FT003
     environment_v2_versioning: Environment,
     project: Project,
     feature: Feature,
@@ -157,7 +157,7 @@ def test_disable_v2_versioning(
 
 
 @responses.activate
-def test_trigger_update_version_webhooks__with_changes(
+def test_trigger_update_version_webhooks__with_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -242,7 +242,7 @@ def test_trigger_update_version_webhooks__with_changes(
 
 
 @responses.activate
-def test_trigger_update_version_webhooks__without_changes(
+def test_trigger_update_version_webhooks__without_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -290,7 +290,7 @@ def test_trigger_update_version_webhooks__without_changes(
     }
 
 
-def test_enable_v2_versioning_for_scheduled_changes(
+def test_enable_v2_versioning_for_scheduled_changes(  # noqa: FT003
     environment: Environment, staff_user: FFAdminUser, feature: Feature
 ) -> None:
     # Given
@@ -396,7 +396,7 @@ def test_enable_v2_versioning_for_scheduled_changes(
     )
 
 
-def test_publish_version_change_set_sends_email_to_change_request_owner_if_conflicts_when_scheduled(
+def test_publish_version_change_set_sends_email_to_change_request_owner_if_conflicts_when_scheduled(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_user: FFAdminUser,
@@ -500,7 +500,7 @@ def test_publish_version_change_set_sends_email_to_change_request_owner_if_confl
     )
 
 
-def test_publish_version_change_set_raises_error_when_segment_override_does_not_exist(
+def test_publish_version_change_set_raises_error_when_segment_override_does_not_exist(  # noqa: FT003
     change_request: ChangeRequest,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -544,7 +544,7 @@ def test_publish_version_change_set_raises_error_when_segment_override_does_not_
     )
 
 
-def test_publish_version_change_set_raises_error_when_serializer_not_valid(
+def test_publish_version_change_set_raises_error_when_serializer_not_valid(  # noqa: FT003
     change_request: ChangeRequest,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -569,7 +569,7 @@ def test_publish_version_change_set_raises_error_when_serializer_not_valid(
     assert str(e.value) == "Unable to publish version change set"
 
 
-def test_publish_version_change_set_uses_current_time_for_version_live_from(
+def test_publish_version_change_set_uses_current_time_for_version_live_from(  # noqa: FT003
     change_request: ChangeRequest,
     feature: Feature,
     environment_v2_versioning: Environment,
@@ -610,7 +610,7 @@ def test_publish_version_change_set_uses_current_time_for_version_live_from(
     )
 
 
-def test_scheduled_versioning_change_set_with_ignore_conflicts_sends_email_if_validation_fails(
+def test_scheduled_versioning_change_set_with_ignore_conflicts_sends_email_if_validation_fails(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     admin_user: FFAdminUser,

--- a/api/tests/unit/features/versioning/test_unit_versioning_versioning_service.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_versioning_service.py
@@ -24,7 +24,7 @@ from segments.models import Segment
 from users.models import FFAdminUser
 
 
-def test_get_environment_flags_queryset_returns_only_latest_versions(  # type: ignore[no-untyped-def]
+def test_get_environment_flags_queryset_returns_only_latest_versions(  # type: ignore[no-untyped-def]  # noqa: FT003
     feature: Feature,
     environment: Environment,
     django_assert_num_queries: DjangoAssertNumQueries,
@@ -51,7 +51,7 @@ def test_get_environment_flags_queryset_returns_only_latest_versions(  # type: i
     assert feature_states.first() == feature_state_v2
 
 
-def test_project_hide_disabled_flags_have_no_effect_on_get_environment_flags_queryset(  # type: ignore[no-untyped-def]
+def test_project_hide_disabled_flags_have_no_effect_on_get_environment_flags_queryset(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, project
 ):
     # Given
@@ -68,7 +68,7 @@ def test_project_hide_disabled_flags_have_no_effect_on_get_environment_flags_que
     assert feature_states.count() == 2
 
 
-def test_get_environment_flags_queryset_filter_using_feature_name(environment, project):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_environment_flags_queryset_filter_using_feature_name(environment, project):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     flag_1_name = "flag_1"
     Feature.objects.create(default_enabled=True, name=flag_1_name, project=project)
@@ -84,7 +84,7 @@ def test_get_environment_flags_queryset_filter_using_feature_name(environment, p
     assert feature_states.first().feature.name == "flag_1"  # type: ignore[union-attr]
 
 
-def test_get_environment_flags_returns_latest_live_versions_of_feature_states(  # type: ignore[no-untyped-def]
+def test_get_environment_flags_returns_latest_live_versions_of_feature_states(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment, feature
 ):
     # Given
@@ -123,7 +123,7 @@ def test_get_environment_flags_returns_latest_live_versions_of_feature_states(  
     }
 
 
-def test_get_environment_flags_v2_versioning_returns_latest_live_versions_of_feature_states(
+def test_get_environment_flags_v2_versioning_returns_latest_live_versions_of_feature_states(  # noqa: FT003
     project: Project,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -166,7 +166,7 @@ def test_get_environment_flags_v2_versioning_returns_latest_live_versions_of_fea
     }
 
 
-def test_get_environment_flags_v2_versioning_does_not_return_removed_segment_override(
+def test_get_environment_flags_v2_versioning_does_not_return_removed_segment_override(  # noqa: FT003
     project: Project,
     feature: Feature,
     admin_user: FFAdminUser,
@@ -207,7 +207,7 @@ def test_get_environment_flags_v2_versioning_does_not_return_removed_segment_ove
     assert len(environment_feature_states) == 1
 
 
-def test_get_current_live_environment_feature_version(
+def test_get_current_live_environment_feature_version(  # noqa: FT003
     environment_v2_versioning: Environment, staff_user: FFAdminUser, feature: Feature
 ) -> None:
     # Given
@@ -236,7 +236,7 @@ def test_get_current_live_environment_feature_version(
     assert latest_version == version_1
 
 
-def test_get_updated_feature_states_for_version_returns_empty_list_when_no_changes(
+def test_get_updated_feature_states_for_version_returns_empty_list_when_no_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -254,7 +254,7 @@ def test_get_updated_feature_states_for_version_returns_empty_list_when_no_chang
     assert updated_feature_states == []
 
 
-def test_get_updated_feature_states_for_version_returns_feature_state_when_enabled_changes(
+def test_get_updated_feature_states_for_version_returns_feature_state_when_enabled_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -282,7 +282,7 @@ def test_get_updated_feature_states_for_version_returns_feature_state_when_enabl
     assert updated_feature_states[0].enabled is not v1_fs.enabled
 
 
-def test_get_updated_feature_states_for_version_returns_feature_state_when_value_changes(
+def test_get_updated_feature_states_for_version_returns_feature_state_when_value_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -307,7 +307,7 @@ def test_get_updated_feature_states_for_version_returns_feature_state_when_value
     assert updated_feature_states[0].get_feature_state_value() == "changed_value"
 
 
-def test_get_updated_feature_states_for_version_returns_new_segment_override(
+def test_get_updated_feature_states_for_version_returns_new_segment_override(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -342,7 +342,7 @@ def test_get_updated_feature_states_for_version_returns_new_segment_override(
     assert updated_feature_states[0].feature_segment == feature_segment
 
 
-def test_get_updated_feature_states_for_version_detects_environment_value_change(
+def test_get_updated_feature_states_for_version_detects_environment_value_change(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -396,7 +396,7 @@ def test_get_updated_feature_states_for_version_detects_environment_value_change
     assert updated_feature_states[0].get_feature_state_value() == "default_value_v2"
 
 
-def test_get_updated_feature_states_for_version_detects_segment_override_changes(
+def test_get_updated_feature_states_for_version_detects_segment_override_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -449,7 +449,7 @@ def test_get_updated_feature_states_for_version_detects_segment_override_changes
     assert updated_feature_states[0].get_feature_state_value() == "segment_value_v2"
 
 
-def test_get_updated_feature_states_for_version_detects_multivariate_segment_override_weight_changes(
+def test_get_updated_feature_states_for_version_detects_multivariate_segment_override_weight_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -528,7 +528,7 @@ def test_get_updated_feature_states_for_version_detects_multivariate_segment_ove
     assert updated_feature_states[0].feature_segment.segment == segment
 
 
-def test_get_updated_feature_states_for_version_detects_segment_override_multivariate_value_changes(
+def test_get_updated_feature_states_for_version_detects_segment_override_multivariate_value_changes(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -602,7 +602,7 @@ def test_get_updated_feature_states_for_version_detects_segment_override_multiva
     assert updated_feature_states[0].get_feature_state_value() == "new_control_value"
 
 
-def test_get_environment_flags_list_with_replica(
+def test_get_environment_flags_list_with_replica(  # noqa: FT003,FT004
     feature: Feature,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/features/versioning/test_unit_versioning_views.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_views.py
@@ -46,7 +46,7 @@ now = timezone.now()
 tomorrow = now + timedelta(days=1)
 
 
-def test_get_versions_for_a_feature_and_environment(
+def test_get_versions_for_a_feature_and_environment(  # noqa: FT003
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
@@ -90,7 +90,7 @@ def test_get_versions_for_a_feature_and_environment(
     )
 
 
-def test_create_new_feature_version(
+def test_create_new_feature_version(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     environment_v2_versioning: Environment,
@@ -118,7 +118,7 @@ def test_create_new_feature_version(
     assert response_json["uuid"]
 
 
-def test_delete_feature_version(
+def test_delete_feature_version(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -148,7 +148,7 @@ def test_delete_feature_version(
     assert environment_feature_version.deleted is True
 
 
-def test_retrieve_environment_feature_version_permission_denied(
+def test_retrieve_environment_feature_version_permission_denied(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_client: APIClient,
@@ -165,7 +165,7 @@ def test_retrieve_environment_feature_version_permission_denied(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_retrieve_feature_version_with_no_previous_version(
+def test_retrieve_feature_version_with_no_previous_version(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_client: APIClient,
@@ -197,7 +197,7 @@ def test_retrieve_feature_version_with_no_previous_version(
     assert response_json["environment"] == environment_v2_versioning.id
 
 
-def test_retrieve_feature_version_with_previous_version(
+def test_retrieve_feature_version_with_previous_version(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_user: FFAdminUser,
@@ -230,7 +230,7 @@ def test_retrieve_feature_version_with_previous_version(
     assert response_json["previous_version_uuid"] == str(version_1.uuid)
 
 
-def test_retrieve_feature_version_for_unpublished_version(
+def test_retrieve_feature_version_for_unpublished_version(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_user: FFAdminUser,
@@ -262,7 +262,7 @@ def test_retrieve_feature_version_for_unpublished_version(
     assert response_json["previous_version_uuid"] == str(version_1.uuid)
 
 
-def test_cannot_delete_live_feature_version(
+def test_cannot_delete_live_feature_version(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -292,7 +292,7 @@ def test_cannot_delete_live_feature_version(
 
 
 @pytest.mark.parametrize("live_from", (None, tomorrow))
-def test_publish_feature_version(
+def test_publish_feature_version(  # noqa: FT003
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
@@ -339,7 +339,7 @@ def test_publish_feature_version(
 
 
 @pytest.mark.parametrize("live_from", (None, tomorrow))
-def test_publish_feature_version_using_master_api_key(
+def test_publish_feature_version_using_master_api_key(  # noqa: FT003
     admin_master_api_key: MasterAPIKey,
     admin_master_api_key_client: APIClient,
     environment_v2_versioning: Environment,
@@ -378,7 +378,7 @@ def test_publish_feature_version_using_master_api_key(
     )
 
 
-def test_list_environment_feature_version_feature_states(
+def test_list_environment_feature_version_feature_states(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -407,7 +407,7 @@ def test_list_environment_feature_version_feature_states(
     assert len(response_json) == 1
 
 
-def test_add_environment_feature_version_feature_state(
+def test_add_environment_feature_version_feature_state(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -448,7 +448,7 @@ def test_add_environment_feature_version_feature_state(
     assert environment_feature_version.feature_segments.count() == 1
 
 
-def test_cannot_add_feature_state_to_published_environment_feature_version(
+def test_cannot_add_feature_state_to_published_environment_feature_version(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -489,7 +489,7 @@ def test_cannot_add_feature_state_to_published_environment_feature_version(
     assert response.json()["detail"] == "Cannot modify published version."
 
 
-def test_update_environment_feature_version_feature_state(
+def test_update_environment_feature_version_feature_state(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -531,7 +531,7 @@ def test_update_environment_feature_version_feature_state(
     assert feature_state.enabled is True
 
 
-def test_cannot_update_feature_state_in_published_environment_feature_version(
+def test_cannot_update_feature_state_in_published_environment_feature_version(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -575,7 +575,7 @@ def test_cannot_update_feature_state_in_published_environment_feature_version(
     assert feature_state.enabled is False
 
 
-def test_delete_environment_feature_version_feature_state(
+def test_delete_environment_feature_version_feature_state(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -617,7 +617,7 @@ def test_delete_environment_feature_version_feature_state(
     assert segment_override.deleted is True
 
 
-def test_cannot_delete_feature_state_in_published_environment_feature_version(
+def test_cannot_delete_feature_state_in_published_environment_feature_version(  # noqa: FT003
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
@@ -665,7 +665,7 @@ def test_cannot_delete_feature_state_in_published_environment_feature_version(
     assert segment_override.deleted is False
 
 
-def test_cannot_delete_environment_default_feature_state_for_unpublished_environment_feature_version(
+def test_cannot_delete_environment_default_feature_state_for_unpublished_environment_feature_version(  # noqa: FT003
     admin_client: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -709,7 +709,7 @@ def test_cannot_delete_environment_default_feature_state_for_unpublished_environ
     assert segment_override.deleted is False
 
 
-def test_filter_versions_by_is_live(
+def test_filter_versions_by_is_live(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     staff_user: FFAdminUser,
@@ -765,7 +765,7 @@ def test_filter_versions_by_is_live(
     )
 
 
-def test_disable_v2_versioning_returns_bad_request_if_not_using_v2_versioning(
+def test_disable_v2_versioning_returns_bad_request_if_not_using_v2_versioning(  # noqa: FT003
     environment: Environment,
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -787,7 +787,7 @@ def test_disable_v2_versioning_returns_bad_request_if_not_using_v2_versioning(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_create_new_version_with_changes_in_single_request(
+def test_create_new_version_with_changes_in_single_request(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     segment_featurestate: FeatureState,
@@ -884,7 +884,7 @@ def test_create_new_version_with_changes_in_single_request(
     assert new_version.is_live is True
 
 
-def test_update_and_create_segment_override_in_single_request(
+def test_update_and_create_segment_override_in_single_request(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     segment_featurestate: FeatureState,
@@ -963,7 +963,7 @@ def test_update_and_create_segment_override_in_single_request(
     assert new_version.is_live is True
 
 
-def test_create_environment_default_when_creating_new_version_fails(
+def test_create_environment_default_when_creating_new_version_fails(  # noqa: FT003
     environment_v2_versioning: Environment,
     feature: Feature,
     admin_client_new: APIClient,
@@ -1000,7 +1000,7 @@ def test_create_environment_default_when_creating_new_version_fails(
     }
 
 
-def test_create_segment_override_for_existing_override_when_creating_new_version_fails(
+def test_create_segment_override_for_existing_override_when_creating_new_version_fails(  # noqa: FT003
     feature: Feature,
     admin_client_new: APIClient,
     segment: Segment,
@@ -1039,7 +1039,7 @@ def test_create_segment_override_for_existing_override_when_creating_new_version
     }
 
 
-def test_create_new_version_for_multivariate_feature(
+def test_create_new_version_for_multivariate_feature(  # noqa: FT003
     multivariate_feature: Feature,
     multivariate_options: list[MultivariateFeatureOption],
     environment_v2_versioning: Environment,
@@ -1099,7 +1099,7 @@ def test_create_new_version_for_multivariate_feature(
     )
 
 
-def test_create_new_version_delete_segment_override_updates_overrides_immediately(
+def test_create_new_version_delete_segment_override_updates_overrides_immediately(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     feature_segment: FeatureSegment,
@@ -1138,7 +1138,7 @@ def test_create_new_version_delete_segment_override_updates_overrides_immediatel
     assert get_feature_segments_response.json()["count"] == 0
 
 
-def test_creating_multiple_segment_overrides_in_multiple_versions_sets_correct_priorities(
+def test_creating_multiple_segment_overrides_in_multiple_versions_sets_correct_priorities(  # noqa: FT003,FT004
     feature: Feature,
     environment_v2_versioning: Environment,
     segment: Segment,
@@ -1221,7 +1221,7 @@ def test_creating_multiple_segment_overrides_in_multiple_versions_sets_correct_p
     )
 
 
-def test_create_new_version_fails_when_breaching_segment_override_limit(
+def test_create_new_version_fails_when_breaching_segment_override_limit(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     another_segment: Segment,
@@ -1293,7 +1293,7 @@ def test_create_new_version_fails_when_breaching_segment_override_limit(
     )
 
 
-def test_segment_override_limit_excludes_older_versions__when_not_creating_any_new_overrides(
+def test_segment_override_limit_excludes_older_versions__when_not_creating_any_new_overrides(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     environment_v2_versioning: Environment,
@@ -1350,7 +1350,7 @@ def test_segment_override_limit_excludes_older_versions__when_not_creating_any_n
     ).exists()
 
 
-def test_segment_override_limit_excludes_older_versions__when_creating_new_override(
+def test_segment_override_limit_excludes_older_versions__when_creating_new_override(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     another_segment: Segment,
@@ -1425,7 +1425,7 @@ def test_segment_override_limit_excludes_older_versions__when_creating_new_overr
     ).exists()
 
 
-def test_segment_override_limit_excludes_overrides_being_deleted_when_creating_new_override(
+def test_segment_override_limit_excludes_overrides_being_deleted_when_creating_new_override(  # noqa: FT003
     feature: Feature,
     segment: Segment,
     another_segment: Segment,
@@ -1501,7 +1501,7 @@ def test_segment_override_limit_excludes_overrides_being_deleted_when_creating_n
     ).exists()
 
 
-def test_cannot_create_new_version_for_environment_not_enabled_for_versioning_v2(
+def test_cannot_create_new_version_for_environment_not_enabled_for_versioning_v2(  # noqa: FT003
     environment: Environment,
     feature: Feature,
     staff_client: APIClient,
@@ -1533,7 +1533,7 @@ def test_cannot_create_new_version_for_environment_not_enabled_for_versioning_v2
     "plan_id, is_saas",
     (("free", True), ("free", False), ("startup", True), ("scale-up", True)),
 )
-def test_list_versions_only_returns_allowed_amount_for_non_enterprise_plan(
+def test_list_versions_only_returns_allowed_amount_for_non_enterprise_plan(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_user: FFAdminUser,
@@ -1596,7 +1596,7 @@ def test_list_versions_only_returns_allowed_amount_for_non_enterprise_plan(
 
 
 @pytest.mark.freeze_time(now - timedelta(days=DEFAULT_VERSION_LIMIT_DAYS + 1))
-def test_list_versions_always_returns_current_version_even_if_outside_limit(
+def test_list_versions_always_returns_current_version_even_if_outside_limit(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_user: FFAdminUser,
@@ -1639,7 +1639,7 @@ def test_list_versions_always_returns_current_version_even_if_outside_limit(
 
 
 @pytest.mark.freeze_time(now - timedelta(days=DEFAULT_VERSION_LIMIT_DAYS + 1))
-def test_list_versions_returns_all_versions_for_enterprise_plan_when_saas(
+def test_list_versions_returns_all_versions_for_enterprise_plan_when_saas(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     staff_user: FFAdminUser,

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_migrations.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_migrations.py
@@ -1,7 +1,7 @@
 from django_test_migrations.migrator import Migrator
 
 
-def test_migrate_add_project_to_change_request(migrator: Migrator) -> None:
+def test_migrate_add_project_to_change_request(migrator: Migrator) -> None:  # noqa: FT003,FT004
     old_state = migrator.apply_initial_migration(
         ("workflows_core", "0010_add_ignore_conflicts_option"),
     )

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -46,7 +46,7 @@ from users.models import FFAdminUser
 now = timezone.now()
 
 
-def test_change_request_approve_by_required_approver(  # type: ignore[no-untyped-def]
+def test_change_request_approve_by_required_approver(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, mocker
 ):
     # Given
@@ -84,7 +84,7 @@ def test_change_request_approve_by_required_approver(  # type: ignore[no-untyped
     assert author_email_call_args.kwargs["fail_silently"] is True
 
 
-def test_change_request_approve_by_new_approver_when_no_approvals_exist(  # type: ignore[no-untyped-def]
+def test_change_request_approve_by_new_approver_when_no_approvals_exist(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, mocker
 ):
     # Given
@@ -101,7 +101,7 @@ def test_change_request_approve_by_new_approver_when_no_approvals_exist(  # type
     assert approval.user == user
 
 
-def test_change_request_approve_by_new_approver_when_approvals_exist(  # type: ignore[no-untyped-def]
+def test_change_request_approve_by_new_approver_when_approvals_exist(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, mocker
 ):
     # Given
@@ -127,7 +127,7 @@ def test_change_request_approve_by_new_approver_when_approvals_exist(  # type: i
     ).exists()
 
 
-def test_change_request_is_approved_returns_true_when_minimum_change_request_approvals_is_none(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_change_request_is_approved_returns_true_when_minimum_change_request_approvals_is_none(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     change_request_no_required_approvals, mocker, environment
 ):
     # Given
@@ -137,7 +137,7 @@ def test_change_request_is_approved_returns_true_when_minimum_change_request_app
     assert change_request_no_required_approvals.is_approved() is True
 
 
-def test_change_request_commit_raises_exception_when_not_approved(  # type: ignore[no-untyped-def]
+def test_change_request_commit_raises_exception_when_not_approved(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     change_request_1_required_approvals,
 ):
     # Given
@@ -148,7 +148,7 @@ def test_change_request_commit_raises_exception_when_not_approved(  # type: igno
         change_request_1_required_approvals.commit(committed_by=user_2)
 
 
-def test_change_request_commit_not_scheduled(  # type: ignore[no-untyped-def]
+def test_change_request_commit_not_scheduled(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, mocker
 ):
     # Given
@@ -168,7 +168,7 @@ def test_change_request_commit_not_scheduled(  # type: ignore[no-untyped-def]
     assert change_request_no_required_approvals.feature_states.first().live_from == now
 
 
-def test_creating_a_change_request_creates_audit_log(environment, admin_user):  # type: ignore[no-untyped-def]
+def test_creating_a_change_request_creates_audit_log(environment, admin_user):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     change_request = ChangeRequest.objects.create(
         environment=environment, title="Change Request", user=admin_user
@@ -185,7 +185,7 @@ def test_creating_a_change_request_creates_audit_log(environment, admin_user):  
     )
 
 
-def test_approving_a_change_request_creates_audit_logs(  # type: ignore[no-untyped-def]
+def test_approving_a_change_request_creates_audit_logs(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, django_user_model, mocker
 ):
     # Given
@@ -210,7 +210,7 @@ def test_approving_a_change_request_creates_audit_logs(  # type: ignore[no-untyp
     )
 
 
-def test_change_request_commit_creates_audit_log(  # type: ignore[no-untyped-def]
+def test_change_request_commit_creates_audit_log(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, mocker, django_assert_num_queries
 ):
     # Given
@@ -231,7 +231,7 @@ def test_change_request_commit_creates_audit_log(  # type: ignore[no-untyped-def
     )
 
 
-def test_change_request_commit_scheduled(  # type: ignore[no-untyped-def]
+def test_change_request_commit_scheduled(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals,
     mocker,
 ):
@@ -258,13 +258,13 @@ def test_change_request_commit_scheduled(  # type: ignore[no-untyped-def]
     )
 
 
-def test_change_request_is_approved_false_when_no_approvals(  # type: ignore[no-untyped-def]
+def test_change_request_is_approved_false_when_no_approvals(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     change_request_no_required_approvals, environment_with_1_required_cr_approval
 ):
     assert change_request_no_required_approvals.is_approved() is False
 
 
-def test_change_request_is_approved_false_when_unapproved_approvals(  # type: ignore[no-untyped-def]
+def test_change_request_is_approved_false_when_unapproved_approvals(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     change_request_no_required_approvals,
     environment_with_1_required_cr_approval,
     django_user_model,
@@ -280,7 +280,7 @@ def test_change_request_is_approved_false_when_unapproved_approvals(  # type: ig
     assert change_request_no_required_approvals.is_approved() is False
 
 
-def test_change_request_is_approved_true_when_enough_approved_approvals(  # type: ignore[no-untyped-def]
+def test_change_request_is_approved_true_when_enough_approved_approvals(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     change_request_no_required_approvals,
     environment_with_1_required_cr_approval,
     django_user_model,
@@ -294,7 +294,7 @@ def test_change_request_is_approved_true_when_enough_approved_approvals(  # type
     assert change_request_no_required_approvals.is_approved() is True
 
 
-def test_user_cannot_approve_their_own_change_requests(  # type: ignore[no-untyped-def]
+def test_user_cannot_approve_their_own_change_requests(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     change_request_no_required_approvals,
 ):
     with pytest.raises(CannotApproveOwnChangeRequest):
@@ -303,7 +303,7 @@ def test_user_cannot_approve_their_own_change_requests(  # type: ignore[no-untyp
         )
 
 
-def test_user_is_notified_when_assigned_to_a_change_request(  # type: ignore[no-untyped-def]
+def test_user_is_notified_when_assigned_to_a_change_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals,
     django_user_model,
     mocker,
@@ -335,7 +335,7 @@ def test_user_is_notified_when_assigned_to_a_change_request(  # type: ignore[no-
     assert call_kwargs["recipient_list"] == [user.email]
 
 
-def test_user_is_not_notified_after_approving_a_change_request(  # type: ignore[no-untyped-def]
+def test_user_is_not_notified_after_approving_a_change_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request_no_required_approvals, django_user_model, mocker
 ):
     # Given
@@ -358,7 +358,7 @@ def test_user_is_not_notified_after_approving_a_change_request(  # type: ignore[
     ]
 
 
-def test_change_request_author_is_notified_after_an_approval_is_created(  # type: ignore[no-untyped-def]
+def test_change_request_author_is_notified_after_an_approval_is_created(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     change_request_no_required_approvals,
     django_user_model,
@@ -394,7 +394,7 @@ def test_change_request_author_is_notified_after_an_approval_is_created(  # type
     ]
 
 
-def test_change_request_author_is_notified_after_an_existing_approval_is_approved(  # type: ignore[no-untyped-def]
+def test_change_request_author_is_notified_after_an_existing_approval_is_approved(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     django_user_model,
     change_request_no_required_approvals,
@@ -438,7 +438,7 @@ def test_change_request_author_is_notified_after_an_existing_approval_is_approve
     ]
 
 
-def test_change_request_url(change_request_no_required_approvals, settings):  # type: ignore[no-untyped-def]
+def test_change_request_url(change_request_no_required_approvals, settings):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     site = Site.objects.filter(id=settings.SITE_ID).first()
     environment_key = change_request_no_required_approvals.environment.api_key
@@ -457,7 +457,7 @@ def test_change_request_url(change_request_no_required_approvals, settings):  # 
     )
 
 
-def test_change_request_email_subject(change_request_no_required_approvals):  # type: ignore[no-untyped-def]
+def test_change_request_email_subject(change_request_no_required_approvals):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert (
         change_request_no_required_approvals.email_subject
         == "Flagsmith Change Request: %s (#%s)"
@@ -468,7 +468,7 @@ def test_change_request_email_subject(change_request_no_required_approvals):  # 
     )
 
 
-def test_committing_cr_after_live_from_creates_correct_audit_log_for_related_feature_states(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_committing_cr_after_live_from_creates_correct_audit_log_for_related_feature_states(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     settings, change_request_no_required_approvals, mocker, admin_user
 ):
     # Given
@@ -498,7 +498,7 @@ def test_committing_cr_after_live_from_creates_correct_audit_log_for_related_fea
         )
 
 
-def test_committing_cr_after_before_from_schedules_tasks_correctly(  # type: ignore[no-untyped-def]
+def test_committing_cr_after_before_from_schedules_tasks_correctly(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings, change_request_no_required_approvals, mocker, admin_user
 ):
     # Given
@@ -521,7 +521,7 @@ def test_committing_cr_after_before_from_schedules_tasks_correctly(  # type: ign
 
 
 @pytest.mark.freeze_time()
-def test_committing_scheduled_change_requests_results_in_correct_versions(  # type: ignore[no-untyped-def]
+def test_committing_scheduled_change_requests_results_in_correct_versions(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, feature, admin_user, freezer
 ):
     # Given
@@ -567,7 +567,7 @@ def test_committing_scheduled_change_requests_results_in_correct_versions(  # ty
     assert feature_states[0] == cr_2_fs
 
 
-def test_change_request_group_assignment_sends_notification_emails_to_group_users(  # type: ignore[no-untyped-def]
+def test_change_request_group_assignment_sends_notification_emails_to_group_users(  # type: ignore[no-untyped-def]  # noqa: FT003
     change_request, user_permission_group, settings, mocker
 ):
     # Given
@@ -594,7 +594,7 @@ def test_change_request_group_assignment_sends_notification_emails_to_group_user
 
 
 @pytest.mark.freeze_time(now)
-def test_commit_change_request_publishes_environment_feature_versions(  # type: ignore[no-untyped-def]
+def test_commit_change_request_publishes_environment_feature_versions(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment,
     feature: Feature,
     admin_user: FFAdminUser,
@@ -647,7 +647,7 @@ def test_commit_change_request_publishes_environment_feature_versions(  # type: 
     )
 
 
-def test_cannot_delete_committed_change_request(
+def test_cannot_delete_committed_change_request(  # noqa: FT003,FT004
     change_request: ChangeRequest, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -662,7 +662,7 @@ def test_cannot_delete_committed_change_request(
     # exception raised
 
 
-def test_can_delete_committed_change_request_scheduled_for_the_future(
+def test_can_delete_committed_change_request_scheduled_for_the_future(  # noqa: FT003
     change_request: ChangeRequest,
     admin_user: FFAdminUser,
     feature: Feature,
@@ -687,7 +687,7 @@ def test_can_delete_committed_change_request_scheduled_for_the_future(
     assert not ChangeRequest.objects.filter(id=change_request.id).exists()
 
 
-def test_can_delete_committed_change_request_scheduled_for_the_future_with_environment_feature_versions(
+def test_can_delete_committed_change_request_scheduled_for_the_future_with_environment_feature_versions(  # noqa: FT003
     change_request: ChangeRequest,
     admin_user: FFAdminUser,
     feature: Feature,
@@ -717,7 +717,7 @@ def test_can_delete_committed_change_request_scheduled_for_the_future_with_envir
     assert not ChangeRequest.objects.filter(id=change_request.id).exists()
 
 
-def test_committing_change_request_with_environment_feature_versions_creates_publish_audit_log(
+def test_committing_change_request_with_environment_feature_versions_creates_publish_audit_log(  # noqa: FT003
     feature: Feature, environment_v2_versioning: Environment, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -744,7 +744,7 @@ def test_committing_change_request_with_environment_feature_versions_creates_pub
     ).exists()
 
 
-def test_change_request_live_from_for_change_request_with_change_set(
+def test_change_request_live_from_for_change_request_with_change_set(  # noqa: FT003
     feature: Feature,
     environment_v2_versioning: Environment,
     admin_user: FFAdminUser,
@@ -781,7 +781,7 @@ def test_change_request_live_from_for_change_request_with_change_set(
     assert change_request.live_from == now
 
 
-def test_publishing_segments_as_part_of_commit(
+def test_publishing_segments_as_part_of_commit(  # noqa: FT003
     segment: Segment,
     change_request: ChangeRequest,
     admin_user: FFAdminUser,
@@ -869,7 +869,7 @@ def test_publishing_segments_as_part_of_commit(
     ]
 
 
-def test_ignore_conflicts_for_multiple_scheduled_change_requests(
+def test_ignore_conflicts_for_multiple_scheduled_change_requests(  # noqa: FT003,FT004
     feature: Feature,
     environment_v2_versioning: Environment,
     admin_user: FFAdminUser,
@@ -987,7 +987,7 @@ def test_ignore_conflicts_for_multiple_scheduled_change_requests(
     assert after_cr_1_flags[0].feature_segment.segment == twenty_percent_segment  # type: ignore[union-attr]
 
 
-def test_approval_via_project(project_change_request: ChangeRequest) -> None:
+def test_approval_via_project(project_change_request: ChangeRequest) -> None:  # noqa: FT003
     # Given - The project change request fixture
     assert project_change_request.environment is None
     assert project_change_request.project.minimum_change_request_approvals is None
@@ -999,7 +999,7 @@ def test_approval_via_project(project_change_request: ChangeRequest) -> None:
     assert is_approved is True
 
 
-def test_url_via_project(project_change_request: ChangeRequest) -> None:
+def test_url_via_project(project_change_request: ChangeRequest) -> None:  # noqa: FT003
     # Given
     assert project_change_request.environment is None
 
@@ -1013,7 +1013,7 @@ def test_url_via_project(project_change_request: ChangeRequest) -> None:
     assert url == expected_url
 
 
-def test_delete_organisation_with_committed_change_request(
+def test_delete_organisation_with_committed_change_request(  # noqa: FT003
     organisation: Organisation,
     feature: Feature,
     change_request_no_required_approvals: ChangeRequest,
@@ -1032,7 +1032,7 @@ def test_delete_organisation_with_committed_change_request(
     assert organisation.deleted_at is not None
 
 
-def test_delete_project_with_v2_versioning_does_not_trigger_audit_log(
+def test_delete_project_with_v2_versioning_does_not_trigger_audit_log(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/import_export/test_unit_import_export_export.py
+++ b/api/tests/unit/import_export/test_unit_import_export_export.py
@@ -52,7 +52,7 @@ from projects.tags.models import Tag
 from segments.models import Condition, Segment, SegmentRule
 
 
-def test_export_organisation(db):  # type: ignore[no-untyped-def]
+def test_export_organisation(db):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     # an organisation
     organisation_name = "test org"
@@ -75,7 +75,7 @@ def test_export_organisation(db):  # type: ignore[no-untyped-def]
     # TODO: test whether the export is importable
 
 
-def test_export_project(organisation):  # type: ignore[no-untyped-def]
+def test_export_project(organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     # a project
     project_name = "test project"
@@ -103,7 +103,7 @@ def test_export_project(organisation):  # type: ignore[no-untyped-def]
     # TODO: test whether the export is importable
 
 
-def test_export_project__only_live_segments_are_exported(  # type: ignore[no-untyped-def]
+def test_export_project__only_live_segments_are_exported(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation: Organisation, project: Project
 ):
     # Given
@@ -133,7 +133,7 @@ def test_export_project__only_live_segments_are_exported(  # type: ignore[no-unt
     assert export[3]["fields"]["uuid"] == str(segment_condition.uuid)
 
 
-def test_export_environments(project):  # type: ignore[no-untyped-def]
+def test_export_environments(project):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     # an environment
     environment_name = "test environment"
@@ -172,7 +172,7 @@ def test_export_environments(project):  # type: ignore[no-untyped-def]
     # TODO: test whether the export is importable
 
 
-def test_export_metadata(environment, organisation, settings):  # type: ignore[no-untyped-def]
+def test_export_metadata(environment, organisation, settings):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     environment_type = ContentType.objects.get_for_model(environment)
 
@@ -235,7 +235,7 @@ def test_export_metadata(environment, organisation, settings):  # type: ignore[n
     assert metadata.content_object == loaded_environment
 
 
-def test_export_features(project, environment, segment, admin_user):  # type: ignore[no-untyped-def]
+def test_export_features(project, environment, segment, admin_user):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     # a standard feature
     standard_feature = Feature.objects.create(project=project, name="standard_feature")
@@ -289,7 +289,7 @@ def test_export_features(project, environment, segment, admin_user):  # type: ig
     # TODO: test whether the export is importable
 
 
-def test_export_features_with_environment_feature_version(  # type: ignore[no-untyped-def]
+def test_export_features_with_environment_feature_version(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment, segment, admin_user
 ):
     # Given
@@ -315,7 +315,7 @@ def test_export_features_with_environment_feature_version(  # type: ignore[no-un
     # TODO: test whether the export is importable
 
 
-def test_export_edge_identities(
+def test_export_edge_identities(  # noqa: FT003
     flagsmith_identities_table: Table,
     project: Project,
     environment: Environment,
@@ -577,7 +577,7 @@ def test_export_edge_identities(
 
 
 @mock_s3
-def test_organisation_exporter_export_to_s3(organisation):  # type: ignore[no-untyped-def]
+def test_organisation_exporter_export_to_s3(organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     bucket_name = "test-bucket"
     file_key = "organisation-exports/org-1.json"
@@ -600,7 +600,7 @@ def test_organisation_exporter_export_to_s3(organisation):  # type: ignore[no-un
     assert retrieved_object.get("ContentLength", 0) > 0
 
 
-def test_export_dynamo_project(
+def test_export_dynamo_project(  # noqa: FT003
     organisation: Organisation, mocker: MockerFixture, fs: FakeFilesystem
 ) -> None:
     # Given - dynamo db project

--- a/api/tests/unit/import_export/test_unit_import_export_import.py
+++ b/api/tests/unit/import_export/test_unit_import_export_import.py
@@ -10,7 +10,7 @@ from organisations.models import Organisation
 
 
 @mock_s3
-def test_import_organisation(organisation):  # type: ignore[no-untyped-def]
+def test_import_organisation(organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     bucket_name = "test-bucket"
     file_key = "organisation-exports/org-1.json"

--- a/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
+++ b/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
@@ -10,7 +10,7 @@ from integrations.amplitude.constants import DEFAULT_AMPLITUDE_API_URL
 from integrations.amplitude.models import AmplitudeConfiguration
 
 
-def test_amplitude_initialized_correctly() -> None:
+def test_amplitude_initialized_correctly() -> None:  # noqa: FT003
     # Given
     config = AmplitudeConfiguration(api_key="123key")
 
@@ -22,7 +22,7 @@ def test_amplitude_initialized_correctly() -> None:
     assert amplitude_wrapper.url == expected_url
 
 
-def test_amplitude_initialized_correctly_with_custom_base_url() -> None:
+def test_amplitude_initialized_correctly_with_custom_base_url() -> None:  # noqa: FT003
     # Given
     base_url = "https://api.eu.amplitude.com"
     config = AmplitudeConfiguration(api_key="123key", base_url=base_url)
@@ -40,7 +40,7 @@ def test_amplitude_initialized_correctly_with_custom_base_url() -> None:
     [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
     indirect=["feature_state_with_value"],
 )
-def test_amplitude_when_generate_user_data_with_correct_values_then_success(
+def test_amplitude_when_generate_user_data_with_correct_values_then_success(  # noqa: FT003
     expected_property_value: typing.Any,
     environment: Environment,
     feature_state: FeatureState,

--- a/api/tests/unit/integrations/amplitude/test_unit_amplitude_models.py
+++ b/api/tests/unit/integrations/amplitude/test_unit_amplitude_models.py
@@ -1,7 +1,7 @@
 from integrations.amplitude.models import AmplitudeConfiguration
 
 
-def test_amplitude_configuration_save_writes_environment_to_dynamodb(  # type: ignore[no-untyped-def]
+def test_amplitude_configuration_save_writes_environment_to_dynamodb(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, mocker
 ):
     """
@@ -24,7 +24,7 @@ def test_amplitude_configuration_save_writes_environment_to_dynamodb(  # type: i
     )
 
 
-def test_amplitude_configuration_delete_writes_environment_to_dynamodb(  # type: ignore[no-untyped-def]
+def test_amplitude_configuration_delete_writes_environment_to_dynamodb(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, mocker
 ):
     """
@@ -48,7 +48,7 @@ def test_amplitude_configuration_delete_writes_environment_to_dynamodb(  # type:
     )
 
 
-def test_amplitude_configuration_update_clears_environment_cache(environment, mocker):  # type: ignore[no-untyped-def]
+def test_amplitude_configuration_update_clears_environment_cache(environment, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_environment_cache = mocker.patch("environments.models.environment_cache")
     amplitude_config = AmplitudeConfiguration.objects.create(

--- a/api/tests/unit/integrations/amplitude/test_unit_amplitude_views.py
+++ b/api/tests/unit/integrations/amplitude/test_unit_amplitude_views.py
@@ -8,7 +8,7 @@ from environments.models import Environment
 from integrations.amplitude.models import AmplitudeConfiguration
 
 
-def test_should_create_amplitude_config_when_post(  # type: ignore[no-untyped-def]
+def test_should_create_amplitude_config_when_post(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ):
@@ -32,7 +32,7 @@ def test_should_create_amplitude_config_when_post(  # type: ignore[no-untyped-de
     assert AmplitudeConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_return_400_when_duplicate_amplitude_config_is_posted(
+def test_should_return_400_when_duplicate_amplitude_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -59,7 +59,7 @@ def test_should_return_400_when_duplicate_amplitude_config_is_posted(
     assert AmplitudeConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -88,7 +88,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_amplitude_config_list_when_requested(
+def test_should_return_amplitude_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -116,7 +116,7 @@ def test_should_return_amplitude_config_list_when_requested(
     assert response.data == [expected_response]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -137,7 +137,7 @@ def test_should_remove_configuration_when_delete(
     assert not AmplitudeConfiguration.objects.filter(environment=environment).exists()
 
 
-def test_create_amplitude_integration(environment, admin_client):  # type: ignore[no-untyped-def]
+def test_create_amplitude_integration(environment, admin_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:environments:integrations-amplitude-list", args=[environment.api_key]
@@ -154,7 +154,7 @@ def test_create_amplitude_integration(environment, admin_client):  # type: ignor
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_create_amplitude_integration_in_environment_with_deleted_integration(  # type: ignore[no-untyped-def]
+def test_create_amplitude_integration_in_environment_with_deleted_integration(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, admin_client, deleted_amplitude_integration
 ):
     # Given

--- a/api/tests/unit/integrations/common/test_unit_integrations_common_serializers.py
+++ b/api/tests/unit/integrations/common/test_unit_integrations_common_serializers.py
@@ -6,7 +6,7 @@ from integrations.webhook.models import WebhookConfiguration
 from integrations.webhook.serializers import WebhookConfigurationSerializer
 
 
-def test_base_environment_integration_model_serializer_save_updates_existing_if_soft_deleted(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_base_environment_integration_model_serializer_save_updates_existing_if_soft_deleted(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     environment,
 ):
     """
@@ -39,7 +39,7 @@ def test_base_environment_integration_model_serializer_save_updates_existing_if_
     assert updated_webhook_config.deleted_at is None
 
 
-def test_base_project_integration_model_serializer_save_updates_existing_if_soft_deleted(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_base_project_integration_model_serializer_save_updates_existing_if_soft_deleted(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     project,
 ):
     """

--- a/api/tests/unit/integrations/datadog/test_unit_datadog.py
+++ b/api/tests/unit/integrations/datadog/test_unit_datadog.py
@@ -19,7 +19,7 @@ from integrations.datadog.datadog import (
         ("https://test.com/", f"https://test.com/{EVENTS_API_URI}"),
     ),
 )
-def test_datadog_initialized_correctly(base_url, expected_events_url):  # type: ignore[no-untyped-def]
+def test_datadog_initialized_correctly(base_url, expected_events_url):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_key = "123key"
 
@@ -44,7 +44,7 @@ def test_datadog_initialized_correctly(base_url, expected_events_url):  # type: 
         ),
     ),
 )
-def test_datadog_track_event(
+def test_datadog_track_event(  # noqa: FT003
     mocker: MockerFixture,
     event_data: dict,  # type: ignore[type-arg]
     use_custom_source: bool,
@@ -71,7 +71,7 @@ def test_datadog_track_event(
     )
 
 
-def test_datadog_when_generate_event_data_with_correct_values_then_success(  # type: ignore[no-untyped-def]
+def test_datadog_when_generate_event_data_with_correct_values_then_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     django_user_model,
     feature,
 ):
@@ -96,7 +96,7 @@ def test_datadog_when_generate_event_data_with_correct_values_then_success(  # t
     assert event_data["tags"][0] == f"env:{environment.name}"
 
 
-def test_datadog_when_generate_event_data_with_missing_author_then_success(feature):  # type: ignore[no-untyped-def]
+def test_datadog_when_generate_event_data_with_missing_author_then_success(feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     log = "some log data"
 
@@ -116,7 +116,7 @@ def test_datadog_when_generate_event_data_with_missing_author_then_success(featu
     assert event_data["tags"][0] == f"env:{environment.name}"
 
 
-def test_datadog_when_generate_event_data_with_missing_env_then_success(  # type: ignore[no-untyped-def]
+def test_datadog_when_generate_event_data_with_missing_env_then_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     django_user_model,
     feature,
 ):

--- a/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
+++ b/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
@@ -8,7 +8,7 @@ from integrations.datadog.models import DataDogConfiguration
 from projects.models import Project
 
 
-def test_should_create_datadog_config_when_post(
+def test_should_create_datadog_config_when_post(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -36,7 +36,7 @@ def test_should_create_datadog_config_when_post(
     assert created_config.use_custom_source == data["use_custom_source"]
 
 
-def test_should_return_400_when_duplicate_datadog_config_is_posted(
+def test_should_return_400_when_duplicate_datadog_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -59,7 +59,7 @@ def test_should_return_400_when_duplicate_datadog_config_is_posted(
     assert DataDogConfiguration.objects.filter(project=project).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -87,7 +87,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_datadog_config_list_when_requested(
+def test_should_return_datadog_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -112,7 +112,7 @@ def test_should_return_datadog_config_list_when_requested(
     ]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -132,7 +132,7 @@ def test_should_remove_configuration_when_delete(
     assert not DataDogConfiguration.objects.filter(project=project).exists()
 
 
-def test_create_datadog_configuration_in_project_with_deleted_configuration(  # type: ignore[no-untyped-def]
+def test_create_datadog_configuration_in_project_with_deleted_configuration(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, deleted_datadog_configuration
 ):
     # Given

--- a/api/tests/unit/integrations/dynatrace/test_unit_dynatrace.py
+++ b/api/tests/unit/integrations/dynatrace/test_unit_dynatrace.py
@@ -14,7 +14,7 @@ from projects.models import Project
 from segments.models import Segment
 
 
-def test_dynatrace_initialized_correctly():  # type: ignore[no-untyped-def]
+def test_dynatrace_initialized_correctly():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_key = "123key"
     base_url = "http://test.com"
@@ -50,7 +50,7 @@ def test_dynatrace_initialized_correctly():  # type: ignore[no-untyped-def]
         ),
     ),
 )
-def test_dynatrace_when_generate_event_data_with_correct_values_then_success(
+def test_dynatrace_when_generate_event_data_with_correct_values_then_success(  # noqa: FT003
     django_user_model: Type[AbstractUser],
     related_object_type: RelatedObjectType,
     related_object: Feature | Segment | FeatureState,
@@ -99,7 +99,7 @@ def test_dynatrace_when_generate_event_data_with_correct_values_then_success(
     )
 
 
-def test_dynatrace_when_generate_event_data_with_missing_author_then_success():  # type: ignore[no-untyped-def]
+def test_dynatrace_when_generate_event_data_with_missing_author_then_success():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     log = "some log data"
 
@@ -122,7 +122,7 @@ def test_dynatrace_when_generate_event_data_with_missing_author_then_success(): 
     assert event_data["properties"]["environment"] == environment.name
 
 
-def test_dynatrace_when_generate_event_data_with_missing_environment_then_success(  # type: ignore[no-untyped-def]
+def test_dynatrace_when_generate_event_data_with_missing_environment_then_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     django_user_model, feature
 ):
     # Given

--- a/api/tests/unit/integrations/dynatrace/test_unit_dynatrace_views.py
+++ b/api/tests/unit/integrations/dynatrace/test_unit_dynatrace_views.py
@@ -8,7 +8,7 @@ from environments.models import Environment
 from integrations.dynatrace.models import DynatraceConfiguration
 
 
-def test_should_create_dynatrace_config_when_post(
+def test_should_create_dynatrace_config_when_post(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -36,7 +36,7 @@ def test_should_create_dynatrace_config_when_post(
     assert DynatraceConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_return_400_when_duplicate_dynatrace_config_is_posted(
+def test_should_return_400_when_duplicate_dynatrace_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -66,7 +66,7 @@ def test_should_return_400_when_duplicate_dynatrace_config_is_posted(
     assert DynatraceConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -98,7 +98,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_dynatrace_config_list_when_requested(
+def test_should_return_dynatrace_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -126,7 +126,7 @@ def test_should_return_dynatrace_config_list_when_requested(
     ]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/integrations/flagsmith/test_unit_flagsmith_client.py
+++ b/api/tests/unit/integrations/flagsmith/test_unit_flagsmith_client.py
@@ -31,7 +31,7 @@ def mock_local_file_handler_class(  # type: ignore[no-untyped-def]
     )
 
 
-def test_get_client_initialises_flagsmith_with_correct_arguments_offline_mode_disabled(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_client_initialises_flagsmith_with_correct_arguments_offline_mode_disabled(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     settings: SettingsWrapper,
     mocker: MockerFixture,
     mock_local_file_handler,
@@ -64,7 +64,7 @@ def test_get_client_initialises_flagsmith_with_correct_arguments_offline_mode_di
     mock_local_file_handler_class.assert_called_once_with(ENVIRONMENT_JSON_PATH)
 
 
-def test_get_client_initialises_flagsmith_with_correct_arguments_offline_mode_enabled(  # type: ignore[no-untyped-def]
+def test_get_client_initialises_flagsmith_with_correct_arguments_offline_mode_enabled(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings: SettingsWrapper,
     mocker: MockerFixture,
     mock_local_file_handler,
@@ -90,7 +90,7 @@ def test_get_client_initialises_flagsmith_with_correct_arguments_offline_mode_en
     mock_local_file_handler_class.assert_called_once_with(ENVIRONMENT_JSON_PATH)
 
 
-def test_get_client_raises_value_error_if_missing_args(  # type: ignore[no-untyped-def]
+def test_get_client_raises_value_error_if_missing_args(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     settings: SettingsWrapper, mock_local_file_handler_class
 ):
     # Given

--- a/api/tests/unit/integrations/flagsmith/test_unit_flagsmith_service.py
+++ b/api/tests/unit/integrations/flagsmith/test_unit_flagsmith_service.py
@@ -59,7 +59,7 @@ def environment_document():  # type: ignore[no-untyped-def]
 
 
 @responses.activate
-def test_update_environment_json(settings, environment_document):  # type: ignore[no-untyped-def]
+def test_update_environment_json(settings, environment_document):  # type: ignore[no-untyped-def]  # noqa: FT003
     """
     Test to verify that, when we call update_environment_json, the response is written
     to the correct file and that the sensitive data from the response is masked.
@@ -90,7 +90,7 @@ def test_update_environment_json(settings, environment_document):  # type: ignor
 
 
 @responses.activate
-def test_update_environment_json_throws_exception_for_failed_request(settings):  # type: ignore[no-untyped-def]
+def test_update_environment_json_throws_exception_for_failed_request(settings):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     api_url = "https://api.flagsmith.com/api/v1"
     settings.FLAGSMITH_ON_FLAGSMITH_SERVER_API_URL = api_url

--- a/api/tests/unit/integrations/github/test_unit_github_github.py
+++ b/api/tests/unit/integrations/github/test_unit_github_github.py
@@ -1,7 +1,7 @@
 from integrations.github.github import tag_feature_per_github_event
 
 
-def test_tag_feature_per_github_event_with_empty_feature(db: None) -> None:
+def test_tag_feature_per_github_event_with_empty_feature(db: None) -> None:  # noqa: FT003
     # Given / When
     result = tag_feature_per_github_event(  # type: ignore[func-returns-value]
         event_type="test",

--- a/api/tests/unit/integrations/github/test_unit_github_views.py
+++ b/api/tests/unit/integrations/github/test_unit_github_views.py
@@ -58,7 +58,7 @@ WEBHOOK_MERGED_ACTION_SIGNATURE = "sha1=f3f7e1e9b43448d570451317447d3b4f8f8142de
 WEBHOOK_SECRET = "secret-key"
 
 
-def test_get_github_configuration(
+def test_get_github_configuration(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -73,7 +73,7 @@ def test_get_github_configuration(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_non_admin_user_get_github_configuration(
+def test_non_admin_user_get_github_configuration(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -92,7 +92,7 @@ def test_non_admin_user_get_github_configuration(
     assert github_configuration_res["id"] == github_configuration.id
 
 
-def test_create_github_configuration(
+def test_create_github_configuration(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -110,7 +110,7 @@ def test_create_github_configuration(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_cannot_create_github_configuration_due_to_unique_constraint(
+def test_cannot_create_github_configuration_due_to_unique_constraint(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -134,7 +134,7 @@ def test_cannot_create_github_configuration_due_to_unique_constraint(
     )
 
 
-def test_cannot_create_github_configuration_when_the_organization_already_has_an_integration(
+def test_cannot_create_github_configuration_when_the_organization_already_has_an_integration(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -159,7 +159,7 @@ def test_cannot_create_github_configuration_when_the_organization_already_has_an
 
 
 @responses.activate
-def test_delete_github_configuration(
+def test_delete_github_configuration(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -194,7 +194,7 @@ def test_delete_github_configuration(
 
 
 @responses.activate
-def test_can_delete_github_configuration_when_delete_github_installation_response_was_404(
+def test_can_delete_github_configuration_when_delete_github_installation_response_was_404(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -228,7 +228,7 @@ def test_can_delete_github_configuration_when_delete_github_installation_respons
     assert not GithubConfiguration.objects.filter(id=github_configuration.id).exists()
 
 
-def test_get_github_repository(  # type: ignore[no-untyped-def]
+def test_get_github_repository(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -244,7 +244,7 @@ def test_get_github_repository(  # type: ignore[no-untyped-def]
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_cannot_get_github_repository_when_github_pk_in_not_a_number(  # type: ignore[no-untyped-def]
+def test_cannot_get_github_repository_when_github_pk_in_not_a_number(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -262,7 +262,7 @@ def test_cannot_get_github_repository_when_github_pk_in_not_a_number(  # type: i
 
 
 @responses.activate
-def test_create_github_repository(
+def test_create_github_repository(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -299,7 +299,7 @@ def test_create_github_repository(
 
 
 @responses.activate
-def test_create_github_repository_and_label_already_Existe(
+def test_create_github_repository_and_label_already_Existe(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -345,7 +345,7 @@ def test_create_github_repository_and_label_already_Existe(
     assert GitHubRepository.objects.filter(repository_owner="repositoryowner").exists()
 
 
-def test_cannot_create_github_repository_when_does_not_have_permissions(
+def test_cannot_create_github_repository_when_does_not_have_permissions(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -370,7 +370,7 @@ def test_cannot_create_github_repository_when_does_not_have_permissions(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_cannot_create_github_repository_due_to_unique_constraint(
+def test_cannot_create_github_repository_due_to_unique_constraint(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -401,7 +401,7 @@ def test_cannot_create_github_repository_due_to_unique_constraint(
     )
 
 
-def test_github_delete_repository(
+def test_github_delete_repository(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -473,7 +473,7 @@ def mocked_requests_get_error(*args, **kwargs):  # type: ignore[no-untyped-def]
     return response
 
 
-def test_fetch_pull_requests(
+def test_fetch_pull_requests(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -508,7 +508,7 @@ def test_fetch_pull_requests(
     )
 
 
-def test_fetch_issues(
+def test_fetch_issues(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -549,7 +549,7 @@ def test_fetch_issues(
 
 
 @responses.activate
-def test_fetch_issues_returns_error_on_bad_response_from_github(
+def test_fetch_issues_returns_error_on_bad_response_from_github(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -583,7 +583,7 @@ def test_fetch_issues_returns_error_on_bad_response_from_github(
 
 
 @responses.activate
-def test_search_issues_returns_error_on_bad_search_params(
+def test_search_issues_returns_error_on_bad_search_params(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -619,7 +619,7 @@ def test_search_issues_returns_error_on_bad_search_params(
 
 
 @responses.activate
-def test_fetch_repositories(
+def test_fetch_repositories(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -673,7 +673,7 @@ def test_fetch_repositories(
         (lazy_fixture("admin_client"), "api-v1:organisations:get-github-pulls"),
     ],
 )
-def test_fetch_issues_and_pull_requests_fails_with_status_400_when_integration_not_configured(
+def test_fetch_issues_and_pull_requests_fails_with_status_400_when_integration_not_configured(  # noqa: FT003,FT004
     client: APIClient,
     organisation: Organisation,
     reverse_url: str,
@@ -694,7 +694,7 @@ def test_fetch_issues_and_pull_requests_fails_with_status_400_when_integration_n
         ("api-v1:organisations:get-github-pulls"),
     ],
 )
-def test_user_cannot_fetch_issues_or_prs_from_organisation_they_do_not_belong_to(
+def test_user_cannot_fetch_issues_or_prs_from_organisation_they_do_not_belong_to(  # noqa: FT003
     api_client: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -715,7 +715,7 @@ def test_user_cannot_fetch_issues_or_prs_from_organisation_they_do_not_belong_to
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_verify_github_webhook_payload() -> None:
+def test_verify_github_webhook_payload() -> None:  # noqa: FT003,FT004
     # When
     result = github_webhook_payload_is_valid(
         payload_body=WEBHOOK_PAYLOAD.encode("utf-8"),
@@ -727,7 +727,7 @@ def test_verify_github_webhook_payload() -> None:
     assert result is True
 
 
-def test_verify_github_webhook_payload_returns_false_on_bad_signature() -> None:
+def test_verify_github_webhook_payload_returns_false_on_bad_signature() -> None:  # noqa: FT003,FT004
     # When
     result = github_webhook_payload_is_valid(
         payload_body=WEBHOOK_PAYLOAD.encode("utf-8"),
@@ -739,7 +739,7 @@ def test_verify_github_webhook_payload_returns_false_on_bad_signature() -> None:
     assert result is False
 
 
-def test_verify_github_webhook_payload_returns_false_on_no_signature_header() -> None:
+def test_verify_github_webhook_payload_returns_false_on_no_signature_header() -> None:  # noqa: FT003,FT004
     # When
     result = github_webhook_payload_is_valid(
         payload_body=WEBHOOK_PAYLOAD.encode("utf-8"),
@@ -751,7 +751,7 @@ def test_verify_github_webhook_payload_returns_false_on_no_signature_header() ->
     assert result is False
 
 
-def test_github_webhook_delete_installation(  # type: ignore[no-untyped-def]
+def test_github_webhook_delete_installation(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient,
     github_configuration: GithubConfiguration,
     set_github_webhook_secret,
@@ -773,7 +773,7 @@ def test_github_webhook_delete_installation(  # type: ignore[no-untyped-def]
     assert not GithubConfiguration.objects.filter(installation_id=1234567).exists()
 
 
-def test_github_webhook_merged_a_pull_request(  # type: ignore[no-untyped-def]
+def test_github_webhook_merged_a_pull_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient,
     feature: Feature,
     github_configuration: GithubConfiguration,
@@ -799,7 +799,7 @@ def test_github_webhook_merged_a_pull_request(  # type: ignore[no-untyped-def]
     assert feature.tags.first().label == "PR Merged"  # type: ignore[union-attr]
 
 
-def test_github_webhook_without_installation_id(  # type: ignore[no-untyped-def]
+def test_github_webhook_without_installation_id(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient,
     mocker: MockerFixture,
     set_github_webhook_secret,
@@ -824,7 +824,7 @@ def test_github_webhook_without_installation_id(  # type: ignore[no-untyped-def]
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_github_webhook_with_non_existing_installation(  # type: ignore[no-untyped-def]
+def test_github_webhook_with_non_existing_installation(  # type: ignore[no-untyped-def]  # noqa: FT003
     api_client: APIClient,
     github_configuration: GithubConfiguration,
     mocker: MockerFixture,
@@ -850,7 +850,7 @@ def test_github_webhook_with_non_existing_installation(  # type: ignore[no-untyp
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_github_webhook_fails_on_signature_header_missing(  # type: ignore[no-untyped-def]
+def test_github_webhook_fails_on_signature_header_missing(  # type: ignore[no-untyped-def]  # noqa: FT003
     github_configuration: GithubConfiguration,
     set_github_webhook_secret,
 ) -> None:
@@ -872,7 +872,7 @@ def test_github_webhook_fails_on_signature_header_missing(  # type: ignore[no-un
     assert GithubConfiguration.objects.filter(installation_id=1234567).exists()
 
 
-def test_github_webhook_fails_on_bad_signature_header_missing(  # type: ignore[no-untyped-def]
+def test_github_webhook_fails_on_bad_signature_header_missing(  # type: ignore[no-untyped-def]  # noqa: FT003
     github_configuration: GithubConfiguration,
     set_github_webhook_secret,
 ) -> None:
@@ -895,7 +895,7 @@ def test_github_webhook_fails_on_bad_signature_header_missing(  # type: ignore[n
     assert response.json() == {"error": "Invalid signature"}
 
 
-def test_github_webhook_bypass_event(  # type: ignore[no-untyped-def]
+def test_github_webhook_bypass_event(  # type: ignore[no-untyped-def]  # noqa: FT003
     github_configuration: GithubConfiguration,
     set_github_webhook_secret,
 ) -> None:
@@ -918,7 +918,7 @@ def test_github_webhook_bypass_event(  # type: ignore[no-untyped-def]
 
 
 @responses.activate
-def test_cannot_fetch_pull_requests_when_github_request_call_failed(
+def test_cannot_fetch_pull_requests_when_github_request_call_failed(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -946,7 +946,7 @@ def test_cannot_fetch_pull_requests_when_github_request_call_failed(
 
 
 @responses.activate
-def test_cannot_fetch_pulls_when_the_github_response_was_invalid(
+def test_cannot_fetch_pulls_when_the_github_response_was_invalid(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -970,7 +970,7 @@ def test_cannot_fetch_pulls_when_the_github_response_was_invalid(
     assert response.status_code == status.HTTP_502_BAD_GATEWAY
 
 
-def test_cannot_fetch_repositories_when_there_is_no_installation_id(
+def test_cannot_fetch_repositories_when_there_is_no_installation_id(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -986,7 +986,7 @@ def test_cannot_fetch_repositories_when_there_is_no_installation_id(
 
 
 @responses.activate
-def test_fetch_github_repo_contributors(
+def test_fetch_github_repo_contributors(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -1044,7 +1044,7 @@ def test_fetch_github_repo_contributors(
     assert response.json() == expected_response
 
 
-def test_fetch_github_repo_contributors_with_invalid_query_params(
+def test_fetch_github_repo_contributors_with_invalid_query_params(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -1069,7 +1069,7 @@ def test_fetch_github_repo_contributors_with_invalid_query_params(
     assert response.json() == {"error": {"repo_name": ["This field is required."]}}
 
 
-def test_github_api_call_error_handler_with_value_error(
+def test_github_api_call_error_handler_with_value_error(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -1103,7 +1103,7 @@ def test_github_api_call_error_handler_with_value_error(
         ),
     ],
 )
-def test_send_the_invalid_number_page_or_page_size_param_returns_400(
+def test_send_the_invalid_number_page_or_page_size_param_returns_400(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -1146,7 +1146,7 @@ def test_send_the_invalid_number_page_or_page_size_param_returns_400(
         ),
     ],
 )
-def test_send_the_invalid_type_page_or_page_size_param_returns_400(
+def test_send_the_invalid_type_page_or_page_size_param_returns_400(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,
@@ -1175,7 +1175,7 @@ def test_send_the_invalid_type_page_or_page_size_param_returns_400(
 
 
 @responses.activate
-def test_label_and_tags_no_added_when_tagging_is_disabled(
+def test_label_and_tags_no_added_when_tagging_is_disabled(  # noqa: FT003
     admin_client_new: APIClient,
     project: Project,
     environment: Environment,
@@ -1214,7 +1214,7 @@ def test_label_and_tags_no_added_when_tagging_is_disabled(
 
 
 @responses.activate
-def test_update_github_repository(
+def test_update_github_repository(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     github_configuration: GithubConfiguration,

--- a/api/tests/unit/integrations/grafana/test_grafana.py
+++ b/api/tests/unit/integrations/grafana/test_grafana.py
@@ -9,7 +9,7 @@ from integrations.grafana.grafana import GrafanaWrapper
 
 
 @pytest.mark.parametrize("base_url", ["test.com", "test.com/"])
-def test_grafana_wrapper__base_url__expected_url(base_url: str) -> None:
+def test_grafana_wrapper__base_url__expected_url(base_url: str) -> None:  # noqa: FT004
     # When
     wrapper = GrafanaWrapper(base_url=base_url, api_key="any")
 

--- a/api/tests/unit/integrations/grafana/test_views.py
+++ b/api/tests/unit/integrations/grafana/test_views.py
@@ -56,7 +56,7 @@ def test_grafana_organisation_view__create_configuration__persist_expected(
     assert created_config.api_key == data["api_key"]
 
 
-def test_grafana_organisation_view__create_configuration__existing__return_expected(
+def test_grafana_organisation_view__create_configuration__existing__return_expected(  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,
@@ -133,7 +133,7 @@ def test_grafana_organisation_view__delete_configuration__return_expected(
     ).exists()
 
 
-def test_grafana_organisation_view__create_configuration__non_admin__return_expected(
+def test_grafana_organisation_view__create_configuration__non_admin__return_expected(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,
@@ -158,7 +158,7 @@ def test_grafana_organisation_view__create_configuration__non_admin__return_expe
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_grafana_organisation_view__get_configuration__non_admin__return_expected(
+def test_grafana_organisation_view__get_configuration__non_admin__return_expected(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,
@@ -176,7 +176,7 @@ def test_grafana_organisation_view__get_configuration__non_admin__return_expecte
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_grafana_organisation_view__delete_configuration__non_admin__return_expected(
+def test_grafana_organisation_view__delete_configuration__non_admin__return_expected(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,

--- a/api/tests/unit/integrations/heap/test_unit_heap.py
+++ b/api/tests/unit/integrations/heap/test_unit_heap.py
@@ -15,7 +15,7 @@ from integrations.heap.models import HeapConfiguration
     [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
     indirect=["feature_state_with_value"],
 )
-def test_heap_when_generate_user_data_with_correct_values_then_success(
+def test_heap_when_generate_user_data_with_correct_values_then_success(  # noqa: FT003
     expected_property_value: typing.Any,
     environment: Environment,
     feature_state: FeatureState,

--- a/api/tests/unit/integrations/heap/test_unit_heap_views.py
+++ b/api/tests/unit/integrations/heap/test_unit_heap_views.py
@@ -8,7 +8,7 @@ from environments.models import Environment
 from integrations.heap.models import HeapConfiguration
 
 
-def test_should_create_heap_config_when_post(
+def test_should_create_heap_config_when_post(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -30,7 +30,7 @@ def test_should_create_heap_config_when_post(
     assert HeapConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_return_400_when_duplicate_heap_config_is_posted(
+def test_should_return_400_when_duplicate_heap_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -56,7 +56,7 @@ def test_should_return_400_when_duplicate_heap_config_is_posted(
     assert HeapConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -85,7 +85,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_heap_config_list_when_requested(
+def test_should_return_heap_config_list_when_requested(  # noqa: FT003,FT004
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -106,7 +106,7 @@ def test_should_return_heap_config_list_when_requested(
     assert response.data == [expected_response]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -27,7 +27,7 @@ from segments.models import Condition, Segment, SegmentRule
 from users.models import FFAdminUser
 
 
-def test_create_import_request__return_expected(
+def test_create_import_request__return_expected(  # noqa: FT003
     ld_client_mock: MagicMock,
     ld_client_class_mock: MagicMock,
     project: Project,
@@ -259,7 +259,7 @@ def test_process_import_request__success__expected_status(  # type: ignore[no-un
     [tag.label for tag in tagged_feature.tags.all()] == ["testtag", "testtag2"]
 
 
-def test_process_import_request__segments_imported(  # type: ignore[no-untyped-def]
+def test_process_import_request__segments_imported(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project: Project,
     import_request: LaunchDarklyImportRequest,
 ):
@@ -459,7 +459,7 @@ def test_process_import_request__segments_imported(  # type: ignore[no-untyped-d
         assert trait_value == identity.identifier
 
 
-def test_process_import_request__rules_imported(  # type: ignore[no-untyped-def]
+def test_process_import_request__rules_imported(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     project: Project,
     import_request: LaunchDarklyImportRequest,
 ):
@@ -632,7 +632,7 @@ def test_process_import_request__large_segments__correctly_imported(
         (True, "True"),
     ],
 )
-def test_serialize_variation_value__return_expected(
+def test_serialize_variation_value__return_expected(  # noqa: FT003,FT004
     value: object,
     expected: str,
 ) -> None:

--- a/api/tests/unit/integrations/launch_darkly/test_views.py
+++ b/api/tests/unit/integrations/launch_darkly/test_views.py
@@ -10,7 +10,7 @@ from projects.models import Project
 from users.models import FFAdminUser
 
 
-def test_launch_darkly_import_request_view__list__wrong_project__return_expected(
+def test_launch_darkly_import_request_view__list__wrong_project__return_expected(  # noqa: FT003
     import_request: LaunchDarklyImportRequest,
     project: Project,
     api_client: APIClient,
@@ -103,7 +103,7 @@ def test_launch_darkly_import_request_view__create__return_expected(
     }
 
 
-def test_launch_darkly_import_request_view__create__existing_unfinished__return_expected(
+def test_launch_darkly_import_request_view__create__existing_unfinished__return_expected(  # noqa: FT003
     ld_client_class_mock: MagicMock,
     project: Project,
     admin_client: APIClient,
@@ -129,7 +129,7 @@ def test_launch_darkly_import_request_view__create__existing_unfinished__return_
     process_launch_darkly_import_request_mock.assert_not_called()
 
 
-def test_launch_darkly_import_request_view__create__existing_finished__return_expected(
+def test_launch_darkly_import_request_view__create__existing_finished__return_expected(  # noqa: FT003
     ld_client_class_mock: MagicMock,
     project: Project,
     admin_client: APIClient,

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_services.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_services.py
@@ -12,7 +12,7 @@ from integrations.lead_tracking.hubspot.services import (
 @pytest.mark.parametrize(
     "hubspot_cookie, expected_hubspot_cookie", [("", False), ("test_cookie", True)]
 )
-def test_create_self_hosted_onboarding_lead_with_existing_company(
+def test_create_self_hosted_onboarding_lead_with_existing_company(  # noqa: FT003
     mocker: MockerFixture,
     hubspot_cookie: str,
     expected_hubspot_cookie: bool,

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
@@ -42,7 +42,7 @@ def hubspot_client(mocker: MockerFixture) -> HubspotClient:
         (None, {}),
     ],
 )
-def test_create_lead_form(
+def test_create_lead_form(  # noqa: FT003
     staff_user: FFAdminUser,
     hubspot_client: HubspotClient,
     hubspot_cookie_body: str | None,
@@ -117,7 +117,7 @@ def test_create_lead_form(
 
 
 @responses.activate
-def test_create_lead_form_error(
+def test_create_lead_form_error(  # noqa: FT003
     staff_user: FFAdminUser,
     hubspot_client: HubspotClient,
     inspecting_handler: logging.Handler,
@@ -148,7 +148,7 @@ def test_create_lead_form_error(
     ]
 
 
-def test_get_company_by_domain(hubspot_client: HubspotClient) -> None:
+def test_get_company_by_domain(hubspot_client: HubspotClient) -> None:  # noqa: FT003
     # Given
     name = "Flagsmith"
     domain = "flagsmith.com"
@@ -178,7 +178,7 @@ def test_get_company_by_domain(hubspot_client: HubspotClient) -> None:
     assert applied_filters[0]["operator"] == "EQ"
 
 
-def test_get_company_by_domain_no_results(hubspot_client: HubspotClient) -> None:
+def test_get_company_by_domain_no_results(hubspot_client: HubspotClient) -> None:  # noqa: FT003
     # Given
     hubspot_response = generate_get_company_by_domain_response_no_results()
 
@@ -193,7 +193,7 @@ def test_get_company_by_domain_no_results(hubspot_client: HubspotClient) -> None
     assert company is None
 
 
-def test_create_company_without_organisation_information(
+def test_create_company_without_organisation_information(  # noqa: FT003
     hubspot_client: HubspotClient,
 ) -> None:
     # Given
@@ -217,7 +217,7 @@ def test_create_company_without_organisation_information(
     }
 
 
-def test_associate_contact_to_company_succeeds(hubspot_client: HubspotClient) -> None:
+def test_associate_contact_to_company_succeeds(hubspot_client: HubspotClient) -> None:  # noqa: FT003
     # Given
     company_id = "456"
     contact_id = "123"
@@ -274,7 +274,7 @@ def test_associate_contact_to_company_succeeds(hubspot_client: HubspotClient) ->
         ),
     ],
 )
-def test_update_company_calls_hubspot_api(
+def test_update_company_calls_hubspot_api(  # noqa: FT003
     hubspot_client: HubspotClient,
     kwargs: dict[str, typing.Any],
     expected_properties: dict[str, typing.Any],

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -60,7 +60,7 @@ def mock_client_existing_contact(mocker: MockerFixture) -> MagicMock:
 
 
 @responses.activate
-def test_create_hubspot_contact_with_lead_form_and_get_hubspot_id(
+def test_create_hubspot_contact_with_lead_form_and_get_hubspot_id(  # noqa: FT003
     db: None,
     settings: SettingsWrapper,
     mocker: MockerFixture,
@@ -95,7 +95,7 @@ def test_create_hubspot_contact_with_lead_form_and_get_hubspot_id(
     assert hubspot_id == HUBSPOT_USER_ID
 
 
-def test_create_organisation_lead_skips_all_tracking_when_lead_exists(
+def test_create_organisation_lead_skips_all_tracking_when_lead_exists(  # noqa: FT003,FT004
     db: None,
     organisation: Organisation,
     mock_client_existing_contact: MagicMock,
@@ -120,7 +120,7 @@ def test_create_organisation_lead_skips_all_tracking_when_lead_exists(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47+00:00")
-def test_hubspot_user_org_hook_creates_hubspot_user_and_organisation_associations(
+def test_hubspot_user_org_hook_creates_hubspot_user_and_organisation_associations(  # noqa: FT003
     organisation: Organisation,
     enable_hubspot: None,
     mock_client_existing_contact: MagicMock,
@@ -176,7 +176,7 @@ def test_hubspot_user_org_hook_creates_hubspot_user_and_organisation_association
     mock_client_existing_contact.get_contact.assert_called_once_with(user)
 
 
-def test_create_organisation_lead_creates_contact_when_not_found_but_not_company(
+def test_create_organisation_lead_creates_contact_when_not_found_but_not_company(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -215,7 +215,7 @@ def test_create_organisation_lead_creates_contact_when_not_found_but_not_company
     mock_client.associate_contact_to_company.assert_not_called()
 
 
-def test_create_organisation_lead_creates_contact_for_existing_org(
+def test_create_organisation_lead_creates_contact_for_existing_org(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -256,7 +256,7 @@ def test_create_organisation_lead_creates_contact_for_existing_org(
     )
 
 
-def test_create_organisation_lead_skips_company_for_filtered_domain(
+def test_create_organisation_lead_skips_company_for_filtered_domain(  # noqa: FT003
     organisation: Organisation,
     settings: SettingsWrapper,
     mock_client_existing_contact: MagicMock,
@@ -284,7 +284,7 @@ def test_create_organisation_lead_skips_company_for_filtered_domain(
     mock_client_existing_contact.associate_contact_to_company.assert_not_called()
 
 
-def test_update_company_active_subscription_calls_update_company(
+def test_update_company_active_subscription_calls_update_company(  # noqa: FT003
     db: None, mocker: MockerFixture
 ) -> None:
     # Given
@@ -313,7 +313,7 @@ def test_update_company_active_subscription_calls_update_company(
     )
 
 
-def test_update_company_active_subscription_returns_none_when_no_hubspot_org(
+def test_update_company_active_subscription_returns_none_when_no_hubspot_org(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -330,7 +330,7 @@ def test_update_company_active_subscription_returns_none_when_no_hubspot_org(
     assert result is None
 
 
-def test_update_company_active_subscription_returns_none_when_no_plan(
+def test_update_company_active_subscription_returns_none_when_no_plan(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -356,7 +356,7 @@ def test_update_company_active_subscription_returns_none_when_no_plan(
         ([None, None, None, None, None, None, None, None], 4, None, False),
     ],
 )
-def test_create_user_hubspot_contact_retries(
+def test_create_user_hubspot_contact_retries(  # noqa: FT003
     db: None,
     mocker: MockerFixture,
     get_contact_return_values: list[dict[str, typing.Any] | None],
@@ -394,7 +394,7 @@ def test_create_user_hubspot_contact_retries(
         ("contact_123", None),
     ],
 )
-def test_create_leads_skips_association_on_missing_ids(
+def test_create_leads_skips_association_on_missing_ids(  # noqa: FT003
     mocker: MockerFixture,
     hubspot_contact_id: str | None,
     hubspot_org_id: str | None,
@@ -419,7 +419,7 @@ def test_create_leads_skips_association_on_missing_ids(
     mock_client.associate_contact_to_company.assert_not_called()
 
 
-def test_register_hubspot_tracker_and_track_user_fallback_to_request_user(
+def test_register_hubspot_tracker_and_track_user_fallback_to_request_user(  # noqa: FT003
     mocker: MockerFixture, staff_user: FFAdminUser, settings: SettingsWrapper
 ) -> None:
     # Given

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_tasks.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_tasks.py
@@ -11,7 +11,7 @@ from organisations.models import Organisation
 from users.models import FFAdminUser
 
 
-def test_create_hubspot_contact_for_user_skips_when_tracking_disabled(
+def test_create_hubspot_contact_for_user_skips_when_tracking_disabled(  # noqa: FT003
     settings: SettingsWrapper,
     admin_user: FFAdminUser,
     mocker: MockerFixture,
@@ -24,7 +24,7 @@ def test_create_hubspot_contact_for_user_skips_when_tracking_disabled(
         create_hubspot_contact_for_user(user_id=admin_user.id)
 
 
-def test_create_hubspot_contact_for_user_skips_when_should_track_false(
+def test_create_hubspot_contact_for_user_skips_when_should_track_false(  # noqa: FT003
     settings: SettingsWrapper,
     admin_user: FFAdminUser,
     mocker: MockerFixture,
@@ -46,7 +46,7 @@ def test_create_hubspot_contact_for_user_skips_when_should_track_false(
     mock_create_contact.assert_not_called()
 
 
-def test_track_hubspot_lead_skips_when_tracking_disabled(
+def test_track_hubspot_lead_skips_when_tracking_disabled(  # noqa: FT003
     settings: SettingsWrapper,
     admin_user: FFAdminUser,
     mocker: MockerFixture,
@@ -59,7 +59,7 @@ def test_track_hubspot_lead_skips_when_tracking_disabled(
         track_hubspot_lead_v2(user_id=admin_user.id, organisation_id=1)
 
 
-def test_track_hubspot_lead_skips_when_should_track_false(
+def test_track_hubspot_lead_skips_when_should_track_false(  # noqa: FT003
     settings: SettingsWrapper,
     admin_user: FFAdminUser,
     mocker: MockerFixture,
@@ -81,7 +81,7 @@ def test_track_hubspot_lead_skips_when_should_track_false(
     mock_create_lead.assert_not_called()
 
 
-def test_update_hubspot_active_subscription_skips_when_tracking_disabled(
+def test_update_hubspot_active_subscription_skips_when_tracking_disabled(  # noqa: FT003
     settings: SettingsWrapper,
     admin_user: FFAdminUser,
     mocker: MockerFixture,
@@ -94,7 +94,7 @@ def test_update_hubspot_active_subscription_skips_when_tracking_disabled(
         update_hubspot_active_subscription(subscription_id=1)
 
 
-def test_update_hubspot_active_subscription_is_triggered_when_tracking_enabled(
+def test_update_hubspot_active_subscription_is_triggered_when_tracking_enabled(  # noqa: FT003
     db: None,
     settings: SettingsWrapper,
     organisation: Organisation,

--- a/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
+++ b/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from projects.models import Project
 
 
-def test_mixpanel_initialized_correctly() -> None:
+def test_mixpanel_initialized_correctly() -> None:  # noqa: FT003
     # Given
     config = MixpanelConfiguration(api_key="123key")
 
@@ -26,7 +26,7 @@ def test_mixpanel_initialized_correctly() -> None:
     assert mixpanel.api_key == config.api_key
 
 
-def test_mixpanel_identity_user__calls_expected(
+def test_mixpanel_identity_user__calls_expected(  # noqa: FT003
     mocker: "MockerFixture",
     caplog: "LogCaptureFixture",
     feature: "Feature",
@@ -70,7 +70,7 @@ def test_mixpanel_identity_user__calls_expected(
     ]
 
 
-def test_mixpanel_generate_user_data(
+def test_mixpanel_generate_user_data(  # noqa: FT003
     project: "Project",
     feature: "Feature",
     identity: "Identity",

--- a/api/tests/unit/integrations/mixpanel/test_unit_mixpanel_views.py
+++ b/api/tests/unit/integrations/mixpanel/test_unit_mixpanel_views.py
@@ -8,7 +8,7 @@ from environments.models import Environment
 from integrations.mixpanel.models import MixpanelConfiguration
 
 
-def test_should_create_mixpanel_config_when_post(  # type: ignore[no-untyped-def]
+def test_should_create_mixpanel_config_when_post(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ):
@@ -31,7 +31,7 @@ def test_should_create_mixpanel_config_when_post(  # type: ignore[no-untyped-def
     assert MixpanelConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_return_400_when_duplicate_mixpanel_config_is_posted(
+def test_should_return_400_when_duplicate_mixpanel_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -57,7 +57,7 @@ def test_should_return_400_when_duplicate_mixpanel_config_is_posted(
     assert MixpanelConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -86,7 +86,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_mixpanel_config_list_when_requested(
+def test_should_return_mixpanel_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -108,7 +108,7 @@ def test_should_return_mixpanel_config_list_when_requested(
     assert response.data == [expected_response]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/integrations/new_relic/test_unit_new_relic.py
+++ b/api/tests/unit/integrations/new_relic/test_unit_new_relic.py
@@ -3,7 +3,7 @@ from environments.models import Environment
 from integrations.new_relic.new_relic import EVENTS_API_URI, NewRelicWrapper
 
 
-def test_new_relic_initialized_correctly():  # type: ignore[no-untyped-def]
+def test_new_relic_initialized_correctly():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_key = "123key"
     app_id = "123id"
@@ -17,7 +17,7 @@ def test_new_relic_initialized_correctly():  # type: ignore[no-untyped-def]
     assert new_relic.url == expected_url
 
 
-def test_new_relic_when_generate_event_data_with_correct_values_then_success(  # type: ignore[no-untyped-def]
+def test_new_relic_when_generate_event_data_with_correct_values_then_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     django_user_model,
 ):
     # Given
@@ -44,7 +44,7 @@ def test_new_relic_when_generate_event_data_with_correct_values_then_success(  #
     assert event_deployment_data["changelog"] == expected_event_text  # type: ignore[index]
 
 
-def test_new_relic_when_generate_event_data_with_missing_author_then_success():  # type: ignore[no-untyped-def]
+def test_new_relic_when_generate_event_data_with_missing_author_then_success():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     log = "some log data"
 
@@ -69,7 +69,7 @@ def test_new_relic_when_generate_event_data_with_missing_author_then_success(): 
     assert event_deployment_data["changelog"] == expected_event_text  # type: ignore[index]
 
 
-def test_new_relic_when_generate_event_data_with_missing_env_then_success(  # type: ignore[no-untyped-def]
+def test_new_relic_when_generate_event_data_with_missing_env_then_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     django_user_model,
 ):
     # Given

--- a/api/tests/unit/integrations/new_relic/test_unit_new_relic_views.py
+++ b/api/tests/unit/integrations/new_relic/test_unit_new_relic_views.py
@@ -8,7 +8,7 @@ from integrations.new_relic.models import NewRelicConfiguration
 from projects.models import Project
 
 
-def test_should_create_new_relic_config_when_post(
+def test_should_create_new_relic_config_when_post(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -31,7 +31,7 @@ def test_should_create_new_relic_config_when_post(
     assert NewRelicConfiguration.objects.filter(project=project).count() == 1
 
 
-def test_should_return_400_when_duplicate_new_relic_config_is_posted(
+def test_should_return_400_when_duplicate_new_relic_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -62,7 +62,7 @@ def test_should_return_400_when_duplicate_new_relic_config_is_posted(
     assert NewRelicConfiguration.objects.filter(project=project).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -100,7 +100,7 @@ def test_should_update_configuration_when_put(
     assert config.app_id == app_id_updated
 
 
-def test_should_return_new_relic_config_list_when_requested(
+def test_should_return_new_relic_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -128,7 +128,7 @@ def test_should_return_new_relic_config_list_when_requested(
     ]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -151,7 +151,7 @@ def test_should_remove_configuration_when_delete(
     assert not NewRelicConfiguration.objects.filter(project=project).exists()
 
 
-def test_create_newrelic_configuration_in_project_with_deleted_configuration(  # type: ignore[no-untyped-def]
+def test_create_newrelic_configuration_in_project_with_deleted_configuration(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, deleted_newrelic_configuration
 ):
     # Given

--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
@@ -5,7 +5,7 @@ from integrations.rudderstack.models import RudderstackConfiguration
 from integrations.rudderstack.rudderstack import RudderstackWrapper
 
 
-def test_rudderstack_wrapper_generate_user_data(  # type: ignore[no-untyped-def]
+def test_rudderstack_wrapper_generate_user_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment,
     feature: Feature,
 ):

--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack_views.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack_views.py
@@ -8,7 +8,7 @@ from environments.models import Environment
 from integrations.rudderstack.models import RudderstackConfiguration
 
 
-def test_should_create_rudderstack_config_when_post(
+def test_should_create_rudderstack_config_when_post(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -32,7 +32,7 @@ def test_should_create_rudderstack_config_when_post(
     assert RudderstackConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_return_400_when_duplicate_rudderstack_config_is_posted(
+def test_should_return_400_when_duplicate_rudderstack_config_is_posted(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -59,7 +59,7 @@ def test_should_return_400_when_duplicate_rudderstack_config_is_posted(
     assert RudderstackConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -88,7 +88,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_rudderstack_config_list_when_requested(
+def test_should_return_rudderstack_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -116,7 +116,7 @@ def test_should_return_rudderstack_config_list_when_requested(
     ]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/integrations/segment/test_unit_segment.py
+++ b/api/tests/unit/integrations/segment/test_unit_segment.py
@@ -9,7 +9,7 @@ from integrations.segment.models import SegmentConfiguration
 from integrations.segment.segment import SegmentWrapper
 
 
-def test_segment_initialized_correctly():  # type: ignore[no-untyped-def]
+def test_segment_initialized_correctly():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_key = "123key"
     base_url = "https://api.segment.io/"
@@ -29,7 +29,7 @@ def test_segment_initialized_correctly():  # type: ignore[no-untyped-def]
     [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
     indirect=["feature_state_with_value"],
 )
-def test_segment_when_generate_user_data_with_correct_values_then_success(
+def test_segment_when_generate_user_data_with_correct_values_then_success(  # noqa: FT003
     expected_property_value: typing.Any,
     environment: Environment,
     feature_state: FeatureState,

--- a/api/tests/unit/integrations/segment/test_unit_segment_views.py
+++ b/api/tests/unit/integrations/segment/test_unit_segment_views.py
@@ -9,7 +9,7 @@ from integrations.segment.constants import DEFAULT_BASE_URL
 from integrations.segment.models import SegmentConfiguration
 
 
-def test_should_create_segment_config_when_post(
+def test_should_create_segment_config_when_post(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
 ) -> None:
@@ -37,7 +37,7 @@ def test_should_create_segment_config_when_post(
     assert segment_configuration.base_url == DEFAULT_BASE_URL
 
 
-def test_should_return_400_when_duplicate_segment_config_is_posted(
+def test_should_return_400_when_duplicate_segment_config_is_posted(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
 ) -> None:
@@ -63,7 +63,7 @@ def test_should_return_400_when_duplicate_segment_config_is_posted(
     assert SegmentConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(
+def test_should_update_configuration_when_put(  # noqa: FT003
     environment: Environment,
     admin_client: APIClient,
 ) -> None:
@@ -92,7 +92,7 @@ def test_should_update_configuration_when_put(
     assert config.api_key == api_key_updated
 
 
-def test_should_return_segment_config_list_when_requested(
+def test_should_return_segment_config_list_when_requested(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -114,7 +114,7 @@ def test_should_return_segment_config_list_when_requested(
     assert response.data == [expected_response]
 
 
-def test_should_remove_configuration_when_delete(
+def test_should_remove_configuration_when_delete(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/integrations/sentry/test_unit_sentry_middleware.py
+++ b/api/tests/unit/integrations/sentry/test_unit_sentry_middleware.py
@@ -1,7 +1,7 @@
 from integrations.sentry.middleware import ForceSentryTraceMiddleware
 
 
-def test_force_sentry_trace_middleware_starts_transaction_when_param_present(  # type: ignore[no-untyped-def]
+def test_force_sentry_trace_middleware_starts_transaction_when_param_present(  # type: ignore[no-untyped-def]  # noqa: FT003
     rf, mocker, settings
 ):
     # Given
@@ -30,7 +30,7 @@ def test_force_sentry_trace_middleware_starts_transaction_when_param_present(  #
     assert response == mock_response
 
 
-def test_force_sentry_trace_middleware_does_nothing_when_key_incorrect(  # type: ignore[no-untyped-def]
+def test_force_sentry_trace_middleware_does_nothing_when_key_incorrect(  # type: ignore[no-untyped-def]  # noqa: FT003
     rf, mocker, settings
 ):
     # Given
@@ -53,7 +53,7 @@ def test_force_sentry_trace_middleware_does_nothing_when_key_incorrect(  # type:
     assert response == mock_response
 
 
-def test_force_sentry_trace_middleware_does_nothing_when_key_missing(  # type: ignore[no-untyped-def]
+def test_force_sentry_trace_middleware_does_nothing_when_key_missing(  # type: ignore[no-untyped-def]  # noqa: FT003
     rf, mocker, settings
 ):
     # Given

--- a/api/tests/unit/integrations/sentry/test_unit_sentry_sampler.py
+++ b/api/tests/unit/integrations/sentry/test_unit_sentry_sampler.py
@@ -7,7 +7,7 @@ SAMPLE_RATE = 0.5
 
 
 @override_settings(DEFAULT_SENTRY_TRACE_SAMPLE_RATE=SAMPLE_RATE)
-def test_traces_sampler_empty_context_returns_default_sample_rate():  # type: ignore[no-untyped-def]
+def test_traces_sampler_empty_context_returns_default_sample_rate():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     sample_rate = traces_sampler({})  # type: ignore[no-untyped-call]
 
@@ -16,7 +16,7 @@ def test_traces_sampler_empty_context_returns_default_sample_rate():  # type: ig
 
 
 @override_settings(DEFAULT_SENTRY_TRACE_SAMPLE_RATE=SAMPLE_RATE)
-def test_traces_sampler_returns_0_for_health_check_transaction():  # type: ignore[no-untyped-def]
+def test_traces_sampler_returns_0_for_health_check_transaction():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     ctx = {"wsgi_environ": {"PATH_INFO": "/health"}}
 
@@ -28,7 +28,7 @@ def test_traces_sampler_returns_0_for_health_check_transaction():  # type: ignor
 
 
 @override_settings(DEFAULT_SENTRY_TRACE_SAMPLE_RATE=SAMPLE_RATE)
-def test_traces_sampler_returns_0_for_home_page_transaction():  # type: ignore[no-untyped-def]
+def test_traces_sampler_returns_0_for_home_page_transaction():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     ctx = {"wsgi_environ": {"PATH_INFO": "/"}}
 
@@ -40,7 +40,7 @@ def test_traces_sampler_returns_0_for_home_page_transaction():  # type: ignore[n
 
 
 @override_settings(DASHBOARD_ENDPOINTS_SENTRY_TRACE_SAMPLE_RATE=SAMPLE_RATE)
-def test_traces_sampler_returns_dashboard_sample_rate_for_dashboard_request():  # type: ignore[no-untyped-def]
+def test_traces_sampler_returns_dashboard_sample_rate_for_dashboard_request():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     ctx = {"wsgi_environ": {"PATH_INFO": "/api/v1/environments/"}}
 
@@ -63,7 +63,7 @@ def test_traces_sampler_returns_dashboard_sample_rate_for_dashboard_request():  
     ),
 )
 @override_settings(DEFAULT_SENTRY_TRACE_SAMPLE_RATE=SAMPLE_RATE)
-def test_traces_sampler_returns_sample_rate_for_sdk_request(path_info):  # type: ignore[no-untyped-def]
+def test_traces_sampler_returns_sample_rate_for_sdk_request(path_info):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     ctx = {"wsgi_environ": {"PATH_INFO": path_info}}
 

--- a/api/tests/unit/integrations/sentry/test_unit_sentry_views.py
+++ b/api/tests/unit/integrations/sentry/test_unit_sentry_views.py
@@ -7,7 +7,7 @@ from environments.models import Environment
 from integrations.sentry.models import SentryChangeTrackingConfiguration
 
 
-def test_sentry__change_tracking__setup__accepts_new_configuration(
+def test_sentry__change_tracking__setup__accepts_new_configuration(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
 ) -> None:
@@ -85,7 +85,7 @@ def test_sentry__change_tracking__setup__accepts_new_configuration(
         ),
     ],
 )
-def test_sentry__change_tracking__setup__rejects_invalid_configuration(
+def test_sentry__change_tracking__setup__rejects_invalid_configuration(  # noqa: FT003
     admin_client: APIClient,
     environment: Environment,
     errors: Any,

--- a/api/tests/unit/integrations/slack/test_unit_slack.py
+++ b/api/tests/unit/integrations/slack/test_unit_slack.py
@@ -7,7 +7,7 @@ from integrations.slack.exceptions import SlackChannelJoinError
 from integrations.slack.slack import SlackChannel, SlackWrapper
 
 
-def test_get_channels_data_response_structure(mocker, mocked_slack_internal_client):  # type: ignore[no-untyped-def]
+def test_get_channels_data_response_structure(mocker, mocked_slack_internal_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_token = "test_token"
     cursor = "dGVhbTpDMDI3MEpNRldNVg=="
@@ -47,7 +47,7 @@ def test_get_channels_data_response_structure(mocker, mocked_slack_internal_clie
     )
 
 
-def test_client_makes_correct_calls(mocker):  # type: ignore[no-untyped-def]
+def test_client_makes_correct_calls(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_token = "random_token"
 
@@ -61,7 +61,7 @@ def test_client_makes_correct_calls(mocker):  # type: ignore[no-untyped-def]
     mocked_web_client.assert_called_with(token=api_token)
 
 
-def test_join_channel_makes_correct_call(mocker, mocked_slack_internal_client):  # type: ignore[no-untyped-def]
+def test_join_channel_makes_correct_call(mocker, mocked_slack_internal_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     channel = "channel_1"
     api_token = "random_token"
@@ -73,7 +73,7 @@ def test_join_channel_makes_correct_call(mocker, mocked_slack_internal_client): 
     mocked_slack_internal_client.conversations_join.assert_called_with(channel=channel)
 
 
-def test_join_channel_raises_slack_channel_join_error_on_slack_api_error(  # type: ignore[no-untyped-def]
+def test_join_channel_raises_slack_channel_join_error_on_slack_api_error(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, mocked_slack_internal_client
 ):
     # Given
@@ -87,7 +87,7 @@ def test_join_channel_raises_slack_channel_join_error_on_slack_api_error(  # typ
         SlackWrapper(api_token=api_token, channel_id=channel).join_channel()  # type: ignore[no-untyped-call]
 
 
-def test_get_bot_token_makes_correct_calls(  # type: ignore[no-untyped-def]
+def test_get_bot_token_makes_correct_calls(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, settings, mocked_slack_internal_client
 ):
     # Given
@@ -114,7 +114,7 @@ def test_get_bot_token_makes_correct_calls(  # type: ignore[no-untyped-def]
     )
 
 
-def test_slack_initialized_correctly(mocker, mocked_slack_internal_client):  # type: ignore[no-untyped-def]
+def test_slack_initialized_correctly(mocker, mocked_slack_internal_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_token = "test_token"
     channel_id = "channel_id_1"
@@ -127,7 +127,7 @@ def test_slack_initialized_correctly(mocker, mocked_slack_internal_client):  # t
     assert slack_wrapper._client == mocked_slack_internal_client
 
 
-def test_track_event_makes_correct_call(mocked_slack_internal_client):  # type: ignore[no-untyped-def]
+def test_track_event_makes_correct_call(mocked_slack_internal_client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     api_token = "test_token"
     channel_id = "channel_id_1"
@@ -144,7 +144,7 @@ def test_track_event_makes_correct_call(mocked_slack_internal_client):  # type: 
     )
 
 
-def test_slack_generate_event_data_with_correct_values(django_user_model):  # type: ignore[no-untyped-def]
+def test_slack_generate_event_data_with_correct_values(django_user_model):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     log = "some log data"
 

--- a/api/tests/unit/integrations/slack/test_unit_slack_authentication.py
+++ b/api/tests/unit/integrations/slack/test_unit_slack_authentication.py
@@ -7,7 +7,7 @@ from integrations.slack.authentication import OauthInitAuthentication
 oauth_init_authentication = OauthInitAuthentication()
 
 
-def test_oauth_init_authentication_failes_if_invalid_signature_is_passed(rf):  # type: ignore[no-untyped-def]
+def test_oauth_init_authentication_failes_if_invalid_signature_is_passed(rf):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     request = rf.get("/url", {"signature": "invalid_signature"})
     # Then
@@ -15,7 +15,7 @@ def test_oauth_init_authentication_failes_if_invalid_signature_is_passed(rf):  #
         oauth_init_authentication.authenticate(request)  # type: ignore[no-untyped-call]
 
 
-def test_oauth_init_authentication_with_valid_signature(django_user_model, rf):  # type: ignore[no-untyped-def]
+def test_oauth_init_authentication_with_valid_signature(django_user_model, rf):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     signer = TimestampSigner()
     user = django_user_model.objects.create(username="test_user")
@@ -24,7 +24,7 @@ def test_oauth_init_authentication_with_valid_signature(django_user_model, rf): 
     oauth_init_authentication.authenticate(request)  # type: ignore[no-untyped-call]
 
 
-def test_oauth_init_authentication_failes_with_correct_error_if_no_signature_is_passed(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_oauth_init_authentication_failes_with_correct_error_if_no_signature_is_passed(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     rf,
 ):
     # Given

--- a/api/tests/unit/integrations/slack/test_unit_slack_permissions.py
+++ b/api/tests/unit/integrations/slack/test_unit_slack_permissions.py
@@ -10,7 +10,7 @@ from users.models import FFAdminUser
 mock_view = mock.MagicMock()
 
 
-def test_oauth_init_permission_with_non_environment_admin_user(  # type: ignore[no-untyped-def]
+def test_oauth_init_permission_with_non_environment_admin_user(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, django_user_model, rf
 ):
     # Given
@@ -25,7 +25,7 @@ def test_oauth_init_permission_with_non_environment_admin_user(  # type: ignore[
     assert oauth_init_permission.has_permission(mock_request, mock_view) is False  # type: ignore[no-untyped-call]
 
 
-def test_oauth_init_permission_with_environment_admin_user(
+def test_oauth_init_permission_with_environment_admin_user(  # noqa: FT003
     environment: Environment, staff_user: FFAdminUser, rf: RequestFactory
 ) -> None:
     # Given

--- a/api/tests/unit/integrations/test_unit_integration.py
+++ b/api/tests/unit/integrations/test_unit_integration.py
@@ -5,7 +5,7 @@ from integrations.integration import identify_integrations
 from integrations.segment.models import SegmentConfiguration
 
 
-def test_identify_integrations_amplitude_called(mocker, environment, identity):  # type: ignore[no-untyped-def]
+def test_identify_integrations_amplitude_called(mocker, environment, identity):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_amplitude_wrapper = mocker.patch(
         "integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async"
@@ -19,7 +19,7 @@ def test_identify_integrations_amplitude_called(mocker, environment, identity): 
     mock_amplitude_wrapper.assert_called()
 
 
-def test_identify_integrations_segment_called(mocker, environment, identity):  # type: ignore[no-untyped-def]
+def test_identify_integrations_segment_called(mocker, environment, identity):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_segment_wrapper = mocker.patch(
         "integrations.segment.segment.SegmentWrapper.identify_user_async"
@@ -32,7 +32,7 @@ def test_identify_integrations_segment_called(mocker, environment, identity):  #
     mock_segment_wrapper.assert_called()
 
 
-def test_identify_integrations_calls_every_integration_in_identity_integrations_dict(  # type: ignore[no-untyped-def]
+def test_identify_integrations_calls_every_integration_in_identity_integrations_dict(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, identity
 ):
     # Given
@@ -99,7 +99,7 @@ def test_identify_integrations_calls_every_integration_in_identity_integrations_
     )
 
 
-def test_identify_integrations_does_not_call_deleted_integrations(  # type: ignore[no-untyped-def]
+def test_identify_integrations_does_not_call_deleted_integrations(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, environment, identity
 ):
     # Given

--- a/api/tests/unit/integrations/webhook/test_unit_webhook.py
+++ b/api/tests/unit/integrations/webhook/test_unit_webhook.py
@@ -10,7 +10,7 @@ from integrations.webhook.webhook import WebhookWrapper
 from segments.models import Segment
 
 
-def test_webhook_generate_user_data_generates_correct_data(  # type: ignore[no-untyped-def]
+def test_webhook_generate_user_data_generates_correct_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     integration_webhook_config, project, identity
 ):
     # Given
@@ -49,7 +49,7 @@ def test_webhook_generate_user_data_generates_correct_data(  # type: ignore[no-u
     assert expected_data == user_data
 
 
-def test_webhook_wrapper_generate_user_data_uses_trait_models_argument_when_provided(  # type: ignore[no-untyped-def]
+def test_webhook_wrapper_generate_user_data_uses_trait_models_argument_when_provided(  # type: ignore[no-untyped-def]  # noqa: FT003
     identity, project, integration_webhook_config
 ):
     # Given

--- a/api/tests/unit/integrations/webhook/test_unit_webhook_serializers.py
+++ b/api/tests/unit/integrations/webhook/test_unit_webhook_serializers.py
@@ -5,7 +5,7 @@ from integrations.webhook.serializers import (
 )
 
 
-def test_integration_feature_state_serializer_environment_weight_is_correct(  # type: ignore[no-untyped-def]
+def test_integration_feature_state_serializer_environment_weight_is_correct(  # type: ignore[no-untyped-def]  # noqa: FT003
     identity, multivariate_feature, mocker
 ):
     # Given
@@ -26,7 +26,7 @@ def test_integration_feature_state_serializer_environment_weight_is_correct(  # 
     assert data["feature_state_value"] == mv_option.value
 
 
-def test_segment_serializer_member_is_correct(  # type: ignore[no-untyped-def]
+def test_segment_serializer_member_is_correct(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     identity, trait, identity_matching_segment
 ):
     # When

--- a/api/tests/unit/integrations/webhook/test_unit_webhook_views.py
+++ b/api/tests/unit/integrations/webhook/test_unit_webhook_views.py
@@ -8,7 +8,7 @@ from integrations.webhook.models import WebhookConfiguration
 valid_webhook_url = "http://my.webhook.com/webhooks"
 
 
-def test_should_create_webhook_config_when_post(  # type: ignore[no-untyped-def]
+def test_should_create_webhook_config_when_post(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, environment
 ):
     # Given
@@ -31,7 +31,7 @@ def test_should_create_webhook_config_when_post(  # type: ignore[no-untyped-def]
     assert WebhookConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_return_BadRequest_when_duplicate_webhook_config_is_posted(  # type: ignore[no-untyped-def]
+def test_should_return_BadRequest_when_duplicate_webhook_config_is_posted(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, environment
 ):
     # Given
@@ -56,7 +56,7 @@ def test_should_return_BadRequest_when_duplicate_webhook_config_is_posted(  # ty
     assert WebhookConfiguration.objects.filter(environment=environment).count() == 1
 
 
-def test_should_update_configuration_when_put(admin_client, organisation, environment):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_should_update_configuration_when_put(admin_client, organisation, environment):  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     config = WebhookConfiguration.objects.create(
         url=valid_webhook_url,
@@ -81,7 +81,7 @@ def test_should_update_configuration_when_put(admin_client, organisation, enviro
     assert config.url == new_url
 
 
-def test_should_return_webhook_config_list_when_requested(  # type: ignore[no-untyped-def]
+def test_should_return_webhook_config_list_when_requested(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, environment
 ):
     # Given
@@ -96,7 +96,7 @@ def test_should_return_webhook_config_list_when_requested(  # type: ignore[no-un
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_should_remove_configuration_when_delete(  # type: ignore[no-untyped-def]
+def test_should_remove_configuration_when_delete(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, environment
 ):
     # Given

--- a/api/tests/unit/metadata/test_serializers.py
+++ b/api/tests/unit/metadata/test_serializers.py
@@ -38,7 +38,7 @@ from segments.models import Segment
         ("multiline_str", "a valid string", True),
     ],
 )
-def test_metadata_serializer_validate_validates_field_value_type_correctly(
+def test_metadata_serializer_validate_validates_field_value_type_correctly(  # noqa: FT003
     organisation: Organisation,
     environment_content_type: ContentType,
     field_type: str,
@@ -86,7 +86,7 @@ def test_metadata_serializer_validate_validates_field_value_type_correctly(
         ),
     ],
 )
-def test_metadata_model_field_serializer_validation(
+def test_metadata_model_field_serializer_validation(  # noqa: FT003
     a_metadata_field: MetadataField,
     feature_content_type: ContentType,
     project: Project,
@@ -127,7 +127,7 @@ def test_metadata_model_field_serializer_validation(
         assert serializer.errors["non_field_errors"][0] == error_message
 
 
-def test_metadata_model_field_serializer_with_empty_is_required_for(
+def test_metadata_model_field_serializer_with_empty_is_required_for(  # noqa: FT003
     a_metadata_field: MetadataField,
     feature_content_type: ContentType,
 ) -> None:
@@ -144,7 +144,7 @@ def test_metadata_model_field_serializer_with_empty_is_required_for(
     assert result is True
 
 
-def test_metadata_model_field_serializer_validation_invalid_content_type(
+def test_metadata_model_field_serializer_validation_invalid_content_type(  # noqa: FT003
     a_metadata_field: MetadataField,
     feature_content_type: ContentType,
     project: Project,

--- a/api/tests/unit/metadata/test_views.py
+++ b/api/tests/unit/metadata/test_views.py
@@ -18,7 +18,7 @@ from projects.models import Project
 from users.models import FFAdminUser
 
 
-def test_can_create_metadata_field(admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_can_create_metadata_field(admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:metadata:metadata-fields-list")
     field_name = "some_id"
@@ -39,7 +39,7 @@ def test_can_create_metadata_field(admin_client, organisation):  # type: ignore[
     assert response.json()["organisation"] == organisation.id
 
 
-def test_can_delete_metadata_field(admin_client, a_metadata_field):  # type: ignore[no-untyped-def]
+def test_can_delete_metadata_field(admin_client, a_metadata_field):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:metadata:metadata-fields-detail", args=[a_metadata_field.id])
 
@@ -50,7 +50,7 @@ def test_can_delete_metadata_field(admin_client, a_metadata_field):  # type: ign
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_can_update_metadata_field(admin_client, a_metadata_field, organisation):  # type: ignore[no-untyped-def]
+def test_can_update_metadata_field(admin_client, a_metadata_field, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:metadata:metadata-fields-detail", args=[a_metadata_field.id])
 
@@ -74,7 +74,7 @@ def test_can_update_metadata_field(admin_client, a_metadata_field, organisation)
     assert response.json()["type"] == new_field_type
 
 
-def test_list_metadata_fields(admin_client, a_metadata_field):  # type: ignore[no-untyped-def]
+def test_list_metadata_fields(admin_client, a_metadata_field):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     base_url = reverse("api-v1:metadata:metadata-fields-list")
 
@@ -89,7 +89,7 @@ def test_list_metadata_fields(admin_client, a_metadata_field):  # type: ignore[n
     assert response.json()["results"][0]["id"] == a_metadata_field.id
 
 
-def test_list_metadata_fields_without_organisation_returns_400(  # type: ignore[no-untyped-def]
+def test_list_metadata_fields_without_organisation_returns_400(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, a_metadata_field
 ):
     # Given
@@ -102,7 +102,7 @@ def test_list_metadata_fields_without_organisation_returns_400(  # type: ignore[
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_retrieve_metadata_fields(admin_client, a_metadata_field):  # type: ignore[no-untyped-def]
+def test_retrieve_metadata_fields(admin_client, a_metadata_field):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:metadata:metadata-fields-detail", args=[a_metadata_field.id])
 
@@ -114,7 +114,7 @@ def test_retrieve_metadata_fields(admin_client, a_metadata_field):  # type: igno
     assert response.json()["id"] == a_metadata_field.id
 
 
-def test_create_metadata_field_returns_403_for_non_org_admin(  # type: ignore[no-untyped-def]
+def test_create_metadata_field_returns_403_for_non_org_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     staff_client: APIClient,
     organisation: Organisation,
 ):
@@ -133,7 +133,7 @@ def test_create_metadata_field_returns_403_for_non_org_admin(  # type: ignore[no
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_list_model_metadata_fields(  # type: ignore[no-untyped-def]
+def test_list_model_metadata_fields(  # type: ignore[no-untyped-def]  # noqa: FT003
     required_a_environment_metadata_field,
     optional_b_environment_metadata_field,
     admin_client,
@@ -152,7 +152,7 @@ def test_list_model_metadata_fields(  # type: ignore[no-untyped-def]
     assert len(response.json()["results"]) == 2
 
 
-def test_list_model_metadata_fields_content_type_filter(  # type: ignore[no-untyped-def]
+def test_list_model_metadata_fields_content_type_filter(  # type: ignore[no-untyped-def]  # noqa: FT003
     required_a_environment_metadata_field,
     optional_b_environment_metadata_field,
     admin_client,
@@ -181,7 +181,7 @@ def test_list_model_metadata_fields_content_type_filter(  # type: ignore[no-unty
     assert response.json()["results"][0]["id"] == a_metadata_project_field.id
 
 
-def test_delete_model_metadata_field(  # type: ignore[no-untyped-def]
+def test_delete_model_metadata_field(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment,
     admin_client,
     a_metadata_field,
@@ -200,7 +200,7 @@ def test_delete_model_metadata_field(  # type: ignore[no-untyped-def]
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_can_not_delete_model_metadata_field_from_other_organisation(  # type: ignore[no-untyped-def]
+def test_can_not_delete_model_metadata_field_from_other_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment,
     admin_client,
     a_metadata_field,
@@ -220,7 +220,7 @@ def test_can_not_delete_model_metadata_field_from_other_organisation(  # type: i
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_update_model_metadata_field(  # type: ignore[no-untyped-def]
+def test_update_model_metadata_field(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment,
     admin_client,
     a_metadata_field,
@@ -258,7 +258,7 @@ def test_update_model_metadata_field(  # type: ignore[no-untyped-def]
     )
 
 
-def test_can_not_update_model_metadata_field_from_other_organisation(  # type: ignore[no-untyped-def]
+def test_can_not_update_model_metadata_field_from_other_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment, admin_client, environment_metadata_field_different_org, organisation
 ):
     # Given
@@ -278,7 +278,7 @@ def test_can_not_update_model_metadata_field_from_other_organisation(  # type: i
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_create_model_metadata_field_for_environments(
+def test_create_model_metadata_field_for_environments(  # noqa: FT003
     admin_client: APIClient,
     a_metadata_field: MetadataField,
     organisation: Organisation,
@@ -311,7 +311,7 @@ def test_create_model_metadata_field_for_environments(
     }
 
 
-def test_create_model_metadata_field_for_features(
+def test_create_model_metadata_field_for_features(  # noqa: FT003
     admin_client: APIClient,
     a_metadata_field: MetadataField,
     organisation: Organisation,
@@ -344,7 +344,7 @@ def test_create_model_metadata_field_for_features(
     }
 
 
-def test_create_model_metadata_field_for_segments(
+def test_create_model_metadata_field_for_segments(  # noqa: FT003
     admin_client: APIClient,
     a_metadata_field: MetadataField,
     organisation: Organisation,
@@ -377,7 +377,7 @@ def test_create_model_metadata_field_for_segments(
     }
 
 
-def test_can_not_create_model_metadata_field_using_field_from_other_organisation(  # type: ignore[no-untyped-def]
+def test_can_not_create_model_metadata_field_using_field_from_other_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, environment_metadata_field_different_org, organisation, project
 ):
     # Given
@@ -398,7 +398,7 @@ def test_can_not_create_model_metadata_field_using_field_from_other_organisation
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_get_supported_content_type(  # type: ignore[no-untyped-def]
+def test_get_supported_content_type(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient, organisation: Organisation
 ):
     # Given
@@ -425,7 +425,7 @@ def test_get_supported_content_type(  # type: ignore[no-untyped-def]
         assert model in supported_models
 
 
-def test_get_supported_required_for_models(admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_get_supported_required_for_models(admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     base_url = reverse(
         "api-v1:organisations:metadata-model-fields-supported-required-for-models",
@@ -521,7 +521,7 @@ def test_create_metadata_field__project_admin__returns_201(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_list_metadata_fields__returns_org_level_only(
+def test_list_metadata_fields__returns_org_level_only(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     project: Project,
@@ -549,7 +549,7 @@ def test_list_metadata_fields__returns_org_level_only(
     assert returned_ids == {org_field.id}
 
 
-def test_list_metadata_fields__response_includes_nested_model_fields(
+def test_list_metadata_fields__response_includes_nested_model_fields(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     environment_content_type: ContentType,
@@ -592,7 +592,7 @@ def test_list_metadata_fields__response_includes_nested_model_fields(
     ]
 
 
-def test_list_project_metadata_fields__returns_project_fields_only(
+def test_list_project_metadata_fields__returns_project_fields_only(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     project: Project,
@@ -667,7 +667,7 @@ def test_list_project_metadata_fields__include_organisation__project_overrides_o
     assert org_field.id not in returned_ids
 
 
-def test_list_project_metadata_fields__excludes_other_project_fields(
+def test_list_project_metadata_fields__excludes_other_project_fields(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     project: Project,
@@ -707,7 +707,7 @@ def test_list_project_metadata_fields__excludes_other_project_fields(
         "same_name_org_and_project_level",
     ],
 )
-def test_create_metadata_field__uniqueness(
+def test_create_metadata_field__uniqueness(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     project: Project,

--- a/api/tests/unit/metrics/test_unit_metrics_service.py
+++ b/api/tests/unit/metrics/test_unit_metrics_service.py
@@ -10,7 +10,7 @@ from metrics.types import EnvMetricsName
 
 @pytest.mark.parametrize("with_workflows", [True, False])
 @pytest.mark.django_db
-def test_environment_metrics_service_builds_expected_metrics(
+def test_environment_metrics_service_builds_expected_metrics(  # noqa: FT003
     monkeypatch: pytest.MonkeyPatch,
     environment: Environment,
     with_workflows: bool,
@@ -73,7 +73,7 @@ def test_environment_metrics_service_builds_expected_metrics(
 
 @pytest.mark.parametrize("uses_dynamo, expected_value", [(True, 99), (False, 1)])
 @pytest.mark.django_db
-def test_dynamo_identity_metric_used(
+def test_dynamo_identity_metric_used(  # noqa: FT003
     monkeypatch: pytest.MonkeyPatch,
     environment: Environment,
     uses_dynamo: bool,

--- a/api/tests/unit/onboarding/test_views.py
+++ b/api/tests/unit/onboarding/test_views.py
@@ -11,7 +11,7 @@ from organisations.models import Organisation
 from users.models import FFAdminUser
 
 
-def test_send_onboarding_request_to_saas_flagsmith_view_for_non_admin_user(
+def test_send_onboarding_request_to_saas_flagsmith_view_for_non_admin_user(  # noqa: FT003
     staff_client: APIClient, is_oss: MagicMock
 ) -> None:
     # Given
@@ -24,7 +24,7 @@ def test_send_onboarding_request_to_saas_flagsmith_view_for_non_admin_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_send_onboarding_request_to_saas_flagsmith_view_without_org(
+def test_send_onboarding_request_to_saas_flagsmith_view_without_org(  # noqa: FT003
     admin_client_original: APIClient, is_oss: MagicMock
 ) -> None:
     # Given
@@ -41,7 +41,7 @@ def test_send_onboarding_request_to_saas_flagsmith_view_without_org(
     )
 
 
-def test_send_onboarding_request_to_saas_flagsmith_view(
+def test_send_onboarding_request_to_saas_flagsmith_view(  # noqa: FT003
     admin_client_original: APIClient,
     mocker: MockerFixture,
     organisation: Organisation,
@@ -69,7 +69,7 @@ def test_send_onboarding_request_to_saas_flagsmith_view(
     )
 
 
-def test_receive_support_request_from_self_hosted_view_without_hubspot_token(
+def test_receive_support_request_from_self_hosted_view_without_hubspot_token(  # noqa: FT003
     settings: SettingsWrapper,
     api_client: APIClient,
     db: None,
@@ -88,7 +88,7 @@ def test_receive_support_request_from_self_hosted_view_without_hubspot_token(
     assert response.json()["message"] == "HubSpot access token not configured"
 
 
-def test_receive_support_request_from_self_hosted_view(
+def test_receive_support_request_from_self_hosted_view(  # noqa: FT003
     settings: SettingsWrapper,
     api_client: APIClient,
     mocker: MockerFixture,
@@ -118,7 +118,7 @@ def test_receive_support_request_from_self_hosted_view(
     mocked_create_self_hosted_onboarding_lead.assert_called_once_with(**data)
 
 
-def test_receive_support_request_throttling(
+def test_receive_support_request_throttling(  # noqa: FT003
     settings: SettingsWrapper,
     api_client: APIClient,
     mocker: MockerFixture,

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_cache.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_cache.py
@@ -12,7 +12,7 @@ from organisations.chargebee.cache import ChargebeeCache, get_item_generator
 from organisations.chargebee.metadata import ChargebeeItem
 
 
-def test_get_item_generator_fetches_all_items(mocker: MockerFixture) -> None:
+def test_get_item_generator_fetches_all_items(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     mocked_chargebee = mocker.patch(
         "organisations.chargebee.cache.chargebee_client", autospec=True
@@ -46,7 +46,7 @@ def test_get_item_generator_fetches_all_items(mocker: MockerFixture) -> None:
     ]
 
 
-def test_chargebee_cache(mocker: MockerFixture, db: None) -> None:
+def test_chargebee_cache(mocker: MockerFixture, db: None) -> None:  # noqa: FT003
     # Given
 
     # a plan

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -158,7 +158,7 @@ class MockChargeBeePortalSession:
         self.access_url = access_url
 
 
-def test_chargebee_get_max_seats_for_plan_returns_max_seats_for_plan(
+def test_chargebee_get_max_seats_for_plan_returns_max_seats_for_plan(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -173,7 +173,7 @@ def test_chargebee_get_max_seats_for_plan_returns_max_seats_for_plan(
     assert max_seats == meta_data["seats"]
 
 
-def test_chargebee_get_max_api_calls_for_plan_returns_max_api_calls_for_plan(
+def test_chargebee_get_max_api_calls_for_plan_returns_max_api_calls_for_plan(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -187,7 +187,7 @@ def test_chargebee_get_max_api_calls_for_plan_returns_max_api_calls_for_plan(
     assert max_api_calls == meta_data["api_calls"]
 
 
-def test_chargebee_get_plan_meta_data_returns_correct_metadata(
+def test_chargebee_get_plan_meta_data_returns_correct_metadata(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -213,7 +213,7 @@ def test_chargebee_get_plan_meta_data_returns_correct_metadata(
     mock_cb.Plan.retrieve.assert_called_with(plan_id)
 
 
-def test_chargebee_get_subscription_data_from_hosted_page_returns_expected_values(
+def test_chargebee_get_subscription_data_from_hosted_page_returns_expected_values(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -245,7 +245,7 @@ def test_chargebee_get_subscription_data_from_hosted_page_returns_expected_value
     assert subscription_data["customer_id"] == customer_id
 
 
-def test_get_chargebee_portal_url(mocker: MockerFixture) -> None:
+def test_get_chargebee_portal_url(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     access_url = "https://test.url.com"
     mock_cb = mocker.patch(
@@ -263,7 +263,7 @@ def test_get_chargebee_portal_url(mocker: MockerFixture) -> None:
     assert portal_url == access_url
 
 
-def test_chargebee_get_customer_id_from_subscription(
+def test_chargebee_get_customer_id_from_subscription(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -282,7 +282,7 @@ def test_chargebee_get_customer_id_from_subscription(
     assert customer_id == expected_customer_id
 
 
-def test_chargebee_get_hosted_page_url_for_subscription_upgrade(
+def test_chargebee_get_hosted_page_url_for_subscription_upgrade(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -311,7 +311,7 @@ def test_chargebee_get_hosted_page_url_for_subscription_upgrade(
     )
 
 
-def test_extract_subscription_metadata(
+def test_extract_subscription_metadata(  # noqa: FT003
     mock_subscription_response_with_addons: MockChargeBeeSubscriptionResponse,
     chargebee_object_metadata: ChargebeeObjMetadata,
 ) -> None:
@@ -351,7 +351,7 @@ def test_extract_subscription_metadata(
     assert subscription_metadata.chargebee_email == customer_email
 
 
-def test_extract_subscription_metadata_when_addon_list_is_empty(
+def test_extract_subscription_metadata_when_addon_list_is_empty(  # noqa: FT003
     mock_subscription_response_with_addons: MockChargeBeeSubscriptionResponse,
     chargebee_object_metadata: ChargebeeObjMetadata,
 ) -> None:
@@ -381,7 +381,7 @@ def test_extract_subscription_metadata_when_addon_list_is_empty(
     assert subscription_metadata.chargebee_email == customer_email
 
 
-def test_get_subscription_metadata_from_id(
+def test_get_subscription_metadata_from_id(  # noqa: FT003
     mock_subscription_response_with_addons: MockChargeBeeSubscriptionResponse,
     chargebee_object_metadata: ChargebeeObjMetadata,
 ) -> None:
@@ -401,7 +401,7 @@ def test_get_subscription_metadata_from_id(
     assert subscription_metadata.chargebee_email == customer_email  # type: ignore[union-attr]
 
 
-def test_cancel_subscription(mocker) -> None:  # type: ignore[no-untyped-def]
+def test_cancel_subscription(mocker) -> None:  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mocked_chargebee = mocker.patch(
         "organisations.chargebee.chargebee.chargebee_client", autospec=True
@@ -418,7 +418,7 @@ def test_cancel_subscription(mocker) -> None:  # type: ignore[no-untyped-def]
     )
 
 
-def test_cancel_subscription_throws_cannot_cancel_error_if_api_error(  # type: ignore[no-untyped-def]
+def test_cancel_subscription_throws_cannot_cancel_error_if_api_error(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, caplog
 ) -> None:
     # Given
@@ -450,7 +450,7 @@ def test_cancel_subscription_throws_cannot_cancel_error_if_api_error(  # type: i
     )
 
 
-def test_get_subscription_metadata_from_id_returns_null_if_chargebee_error(  # type: ignore[no-untyped-def]
+def test_get_subscription_metadata_from_id_returns_null_if_chargebee_error(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, chargebee_object_metadata
 ) -> None:
     # Given
@@ -474,7 +474,7 @@ def test_get_subscription_metadata_from_id_returns_null_if_chargebee_error(  # t
     "subscription_id",
     [None, "", " "],
 )
-def test_get_subscription_metadata_from_id_returns_none_for_invalid_subscription_id(  # type: ignore[no-untyped-def]
+def test_get_subscription_metadata_from_id_returns_none_for_invalid_subscription_id(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, chargebee_object_metadata, subscription_id
 ) -> None:
     # Given
@@ -490,7 +490,7 @@ def test_get_subscription_metadata_from_id_returns_none_for_invalid_subscription
     assert subscription_metadata is None
 
 
-def test_get_subscription_metadata_from_id_returns_valid_metadata_if_addons_is_none(
+def test_get_subscription_metadata_from_id_returns_valid_metadata_if_addons_is_none(  # noqa: FT003
     mock_subscription_response: MockChargeBeeSubscriptionResponse,
     chargebee_object_metadata: ChargebeeObjMetadata,
 ) -> None:
@@ -507,7 +507,7 @@ def test_get_subscription_metadata_from_id_returns_valid_metadata_if_addons_is_n
     assert subscription_metadata.projects == chargebee_object_metadata.projects  # type: ignore[union-attr]
 
 
-def test_add_single_seat_with_existing_addon(mocker) -> None:  # type: ignore[no-untyped-def]
+def test_add_single_seat_with_existing_addon(mocker) -> None:  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     plan_id = "plan-id"
     addon_id = ADDITIONAL_SEAT_ADDON_ID
@@ -547,7 +547,7 @@ def test_add_single_seat_with_existing_addon(mocker) -> None:  # type: ignore[no
     )
 
 
-def test_add_single_seat_without_existing_addon(mocker) -> None:  # type: ignore[no-untyped-def]
+def test_add_single_seat_without_existing_addon(mocker) -> None:  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     subscription_id = "subscription-id"
 
@@ -584,7 +584,7 @@ def test_add_single_seat_without_existing_addon(mocker) -> None:  # type: ignore
     )
 
 
-def test_add_single_seat_throws_upgrade_seats_error_error_if_api_error(  # type: ignore[no-untyped-def]
+def test_add_single_seat_throws_upgrade_seats_error_error_if_api_error(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, caplog
 ) -> None:
     # Given
@@ -643,7 +643,7 @@ def test_add_single_seat_throws_upgrade_seats_error_error_if_api_error(  # type:
     )
 
 
-def test_add_100k_api_calls_when_count_is_empty(mocker: MockerFixture) -> None:
+def test_add_100k_api_calls_when_count_is_empty(mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     subscription_mock = mocker.patch(
         "organisations.chargebee.chargebee.chargebee_client", autospec=True
@@ -662,7 +662,7 @@ def test_add_100k_api_calls_when_count_is_empty(mocker: MockerFixture) -> None:
     subscription_mock.Subscription.update.assert_not_called()
 
 
-def test_add_100k_api_calls_when_chargebee_api_error_has_error_code(
+def test_add_100k_api_calls_when_chargebee_api_error_has_error_code(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -691,7 +691,7 @@ def test_add_100k_api_calls_when_chargebee_api_error_has_error_code(
         )
 
 
-def test_add_100k_api_calls_when_chargebee_api_error_has_no_error_code(
+def test_add_100k_api_calls_when_chargebee_api_error_has_no_error_code(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     # Given

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_metadata.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_metadata.py
@@ -1,7 +1,7 @@
 from organisations.chargebee.metadata import ChargebeeObjMetadata
 
 
-def test_add_chargebee_object_meta_data():  # type: ignore[no-untyped-def]
+def test_add_chargebee_object_meta_data():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     a_obj_metadata = ChargebeeObjMetadata(seats=10, api_calls=100)
     another_obj_metadata = ChargebeeObjMetadata(seats=20, api_calls=200, projects=100)
@@ -15,7 +15,7 @@ def test_add_chargebee_object_meta_data():  # type: ignore[no-untyped-def]
     assert added_chargebee_obj_metadata.projects is None
 
 
-def test_multiply_chargebee_object_metadata():  # type: ignore[no-untyped-def]
+def test_multiply_chargebee_object_metadata():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     metadata = ChargebeeObjMetadata(seats=10, api_calls=100)
 
@@ -28,7 +28,7 @@ def test_multiply_chargebee_object_metadata():  # type: ignore[no-untyped-def]
     assert new_metadata.projects is None
 
 
-def test_multiply_chargebee_object_metadata_works_for_null_values():  # type: ignore[no-untyped-def]
+def test_multiply_chargebee_object_metadata_works_for_null_values():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     metadata = ChargebeeObjMetadata(seats=10, api_calls=100, projects=None)
 

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_tasks.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_tasks.py
@@ -1,7 +1,7 @@
 from organisations.chargebee.tasks import update_chargebee_cache
 
 
-def test_update_chargebee_cache(mocker):  # type: ignore[no-untyped-def]
+def test_update_chargebee_cache(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_chargebee_cache = mocker.MagicMock()
     mocker.patch(

--- a/api/tests/unit/organisations/invites/test_unit_invites_models.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_models.py
@@ -14,7 +14,7 @@ if typing.TYPE_CHECKING:
     from pytest_django.fixtures import SettingsWrapper
 
 
-def test_invite_link_is_expired_expiry_date_in_past(
+def test_invite_link_is_expired_expiry_date_in_past(  # noqa: FT003
     organisation: Organisation,
 ) -> None:
     # Given
@@ -30,7 +30,7 @@ def test_invite_link_is_expired_expiry_date_in_past(
     assert is_expired
 
 
-def test_invite_link_is_expired_expiry_date_in_future(
+def test_invite_link_is_expired_expiry_date_in_future(  # noqa: FT003
     organisation: Organisation,
 ) -> None:
     # Given
@@ -46,7 +46,7 @@ def test_invite_link_is_expired_expiry_date_in_future(
     assert not is_expired
 
 
-def test_invite_link_is_expired_no_expiry_date(
+def test_invite_link_is_expired_no_expiry_date(  # noqa: FT003
     organisation: Organisation,
 ) -> None:
     # Given
@@ -60,7 +60,7 @@ def test_invite_link_is_expired_no_expiry_date(
 
 
 @pytest.mark.django_db
-def test_cannot_create_invite_link_if_disabled(settings: "SettingsWrapper") -> None:
+def test_cannot_create_invite_link_if_disabled(settings: "SettingsWrapper") -> None:  # noqa: FT003
     # Given
     settings.DISABLE_INVITE_LINKS = True
 
@@ -70,7 +70,7 @@ def test_cannot_create_invite_link_if_disabled(settings: "SettingsWrapper") -> N
 
 
 @pytest.mark.django_db
-def test_save_invalid_invite__dont_send(mailoutbox: "list[EmailMessage]") -> None:
+def test_save_invalid_invite__dont_send(mailoutbox: "list[EmailMessage]") -> None:  # noqa: FT003
     # Given
     email = "unknown@test.com"
     organisation = Organisation.objects.create(name="ssg")

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -19,7 +19,7 @@ from organisations.models import Organisation, OrganisationRole, Subscription
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_create_invite_link(
+def test_create_invite_link(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
 ) -> None:
@@ -44,7 +44,7 @@ def test_create_invite_link(
     assert response.data["role"] == "USER"
 
 
-def test_get_invite_links_for_organisation(
+def test_get_invite_links_for_organisation(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
 ) -> None:
@@ -72,7 +72,7 @@ def test_get_invite_links_for_organisation(
         assert all(attr in invite_link for attr in expected_attributes)
 
 
-def test_get_invite_links_for_organisation_returns_400_if_seats_are_over(
+def test_get_invite_links_for_organisation_returns_400_if_seats_are_over(  # noqa: FT003
     settings: SettingsWrapper,
     organisation: Organisation,
     admin_client: APIClient,
@@ -94,7 +94,7 @@ def test_get_invite_links_for_organisation_returns_400_if_seats_are_over(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_delete_invite_link_for_organisation(
+def test_delete_invite_link_for_organisation(  # noqa: FT003
     settings: SettingsWrapper,
     organisation: Organisation,
     admin_client: APIClient,
@@ -118,7 +118,7 @@ def test_delete_invite_link_for_organisation(
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_delete_invite_link_for_organisation_return_400_if_seats_are_over(
+def test_delete_invite_link_for_organisation_return_400_if_seats_are_over(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
     settings: SettingsWrapper,
@@ -138,7 +138,7 @@ def test_delete_invite_link_for_organisation_return_400_if_seats_are_over(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_update_invite_link_returns_405(invite_link, admin_client, organisation):  # type: ignore[no-untyped-def]
+def test_update_invite_link_returns_405(invite_link, admin_client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:organisations:organisation-invite-links-detail",
@@ -156,7 +156,7 @@ def test_update_invite_link_returns_405(invite_link, admin_client, organisation)
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_join_organisation_with_permission_groups(
+def test_join_organisation_with_permission_groups(  # noqa: FT003
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
     enterprise_subscription: Subscription,
@@ -194,7 +194,7 @@ def test_join_organisation_with_permission_groups(
 
 
 @pytest.mark.saas_mode
-def test_create_invite_with_permission_groups(
+def test_create_invite_with_permission_groups(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
@@ -226,7 +226,7 @@ def test_create_invite_with_permission_groups(
 
 
 @pytest.mark.saas_mode
-def test_create_invite_with_permission_groups_fails_if_permission_group_belongs_to_another_organisation(
+def test_create_invite_with_permission_groups_fails_if_permission_group_belongs_to_another_organisation(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     chargebee_subscription: Subscription,
@@ -264,7 +264,7 @@ def test_create_invite_with_permission_groups_fails_if_permission_group_belongs_
     }
 
 
-def test_create_invite_returns_400_if_seats_are_over(
+def test_create_invite_returns_400_if_seats_are_over(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
@@ -289,7 +289,7 @@ def test_create_invite_returns_400_if_seats_are_over(
     )
 
 
-def test_retrieve_invite(admin_client, organisation, user_permission_group, invite):  # type: ignore[no-untyped-def]
+def test_retrieve_invite(admin_client, organisation, user_permission_group, invite):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:organisations:organisation-invites-detail",
@@ -301,7 +301,7 @@ def test_retrieve_invite(admin_client, organisation, user_permission_group, invi
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_delete_invite(admin_client, organisation, user_permission_group, invite):  # type: ignore[no-untyped-def]
+def test_delete_invite(admin_client, organisation, user_permission_group, invite):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:organisations:organisation-invites-detail",
@@ -313,7 +313,7 @@ def test_delete_invite(admin_client, organisation, user_permission_group, invite
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_update_invite_returns_405(  # type: ignore[no-untyped-def]
+def test_update_invite_returns_405(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, organisation, user_permission_group, invite
 ):
     # Given
@@ -338,7 +338,7 @@ def test_update_invite_returns_405(  # type: ignore[no-untyped-def]
         (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
-def test_join_organisation_returns_400_if_exceeds_plan_limit_for_saas(
+def test_join_organisation_returns_400_if_exceeds_plan_limit_for_saas(  # noqa: FT003
     staff_client: APIClient,
     invite_object: Invite | InviteLink,
     url: str,
@@ -366,7 +366,7 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit_for_saas(
         (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
-def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_enterprise(
+def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_enterprise(  # noqa: FT003
     staff_client: APIClient,
     invite_object: Invite | InviteLink,
     url: str,
@@ -398,7 +398,7 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit_for_self_hosted_ent
         (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
-def test_join_organisation_returns_400_if_payment_fails(
+def test_join_organisation_returns_400_if_payment_fails(  # noqa: FT003
     staff_client: APIClient,
     invite_object: Invite | InviteLink,
     url: str,
@@ -445,7 +445,7 @@ def test_join_organisation_returns_400_if_payment_fails(
     )
 
 
-def test_join_organisation_from_link_returns_403_if_invite_links_disabled(
+def test_join_organisation_from_link_returns_403_if_invite_links_disabled(  # noqa: FT003
     organisation: Organisation,
     invite_link: InviteLink,
     settings: SettingsWrapper,

--- a/api/tests/unit/organisations/permissions/test_unit_organisations_migrations.py
+++ b/api/tests/unit/organisations/permissions/test_unit_organisations_migrations.py
@@ -8,7 +8,7 @@ from organisations.permissions.permissions import (
 from permissions.models import ORGANISATION_PERMISSION_TYPE
 
 
-def test_migration_creates_create_project_permissions_for_org_users(
+def test_migration_creates_create_project_permissions_for_org_users(  # noqa: FT003
     migrator: Migrator,
 ) -> None:
     # Given
@@ -67,7 +67,7 @@ def test_migration_creates_create_project_permissions_for_org_users(
     ).exists()
 
 
-def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
+def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:  # noqa: FT003
     # Given - the migration state is at 0002 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("organisation_permissions", "0002_add_related_query_name")
@@ -161,7 +161,7 @@ def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
     ).exists()
 
 
-def test_update_audit_and_history_limits(migrator: Migrator) -> None:
+def test_update_audit_and_history_limits(migrator: Migrator) -> None:  # noqa: FT003
     # Given
     old_state = migrator.apply_initial_migration(
         ("organisations", "0056_create_organisation_breached_grace_period")

--- a/api/tests/unit/organisations/permissions/test_unit_organisations_permissions.py
+++ b/api/tests/unit/organisations/permissions/test_unit_organisations_permissions.py
@@ -5,7 +5,7 @@ from organisations.permissions.permissions import OrganisationUsersPermission
 from users.models import FFAdminUser
 
 
-def test_org_user_can_list_users(
+def test_org_user_can_list_users(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -24,7 +24,7 @@ def test_org_user_can_list_users(
     assert result is True
 
 
-def test_org_user_cannot_create_user(
+def test_org_user_cannot_create_user(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:

--- a/api/tests/unit/organisations/permissions/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/permissions/test_unit_organisations_views.py
@@ -11,7 +11,7 @@ from organisations.permissions.permissions import CREATE_PROJECT
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_regular_user_cannot_create_user_organisation_permissions(
+def test_regular_user_cannot_create_user_organisation_permissions(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -42,7 +42,7 @@ def test_regular_user_cannot_create_user_organisation_permissions(
     )
 
 
-def test_create_user_organisation_permission(
+def test_create_user_organisation_permission(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     organisation: Organisation,
@@ -69,7 +69,7 @@ def test_create_user_organisation_permission(
     )
 
 
-def test_list_user_organisation_permissions(
+def test_list_user_organisation_permissions(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_client: APIClient,
@@ -96,7 +96,7 @@ def test_list_user_organisation_permissions(
     assert response.data[0]["permissions"] == [CREATE_PROJECT]
 
 
-def test_destroy_user_organisation_permission(
+def test_destroy_user_organisation_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_client: APIClient,
@@ -125,7 +125,7 @@ def test_destroy_user_organisation_permission(
     )
 
 
-def test_update_user_organisation_permission(
+def test_update_user_organisation_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_client: APIClient,
@@ -154,7 +154,7 @@ def test_update_user_organisation_permission(
     )
 
 
-def test_regular_user_cannot_create_user_group_permissions(
+def test_regular_user_cannot_create_user_group_permissions(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -189,7 +189,7 @@ def test_regular_user_cannot_create_user_group_permissions(
     )
 
 
-def test_create_user_group_organisation_permission(
+def test_create_user_group_organisation_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_client: APIClient,
@@ -220,7 +220,7 @@ def test_create_user_group_organisation_permission(
     )
 
 
-def test_list_user_group_permissions(
+def test_list_user_group_permissions(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -249,7 +249,7 @@ def test_list_user_group_permissions(
     assert response.data[0]["permissions"] == [CREATE_PROJECT]
 
 
-def test_destroy_user_group_permission(
+def test_destroy_user_group_permission(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     organisation: Organisation,
@@ -281,7 +281,7 @@ def test_destroy_user_group_permission(
     )
 
 
-def test_update_user_group_permission(
+def test_update_user_group_permission(  # noqa: FT003
     admin_client: APIClient,
     staff_user: FFAdminUser,
     organisation: Organisation,

--- a/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
+++ b/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
@@ -16,7 +16,7 @@ from organisations.subscriptions.serializers.mixins import (
         ("invalid-plan-id", tuple(), "invalid-.*"),
     ),
 )
-def test_read_only_if_not_valid_plan_mixin_sets_read_only_if_plan_not_valid(
+def test_read_only_if_not_valid_plan_mixin_sets_read_only_if_plan_not_valid(  # noqa: FT003
     plan_id: str, invalid_plans_: list[str], invalid_plans_regex_: str
 ) -> None:
     # Given
@@ -43,7 +43,7 @@ def test_read_only_if_not_valid_plan_mixin_sets_read_only_if_plan_not_valid(
     assert serializer.fields["foo"].read_only is True
 
 
-def test_read_only_if_not_valid_plan_mixin_does_not_set_read_only_if_plan_valid():  # type: ignore[no-untyped-def]
+def test_read_only_if_not_valid_plan_mixin_does_not_set_read_only_if_plan_valid():  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     valid_plan_id = "plan-id"
     invalid_plan_id = "invalid-plan-id"

--- a/api/tests/unit/organisations/subscriptions/test_unit_subscriptions_dataclasses.py
+++ b/api/tests/unit/organisations/subscriptions/test_unit_subscriptions_dataclasses.py
@@ -11,7 +11,7 @@ class SourceBSubscriptionMetadata(BaseSubscriptionMetadata):
     payment_source = "SOURCE_B"  # type: ignore[assignment]
 
 
-def test_base_subscription_metadata_add_raises_error_if_not_matching_payment_source():  # type: ignore[no-untyped-def]
+def test_base_subscription_metadata_add_raises_error_if_not_matching_payment_source():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     source_a_metadata = SourceASubscriptionMetadata(seats=1, api_calls=50000)
     source_b_metadata = SourceBSubscriptionMetadata(seats=1, api_calls=50000)
@@ -54,5 +54,5 @@ def test_base_subscription_metadata_add_raises_error_if_not_matching_payment_sou
         ),
     ),
 )
-def test_base_subscription_metadata_add(add_to, add, expected_result):  # type: ignore[no-untyped-def]
+def test_base_subscription_metadata_add(add_to, add, expected_result):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert add_to + add == expected_result

--- a/api/tests/unit/organisations/subscriptions/test_unit_subscriptions_decorators.py
+++ b/api/tests/unit/organisations/subscriptions/test_unit_subscriptions_decorators.py
@@ -7,7 +7,7 @@ from organisations.subscriptions.decorators import require_plan
 from organisations.subscriptions.exceptions import InvalidSubscriptionPlanError
 
 
-def test_require_plan_raises_exception_if_plan_invalid():  # type: ignore[no-untyped-def]
+def test_require_plan_raises_exception_if_plan_invalid():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     valid_plan_id = "plan-id"
     invalid_plan_id = "invalid-plan-id"
@@ -27,7 +27,7 @@ def test_require_plan_raises_exception_if_plan_invalid():  # type: ignore[no-unt
     # Exception is raised
 
 
-def test_require_plan_does_not_raise_exception_if_plan_valid(rf):  # type: ignore[no-untyped-def]
+def test_require_plan_does_not_raise_exception_if_plan_valid(rf):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     valid_plan_id = "plan-id"
 

--- a/api/tests/unit/organisations/test_unit_organisations_migrations.py
+++ b/api/tests/unit/organisations/test_unit_organisations_migrations.py
@@ -1,7 +1,7 @@
 from django_test_migrations.migrator import Migrator
 
 
-def test_migration_creates_default_subscription_for_organisations_without_subscription(  # noqa: E501
+def test_migration_creates_default_subscription_for_organisations_without_subscription(  # noqa: E501,FT003
     migrator: Migrator,
 ) -> None:
     # Given

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -34,7 +34,7 @@ from organisations.subscriptions.xero.metadata import XeroSubscriptionMetadata
 from users.models import FFAdminUser
 
 
-def test_organisation_has_paid_subscription_true(db: None) -> None:
+def test_organisation_has_paid_subscription_true(db: None) -> None:  # noqa: FT003,FT004
     # Given
     organisation = Organisation.objects.create(name="Test org")
     Subscription.objects.filter(organisation=organisation).update(
@@ -64,7 +64,7 @@ def test_organisation_has_paid_subscription_true(db: None) -> None:
         ("start-up-v2-annual", False),
     ),
 )
-def test_organisation_has_enterprise_subscription(
+def test_organisation_has_enterprise_subscription(  # noqa: FT003,FT004
     plan_id: str, expected_has_enterprise: bool, organisation: Organisation
 ) -> None:
     # Given
@@ -79,7 +79,7 @@ def test_organisation_has_enterprise_subscription(
     assert organisation.has_enterprise_subscription() is expected_has_enterprise
 
 
-def test_organisation_has_paid_subscription_missing_subscription_id(db: None) -> None:
+def test_organisation_has_paid_subscription_missing_subscription_id(db: None) -> None:  # noqa: FT003,FT004
     # Given
     organisation = Organisation.objects.create(name="Test org")
     assert (
@@ -92,7 +92,7 @@ def test_organisation_has_paid_subscription_missing_subscription_id(db: None) ->
 
 
 @mock.patch("organisations.models.cancel_chargebee_subscription")
-def test_organisation_cancel_subscription_cancels_chargebee_subscription(  # type: ignore[no-untyped-def]
+def test_organisation_cancel_subscription_cancels_chargebee_subscription(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocked_cancel_chargebee_subscription,
     organisation: Organisation,
 ):
@@ -122,7 +122,7 @@ def test_organisation_cancel_subscription_cancels_chargebee_subscription(  # typ
     assert subscription.plan == FREE_PLAN_ID
 
 
-def test_organisation_rebuild_environment_document_on_stop_serving_flags_changed(  # type: ignore[no-untyped-def]
+def test_organisation_rebuild_environment_document_on_stop_serving_flags_changed(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment, organisation: Organisation, mocker: MockerFixture
 ):
     # Given
@@ -141,7 +141,7 @@ def test_organisation_rebuild_environment_document_on_stop_serving_flags_changed
     )
 
 
-def test_organisation_rebuild_environment_document_on_stop_serving_flags_unchanged(  # type: ignore[no-untyped-def]
+def test_organisation_rebuild_environment_document_on_stop_serving_flags_unchanged(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment: Environment, organisation: Organisation, mocker: MockerFixture
 ):
     # Given
@@ -157,7 +157,7 @@ def test_organisation_rebuild_environment_document_on_stop_serving_flags_unchang
     mocked_rebuild_environment_document.delay.assert_not_called()
 
 
-def test_organisation_over_plan_seats_limit_returns_false_if_not_over_plan_seats_limit(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_organisation_over_plan_seats_limit_returns_false_if_not_over_plan_seats_limit(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     organisation, chargebee_subscription, mocker
 ):
     # Given
@@ -172,7 +172,7 @@ def test_organisation_over_plan_seats_limit_returns_false_if_not_over_plan_seats
     mocked_get_subscription_metadata.assert_called_once_with(chargebee_subscription)
 
 
-def test_organisation_over_plan_seats_limit_returns_true_if_over_plan_seats_limit(  # type: ignore[no-untyped-def]
+def test_organisation_over_plan_seats_limit_returns_true_if_over_plan_seats_limit(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, chargebee_subscription, mocker, admin_user
 ):
     # Given
@@ -187,7 +187,7 @@ def test_organisation_over_plan_seats_limit_returns_true_if_over_plan_seats_limi
     mocked_get_subscription_metadata.assert_called_once_with(chargebee_subscription)
 
 
-def test_organisation_over_plan_seats_no_subscription(organisation, mocker, admin_user):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_organisation_over_plan_seats_no_subscription(organisation, mocker, admin_user):  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     # Given
     organisation.subscription.max_seats = 0
     organisation.subscription.save()
@@ -202,7 +202,7 @@ def test_organisation_over_plan_seats_no_subscription(organisation, mocker, admi
 
 
 @pytest.mark.saas_mode
-def test_organisation_is_auto_seat_upgrade_available(
+def test_organisation_is_auto_seat_upgrade_available(  # noqa: FT003,FT004
     organisation: Organisation,
 ) -> None:
     # Given
@@ -220,7 +220,7 @@ def test_organisation_is_auto_seat_upgrade_available(
     assert organisation.is_auto_seat_upgrade_available() is True
 
 
-def test_organisation_default_subscription_have_one_max_seat(
+def test_organisation_default_subscription_have_one_max_seat(  # noqa: FT003,FT004
     organisation: Organisation,
 ) -> None:
     # Given
@@ -230,21 +230,21 @@ def test_organisation_default_subscription_have_one_max_seat(
     assert subscription.max_seats == 1
 
 
-def test_organisation_is_paid_returns_false_if_subscription_does_not_exists(db):  # type: ignore[no-untyped-def]
+def test_organisation_is_paid_returns_false_if_subscription_does_not_exists(db):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     organisation = Organisation.objects.create(name="Test org")
     # Then
     assert organisation.is_paid is False
 
 
-def test_organisation_is_paid_returns_true_if_active_subscription_exists(  # type: ignore[no-untyped-def]
+def test_organisation_is_paid_returns_true_if_active_subscription_exists(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, chargebee_subscription
 ):
     # When/Then
     assert organisation.is_paid is True
 
 
-def test_organisation_is_paid_returns_false_if_cancelled_subscription_exists(  # type: ignore[no-untyped-def]
+def test_organisation_is_paid_returns_false_if_cancelled_subscription_exists(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, chargebee_subscription
 ):
     # Given
@@ -256,7 +256,7 @@ def test_organisation_is_paid_returns_false_if_cancelled_subscription_exists(  #
     assert organisation.is_paid is False
 
 
-def test_organisation_subscription_get_subscription_metadata_returns_cb_metadata_for_cb_subscription(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_organisation_subscription_get_subscription_metadata_returns_cb_metadata_for_cb_subscription(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     organisation: Organisation,
     mocker: MockerFixture,
     settings: SettingsWrapper,
@@ -292,7 +292,7 @@ def test_organisation_subscription_get_subscription_metadata_returns_cb_metadata
     assert subscription_metadata == expected_metadata
 
 
-def test_get_subscription_metadata_returns_unlimited_values_for_audit_and_versions_when_released(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_subscription_metadata_returns_unlimited_values_for_audit_and_versions_when_released(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     organisation: Organisation,
     mocker: MockerFixture,
     settings: SettingsWrapper,
@@ -341,7 +341,7 @@ def test_get_subscription_metadata_returns_unlimited_values_for_audit_and_versio
     assert subscription_metadata == expected_metadata
 
 
-def test_organisation_subscription_get_subscription_metadata_returns_xero_metadata_for_xero_sub(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_organisation_subscription_get_subscription_metadata_returns_xero_metadata_for_xero_sub(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker: MockerFixture,
 ):
     # Given
@@ -360,7 +360,7 @@ def test_organisation_subscription_get_subscription_metadata_returns_xero_metada
     assert subscription_metadata == expected_metadata
 
 
-def test_organisation_subscription_get_subscription_metadata_returns_free_plan_metadata_for_no_plan():  # type: ignore[no-untyped-def]  # noqa: E501
+def test_organisation_subscription_get_subscription_metadata_returns_free_plan_metadata_for_no_plan():  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     # Given
     subscription = Subscription()
 
@@ -388,7 +388,7 @@ def test_organisation_subscription_get_subscription_metadata_returns_free_plan_m
         (TRIAL_SUBSCRIPTION_ID, "enterprise", 20, 5000000, 20, 5000000, None),
     ),
 )
-def test_organisation_get_subscription_metadata_for_manually_added_enterprise_saas_licenses(
+def test_organisation_get_subscription_metadata_for_manually_added_enterprise_saas_licenses(  # noqa: FT003
     organisation: Organisation,
     subscription_id: str | None,
     plan: str,
@@ -423,7 +423,7 @@ def test_organisation_get_subscription_metadata_for_manually_added_enterprise_sa
     assert subscription_metadata.api_calls == expected_api_calls
 
 
-def test_organisation_get_subscription_metadata_for_self_hosted_open_source(
+def test_organisation_get_subscription_metadata_for_self_hosted_open_source(  # noqa: FT003
     organisation: Organisation, mocker: MockerFixture
 ) -> None:
     """
@@ -449,7 +449,7 @@ def test_organisation_get_subscription_metadata_for_self_hosted_open_source(
 
 
 @pytest.mark.saas_mode
-def test_organisation_subscription_add_single_seat_calls_correct_chargebee_method_for_upgradable_plan(  # noqa: E501
+def test_organisation_subscription_add_single_seat_calls_correct_chargebee_method_for_upgradable_plan(  # noqa: E501,FT003
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -466,7 +466,7 @@ def test_organisation_subscription_add_single_seat_calls_correct_chargebee_metho
     mocked_add_single_seat.assert_called_once_with(subscription_id)
 
 
-def test_organisation_subscription_add_single_seat_raises_error_for_non_upgradable_plan(  # noqa: E501
+def test_organisation_subscription_add_single_seat_raises_error_for_non_upgradable_plan(  # noqa: E501,FT003,FT004
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -487,7 +487,7 @@ def test_organisation_subscription_add_single_seat_raises_error_for_non_upgradab
     mocked_add_single_seat.assert_not_called()
 
 
-def test_organisation_update_clears_environment_caches(  # type: ignore[no-untyped-def]
+def test_organisation_update_clears_environment_caches(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, organisation, environment
 ):
     # Given
@@ -501,7 +501,7 @@ def test_organisation_update_clears_environment_caches(  # type: ignore[no-untyp
     mock_environment_cache.delete_many.assert_called_once_with([environment.api_key])
 
 
-def test_reset_of_api_notifications(organisation: Organisation) -> None:
+def test_reset_of_api_notifications(organisation: Organisation) -> None:  # noqa: FT003
     # Given
     now = timezone.now()
     osic = OrganisationSubscriptionInformationCache.objects.create(
@@ -538,7 +538,7 @@ def test_reset_of_api_notifications(organisation: Organisation) -> None:
     assert OrganisationAPIUsageNotification.objects.first() == oapiun
 
 
-def test_organisation_creates_subscription_cache(
+def test_organisation_creates_subscription_cache(  # noqa: FT003
     db: None, mocker: MockerFixture
 ) -> None:
     # Given
@@ -575,7 +575,7 @@ def test_organisation_creates_subscription_cache(
         ("start-up-v2-annual", SubscriptionPlanFamily.START_UP),
     ),
 )
-def test_subscription_plan_family(
+def test_subscription_plan_family(  # noqa: FT003,FT004
     plan_id: str, expected_plan_family: SubscriptionPlanFamily
 ) -> None:
     assert Subscription(plan=plan_id).subscription_plan_family == expected_plan_family
@@ -597,7 +597,7 @@ def test_subscription_plan_family(
         ("start-up-v2-annual", False),
     ),
 )
-def test_subscription_is_enterprise_property(
+def test_subscription_is_enterprise_property(  # noqa: FT003,FT004
     plan_id: str, expected_is_enterprise: bool, organisation: Organisation
 ) -> None:
     # Given
@@ -631,7 +631,7 @@ def test_subscription_is_enterprise_property(
         ),
     ],
 )
-def test_organisation_has_billing_periods(
+def test_organisation_has_billing_periods(  # noqa: FT003
     organisation: Organisation,
     billing_term_starts_at: datetime,
     billing_term_ends_at: datetime,
@@ -653,7 +653,7 @@ def test_organisation_has_billing_periods(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47+00:00")
-def test_user_organisation_create_calls_hubspot_lead_tracking(
+def test_user_organisation_create_calls_hubspot_lead_tracking(  # noqa: FT003
     mocker: MagicMock, db: None, settings: SettingsWrapper, organisation: Organisation
 ) -> None:
     # Given
@@ -719,7 +719,7 @@ def test_subscription_get_portal_url__customer_id_exists__returns_url(
     assert result == expected_url
 
 
-def test_subscription_update_plan__updates_fields_from_chargebee(
+def test_subscription_update_plan__updates_fields_from_chargebee(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:

--- a/api/tests/unit/organisations/test_unit_organisations_permissions.py
+++ b/api/tests/unit/organisations/test_unit_organisations_permissions.py
@@ -10,7 +10,7 @@ from organisations.permissions.permissions import (
 @pytest.mark.parametrize(
     "has_organisation_permission, expected_result", ((True, True), (False, False))
 )
-def test_has_organisation_permission(  # type: ignore[no-untyped-def]
+def test_has_organisation_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, organisation, has_organisation_permission, expected_result
 ):
     # Given
@@ -33,7 +33,7 @@ def test_has_organisation_permission(  # type: ignore[no-untyped-def]
     )
 
 
-def test_user_organisation_permissions_has_permission_allows_organisation_members_to_list_groups(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_user_organisation_permissions_has_permission_allows_organisation_members_to_list_groups(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     organisation_one, organisation_one_user, mocker
 ):
     # Given
@@ -51,7 +51,7 @@ def test_user_organisation_permissions_has_permission_allows_organisation_member
     assert result is True
 
 
-def test_user_organisation_permissions_has_permission_permits_users_with_manage_groups(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_user_organisation_permissions_has_permission_permits_users_with_manage_groups(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     organisation, mocker
 ):
     # Given
@@ -72,7 +72,7 @@ def test_user_organisation_permissions_has_permission_permits_users_with_manage_
     assert result is True
 
 
-def test_user_organisation_permissions_has_object_permission_permits_users_with_manage_groups(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_user_organisation_permissions_has_object_permission_permits_users_with_manage_groups(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     organisation, mocker
 ):
     # Given
@@ -93,7 +93,7 @@ def test_user_organisation_permissions_has_object_permission_permits_users_with_
     assert result is True
 
 
-def test_user_permission_group_permissions_has_object_permission_permits_group_admin(  # type: ignore[no-untyped-def]
+def test_user_permission_group_permissions_has_object_permission_permits_group_admin(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation, user_permission_group, admin_user, mocker
 ):
     # Given

--- a/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
+++ b/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
@@ -17,7 +17,7 @@ from organisations.subscriptions.constants import SubscriptionCacheEntity
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_update_caches(mocker, organisation, chargebee_subscription, settings):  # type: ignore[no-untyped-def]
+def test_update_caches(mocker, organisation, chargebee_subscription, settings):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     settings.CHARGEBEE_API_KEY = "api-key"
     settings.INFLUXDB_TOKEN = "token"
@@ -86,7 +86,7 @@ def test_update_caches(mocker, organisation, chargebee_subscription, settings): 
     ]
 
 
-def test_update_caches_empty(
+def test_update_caches_empty(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     chargebee_subscription: Subscription,

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -54,7 +54,7 @@ from organisations.tasks import (  # type: ignore[attr-defined]
 from users.models import FFAdminUser
 
 
-def test_send_org_over_limit_alert_for_organisation_with_free_subscription(  # type: ignore[no-untyped-def]
+def test_send_org_over_limit_alert_for_organisation_with_free_subscription(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation, mocker
 ):
     # Given
@@ -79,7 +79,7 @@ def test_send_org_over_limit_alert_for_organisation_with_free_subscription(  # t
 @pytest.mark.parametrize(
     "SubscriptionMetadata", [ChargebeeObjMetadata, XeroSubscriptionMetadata]
 )
-def test_send_org_over_limit_alert_for_organisation_with_subscription(  # type: ignore[no-untyped-def]
+def test_send_org_over_limit_alert_for_organisation_with_subscription(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation, subscription, mocker, SubscriptionMetadata
 ):
     # Given
@@ -106,7 +106,7 @@ def test_send_org_over_limit_alert_for_organisation_with_subscription(  # type: 
     assert kwargs["subject"] == ALERT_EMAIL_SUBJECT
 
 
-def test_subscription_cancellation(db: None) -> None:
+def test_subscription_cancellation(db: None) -> None:  # noqa: FT003
     # Given
     organisation = Organisation.objects.create()
     OrganisationSubscriptionInformationCache.objects.create(
@@ -180,7 +180,7 @@ def test_subscription_cancellation(db: None) -> None:
 
 
 @pytest.mark.freeze_time("2023-01-19T09:12:34+00:00")
-def test_finish_subscription_cancellation(db: None, mocker: MockerFixture) -> None:
+def test_finish_subscription_cancellation(db: None, mocker: MockerFixture) -> None:  # noqa: FT003
     # Given
     send_org_subscription_cancelled_alert_task = mocker.patch(
         "organisations.tasks.send_org_subscription_cancelled_alert"
@@ -255,7 +255,7 @@ def test_finish_subscription_cancellation(db: None, mocker: MockerFixture) -> No
     assert organisation4.num_seats == organisation_user_count
 
 
-def test_send_org_subscription_cancelled_alert(
+def test_send_org_subscription_cancelled_alert(  # noqa: FT003
     mocker: MockerFixture, settings: SettingsWrapper
 ) -> None:
     # Given
@@ -280,7 +280,7 @@ def test_send_org_subscription_cancelled_alert(
     )
 
 
-def test_handle_api_usage_notification_for_organisation_when_billing_starts_at_is_none(
+def test_handle_api_usage_notification_for_organisation_when_billing_starts_at_is_none(  # noqa: FT003
     organisation: Organisation,
     inspecting_handler: logging.Handler,
     mocker: MockerFixture,
@@ -313,7 +313,7 @@ def test_handle_api_usage_notification_for_organisation_when_billing_starts_at_i
     ]
 
 
-def test_handle_api_usage_notification_for_organisation_when_cancellation_date_is_set(
+def test_handle_api_usage_notification_for_organisation_when_cancellation_date_is_set(  # noqa: FT003
     organisation: Organisation,
     inspecting_handler: logging.Handler,
     mocker: MockerFixture,
@@ -349,7 +349,7 @@ def test_handle_api_usage_notification_for_organisation_when_cancellation_date_i
     assert inspecting_handler.messages == []  # type: ignore[attr-defined]
 
 
-def test_handle_api_usage_notification_for_organisation_when_billing_starts_at_is_more_than_12_months_ago(
+def test_handle_api_usage_notification_for_organisation_when_billing_starts_at_is_more_than_12_months_ago(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -381,7 +381,7 @@ def test_handle_api_usage_notification_for_organisation_when_billing_starts_at_i
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_handle_api_usage_notifications_when_feature_flag_is_off(
+def test_handle_api_usage_notifications_when_feature_flag_is_off(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
@@ -429,7 +429,7 @@ def test_handle_api_usage_notifications_when_feature_flag_is_off(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_handle_api_usage_notifications_below_100(
+def test_handle_api_usage_notifications_below_100(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
@@ -541,7 +541,7 @@ def test_handle_api_usage_notifications_below_100(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_handle_api_usage_notifications_below_api_usage_alert_thresholds(
+def test_handle_api_usage_notifications_below_api_usage_alert_thresholds(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
@@ -591,7 +591,7 @@ def test_handle_api_usage_notifications_below_api_usage_alert_thresholds(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_handle_api_usage_notifications_above_100(
+def test_handle_api_usage_notifications_above_100(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
@@ -686,7 +686,7 @@ def test_handle_api_usage_notifications_above_100(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_handle_api_usage_notifications_with_error(
+def test_handle_api_usage_notifications_with_error(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     inspecting_handler: logging.Handler,
@@ -740,7 +740,7 @@ def test_handle_api_usage_notifications_with_error(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_handle_api_usage_notifications_for_free_accounts(
+def test_handle_api_usage_notifications_for_free_accounts(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
@@ -838,7 +838,7 @@ def test_handle_api_usage_notifications_for_free_accounts(
     assert OrganisationAPIUsageNotification.objects.first() == api_usage_notification
 
 
-def test_handle_api_usage_notifications_missing_info_cache(
+def test_handle_api_usage_notifications_missing_info_cache(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
@@ -877,7 +877,7 @@ def test_handle_api_usage_notifications_missing_info_cache(
 
 @pytest.mark.parametrize("plan", ("scale-up", "scale-up-v2", "scale-up-v3"))
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_scale_up(
+def test_charge_for_api_call_count_overages_scale_up(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
     plan: str,
@@ -958,7 +958,7 @@ def test_charge_for_api_call_count_overages_scale_up(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_cancellation_date(
+def test_charge_for_api_call_count_overages_cancellation_date(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1002,7 +1002,7 @@ def test_charge_for_api_call_count_overages_cancellation_date(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_scale_up_when_flagsmith_client_sets_is_enabled_to_false(
+def test_charge_for_api_call_count_overages_scale_up_when_flagsmith_client_sets_is_enabled_to_false(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1064,7 +1064,7 @@ def test_charge_for_api_call_count_overages_scale_up_when_flagsmith_client_sets_
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_grace_period(
+def test_charge_for_api_call_count_overages_grace_period(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1114,7 +1114,7 @@ def test_charge_for_api_call_count_overages_grace_period(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_grace_period_over(
+def test_charge_for_api_call_count_overages_grace_period_over(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1173,7 +1173,7 @@ def test_charge_for_api_call_count_overages_grace_period_over(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_with_not_covered_plan(
+def test_charge_for_api_call_count_overages_with_not_covered_plan(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1229,7 +1229,7 @@ def test_charge_for_api_call_count_overages_with_not_covered_plan(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_under_api_limit(
+def test_charge_for_api_call_count_overages_under_api_limit(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1282,7 +1282,7 @@ def test_charge_for_api_call_count_overages_under_api_limit(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_start_up(
+def test_charge_for_api_call_count_overages_start_up(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1373,7 +1373,7 @@ def test_charge_for_api_call_count_overages_start_up(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_non_standard(
+def test_charge_for_api_call_count_overages_non_standard(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
     inspecting_handler: logging.Handler,
@@ -1436,7 +1436,7 @@ def test_charge_for_api_call_count_overages_non_standard(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_with_exception(
+def test_charge_for_api_call_count_overages_with_exception(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
     inspecting_handler: logging.Handler,
@@ -1499,7 +1499,7 @@ def test_charge_for_api_call_count_overages_with_exception(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_start_up_with_api_billing(
+def test_charge_for_api_call_count_overages_start_up_with_api_billing(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1571,7 +1571,7 @@ def test_charge_for_api_call_count_overages_start_up_with_api_billing(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_with_yearly_account(
+def test_charge_for_api_call_count_overages_with_yearly_account(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1620,7 +1620,7 @@ def test_charge_for_api_call_count_overages_with_yearly_account(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_with_bad_plan(
+def test_charge_for_api_call_count_overages_with_bad_plan(  # noqa: FT003
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -1670,7 +1670,7 @@ def test_charge_for_api_call_count_overages_with_bad_plan(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_restrict_use_due_to_api_limit_grace_period_over(
+def test_restrict_use_due_to_api_limit_grace_period_over(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     freezer: FrozenDateTimeFactory,
@@ -1910,7 +1910,7 @@ def test_restrict_use_due_to_api_limit_grace_period_over(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_restrict_use_due_to_api_limit_grace_period_breached(
+def test_restrict_use_due_to_api_limit_grace_period_breached(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     freezer: FrozenDateTimeFactory,
@@ -1968,7 +1968,7 @@ def test_restrict_use_due_to_api_limit_grace_period_breached(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_restrict_use_due_to_api_limit_grace_period_over_missing_subscription_information_cache(
+def test_restrict_use_due_to_api_limit_grace_period_over_missing_subscription_information_cache(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     freezer: FrozenDateTimeFactory,
@@ -2010,7 +2010,7 @@ def test_restrict_use_due_to_api_limit_grace_period_over_missing_subscription_in
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_restrict_use_due_to_api_limit_grace_period_over_with_reduced_api_usage(
+def test_restrict_use_due_to_api_limit_grace_period_over_with_reduced_api_usage(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     freezer: FrozenDateTimeFactory,
@@ -2073,7 +2073,7 @@ def test_restrict_use_due_to_api_limit_grace_period_over_with_reduced_api_usage(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_unrestrict_after_api_limit_grace_period_is_stale(
+def test_unrestrict_after_api_limit_grace_period_is_stale(  # noqa: FT003
     organisation: Organisation,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -2158,7 +2158,7 @@ def test_unrestrict_after_api_limit_grace_period_is_stale(
     assert getattr(organisation4, "api_limit_access_block", None) is None
 
 
-def test_register_recurring_tasks(
+def test_register_recurring_tasks(  # noqa: FT003
     mocker: MockerFixture, settings: SettingsWrapper
 ) -> None:
     # Given

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -64,7 +64,7 @@ from users.models import (
 User = get_user_model()
 
 
-def test_should_return_organisation_list_when_requested(
+def test_should_return_organisation_list_when_requested(  # noqa: FT003,FT004
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -78,7 +78,7 @@ def test_should_return_organisation_list_when_requested(
     assert response.data["results"][0]["name"] == organisation.name
 
 
-def test_get_by_uuid_returns_organisation(
+def test_get_by_uuid_returns_organisation(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -96,7 +96,7 @@ def test_get_by_uuid_returns_organisation(
     assert response.json()["uuid"] == str(organisation.uuid)
 
 
-def test_get_by_uuid_returns_404_for_organisation_that_does_not_belong_to_the_user(
+def test_get_by_uuid_returns_404_for_organisation_that_does_not_belong_to_the_user(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -114,7 +114,7 @@ def test_get_by_uuid_returns_404_for_organisation_that_does_not_belong_to_the_us
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_non_superuser_can_create_new_organisation_by_default(
+def test_non_superuser_can_create_new_organisation_by_default(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
 ) -> None:
@@ -141,7 +141,7 @@ def test_non_superuser_can_create_new_organisation_by_default(
     )
 
 
-def test_colliding_hubspot_cookies_are_ignored(
+def test_colliding_hubspot_cookies_are_ignored(  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     admin_user: FFAdminUser,
@@ -176,7 +176,7 @@ def test_colliding_hubspot_cookies_are_ignored(
 
 
 @override_settings(RESTRICT_ORG_CREATE_TO_SUPERUSERS=True)  # type: ignore[misc]
-def test_create_new_orgnisation_returns_403_with_non_superuser(
+def test_create_new_orgnisation_returns_403_with_non_superuser(  # noqa: FT003
     staff_client: APIClient,
 ) -> None:
     # Given
@@ -196,7 +196,7 @@ def test_create_new_orgnisation_returns_403_with_non_superuser(
     )
 
 
-def test_saml_users_cannot_create_organisation(
+def test_saml_users_cannot_create_organisation(  # noqa: FT003
     mocker: MockerFixture,
     staff_client: APIClient,
     staff_user: FFAdminUser,
@@ -227,7 +227,7 @@ def test_saml_users_cannot_create_organisation(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_should_update_organisation_data(
+def test_should_update_organisation_data(  # noqa: FT003
     client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -254,7 +254,7 @@ def test_should_update_organisation_data(
         (timezone.now() - timedelta(days=5), timezone.now() - timedelta(days=1), False),
     ],
 )
-def test_get_subscription_metadata_returns_expected_result(
+def test_get_subscription_metadata_returns_expected_result(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
     current_billing_term_starts_at: datetime,
@@ -279,7 +279,7 @@ def test_get_subscription_metadata_returns_expected_result(
     )
 
 
-def test_should_invite_users_to_organisation(
+def test_should_invite_users_to_organisation(  # noqa: FT003
     settings: SettingsWrapper,
     admin_client: APIClient,
     organisation: Organisation,
@@ -300,7 +300,7 @@ def test_should_invite_users_to_organisation(
     assert Invite.objects.filter(email="test@example.com").exists()
 
 
-def test_should_fail_if_invite_exists_already(
+def test_should_fail_if_invite_exists_already(  # noqa: FT003
     settings: SettingsWrapper,
     admin_client: APIClient,
     organisation: Organisation,
@@ -348,7 +348,7 @@ def test_organisation_invite__non_admin__return_expected(
     assert not Invite.objects.filter(email=email, organisation=organisation).exists()
 
 
-def test_should_return_all_invites_and_can_resend(
+def test_should_return_all_invites_and_can_resend(  # noqa: FT003
     settings: SettingsWrapper,
     admin_client: APIClient,
     organisation: Organisation,
@@ -374,7 +374,7 @@ def test_should_return_all_invites_and_can_resend(
     assert invite_resend_response.status_code == status.HTTP_200_OK
 
 
-def test_remove_user_from_an_organisation_also_removes_from_group(
+def test_remove_user_from_an_organisation_also_removes_from_group(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
     admin_user: FFAdminUser,
@@ -406,7 +406,7 @@ def test_remove_user_from_an_organisation_also_removes_from_group(
     assert group in admin_user.permission_groups.all()
 
 
-def test_remove_user_from_an_organisation_also_removes_users_environment_and_project_permission(
+def test_remove_user_from_an_organisation_also_removes_users_environment_and_project_permission(  # noqa: FT003,FT004
     organisation: Organisation,
     admin_client: APIClient,
     admin_user: FFAdminUser,
@@ -453,7 +453,7 @@ def test_remove_user_from_an_organisation_also_removes_users_environment_and_pro
     )
 
 
-def test_can_invite_user_as_admin(
+def test_can_invite_user_as_admin(  # noqa: FT003
     settings: SettingsWrapper,
     admin_client: APIClient,
     organisation: Organisation,
@@ -478,7 +478,7 @@ def test_can_invite_user_as_admin(
     assert Invite.objects.get(email=invited_email).role == OrganisationRole.ADMIN.name
 
 
-def test_can_invite_user_as_user(
+def test_can_invite_user_as_user(  # noqa: FT003
     settings: SettingsWrapper,
     admin_client: APIClient,
     organisation: Organisation,
@@ -508,7 +508,7 @@ def test_can_invite_user_as_user(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("staff_client")],
 )
-def test_user_can_get_projects_for_an_organisation(
+def test_user_can_get_projects_for_an_organisation(  # noqa: FT003
     organisation: Organisation,
     client: APIClient,
     project: Project,
@@ -527,7 +527,7 @@ def test_user_can_get_projects_for_an_organisation(
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @mock.patch("app_analytics.influxdb_wrapper.influxdb_client")
-def test_should_get_usage_for_organisation(
+def test_should_get_usage_for_organisation(  # noqa: FT003
     mock_influxdb_client: MagicMock,
     organisation: Organisation,
     admin_client: APIClient,
@@ -565,7 +565,7 @@ def test_should_get_usage_for_organisation(
 
 
 @mock.patch("organisations.serializers.get_subscription_data_from_hosted_page")
-def test_update_subscription_gets_subscription_data_from_chargebee(
+def test_update_subscription_gets_subscription_data_from_chargebee(  # noqa: FT003
     mock_get_subscription_data: MagicMock,
     settings: SettingsWrapper,
     organisation: Organisation,
@@ -611,7 +611,7 @@ def test_update_subscription_gets_subscription_data_from_chargebee(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_delete_organisation(
+def test_delete_organisation(  # noqa: FT003
     organisation: Organisation,
     client: APIClient,
     project: Project,
@@ -645,7 +645,7 @@ def test_delete_organisation(
 
 
 @mock.patch("organisations.serializers.get_hosted_page_url_for_subscription_upgrade")
-def test_get_hosted_page_url_for_subscription_upgrade(
+def test_get_hosted_page_url_for_subscription_upgrade(  # noqa: FT003
     mock_get_hosted_page_url: MagicMock,
     organisation: Organisation,
     admin_client: APIClient,
@@ -678,7 +678,7 @@ def test_get_hosted_page_url_for_subscription_upgrade(
     )
 
 
-def test_get_organisation_permissions(
+def test_get_organisation_permissions(  # noqa: FT003
     staff_client: APIClient,
 ) -> None:
     # Given
@@ -692,7 +692,7 @@ def test_get_organisation_permissions(
     assert len(response.json()) == 2
 
 
-def test_get_my_permissions_for_non_admin(
+def test_get_my_permissions_for_non_admin(  # noqa: FT003
     organisation: Organisation,
     staff_client: APIClient,
     staff_user: FFAdminUser,
@@ -716,7 +716,7 @@ def test_get_my_permissions_for_non_admin(
     assert response.data["admin"] is False
 
 
-def test_get_my_permissions_for_admin(
+def test_get_my_permissions_for_admin(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
 ) -> None:
@@ -736,7 +736,7 @@ def test_get_my_permissions_for_admin(
 
 @pytest.mark.parametrize("subscription_status", ("active", "in_trial"))
 @mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
-def test_chargebee_webhook(
+def test_chargebee_webhook(  # noqa: FT003
     mock_extract_subscription_metadata: MagicMock,
     staff_user: FFAdminUser,
     staff_client: APIClient,
@@ -803,7 +803,7 @@ def test_chargebee_webhook(
 
 
 @mock.patch("organisations.models.cancel_chargebee_subscription")
-def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and_alert_sent(
+def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and_alert_sent(  # noqa: FT003
     mocked_cancel_chargebee_subscription: MagicMock,
     subscription: Subscription,
     staff_user: FFAdminUser,
@@ -846,7 +846,7 @@ def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @mock.patch("organisations.models.cancel_chargebee_subscription")
-def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and_current_term_end_is_missing(
+def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and_current_term_end_is_missing(  # noqa: FT003
     mocked_cancel_chargebee_subscription: MagicMock,
     chargebee_subscription: Subscription,
     staff_user: FFAdminUser,
@@ -882,7 +882,7 @@ def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and
     mocked_cancel_chargebee_subscription.assert_not_called()
 
 
-def test_when_subscription_is_cancelled_then_cancellation_date_set_and_alert_sent(
+def test_when_subscription_is_cancelled_then_cancellation_date_set_and_alert_sent(  # noqa: FT003
     subscription: Subscription,
     staff_user: FFAdminUser,
     staff_client: APIClient,
@@ -921,7 +921,7 @@ def test_when_subscription_is_cancelled_then_cancellation_date_set_and_alert_sen
 
 
 @mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
-def test_when_cancelled_subscription_is_renewed_then_subscription_activated_and_no_cancellation_email_sent(
+def test_when_cancelled_subscription_is_renewed_then_subscription_activated_and_no_cancellation_email_sent(  # noqa: FT003
     mock_extract_subscription_metadata: MagicMock,
     subscription: Subscription,
     staff_user: FFAdminUser,
@@ -960,7 +960,7 @@ def test_when_cancelled_subscription_is_renewed_then_subscription_activated_and_
     assert not mail.outbox
 
 
-def test_when_chargebee_webhook_received_with_unknown_subscription_id_then_200(
+def test_when_chargebee_webhook_received_with_unknown_subscription_id_then_200(  # noqa: FT003
     api_client: APIClient, caplog: LogCaptureFixture, django_user_model: Type[Model]
 ) -> None:
     # Given
@@ -990,7 +990,7 @@ def test_when_chargebee_webhook_received_with_unknown_subscription_id_then_200(
     )
 
 
-def test_user_can_create_new_webhook(
+def test_user_can_create_new_webhook(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -1008,7 +1008,7 @@ def test_user_can_create_new_webhook(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_can_update_secret_for_webhook(
+def test_can_update_secret_for_webhook(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
 ) -> None:
@@ -1036,7 +1036,7 @@ def test_can_update_secret_for_webhook(
     assert webhook.secret == data["secret"]
 
 
-def test_get_subscription_metadata_when_subscription_information_cache_exist(
+def test_get_subscription_metadata_when_subscription_information_cache_exist(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
     chargebee_subscription: Subscription,
@@ -1085,7 +1085,7 @@ def test_get_subscription_metadata_when_subscription_information_cache_exist(
     }
 
 
-def test_get_subscription_metadata_when_subscription_information_cache_does_not_exist(
+def test_get_subscription_metadata_when_subscription_information_cache_does_not_exist(  # noqa: FT003
     mocker: MockerFixture,
     organisation: Organisation,
     admin_client: APIClient,
@@ -1136,7 +1136,7 @@ def test_get_subscription_metadata_when_subscription_information_cache_does_not_
     )
 
 
-def test_get_subscription_metadata_returns_200_if_the_organisation_have_no_paid_subscription(
+def test_get_subscription_metadata_returns_200_if_the_organisation_have_no_paid_subscription(  # noqa: FT003
     mocker: MockerFixture, organisation: Organisation, admin_client: APIClient
 ) -> None:
     # Given
@@ -1169,7 +1169,7 @@ def test_get_subscription_metadata_returns_200_if_the_organisation_have_no_paid_
     get_subscription_metadata.assert_not_called()
 
 
-def test_get_subscription_metadata_returns_defaults_if_chargebee_error(  # type: ignore[no-untyped-def]
+def test_get_subscription_metadata_returns_defaults_if_chargebee_error(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation, admin_client, chargebee_subscription
 ) -> None:
     # Given
@@ -1195,7 +1195,7 @@ def test_get_subscription_metadata_returns_defaults_if_chargebee_error(  # type:
     }
 
 
-def test_can_invite_user_with_permission_groups(  # type: ignore[no-untyped-def]
+def test_can_invite_user_with_permission_groups(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings, admin_client, organisation, user_permission_group
 ) -> None:
     # Given
@@ -1237,7 +1237,7 @@ def test_can_invite_user_with_permission_groups(  # type: ignore[no-untyped-def]
         ("environment_id=1", {"environment_id": 1}),
     ),
 )
-def test_organisation_get_influx_data(  # type: ignore[no-untyped-def]
+def test_organisation_get_influx_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, admin_client, organisation, query_string, expected_filter_args
 ) -> None:
     # Given
@@ -1271,7 +1271,7 @@ def test_organisation_get_influx_data(  # type: ignore[no-untyped-def]
 )
 @mock.patch("organisations.models.get_plan_meta_data")
 @mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
-def test_when_plan_is_changed_max_seats_and_max_api_calls_are_updated(  # type: ignore[no-untyped-def]
+def test_when_plan_is_changed_max_seats_and_max_api_calls_are_updated(  # type: ignore[no-untyped-def]  # noqa: FT003
     mock_extract_subscription_metadata,
     mock_get_plan_meta_data,
     subscription,
@@ -1351,7 +1351,7 @@ def test_when_plan_is_changed_max_seats_and_max_api_calls_are_updated(  # type: 
         assert subscription_information_cache.chargebee_updated_at > updated_at
 
 
-def test_delete_organisation_does_not_delete_all_subscriptions_from_the_database(  # type: ignore[no-untyped-def]
+def test_delete_organisation_does_not_delete_all_subscriptions_from_the_database(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, admin_user, organisation, subscription
 ) -> None:
     """
@@ -1375,7 +1375,7 @@ def test_delete_organisation_does_not_delete_all_subscriptions_from_the_database
     assert Subscription.objects.filter(organisation=another_organisation).exists()
 
 
-def test_make_user_group_admin_user_does_not_belong_to_group(  # type: ignore[no-untyped-def]
+def test_make_user_group_admin_user_does_not_belong_to_group(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, admin_user, organisation, user_permission_group
 ) -> None:
     # Given
@@ -1393,7 +1393,7 @@ def test_make_user_group_admin_user_does_not_belong_to_group(  # type: ignore[no
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_make_user_group_admin_success(  # type: ignore[no-untyped-def]
+def test_make_user_group_admin_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, admin_user, organisation, user_permission_group
 ) -> None:
     # Given
@@ -1419,7 +1419,7 @@ def test_make_user_group_admin_success(  # type: ignore[no-untyped-def]
     )
 
 
-def test_make_user_group_admin_forbidden(
+def test_make_user_group_admin_forbidden(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
@@ -1440,7 +1440,7 @@ def test_make_user_group_admin_forbidden(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_remove_user_as_group_admin_user_does_not_belong_to_group(  # type: ignore[no-untyped-def]
+def test_remove_user_as_group_admin_user_does_not_belong_to_group(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, admin_user, organisation, user_permission_group
 ) -> None:
     # Given
@@ -1458,7 +1458,7 @@ def test_remove_user_as_group_admin_user_does_not_belong_to_group(  # type: igno
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_remove_user_as_group_admin_success(  # type: ignore[no-untyped-def]
+def test_remove_user_as_group_admin_success(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, admin_user, organisation, user_permission_group
 ) -> None:
     # Given
@@ -1485,7 +1485,7 @@ def test_remove_user_as_group_admin_success(  # type: ignore[no-untyped-def]
     )
 
 
-def test_remove_user_as_group_admin_forbidden(
+def test_remove_user_as_group_admin_forbidden(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
@@ -1506,7 +1506,7 @@ def test_remove_user_as_group_admin_forbidden(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_list_user_groups_as_group_admin(organisation, api_client) -> None:  # type: ignore[no-untyped-def]
+def test_list_user_groups_as_group_admin(organisation, api_client) -> None:  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     user1 = FFAdminUser.objects.create(email="user1@example.com")
     user2 = FFAdminUser.objects.create(email="user2@example.com")
@@ -1547,7 +1547,7 @@ def test_list_user_groups_as_group_admin(organisation, api_client) -> None:  # t
     assert response_json["results"][0]["id"] == user_permission_group_1.id
 
 
-def test_list_my_groups(organisation, api_client) -> None:  # type: ignore[no-untyped-def]
+def test_list_my_groups(organisation, api_client) -> None:  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     user1 = FFAdminUser.objects.create(email="user1@example.com")
     user2 = FFAdminUser.objects.create(email="user2@example.com")
@@ -1590,7 +1590,7 @@ def test_list_my_groups(organisation, api_client) -> None:  # type: ignore[no-un
     }
 
 
-def test_payment_failed_chargebee_webhook(
+def test_payment_failed_chargebee_webhook(  # noqa: FT003
     staff_client: FFAdminUser, subscription: Subscription
 ) -> None:
     # Given
@@ -1625,7 +1625,7 @@ def test_payment_failed_chargebee_webhook(
     assert subscription.billing_status == SUBSCRIPTION_BILLING_STATUS_DUNNING
 
 
-def test_payment_failed_chargebee_webhook_when_not_dunning(
+def test_payment_failed_chargebee_webhook_when_not_dunning(  # noqa: FT003
     staff_client: FFAdminUser, subscription: Subscription
 ) -> None:
     # Given
@@ -1662,7 +1662,7 @@ def test_payment_failed_chargebee_webhook_when_not_dunning(
     assert subscription.billing_status == SUBSCRIPTION_BILLING_STATUS_ACTIVE
 
 
-def test_when_subscription_is_cancelled_then_remove_all_but_the_first_user(
+def test_when_subscription_is_cancelled_then_remove_all_but_the_first_user(  # noqa: FT003
     staff_client: APIClient,
     subscription: Subscription,
     organisation: Organisation,
@@ -1705,7 +1705,7 @@ def test_when_subscription_is_cancelled_then_remove_all_but_the_first_user(
     assert organisation.num_seats == 1
 
 
-def test_payment_failed_chargebee_webhook_no_subscription_id(
+def test_payment_failed_chargebee_webhook_no_subscription_id(  # noqa: FT003
     staff_client: FFAdminUser, subscription: Subscription
 ) -> None:
     # Given
@@ -1739,7 +1739,7 @@ def test_payment_failed_chargebee_webhook_no_subscription_id(
     assert subscription.billing_status == SUBSCRIPTION_BILLING_STATUS_ACTIVE
 
 
-def test_cache_rebuild_event_chargebee_webhook(
+def test_cache_rebuild_event_chargebee_webhook(  # noqa: FT003
     staff_client: FFAdminUser,
     mocker: MockerFixture,
 ) -> None:
@@ -1780,7 +1780,7 @@ def test_cache_rebuild_event_chargebee_webhook(
     task.delay.assert_called_once_with()
 
 
-def test_payment_succeeded_chargebee_webhook(
+def test_payment_succeeded_chargebee_webhook(  # noqa: FT003
     staff_client: FFAdminUser, subscription: Subscription
 ) -> None:
     # Given
@@ -1814,7 +1814,7 @@ def test_payment_succeeded_chargebee_webhook(
     assert subscription.billing_status == SUBSCRIPTION_BILLING_STATUS_ACTIVE
 
 
-def test_payment_succeeded_chargebee_webhook_no_subscription_id(
+def test_payment_succeeded_chargebee_webhook_no_subscription_id(  # noqa: FT003
     staff_client: FFAdminUser, subscription: Subscription
 ) -> None:
     # Given
@@ -1846,7 +1846,7 @@ def test_payment_succeeded_chargebee_webhook_no_subscription_id(
     assert subscription.billing_status == SUBSCRIPTION_BILLING_STATUS_DUNNING
 
 
-def test_list_organisations_shows_dunning(
+def test_list_organisations_shows_dunning(  # noqa: FT003
     staff_client: FFAdminUser, subscription: Subscription
 ) -> None:
     # Given
@@ -1865,7 +1865,7 @@ def test_list_organisations_shows_dunning(
     assert _subscription["billing_status"] == SUBSCRIPTION_BILLING_STATUS_DUNNING
 
 
-def test_list_group_summaries(
+def test_list_group_summaries(  # noqa: FT003
     organisation: Organisation, staff_client: APIClient
 ) -> None:
     # Given
@@ -1898,7 +1898,7 @@ def test_list_group_summaries(
     }
 
 
-def test_user_from_another_organisation_cannot_list_group_summaries(
+def test_user_from_another_organisation_cannot_list_group_summaries(  # noqa: FT003
     organisation: Organisation, api_client: APIClient
 ) -> None:
     # Given
@@ -1920,7 +1920,7 @@ def test_user_from_another_organisation_cannot_list_group_summaries(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_defaults_to_empty_api_notifications_when_no_subscription_information_cache(
+def test_defaults_to_empty_api_notifications_when_no_subscription_information_cache(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -1950,7 +1950,7 @@ def test_defaults_to_empty_api_notifications_when_no_subscription_information_ca
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_retrieves_api_usage_notifications(
+def test_retrieves_api_usage_notifications(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -2001,7 +2001,7 @@ def test_retrieves_api_usage_notifications(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_doesnt_retrieve_stale_api_usage_notifications(
+def test_doesnt_retrieve_stale_api_usage_notifications(  # noqa: FT003
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -2037,7 +2037,7 @@ def test_doesnt_retrieve_stale_api_usage_notifications(
     assert len(response.data["results"]) == 0
 
 
-def test_non_organisation_user_cannot_remove_user_from_organisation(
+def test_non_organisation_user_cannot_remove_user_from_organisation(  # noqa: FT003
     staff_user: FFAdminUser, organisation: Organisation, api_client: APIClient
 ) -> None:
     # Given
@@ -2061,7 +2061,7 @@ def test_non_organisation_user_cannot_remove_user_from_organisation(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_non_admin_user_cannot_remove_user_from_organisation(
+def test_non_admin_user_cannot_remove_user_from_organisation(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     staff_client: APIClient,
@@ -2083,7 +2083,7 @@ def test_non_admin_user_cannot_remove_user_from_organisation(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_validation_error_if_non_numeric_organisation_id(
+def test_validation_error_if_non_numeric_organisation_id(  # noqa: FT003
     staff_client: APIClient,
 ) -> None:
     # Given
@@ -2100,7 +2100,7 @@ def test_validation_error_if_non_numeric_organisation_id(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_organisation_user_can_get_their_detailed_permissions(
+def test_organisation_user_can_get_their_detailed_permissions(  # noqa: FT003
     staff_client: APIClient,
     with_organisation_permissions: WithOrganisationPermissionsCallable,
     organisation: Organisation,
@@ -2130,7 +2130,7 @@ def test_organisation_user_can_get_their_detailed_permissions(
     ]
 
 
-def test_organisation_user_can_not_get_detailed_permissions_of_other_user(
+def test_organisation_user_can_not_get_detailed_permissions_of_other_user(  # noqa: FT003
     staff_client: APIClient,
     with_organisation_permissions: WithOrganisationPermissionsCallable,
     organisation: Organisation,
@@ -2150,7 +2150,7 @@ def test_organisation_user_can_not_get_detailed_permissions_of_other_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_organisation_admin_can_get_detailed_permissions_of_other_user(
+def test_organisation_admin_can_get_detailed_permissions_of_other_user(  # noqa: FT003
     admin_client: APIClient,
     with_organisation_permissions: WithOrganisationPermissionsCallable,
     organisation: Organisation,

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
@@ -25,7 +25,7 @@ from projects.models import (
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_get_permitted_environments_for_user_returns_all_environments_for_org_admin(  # type: ignore[no-untyped-def]
+def test_get_permitted_environments_for_user_returns_all_environments_for_org_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_user, environment, project, project_two_environment
 ):
     for permission in EnvironmentPermissionModel.objects.all().values_list(
@@ -45,7 +45,7 @@ def test_get_permitted_environments_for_user_returns_all_environments_for_org_ad
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_get_permitted_environments_for_user_returns_all_the_environments_for_project_admin(  # noqa: E501
+def test_get_permitted_environments_for_user_returns_all_the_environments_for_project_admin(  # noqa: E501,FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     project: Project,
@@ -71,7 +71,7 @@ def test_get_permitted_environments_for_user_returns_all_the_environments_for_pr
         (lazy_fixture("environment_admin_via_user_permission_group")),
     ],
 )
-def test_get_permitted_environments_for_user_returns_the_environment_for_environment_admin(  # noqa: E501
+def test_get_permitted_environments_for_user_returns_the_environment_for_environment_admin(  # noqa: E501,FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     project: Project,
@@ -90,7 +90,7 @@ def test_get_permitted_environments_for_user_returns_the_environment_for_environ
         )
 
 
-def test_get_permitted_environments_for_user_returns_correct_environment(
+def test_get_permitted_environments_for_user_returns_correct_environment(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     project_two_environment: Environment,
@@ -151,7 +151,7 @@ def test_get_permitted_environments_for_user_returns_correct_environment(
         )
 
 
-def test_get_permitted_environments_for_user__does_not_return_environment_for_orphan_group_permission(
+def test_get_permitted_environments_for_user__does_not_return_environment_for_orphan_group_permission(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     environment: Environment,

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_projects_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_projects_for_user.py
@@ -20,7 +20,7 @@ from projects.models import (
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_get_permitted_projects_for_user_returns_all_projects_for_org_admin(  # type: ignore[no-untyped-def]
+def test_get_permitted_projects_for_user_returns_all_projects_for_org_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_user, project, project_two
 ):
     for permission in ProjectPermissionModel.objects.all().values_list(
@@ -37,7 +37,7 @@ def test_get_permitted_projects_for_user_returns_all_projects_for_org_admin(  # 
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_get_permitted_projects_for_user_returns_the_project_for_project_admin(
+def test_get_permitted_projects_for_user_returns_the_project_for_project_admin(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
     project_admin: typing.Union[
@@ -52,7 +52,7 @@ def test_get_permitted_projects_for_user_returns_the_project_for_project_admin(
         assert get_permitted_projects_for_user(staff_user, permission).count() == 1
 
 
-def test_get_permitted_projects_for_user_returns_correct_project(
+def test_get_permitted_projects_for_user_returns_correct_project(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
     view_project_permission: PermissionModel,
@@ -106,7 +106,7 @@ def test_get_permitted_projects_for_user_returns_correct_project(
         )
 
 
-def test_get_permitted_project_for_user__does_not_return_project_for_orphan_group_permission(
+def test_get_permitted_project_for_user__does_not_return_project_for_orphan_group_permission(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     user_permission_group: UserPermissionGroup,

--- a/api/tests/unit/permissions/permission_service/test_is_user_environment_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_environment_admin.py
@@ -19,7 +19,7 @@ from projects.models import (
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_is_user_environment_admin_returns_true_for_org_admin(admin_user, environment):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_is_user_environment_admin_returns_true_for_org_admin(admin_user, environment):  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     assert is_user_environment_admin(admin_user, environment) is True
 
 
@@ -30,7 +30,7 @@ def test_is_user_environment_admin_returns_true_for_org_admin(admin_user, enviro
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_is_user_environment_admin_returns_true_for_project_admin(
+def test_is_user_environment_admin_returns_true_for_project_admin(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     project_admin: typing.Union[
@@ -48,7 +48,7 @@ def test_is_user_environment_admin_returns_true_for_project_admin(
         (lazy_fixture("environment_admin_via_user_permission_group")),
     ],
 )
-def test_is_user_environment_admin_returns_true_for_environment_admin(  # type: ignore[no-untyped-def]
+def test_is_user_environment_admin_returns_true_for_environment_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     environment_admin: typing.Union[
@@ -59,14 +59,14 @@ def test_is_user_environment_admin_returns_true_for_environment_admin(  # type: 
     assert is_user_environment_admin(staff_user, environment) is True
 
 
-def test_is_user_environment_admin_returns_false_for_user_with_no_permission(
+def test_is_user_environment_admin_returns_false_for_user_with_no_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
 ) -> None:
     assert is_user_environment_admin(staff_user, environment) is False
 
 
-def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_of_other_org(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_of_other_org(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     admin_user,
     organisation_two_project_one_environment_one,
 ):
@@ -78,7 +78,7 @@ def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_
     )
 
 
-def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_of_other_environment(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_of_other_environment(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     django_user_model,
     environment,
     user_project_permission,
@@ -106,7 +106,7 @@ def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_
     assert is_user_environment_admin(user, environment) is False
 
 
-def test_is_user_environment_admin__does_not_return_environment_for_orphan_group_permission(
+def test_is_user_environment_admin__does_not_return_environment_for_orphan_group_permission(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     environment: Environment,
@@ -137,7 +137,7 @@ def test_is_user_environment_admin__does_not_return_environment_for_orphan_group
     assert not is_user_environment_admin(user=staff_user, environment=environment)
 
 
-def test_is_user_environment_admin__short_circuits_on_direct_permission(
+def test_is_user_environment_admin__short_circuits_on_direct_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     environment_admin_via_user_permission: UserEnvironmentPermission,
@@ -156,7 +156,7 @@ def test_is_user_environment_admin__short_circuits_on_direct_permission(
         assert is_user_environment_admin(staff_user, environment) is True
 
 
-def test_is_user_environment_admin__short_circuits_on_group_permission(
+def test_is_user_environment_admin__short_circuits_on_group_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     environment: Environment,
     environment_admin_via_user_permission_group: UserPermissionGroupEnvironmentPermission,

--- a/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
@@ -13,7 +13,7 @@ from projects.models import (
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_is_user_project_admin_returns_true_for_org_admin(admin_user, project):  # type: ignore[no-untyped-def]
+def test_is_user_project_admin_returns_true_for_org_admin(admin_user, project):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert is_user_project_admin(admin_user, project) is True
 
 
@@ -24,7 +24,7 @@ def test_is_user_project_admin_returns_true_for_org_admin(admin_user, project): 
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_is_user_project_admin_returns_true_for_project_admin(
+def test_is_user_project_admin_returns_true_for_project_admin(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
     project_admin: typing.Union[
@@ -35,21 +35,21 @@ def test_is_user_project_admin_returns_true_for_project_admin(
     assert is_user_project_admin(staff_user, project) is True
 
 
-def test_is_user_project_admin_returns_false_for_user_with_no_permission(
+def test_is_user_project_admin_returns_false_for_user_with_no_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
     assert is_user_project_admin(staff_user, project) is False
 
 
-def test_is_user_project_admin_returns_false_for_user_with_admin_permission_of_other_org(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_is_user_project_admin_returns_false_for_user_with_admin_permission_of_other_org(  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     admin_user,
     organisation_two_project_one,
 ):
     assert is_user_project_admin(admin_user, organisation_two_project_one) is False
 
 
-def test_is_user_project_admin_returns_false_for_user_with_incorrect_permission(  # type: ignore[no-untyped-def]
+def test_is_user_project_admin_returns_false_for_user_with_incorrect_permission(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_user,
     user_project_permission,
     user_project_permission_group,
@@ -68,7 +68,7 @@ def test_is_user_project_admin_returns_false_for_user_with_incorrect_permission(
     assert is_user_project_admin(admin_user, organisation_two_project_one) is False
 
 
-def test_is_user_project_admin__does_not_return_project_for_orphan_group_permission(
+def test_is_user_project_admin__does_not_return_project_for_orphan_group_permission(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     user_permission_group: UserPermissionGroup,
@@ -98,7 +98,7 @@ def test_is_user_project_admin__does_not_return_project_for_orphan_group_permiss
     assert not is_user_project_admin(user=staff_user, project=project)
 
 
-def test_is_user_project_admin__short_circuits_on_direct_permission(
+def test_is_user_project_admin__short_circuits_on_direct_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
     project_admin_via_user_permission: UserProjectPermission,
@@ -112,7 +112,7 @@ def test_is_user_project_admin__short_circuits_on_direct_permission(
         assert is_user_project_admin(staff_user, project) is True
 
 
-def test_is_user_project_admin__short_circuits_on_group_permission(
+def test_is_user_project_admin__short_circuits_on_group_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
     project_admin_via_user_permission_group: UserPermissionGroupProjectPermission,

--- a/api/tests/unit/permissions/permission_service/test_master_api_key_permission_service.py
+++ b/api/tests/unit/permissions/permission_service/test_master_api_key_permission_service.py
@@ -30,7 +30,7 @@ from projects.models import ProjectPermissionModel
         ),
     ],
 )
-def test_is_master_api_key_project_admin(  # type: ignore[no-untyped-def]
+def test_is_master_api_key_project_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_project,
     for_master_api_key,
     expected_is_admin,
@@ -64,7 +64,7 @@ def test_is_master_api_key_project_admin(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_is_master_api_key_environment_admin(  # type: ignore[no-untyped-def]
+def test_is_master_api_key_environment_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_environment,
     for_master_api_key,
     expected_is_admin,
@@ -93,7 +93,7 @@ def test_is_master_api_key_environment_admin(  # type: ignore[no-untyped-def]
         ),
     ],
 )
-def test_get_permitted_projects_for_master_api_key(  # type: ignore[no-untyped-def]
+def test_get_permitted_projects_for_master_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_project,
     for_master_api_key,
     expected_count,
@@ -128,7 +128,7 @@ def test_get_permitted_projects_for_master_api_key(  # type: ignore[no-untyped-d
         ),
     ],
 )
-def test_get_permitted_environments_for_master_api_key(  # type: ignore[no-untyped-def]
+def test_get_permitted_environments_for_master_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_project,
     for_master_api_key,
     expected_count,
@@ -172,7 +172,7 @@ def test_get_permitted_environments_for_master_api_key(  # type: ignore[no-untyp
         ),
     ],
 )
-def test_master_api_key_has_organisation_permission(  # type: ignore[no-untyped-def]
+def test_master_api_key_has_organisation_permission(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     for_organisation,
     for_master_api_key,
     expected_has_permission,

--- a/api/tests/unit/permissions/permission_service/test_user_has_organisation_permissions.py
+++ b/api/tests/unit/permissions/permission_service/test_user_has_organisation_permissions.py
@@ -13,7 +13,7 @@ from permissions.permission_service import user_has_organisation_permission
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_user_has_organisation_permission_returns_false_if_user_does_not_have_permission(
+def test_user_has_organisation_permission_returns_false_if_user_does_not_have_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -26,7 +26,7 @@ def test_user_has_organisation_permission_returns_false_if_user_does_not_have_pe
         )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_is_admin(  # type: ignore[no-untyped-def]
+def test_user_has_organisation_permission_returns_true_if_user_is_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_user, organisation
 ):
     for permission in OrganisationPermissionModel.objects.all().values_list(
@@ -38,7 +38,7 @@ def test_user_has_organisation_permission_returns_true_if_user_is_admin(  # type
         )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_has_permission_directly(
+def test_user_has_organisation_permission_returns_true_if_user_has_permission_directly(  # noqa: FT003,FT004
     staff_user: FFAdminUser, organisation: Organisation
 ) -> None:
     # Given
@@ -59,7 +59,7 @@ def test_user_has_organisation_permission_returns_true_if_user_has_permission_di
     )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group(
+def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
@@ -83,7 +83,7 @@ def test_user_has_organisation_permission_returns_true_if_user_has_permission_vi
     )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group_and_directly(
+def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group_and_directly(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
@@ -111,7 +111,7 @@ def test_user_has_organisation_permission_returns_true_if_user_has_permission_vi
     )
 
 
-def test_user_has_organisation_permission__returns_false_for_orphan_group_permission(
+def test_user_has_organisation_permission__returns_false_for_orphan_group_permission(  # noqa: FT003
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
     staff_user: FFAdminUser,

--- a/api/tests/unit/permissions/test_migrations.py
+++ b/api/tests/unit/permissions/test_migrations.py
@@ -3,7 +3,7 @@ from django_test_migrations.migrator import Migrator
 from organisations.models import OrganisationRole
 
 
-def test_migration_only_remove_permissions_for_users_that_are_not_part_of_the_organisation(  # noqa: E501
+def test_migration_only_remove_permissions_for_users_that_are_not_part_of_the_organisation(  # noqa: E501,FT003,FT004
     migrator: Migrator,
 ) -> None:
     # Given - the migration state is at 0004 (before the migration we want to test)

--- a/api/tests/unit/permissions/test_unit_permissions_calculator.py
+++ b/api/tests/unit/permissions/test_unit_permissions_calculator.py
@@ -74,7 +74,7 @@ from users.models import FFAdminUser, UserPermissionGroup
         ),
     ),
 )
-def test_project_permissions_calculator_get_permission_data(  # type: ignore[no-untyped-def]
+def test_project_permissions_calculator_get_permission_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     project,
     organisation,
     django_user_model,
@@ -120,7 +120,7 @@ def test_project_permissions_calculator_get_permission_data(  # type: ignore[no-
     assert user_permission_data.inherited_admin_roles == []
 
 
-def test_project_permissions_calculator_get_permission_data_for_organisation_admin(
+def test_project_permissions_calculator_get_permission_data_for_organisation_admin(  # noqa: FT003
     project: Project, organisation: Organisation, django_user_model: FFAdminUser
 ) -> None:
     # Given
@@ -182,7 +182,7 @@ def test_project_permissions_calculator_get_permission_data_for_organisation_adm
         ),
     ),
 )
-def test_environment_permissions_calculator_get_permission_data(  # type: ignore[no-untyped-def]
+def test_environment_permissions_calculator_get_permission_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     environment,
     organisation,
     django_user_model,
@@ -238,7 +238,7 @@ def test_environment_permissions_calculator_get_permission_data(  # type: ignore
     assert user_permission_data.inherited_admin_roles == []
 
 
-def test_environment_permissions_calculator_get_permission_data_for_direct_project_admin(
+def test_environment_permissions_calculator_get_permission_data_for_direct_project_admin(  # noqa: FT003
     environment: Environment,
     project: Project,
     organisation: Organisation,
@@ -259,7 +259,7 @@ def test_environment_permissions_calculator_get_permission_data_for_direct_proje
     assert user_permission_data.admin is True
 
 
-def test_environment_permissions_calculator_get_permission_data_for_project_admin_through_group(
+def test_environment_permissions_calculator_get_permission_data_for_project_admin_through_group(  # noqa: FT003
     environment: Environment,
     project: Project,
     organisation: Organisation,
@@ -293,7 +293,7 @@ def test_environment_permissions_calculator_get_permission_data_for_project_admi
     assert user_permission_data.inherited_admin_roles == []
 
 
-def test_environment_permissions_calculator_get_permission_data_for_project_admin_through_role(
+def test_environment_permissions_calculator_get_permission_data_for_project_admin_through_role(  # noqa: FT003
     environment: Environment,
     project: Project,
     organisation: Organisation,
@@ -334,7 +334,7 @@ def test_environment_permissions_calculator_get_permission_data_for_project_admi
     assert user_permission_data.inherited_admin_roles == [admin_role]
 
 
-def test_environment_permissions_calculator_get_permission_data_for_organisation_admin(
+def test_environment_permissions_calculator_get_permission_data_for_organisation_admin(  # noqa: FT003
     environment: Environment,
     organisation: Organisation,
     django_user_model: FFAdminUser,
@@ -376,7 +376,7 @@ def test_environment_permissions_calculator_get_permission_data_for_organisation
         ),
     ),
 )
-def test_organisation_permissions_calculator_get_permission_data(  # type: ignore[no-untyped-def]
+def test_organisation_permissions_calculator_get_permission_data(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation,
     django_user_model,
     user_permissions,
@@ -431,7 +431,7 @@ def test_organisation_permissions_calculator_get_permission_data(  # type: ignor
     assert user_permission_data.inherited_admin_roles == []
 
 
-def test_permission_data_to_detailed_permissions_data() -> None:
+def test_permission_data_to_detailed_permissions_data() -> None:  # noqa: FT003
     # Given
     user_permission_data = UserPermissionData(
         admin=True, permissions={CREATE_CHANGE_REQUEST}

--- a/api/tests/unit/platform_hub/test_services.py
+++ b/api/tests/unit/platform_hub/test_services.py
@@ -118,7 +118,7 @@ def test_get_summary__no_analytics__returns_zero_api_calls(
     assert result["total_api_calls_30d"] == 0
 
 
-def test_get_organisation_metrics__returns_nested_structure(
+def test_get_organisation_metrics__returns_nested_structure(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
@@ -147,7 +147,7 @@ def test_get_organisation_metrics__returns_nested_structure(
     assert len(org_data["projects"][0]["environments"]) == 1
 
 
-def test_get_organisation_metrics__includes_overage_calculations(
+def test_get_organisation_metrics__includes_overage_calculations(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
@@ -176,7 +176,7 @@ def test_get_organisation_metrics__includes_overage_calculations(
     assert org_data["overage_90d"] == 0
 
 
-def test_get_organisation_metrics__filters_to_given_orgs(
+def test_get_organisation_metrics__filters_to_given_orgs(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
@@ -387,7 +387,7 @@ def test_get_usage_trends__no_analytics__returns_empty(
     assert result == []
 
 
-def test_get_organisation_metrics__query_count_stable_across_projects(
+def test_get_organisation_metrics__query_count_stable_across_projects(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
@@ -424,7 +424,7 @@ def test_get_organisation_metrics__query_count_stable_across_projects(
     assert result[0]["project_count"] == 2
 
 
-def test_get_stale_flags_per_project__query_count_stable_across_projects(
+def test_get_stale_flags_per_project__query_count_stable_across_projects(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_admin_user: FFAdminUser,
 ) -> None:
@@ -507,7 +507,7 @@ def test_get_stale_flags_per_project__no_flags__skips_project(
     assert result == []
 
 
-def test_get_stale_flags_per_project__filters_to_given_orgs(
+def test_get_stale_flags_per_project__filters_to_given_orgs(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
@@ -528,7 +528,7 @@ def test_get_stale_flags_per_project__filters_to_given_orgs(
     assert other_org_project.id not in project_ids
 
 
-def test_get_integration_breakdown__counts_all_types_with_scope(
+def test_get_integration_breakdown__counts_all_types_with_scope(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,
@@ -570,7 +570,7 @@ def test_get_release_pipeline_stats__not_installed__returns_empty(
     assert result == []
 
 
-def test_get_release_pipeline_stats__returns_stage_hierarchy(
+def test_get_release_pipeline_stats__returns_stage_hierarchy(  # noqa: FT003
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
     platform_hub_environment: Environment,

--- a/api/tests/unit/platform_hub/test_views.py
+++ b/api/tests/unit/platform_hub/test_views.py
@@ -146,7 +146,7 @@ def test_organisations_view__user_admin_of_one_org__returns_only_that_org(
     assert data[0]["name"] == "Platform Hub Org"
 
 
-def test_organisations_view__other_orgs_data_not_visible(
+def test_organisations_view__other_orgs_data_not_visible(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
     other_organisation: Organisation,
@@ -170,7 +170,7 @@ def test_organisations_view__other_orgs_data_not_visible(
     assert other_organisation.id not in org_ids
 
 
-def test_organisations_view__returns_nested_projects_and_environments(
+def test_organisations_view__returns_nested_projects_and_environments(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
@@ -197,7 +197,7 @@ def test_organisations_view__returns_nested_projects_and_environments(
     assert org["projects"][0]["environments"][0]["name"] == "Hub Environment"
 
 
-def test_organisations_view__includes_overage_fields(
+def test_organisations_view__includes_overage_fields(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
@@ -223,7 +223,7 @@ def test_organisations_view__includes_overage_fields(
     assert "api_calls_allowed" in org
 
 
-def test_usage_trends_view__returns_trends_for_admin_orgs_only(
+def test_usage_trends_view__returns_trends_for_admin_orgs_only(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
 ) -> None:
@@ -238,7 +238,7 @@ def test_usage_trends_view__returns_trends_for_admin_orgs_only(
     assert isinstance(response.json(), list)
 
 
-def test_stale_flags_view__returns_stale_flags_for_admin_orgs_only(
+def test_stale_flags_view__returns_stale_flags_for_admin_orgs_only(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
@@ -262,7 +262,7 @@ def test_stale_flags_view__returns_stale_flags_for_admin_orgs_only(
     assert other_organisation.id not in org_ids
 
 
-def test_integrations_view__returns_integrations_for_admin_orgs_only(
+def test_integrations_view__returns_integrations_for_admin_orgs_only(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
     platform_hub_project: Project,
@@ -289,7 +289,7 @@ def test_integrations_view__returns_integrations_for_admin_orgs_only(
         assert item["organisation_id"] != other_organisation.id
 
 
-def test_release_pipelines_view__returns_pipelines_for_admin_orgs_only(
+def test_release_pipelines_view__returns_pipelines_for_admin_orgs_only(  # noqa: FT003
     platform_hub_admin_client: APIClient,
     platform_hub_organisation: Organisation,
 ) -> None:

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_services.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_services.py
@@ -11,7 +11,7 @@ from projects.code_references.types import VCSProvider
         "https://github.com/Flagsmith/flagsmith/",  # with trailing slash
     ],
 )
-def test_get_permalink_generates_valid_public_github_url(
+def test_get_permalink_generates_valid_public_github_url(  # noqa: FT003,FT004
     repository_url: str,
 ) -> None:
     # When
@@ -36,7 +36,7 @@ def test_get_permalink_generates_valid_public_github_url(
         "https://github.flagsmith.com/flagsmith/backend/",  # with trailing slash
     ],
 )
-def test_get_permalink_generates_valid_private_github_url(
+def test_get_permalink_generates_valid_private_github_url(  # noqa: FT003,FT004
     repository_url: str,
 ) -> None:
     # When

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
@@ -7,7 +7,7 @@ from projects.models import Project
 
 
 @freezegun.freeze_time("2025-04-14T09:30:00-0300")
-def test_CodeReferenceCreateAPIView__responds_201_with_accepted_code_references(
+def test_CodeReferenceCreateAPIView__responds_201_with_accepted_code_references(  # noqa: FT003,FT004
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -64,7 +64,7 @@ def test_CodeReferenceCreateAPIView__responds_201_with_accepted_code_references(
     ]
 
 
-def test_CodeReferenceCreateView__responds_401_if_not_authenticated(
+def test_CodeReferenceCreateView__responds_401_if_not_authenticated(  # noqa: FT003,FT004
     client: APIClient,
     project: Project,
 ) -> None:
@@ -90,7 +90,7 @@ def test_CodeReferenceCreateView__responds_401_if_not_authenticated(
     assert not FeatureFlagCodeReferencesScan.objects.exists()
 
 
-def test_CodeReferenceCreateAPIView__responds_403_if_incorrect_permissions(
+def test_CodeReferenceCreateAPIView__responds_403_if_incorrect_permissions(  # noqa: FT003,FT004
     project: Project,
     staff_client: APIClient,
 ) -> None:
@@ -116,7 +116,7 @@ def test_CodeReferenceCreateAPIView__responds_403_if_incorrect_permissions(
     assert not FeatureFlagCodeReferencesScan.objects.exists()
 
 
-def test_CodeReferenceCreateAPIView__responds_400_when_missing_field(
+def test_CodeReferenceCreateAPIView__responds_400_when_missing_field(  # noqa: FT003,FT004
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -145,7 +145,7 @@ def test_CodeReferenceCreateAPIView__responds_400_when_missing_field(
     assert not FeatureFlagCodeReferencesScan.objects.exists()
 
 
-def test_CodeReferenceCreateAPIView__responds_400_when_file_path_too_long(
+def test_CodeReferenceCreateAPIView__responds_400_when_file_path_too_long(  # noqa: FT003,FT004
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
@@ -176,7 +176,7 @@ def test_CodeReferenceCreateAPIView__responds_400_when_file_path_too_long(
     assert not FeatureFlagCodeReferencesScan.objects.exists()
 
 
-def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_for_given_feature(
+def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_for_given_feature(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -279,7 +279,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_f
     ]
 
 
-def test_FeatureCodeReferencesDetailAPIView__responds_200_with_feature_flag_removed(
+def test_FeatureCodeReferencesDetailAPIView__responds_200_with_feature_flag_removed(  # noqa: FT003
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -325,7 +325,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_feature_flag_remo
     ]
 
 
-def test_FeatureCodeReferencesDetailAPIView__responds_200_even_without_code_references(
+def test_FeatureCodeReferencesDetailAPIView__responds_200_even_without_code_references(  # noqa: FT003,FT004
     admin_client_new: APIClient,
     feature: Feature,
     project: Project,
@@ -340,7 +340,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_even_without_code_refe
     assert response.json() == []
 
 
-def test_FeatureCodeReferencesDetailAPIView__responds_401_if_not_authenticated(
+def test_FeatureCodeReferencesDetailAPIView__responds_401_if_not_authenticated(  # noqa: FT003,FT004
     client: APIClient,
     feature: Feature,
     project: Project,
@@ -355,7 +355,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_401_if_not_authenticated(
     assert response.data["detail"] == "Authentication credentials were not provided."
 
 
-def test_FeatureCodeReferencesDetailAPIView__responds_403_if_incorrect_permissions(
+def test_FeatureCodeReferencesDetailAPIView__responds_403_if_incorrect_permissions(  # noqa: FT003,FT004
     feature: Feature,
     project: Project,
     staff_client: APIClient,
@@ -369,7 +369,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_403_if_incorrect_permissio
     assert response.status_code == 403
 
 
-def test_FeatureCodeReferencesDetailAPIView__responds_404_when_feature_not_found(
+def test_FeatureCodeReferencesDetailAPIView__responds_404_when_feature_not_found(  # noqa: FT003,FT004
     project: Project,
     admin_client_new: APIClient,
 ) -> None:

--- a/api/tests/unit/projects/tags/test_unit_projects_tags_permissions.py
+++ b/api/tests/unit/projects/tags/test_unit_projects_tags_permissions.py
@@ -17,7 +17,7 @@ mock_view = mock.MagicMock()
 permissions = TagPermissions()
 
 
-def test_project_admin_has_permission(
+def test_project_admin_has_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -38,7 +38,7 @@ def test_project_admin_has_permission(
     assert all(results)
 
 
-def test_project_admin_has_object_permission(
+def test_project_admin_has_object_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -59,7 +59,7 @@ def test_project_admin_has_object_permission(
     assert all(results)
 
 
-def test_project_user_has_list_permission(
+def test_project_user_has_list_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -81,7 +81,7 @@ def test_project_user_has_list_permission(
     assert result is True
 
 
-def test_project_user_has_no_create_permission(
+def test_project_user_has_no_create_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -103,7 +103,7 @@ def test_project_user_has_no_create_permission(
     assert result is False
 
 
-def test_project_user_has_no_update_or_delete_permission(
+def test_project_user_has_no_update_or_delete_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -126,7 +126,7 @@ def test_project_user_has_no_update_or_delete_permission(
     assert all(result is False for result in results)
 
 
-def test_project_user_has_detail_permission(
+def test_project_user_has_detail_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -148,7 +148,7 @@ def test_project_user_has_detail_permission(
     assert result is True
 
 
-def test_project_user_with_manage_tags_has_permission_to_create(
+def test_project_user_with_manage_tags_has_permission_to_create(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -170,7 +170,7 @@ def test_project_user_with_manage_tags_has_permission_to_create(
     assert result is True
 
 
-def test_project_user_with_view_project_does_not_have_permission_to_create(
+def test_project_user_with_view_project_does_not_have_permission_to_create(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -192,7 +192,7 @@ def test_project_user_with_view_project_does_not_have_permission_to_create(
     assert result is False
 
 
-def test_project_user_with_manage_tags_has_detail_permission(
+def test_project_user_with_manage_tags_has_detail_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,

--- a/api/tests/unit/projects/tags/test_unit_projects_tags_views.py
+++ b/api/tests/unit/projects/tags/test_unit_projects_tags_views.py
@@ -16,7 +16,7 @@ from tests.types import WithProjectPermissionsCallable
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_get_tag_by_uuid(client: APIClient, project: Project, tag: Tag):  # type: ignore[no-untyped-def]
+def test_get_tag_by_uuid(client: APIClient, project: Project, tag: Tag):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     url = reverse("api-v1:projects:tags-get-by-uuid", args=[project.id, str(tag.uuid)])
 
     # When
@@ -27,7 +27,7 @@ def test_get_tag_by_uuid(client: APIClient, project: Project, tag: Tag):  # type
     assert response.json()["uuid"] == str(tag.uuid)
 
 
-def test_get_tag_by_uuid__returns_403_for_user_without_permission(  # type: ignore[no-untyped-def]
+def test_get_tag_by_uuid__returns_403_for_user_without_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     staff_client: APIClient,
     organisation_one_project_two: Project,
     project: Project,
@@ -50,7 +50,7 @@ def test_get_tag_by_uuid__returns_403_for_user_without_permission(  # type: igno
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_get_tag_by__uuid_returns_200_for_user_with_view_project_permission(  # type: ignore[no-untyped-def]
+def test_get_tag_by__uuid_returns_200_for_user_with_view_project_permission(  # type: ignore[no-untyped-def]  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     tag: Tag,
@@ -72,7 +72,7 @@ def test_get_tag_by__uuid_returns_200_for_user_with_view_project_permission(  # 
     assert response.json()["uuid"] == str(tag.uuid)
 
 
-def test_cannot_delete_a_system_tag(
+def test_cannot_delete_a_system_tag(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -91,7 +91,7 @@ def test_cannot_delete_a_system_tag(
     assert response.json() == {"message": "Cannot delete a system tag."}
 
 
-def test_cannot_update_a_system_tag(  # type: ignore[no-untyped-def]
+def test_cannot_update_a_system_tag(  # type: ignore[no-untyped-def]  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,

--- a/api/tests/unit/projects/test_migrations.py
+++ b/api/tests/unit/projects/test_migrations.py
@@ -5,7 +5,7 @@ from common.projects.permissions import (
 from django_test_migrations.migrator import Migrator
 
 
-def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:
+def test_merge_duplicate_permissions_migration(migrator: Migrator) -> None:  # noqa: FT003
     # Given - the migration state is at 0016 (before the migration we want to test)
     old_state = migrator.apply_initial_migration(
         ("projects", "0016_soft_delete_projects")

--- a/api/tests/unit/projects/test_unit_projects_admin.py
+++ b/api/tests/unit/projects/test_unit_projects_admin.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:
     from organisations.models import Organisation
 
 
-def test_project_admin_delete_all_segments(organisation: "Organisation"):  # type: ignore[no-untyped-def]
+def test_project_admin_delete_all_segments(organisation: "Organisation"):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     project_1 = Project.objects.create(name="project_1", organisation=organisation)
     project_2 = Project.objects.create(name="project_2", organisation=organisation)
@@ -66,7 +66,7 @@ def test_project_admin_delete_all_segments(organisation: "Organisation"):  # typ
 @pytest.mark.parametrize(
     "is_superuser, expected_result", ((True, True), (False, False))
 )
-def test_project_admin_has_delete_all_segments_permission(  # type: ignore[no-untyped-def]
+def test_project_admin_has_delete_all_segments_permission(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     is_superuser: bool, expected_result: bool, django_user_model: type["AbstractUser"]
 ):
     # Given

--- a/api/tests/unit/projects/test_unit_projects_models.py
+++ b/api/tests/unit/projects/test_unit_projects_models.py
@@ -16,7 +16,7 @@ yesterday = now - timedelta(days=1)
 
 
 @pytest.mark.django_db()
-def test_get_segments_from_cache(project, monkeypatch):  # type: ignore[no-untyped-def]
+def test_get_segments_from_cache(project, monkeypatch):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_project_segments_cache = mock.MagicMock()
     mock_project_segments_cache.get.return_value = None
@@ -36,7 +36,7 @@ def test_get_segments_from_cache(project, monkeypatch):  # type: ignore[no-untyp
 
 
 @pytest.mark.django_db()
-def test_get_segments_from_cache_set_not_called(project, segments, monkeypatch):  # type: ignore[no-untyped-def]
+def test_get_segments_from_cache_set_not_called(project, segments, monkeypatch):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_project_segments_cache = mock.MagicMock()
     mock_project_segments_cache.get.return_value = project.segments.all()
@@ -56,7 +56,7 @@ def test_get_segments_from_cache_set_not_called(project, segments, monkeypatch):
     mock_project_segments_cache.set.assert_not_called()
 
 
-def test_get_segments_from_cache_set_to_empty_list(
+def test_get_segments_from_cache_set_to_empty_list(  # noqa: FT003
     project: Project,
     segment: Segment,
     monkeypatch: pytest.MonkeyPatch,
@@ -88,7 +88,7 @@ def test_get_segments_from_cache_set_to_empty_list(
     "edge_enabled, expected_enable_dynamo_db_value",
     ((True, True), (False, False)),
 )
-def test_create_project_sets_enable_dynamo_db(  # type: ignore[no-untyped-def]
+def test_create_project_sets_enable_dynamo_db(  # type: ignore[no-untyped-def]  # noqa: FT003
     db, edge_enabled, expected_enable_dynamo_db_value, settings, organisation
 ):
     # Given
@@ -105,7 +105,7 @@ def test_create_project_sets_enable_dynamo_db(  # type: ignore[no-untyped-def]
     "edge_release_datetime, expected",
     ((yesterday, True), (tomorrow, False), (None, False)),
 )
-def test_is_edge_project_by_default(  # type: ignore[no-untyped-def]
+def test_is_edge_project_by_default(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings, organisation, edge_release_datetime, expected
 ):
     # Given
@@ -127,7 +127,7 @@ def test_is_edge_project_by_default(  # type: ignore[no-untyped-def]
         ("^[a-z]+$", "InvalidFeature", False),
     ),
 )
-def test_is_feature_name_valid(feature_name_regex, feature_name, expected_result):  # type: ignore[no-untyped-def]
+def test_is_feature_name_valid(feature_name_regex, feature_name, expected_result):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert (
         Project(
             name="test", feature_name_regex=feature_name_regex
@@ -136,7 +136,7 @@ def test_is_feature_name_valid(feature_name_regex, feature_name, expected_result
     )
 
 
-def test_updating_project_clears_environment_caches(environment, project, mocker):  # type: ignore[no-untyped-def]
+def test_updating_project_clears_environment_caches(environment, project, mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mock_environment_cache = mocker.patch("projects.models.environment_cache")
 
@@ -148,7 +148,7 @@ def test_updating_project_clears_environment_caches(environment, project, mocker
     mock_environment_cache.delete_many.assert_called_once_with([environment.api_key])
 
 
-def test_environments_are_updated_in_dynamodb_when_project_id_updated(  # type: ignore[no-untyped-def]
+def test_environments_are_updated_in_dynamodb_when_project_id_updated(  # type: ignore[no-untyped-def]  # noqa: FT003
     dynamo_enabled_project,
     dynamo_enabled_project_environment_one,
     dynamo_enabled_project_environment_two,
@@ -176,7 +176,7 @@ def test_environments_are_updated_in_dynamodb_when_project_id_updated(  # type: 
         (EdgeV2MigrationStatus.INCOMPLETE, False),
     ),
 )
-def test_show_edge_identity_overrides_for_feature(  # type: ignore[no-untyped-def]
+def test_show_edge_identity_overrides_for_feature(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     edge_v2_migration_status: EdgeV2MigrationStatus,
     expected_value: bool,
 ):
@@ -188,7 +188,7 @@ def test_show_edge_identity_overrides_for_feature(  # type: ignore[no-untyped-de
     )
 
 
-def test_create_project_sets_edge_v2_migration_status_if_edge_enabled(
+def test_create_project_sets_edge_v2_migration_status_if_edge_enabled(  # noqa: FT003
     settings: SettingsWrapper, organisation: Organisation
 ) -> None:
     # Given

--- a/api/tests/unit/projects/test_unit_projects_permissions.py
+++ b/api/tests/unit/projects/test_unit_projects_permissions.py
@@ -20,7 +20,7 @@ mock_request = mock.MagicMock()
 mock_view = mock.MagicMock()
 
 
-def test_list_project_has_permission(
+def test_list_project_has_permission(  # noqa: FT003
     staff_user: FFAdminUser,
 ) -> None:
     """All users should be able to create project"""
@@ -36,7 +36,7 @@ def test_list_project_has_permission(
     assert response is True
 
 
-def test_create_project_has_permission(
+def test_create_project_has_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     with_organisation_permissions: WithOrganisationPermissionsCallable,
@@ -56,7 +56,7 @@ def test_create_project_has_permission(
     assert response is True
 
 
-def test_create_project_has_permission_with_e2e_test_auth_token(
+def test_create_project_has_permission_with_e2e_test_auth_token(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     with_organisation_permissions: WithOrganisationPermissionsCallable,
@@ -81,7 +81,7 @@ def test_create_project_has_permission_with_e2e_test_auth_token(
     assert response is True
 
 
-def test_admin_can_update_project_has_permission(
+def test_admin_can_update_project_has_permission(  # noqa: FT003
     organisation: Organisation,
     staff_user: FFAdminUser,
     project: Project,
@@ -100,7 +100,7 @@ def test_admin_can_update_project_has_permission(
     assert result is True
 
 
-def test_admin_group_can_update_project_has_permission(
+def test_admin_group_can_update_project_has_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -125,7 +125,7 @@ def test_admin_group_can_update_project_has_permission(
     assert result is True
 
 
-def test_regular_user_cannot_update_project_missing_permission(
+def test_regular_user_cannot_update_project_missing_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -144,7 +144,7 @@ def test_regular_user_cannot_update_project_missing_permission(
     assert result is False
 
 
-def test_admin_can_delete_project_has_permission(
+def test_admin_can_delete_project_has_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -168,7 +168,7 @@ def test_admin_can_delete_project_has_permission(
     assert result is True
 
 
-def test_regular_user_cannot_delete_project(
+def test_regular_user_cannot_delete_project(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -187,7 +187,7 @@ def test_regular_user_cannot_delete_project(
     assert result is False
 
 
-def test_organisation_admin_can_perform_all_actions_on_a_project(
+def test_organisation_admin_can_perform_all_actions_on_a_project(  # noqa: FT003
     admin_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -218,7 +218,7 @@ def test_organisation_admin_can_perform_all_actions_on_a_project(
     assert all(result for result in results)
 
 
-def test_user_with_view_project_permission_can_view_project(
+def test_user_with_view_project_permission_can_view_project(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -236,7 +236,7 @@ def test_user_with_view_project_permission_can_view_project(
     assert result
 
 
-def test_project_admin_has_permission(
+def test_project_admin_has_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -258,7 +258,7 @@ def test_project_admin_has_permission(
     assert all(results)
 
 
-def test_project_admin_has_object_permission(
+def test_project_admin_has_object_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -280,7 +280,7 @@ def test_project_admin_has_object_permission(
     assert all(results)
 
 
-def test_organisation_admin_has_permission(
+def test_organisation_admin_has_permission(  # noqa: FT003
     admin_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -301,7 +301,7 @@ def test_organisation_admin_has_permission(
     assert all(results)
 
 
-def test_organisation_admin_has_object_permission(
+def test_organisation_admin_has_object_permission(  # noqa: FT003
     admin_user: FFAdminUser,
     staff_user: FFAdminUser,
     organisation: Organisation,
@@ -327,7 +327,7 @@ def test_organisation_admin_has_object_permission(
     assert all(results)
 
 
-def test_regular_user_has_no_list_permission(
+def test_regular_user_has_no_list_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -345,7 +345,7 @@ def test_regular_user_has_no_list_permission(
     assert result is False
 
 
-def test_regular_user_has_no_create_permission(
+def test_regular_user_has_no_create_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -363,7 +363,7 @@ def test_regular_user_has_no_create_permission(
     assert result is False
 
 
-def test_regular_user_has_no_update_permission(
+def test_regular_user_has_no_update_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -383,7 +383,7 @@ def test_regular_user_has_no_update_permission(
     assert result is False
 
 
-def test_regular_user_has_no_destroy_permission(
+def test_regular_user_has_no_destroy_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -404,7 +404,7 @@ def test_regular_user_has_no_destroy_permission(
 
 
 @pytest.mark.django_db
-def test_free_plan_has_only_fixed_projects_permission() -> None:
+def test_free_plan_has_only_fixed_projects_permission() -> None:  # noqa: FT003
     # Given
     organisation = Organisation.objects.create(name="Test organisation")
 
@@ -428,7 +428,7 @@ def test_free_plan_has_only_fixed_projects_permission() -> None:
     assert not project_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
 
 
-def test_is_project_admin_has_permission_raises_permission_denied_if_not_found(  # type: ignore[no-untyped-def]
+def test_is_project_admin_has_permission_raises_permission_denied_if_not_found(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, admin_user
 ) -> None:
     # Given
@@ -440,7 +440,7 @@ def test_is_project_admin_has_permission_raises_permission_denied_if_not_found( 
         IsProjectAdmin().has_permission(request, view)  # type: ignore[no-untyped-call]
 
 
-def test_is_project_admin_has_permission_raises_api_exception_if_no_kwarg(  # type: ignore[no-untyped-def]
+def test_is_project_admin_has_permission_raises_api_exception_if_no_kwarg(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, admin_user
 ) -> None:
     # Given
@@ -452,7 +452,7 @@ def test_is_project_admin_has_permission_raises_api_exception_if_no_kwarg(  # ty
         IsProjectAdmin().has_permission(request, view)  # type: ignore[no-untyped-call]
 
 
-def test_is_project_admin_has_permission_returns_true_if_project_admin(  # type: ignore[no-untyped-def]
+def test_is_project_admin_has_permission_returns_true_if_project_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     mocker, admin_user, organisation, project
 ) -> None:
     # Given

--- a/api/tests/unit/projects/test_unit_projects_serializers.py
+++ b/api/tests/unit/projects/test_unit_projects_serializers.py
@@ -10,7 +10,7 @@ from projects.serializers import (
 )
 
 
-def test_ProjectListSerializer_get_migration_status_returns_migration_not_applicable_if_not_configured(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_ProjectListSerializer_get_migration_status_returns_migration_not_applicable_if_not_configured(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker, project, settings
 ):
     # Given
@@ -29,7 +29,7 @@ def test_ProjectListSerializer_get_migration_status_returns_migration_not_applic
     mocked_identity_migrator.assert_not_called()
 
 
-def test_ProjectListSerializer_get_migration_status_returns_migration_completed_for_new_projects(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_ProjectListSerializer_get_migration_status_returns_migration_completed_for_new_projects(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker, project, settings
 ):
     # Given
@@ -49,7 +49,7 @@ def test_ProjectListSerializer_get_migration_status_returns_migration_completed_
     mocked_identity_migrator.assert_not_called()
 
 
-def test_ProjectListSerializer_get_migration_status_calls_migrator_with_correct_arguments_for_old_projects(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_ProjectListSerializer_get_migration_status_calls_migrator_with_correct_arguments_for_old_projects(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker, project, settings
 ):
     # Given
@@ -81,7 +81,7 @@ def test_ProjectListSerializer_get_migration_status_calls_migrator_with_correct_
         (ProjectIdentityMigrationStatus.NOT_APPLICABLE.value, False),
     ],
 )
-def test_ProjectListSerializer_get_use_edge_identities(  # type: ignore[no-untyped-def]
+def test_ProjectListSerializer_get_use_edge_identities(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, migration_status, expected
 ):
     # Given
@@ -100,7 +100,7 @@ def test_ProjectListSerializer_get_use_edge_identities(  # type: ignore[no-untyp
         (ProjectIdentityMigrationStatus.NOT_APPLICABLE.value, False),
     ],
 )
-def test_ProjectRetrieveSerializer_get_use_edge_identities(  # type: ignore[no-untyped-def]
+def test_ProjectRetrieveSerializer_get_use_edge_identities(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, migration_status, expected
 ):
     # Given

--- a/api/tests/unit/projects/test_unit_projects_tasks.py
+++ b/api/tests/unit/projects/test_unit_projects_tasks.py
@@ -47,7 +47,7 @@ def project_v2_migration_in_progress(
         ),
     ),
 )
-def test_migrate_project_environments_to_v2__calls_expected(  # type: ignore[no-untyped-def]
+def test_migrate_project_environments_to_v2__calls_expected(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
     project_v2_migration_in_progress: Project,
     migrate_environments_to_v2_return_value: EdgeV2MigrationResult | None,
@@ -75,7 +75,7 @@ def test_migrate_project_environments_to_v2__calls_expected(  # type: ignore[no-
     assert project_v2_migration_in_progress.edge_v2_migration_status == expected_status
 
 
-def test_migrate_project_environments_to_v2__expected_status_on_error(  # type: ignore[no-untyped-def]
+def test_migrate_project_environments_to_v2__expected_status_on_error(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
     project_v2_migration_in_progress: Project,
 ):
@@ -135,7 +135,7 @@ def test_migrate_project_environments_to_v2__project_capacity_budget_none__call_
     )
 
 
-def test_handle_cascade_delete(
+def test_handle_cascade_delete(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -40,7 +40,7 @@ now = timezone.now()
 yesterday = now - timedelta(days=1)
 
 
-def test_should_create_a_project(
+def test_should_create_a_project(  # noqa: FT003
     settings: SettingsWrapper,
     admin_user: FFAdminUser,
     admin_client: APIClient,
@@ -87,7 +87,7 @@ def test_should_create_a_project(
     assert get_project_response.status_code == status.HTTP_200_OK
 
 
-def test_should_create_a_project_with_admin_master_api_key_client(  # type: ignore[no-untyped-def]
+def test_should_create_a_project_with_admin_master_api_key_client(  # type: ignore[no-untyped-def]  # noqa: FT003
     settings, organisation, admin_master_api_key_client
 ):
     # Given
@@ -113,7 +113,7 @@ def test_should_create_a_project_with_admin_master_api_key_client(  # type: igno
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_can_update_project(
+def test_can_update_project(  # noqa: FT003
     client: APIClient,
     project: Project,
     organisation: Organisation,
@@ -139,7 +139,7 @@ def test_can_update_project(
     assert response.json()["stale_flags_limit_days"] == new_stale_flags_limit_days
 
 
-def test_can_not_update_project_organisation(
+def test_can_not_update_project_organisation(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     organisation: Organisation,
@@ -167,7 +167,7 @@ def test_can_not_update_project_organisation(
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_can_list_project_permission(client: APIClient, project: Project) -> None:
+def test_can_list_project_permission(client: APIClient, project: Project) -> None:  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-permissions")
 
@@ -187,7 +187,7 @@ def test_can_list_project_permission(client: APIClient, project: Project) -> Non
     assert set(returned_supported_permissions) == set(TAG_SUPPORTED_PERMISSIONS)
 
 
-def test_my_permissions_for_a_project_return_400_with_master_api_key(  # type: ignore[no-untyped-def]
+def test_my_permissions_for_a_project_return_400_with_master_api_key(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_master_api_key_client, project, organisation
 ):
     # Given
@@ -204,7 +204,7 @@ def test_my_permissions_for_a_project_return_400_with_master_api_key(  # type: i
     )
 
 
-def test_create_project_returns_403_if_user_is_not_organisation_admin(
+def test_create_project_returns_403_if_user_is_not_organisation_admin(  # noqa: FT003
     organisation: Organisation,
     staff_user: FFAdminUser,
     staff_client: APIClient,
@@ -226,7 +226,7 @@ def test_create_project_returns_403_if_user_is_not_organisation_admin(
     )
 
 
-def test_user_with_create_project_permission_can_create_project(
+def test_user_with_create_project_permission_can_create_project(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     organisation: Organisation,
@@ -250,7 +250,7 @@ def test_user_with_create_project_permission_can_create_project(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_user_with_create_project_permission_cannot_create_project_if_restricted_to_admin(
+def test_user_with_create_project_permission_cannot_create_project_if_restricted_to_admin(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     organisation: Organisation,
@@ -279,7 +279,7 @@ def test_user_with_create_project_permission_cannot_create_project_if_restricted
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_user_with_view_project_permission_can_view_project(
+def test_user_with_view_project_permission_can_view_project(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     organisation: Organisation,
@@ -297,7 +297,7 @@ def test_user_with_view_project_permission_can_view_project(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_user_with_view_project_permission_can_get_their_permissions_for_a_project(
+def test_user_with_view_project_permission_can_get_their_permissions_for_a_project(  # noqa: FT003
     staff_client: APIClient,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -313,7 +313,7 @@ def test_user_with_view_project_permission_can_get_their_permissions_for_a_proje
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_user_can_list_all_user_permissions_for_a_project(
+def test_user_can_list_all_user_permissions_for_a_project(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -330,7 +330,7 @@ def test_user_can_list_all_user_permissions_for_a_project(
     assert len(response.json()) == 1
 
 
-def test_user_can_create_new_user_permission_for_a_project(
+def test_user_can_create_new_user_permission_for_a_project(  # noqa: FT003
     staff_user: FFAdminUser,
     admin_client: APIClient,
     project: Project,
@@ -360,7 +360,7 @@ def test_user_can_create_new_user_permission_for_a_project(
     assert user_project_permission.permissions.count() == 2
 
 
-def test_user_can_update_user_permission_for_a_project(
+def test_user_can_update_user_permission_for_a_project(  # noqa: FT003
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
     admin_client: APIClient,
@@ -385,7 +385,7 @@ def test_user_can_update_user_permission_for_a_project(
     assert CREATE_FEATURE in upp.permissions.values_list("key", flat=True)
 
 
-def test_user_can_delete_user_permission_for_a_project(
+def test_user_can_delete_user_permission_for_a_project(  # noqa: FT003
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
     admin_client: APIClient,
@@ -405,7 +405,7 @@ def test_user_can_delete_user_permission_for_a_project(
     assert not UserProjectPermission.objects.filter(id=upp.id).exists()
 
 
-def test_user_can_list_all_user_group_permissions_for_a_project(
+def test_user_can_list_all_user_group_permissions_for_a_project(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
     organisation: Organisation,
@@ -433,7 +433,7 @@ def test_user_can_list_all_user_group_permissions_for_a_project(
     assert len(response.json()) == 1
 
 
-def test_user_can_create_new_user_group_permission_for_a_project(
+def test_user_can_create_new_user_group_permission_for_a_project(  # noqa: FT003
     organisation: Organisation,
     project: Project,
     staff_user: FFAdminUser,
@@ -472,7 +472,7 @@ def test_user_can_create_new_user_group_permission_for_a_project(
     assert user_group_project_permission.permissions.count() == 2
 
 
-def test_user_can_update_user_group_permission_for_a_project(
+def test_user_can_update_user_group_permission_for_a_project(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     staff_user: FFAdminUser,
@@ -506,7 +506,7 @@ def test_user_can_update_user_group_permission_for_a_project(
     assert CREATE_FEATURE in upgpp.permissions.values_list("key", flat=True)
 
 
-def test_user_group_can_delete_user_permission_for_a_project(
+def test_user_group_can_delete_user_permission_for_a_project(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     staff_user: FFAdminUser,
@@ -535,7 +535,7 @@ def test_user_group_can_delete_user_permission_for_a_project(
     assert not UserPermissionGroupProjectPermission.objects.filter(id=upgpp.id).exists()
 
 
-def test_project_migrate_to_edge_calls_trigger_migration(  # type: ignore[no-untyped-def]
+def test_project_migrate_to_edge_calls_trigger_migration(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, mocker, settings
 ):
     # Given
@@ -553,7 +553,7 @@ def test_project_migrate_to_edge_calls_trigger_migration(  # type: ignore[no-unt
     mocked_identity_migrator.return_value.trigger_migration.assert_called_once()
 
 
-def test_project_migrate_to_edge_returns_400_if_can_migrate_is_false(  # type: ignore[no-untyped-def]
+def test_project_migrate_to_edge_returns_400_if_can_migrate_is_false(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, mocker, settings
 ):
     # Given
@@ -572,7 +572,7 @@ def test_project_migrate_to_edge_returns_400_if_can_migrate_is_false(  # type: i
     mocked_identity_migrator.return_value.trigger_migration.assert_not_called()
 
 
-def test_project_migrate_to_edge_returns_400_if_project_have_too_many_identities(  # type: ignore[no-untyped-def]
+def test_project_migrate_to_edge_returns_400_if_project_have_too_many_identities(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, mocker, settings, identity, environment
 ):
     # Given
@@ -592,7 +592,7 @@ def test_project_migrate_to_edge_returns_400_if_project_have_too_many_identities
     mocked_identity_migrator.assert_not_called()
 
 
-def test_project_migrate_to_edge_returns_400_if_project_have_too_many_features(  # type: ignore[no-untyped-def]
+def test_project_migrate_to_edge_returns_400_if_project_have_too_many_features(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, mocker, environment, feature, multivariate_feature, settings
 ):
     # Given
@@ -613,7 +613,7 @@ def test_project_migrate_to_edge_returns_400_if_project_have_too_many_features( 
     mocked_identity_migrator.assert_not_called()
 
 
-def test_project_migrate_to_edge_returns_400_if_project_have_too_many_segments(  # type: ignore[no-untyped-def]
+def test_project_migrate_to_edge_returns_400_if_project_have_too_many_segments(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client,
     project,
     mocker,
@@ -641,7 +641,7 @@ def test_project_migrate_to_edge_returns_400_if_project_have_too_many_segments( 
     mocked_identity_migrator.assert_not_called()
 
 
-def test_project_migrate_to_edge_returns_400_if_project_have_too_many_segment_overrides(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_project_migrate_to_edge_returns_400_if_project_have_too_many_segment_overrides(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     admin_client,
     project,
     mocker,
@@ -674,7 +674,7 @@ def test_project_migrate_to_edge_returns_400_if_project_have_too_many_segment_ov
     mocked_identity_migrator.assert_not_called()
 
 
-def test_list_project_with_uuid_filter_returns_correct_project(  # type: ignore[no-untyped-def]
+def test_list_project_with_uuid_filter_returns_correct_project(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client, project, mocker, settings, organisation
 ):
     # Given
@@ -697,7 +697,7 @@ def test_list_project_with_uuid_filter_returns_correct_project(  # type: ignore[
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_get_project_by_uuid(client, project, mocker, settings, organisation):  # type: ignore[no-untyped-def]
+def test_get_project_by_uuid(client, project, mocker, settings, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-get-by-uuid", args=[str(project.uuid)])
 
@@ -718,7 +718,7 @@ def test_get_project_by_uuid(client, project, mocker, settings, organisation):  
         (lazy_fixture("enterprise_subscription"), True),
     ],
 )
-def test_can_enable_realtime_updates_for_enterprise(  # type: ignore[no-untyped-def]
+def test_can_enable_realtime_updates_for_enterprise(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     organisation: Organisation,
@@ -747,7 +747,7 @@ def test_can_enable_realtime_updates_for_enterprise(  # type: ignore[no-untyped-
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_update_project(client, project, mocker, settings, organisation):  # type: ignore[no-untyped-def]
+def test_update_project(client, project, mocker, settings, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-detail", args=[project.id])
     feature_name_regex = r"^[a-zA-Z0-9_]+$"
@@ -778,7 +778,7 @@ def test_update_project(client, project, mocker, settings, organisation):  # typ
     "client",
     (lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")),
 )
-def test_get_project_list_data(client, organisation):  # type: ignore[no-untyped-def]
+def test_get_project_list_data(client, organisation):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     list_url = reverse("api-v1:projects:project-list")
 
@@ -824,7 +824,7 @@ def test_get_project_list_data(client, organisation):  # type: ignore[no-untyped
     "client",
     (lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")),
 )
-def test_get_project_data_by_id(
+def test_get_project_data_by_id(  # noqa: FT003
     client: APIClient, organisation: Organisation, project: Project
 ) -> None:
     # Given
@@ -855,7 +855,7 @@ def test_get_project_data_by_id(
     assert response_json["show_edge_identity_overrides_for_feature"] is False
 
 
-def test_delete_project_delete_handles_cascade_delete(
+def test_delete_project_delete_handles_cascade_delete(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
     mocker: MockerFixture,
@@ -877,7 +877,7 @@ def test_delete_project_delete_handles_cascade_delete(
     )
 
 
-def test_cannot_create_duplicate_project_name(
+def test_cannot_create_duplicate_project_name(  # noqa: FT003
     admin_client: APIClient,
     project: Project,
 ) -> None:
@@ -900,7 +900,7 @@ def test_cannot_create_duplicate_project_name(
     }
 
 
-def test_can_create_project_with_duplicate_name_in_another_organisation(
+def test_can_create_project_with_duplicate_name_in_another_organisation(  # noqa: FT003
     admin_user: FFAdminUser,
     admin_client: APIClient,
     project: Project,
@@ -925,7 +925,7 @@ def test_can_create_project_with_duplicate_name_in_another_organisation(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_project_user_can_get_their_detailed_permissions(
+def test_project_user_can_get_their_detailed_permissions(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -955,7 +955,7 @@ def test_project_user_can_get_their_detailed_permissions(
     ]
 
 
-def test_project_user_can_not_get_detailed_permissions_of_other_user(
+def test_project_user_can_not_get_detailed_permissions_of_other_user(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -975,7 +975,7 @@ def test_project_user_can_not_get_detailed_permissions_of_other_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_project_admin_can_get_detailed_permissions_of_other_user(
+def test_project_admin_can_get_detailed_permissions_of_other_user(  # noqa: FT003
     admin_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -28,7 +28,7 @@ from users.models import FFAdminUser
     "allowed_calls_30d, actual_calls_30d, expected_overage",
     ((1000000, 500000, 0), (1000000, 1100000, 100000), (0, 100000, 100000)),
 )
-def test_organisation_subscription_get_api_call_overage(
+def test_organisation_subscription_get_api_call_overage(  # noqa: FT003,FT004
     organisation: Organisation,
     allowed_calls_30d: int,
     actual_calls_30d: int,
@@ -50,7 +50,7 @@ def test_organisation_subscription_get_api_call_overage(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_get_organisation_info__get_event_list_for_organisation(
+def test_get_organisation_info__get_event_list_for_organisation(  # noqa: FT003
     organisation: Organisation,
     superuser_client: APIClient,
     settings: SettingsWrapper,
@@ -80,7 +80,7 @@ def test_get_organisation_info__get_event_list_for_organisation(
     event_list_mock.assert_called_once_with(organisation.id, date_start)
 
 
-def test_list_organisations_search_by_name(
+def test_list_organisations_search_by_name(  # noqa: FT003
     organisation: Organisation,
     superuser_client: Client,
 ) -> None:
@@ -99,7 +99,7 @@ def test_list_organisations_search_by_name(
     assert list(response.context_data["organisation_list"]) == [organisation]  # type: ignore[index]
 
 
-def test_list_organisations_search_by_subscription_id(
+def test_list_organisations_search_by_subscription_id(  # noqa: FT003
     organisation: Organisation,
     chargebee_subscription: Subscription,
     superuser_client: Client,
@@ -117,7 +117,7 @@ def test_list_organisations_search_by_subscription_id(
     assert list(response.context_data["organisation_list"]) == [organisation]  # type: ignore[index]
 
 
-def test_list_organisations_search_by_user_email(
+def test_list_organisations_search_by_user_email(  # noqa: FT003
     organisation: Organisation,
     superuser_client: Client,
     admin_user: FFAdminUser,
@@ -135,7 +135,7 @@ def test_list_organisations_search_by_user_email(
     assert list(response.context_data["organisation_list"]) == [organisation]  # type: ignore[index]
 
 
-def test_list_organisations_search_by_user_email_for_non_existent_user(
+def test_list_organisations_search_by_user_email_for_non_existent_user(  # noqa: FT003
     organisation: Organisation,
     superuser_client: Client,
 ) -> None:
@@ -155,7 +155,7 @@ def test_list_organisations_search_by_user_email_for_non_existent_user(
     assert list(response.context_data["organisation_list"]) == []  # type: ignore[index]
 
 
-def test_list_organisations_search_by_domain(
+def test_list_organisations_search_by_domain(  # noqa: FT003
     organisation: Organisation,
     superuser_client: Client,
 ) -> None:
@@ -174,7 +174,7 @@ def test_list_organisations_search_by_domain(
     assert list(response.context_data["organisation_list"]) == [organisation]  # type: ignore[index]
 
 
-def test_list_organisations_filter_plan(
+def test_list_organisations_filter_plan(  # noqa: FT003
     organisation: Organisation,
     chargebee_subscription: Subscription,
     superuser_client: Client,
@@ -193,7 +193,7 @@ def test_list_organisations_filter_plan(
     assert list(response.context_data["organisation_list"]) == [organisation]  # type: ignore[index]
 
 
-def test_list_organisations_fails_if_not_staff(
+def test_list_organisations_fails_if_not_staff(  # noqa: FT003
     organisation: Organisation,
     client: Client,
 ) -> None:
@@ -211,7 +211,7 @@ def test_list_organisations_fails_if_not_staff(
     assert response.url == "/admin/login/?next=/sales-dashboard/"  # type: ignore[attr-defined]
 
 
-def test_get_email_usage_fails_if_not_staff(
+def test_get_email_usage_fails_if_not_staff(  # noqa: FT003
     organisation: Organisation,
     client: Client,
 ) -> None:
@@ -229,7 +229,7 @@ def test_get_email_usage_fails_if_not_staff(
     assert response.url == "/admin/login/?next=/sales-dashboard/usage/"  # type: ignore[attr-defined]
 
 
-def test_start_trial(
+def test_start_trial(  # noqa: FT003
     organisation: Organisation,
     client: Client,
     admin_user: FFAdminUser,
@@ -268,7 +268,7 @@ def test_start_trial(
     assert subscription_information_cache.feature_history_visibility_days is None
 
 
-def test_end_trial(
+def test_end_trial(  # noqa: FT003
     in_trial_organisation: Organisation,
     client: Client,
     admin_user: FFAdminUser,
@@ -315,7 +315,7 @@ def test_end_trial(
 
 
 @pytest.mark.django_db
-def test_list_organisations_with_empty_organisation_returns_zero_counts_not_none(
+def test_list_organisations_with_empty_organisation_returns_zero_counts_not_none(  # noqa: FT003
     rf: RequestFactory,
 ) -> None:
     # Given

--- a/api/tests/unit/segments/test_unit_segments_migrations.py
+++ b/api/tests/unit/segments/test_unit_segments_migrations.py
@@ -11,7 +11,7 @@ from pytest_django.fixtures import SettingsWrapper
     test_settings.SKIP_MIGRATION_TESTS is True,
     reason="Skip migration tests to speed up tests where necessary",
 )
-def test_create_whitelisted_segments_migration(
+def test_create_whitelisted_segments_migration(  # noqa: FT003
     migrator: Migrator,
     settings: SettingsWrapper,
 ) -> None:
@@ -110,7 +110,7 @@ def test_create_whitelisted_segments_migration(
     test_settings.SKIP_MIGRATION_TESTS is True,
     reason="Skip migration tests to speed up tests where necessary",
 )
-def test_add_versioning_to_segments_forwards(migrator: Migrator) -> None:
+def test_add_versioning_to_segments_forwards(migrator: Migrator) -> None:  # noqa: FT003
     # Given - The migration state is at 0021 (before the migration we want to test).
     old_state = migrator.apply_initial_migration(
         ("segments", "0022_add_soft_delete_to_segment_rules_and_conditions")
@@ -162,7 +162,7 @@ def test_add_versioning_to_segments_forwards(migrator: Migrator) -> None:
     test_settings.SKIP_MIGRATION_TESTS is True,
     reason="Skip migration tests to speed up tests where necessary",
 )
-def test_add_versioning_to_segments_reverse(migrator: Migrator) -> None:
+def test_add_versioning_to_segments_reverse(migrator: Migrator) -> None:  # noqa: FT003
     # Given - The migration state is at 0023 (after the migration we want to test).
     old_state = migrator.apply_initial_migration(
         ("segments", "0023_add_versioning_to_segments")

--- a/api/tests/unit/segments/test_unit_segments_models.py
+++ b/api/tests/unit/segments/test_unit_segments_models.py
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 from segments.models import Condition, Segment, SegmentRule
 
 
-def test_Condition_str__returns_readable_representation_of_condition(
+def test_Condition_str__returns_readable_representation_of_condition(  # noqa: FT003
     segment: Segment,
     segment_rule: SegmentRule,
 ) -> None:
@@ -83,7 +83,7 @@ def test_Condition_get_skip_create_audit_log__segment_deleted__returns_true(
     assert condition.get_skip_create_audit_log() is True
 
 
-def test_LiveSegmentManager__returns_only_highest_version_of_segments(
+def test_LiveSegmentManager__returns_only_highest_version_of_segments(  # noqa: FT003
     segment: Segment,
 ) -> None:
     # Given
@@ -109,7 +109,7 @@ def test_LiveSegmentManager__returns_only_highest_version_of_segments(
         lambda segment, rule: {"segment": None, "rule": None},
     ],
 )
-def test_SegmentRule_clean__validates_rule_has_only_one_parent(
+def test_SegmentRule_clean__validates_rule_has_only_one_parent(  # noqa: FT003
     get_parents: Callable[[Segment, SegmentRule], dict[str, Any]],
     segment: Segment,
     segment_rule: SegmentRule,
@@ -129,7 +129,7 @@ def test_SegmentRule_clean__validates_rule_has_only_one_parent(
     )
 
 
-def test_SegmentRule_get_skip_create_audit_log__returns_true(
+def test_SegmentRule_get_skip_create_audit_log__returns_true(  # noqa: FT003
     segment: Segment,
 ) -> None:
     # Given
@@ -169,7 +169,7 @@ def test_Segment_delete__multiple_rules_conditions__schedules_audit_log_task_onc
     assert task.delay.call_count == 1
 
 
-def test_Segment_clone__can_create_standalone_segment_clone(
+def test_Segment_clone__can_create_standalone_segment_clone(  # noqa: FT003
     segment: Segment,
 ) -> None:
     # Given
@@ -283,7 +283,7 @@ def test_Segment_clone__segment_with_rules__returns_new_segment_with_copied_rule
     ]
 
 
-def test_Segment_get_skip_create_audit_log__system_segment__returns_true(
+def test_Segment_get_skip_create_audit_log__system_segment__returns_true(  # noqa: FT004
     system_segment: Segment,
 ) -> None:
     # When

--- a/api/tests/unit/segments/test_unit_segments_permissions.py
+++ b/api/tests/unit/segments/test_unit_segments_permissions.py
@@ -21,7 +21,7 @@ mock_view = mock.MagicMock()
 segment_permissions = SegmentPermissions()
 
 
-def test_has_permission_returns_false_for_non_existent_project(
+def test_has_permission_returns_false_for_non_existent_project(  # noqa: FT003
     staff_user: FFAdminUser,
 ) -> None:
     # Given
@@ -39,7 +39,7 @@ def test_has_permission_returns_false_for_non_existent_project(
     assert result is False
 
 
-def test_staff_user_has_permission(staff_user: FFAdminUser, project: Project) -> None:
+def test_staff_user_has_permission(staff_user: FFAdminUser, project: Project) -> None:  # noqa: FT003
     # Given
     mock_request = mock.MagicMock()
     mock_request.user = staff_user
@@ -58,7 +58,7 @@ def test_staff_user_has_permission(staff_user: FFAdminUser, project: Project) ->
     assert all(results)
 
 
-def test_project_admin_has_object_permission(
+def test_project_admin_has_object_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     project: Project,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -85,7 +85,7 @@ def test_project_admin_has_object_permission(
     assert all(results)
 
 
-def test_project_user_has_list_permission(
+def test_project_user_has_list_permission(  # noqa: FT003
     project: Project,
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -108,7 +108,7 @@ def test_project_user_has_list_permission(
     assert result is True
 
 
-def test_project_user_has_no_create_permission(
+def test_project_user_has_no_create_permission(  # noqa: FT003
     project: Project,
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -131,7 +131,7 @@ def test_project_user_has_no_create_permission(
     assert result is False
 
 
-def test_project_user_has_object_permission(
+def test_project_user_has_object_permission(  # noqa: FT003
     project: Project,
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
@@ -162,7 +162,7 @@ def test_project_user_has_object_permission(
         )
 
 
-def test_environment_admin_can_get_segments_for_an_identity(
+def test_environment_admin_can_get_segments_for_an_identity(  # noqa: FT003
     project: Project,
     staff_user: FFAdminUser,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
@@ -188,7 +188,7 @@ def test_environment_admin_can_get_segments_for_an_identity(
     assert result
 
 
-def test_user_with_view_project_permission_can_list_segments_for_an_identity(  # type: ignore[no-untyped-def]
+def test_user_with_view_project_permission_can_list_segments_for_an_identity(  # type: ignore[no-untyped-def]  # noqa: FT003
     segment, django_user_model, mocker
 ):
     # Given

--- a/api/tests/unit/segments/test_unit_segments_services.py
+++ b/api/tests/unit/segments/test_unit_segments_services.py
@@ -44,7 +44,7 @@ def _create_segment_with_nested_rules(
     return segment
 
 
-def test_delete_segment_soft_deletes_segment(
+def test_delete_segment_soft_deletes_segment(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -59,7 +59,7 @@ def test_delete_segment_soft_deletes_segment(
     assert segment.deleted_at is not None
 
 
-def test_delete_segment_soft_deletes_all_rules(
+def test_delete_segment_soft_deletes_all_rules(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -88,7 +88,7 @@ def test_delete_segment_soft_deletes_all_rules(
         assert rule.deleted_at is not None
 
 
-def test_delete_segment_soft_deletes_all_conditions(
+def test_delete_segment_soft_deletes_all_conditions(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -109,7 +109,7 @@ def test_delete_segment_soft_deletes_all_conditions(
         assert condition.deleted_at is not None
 
 
-def test_delete_segment_creates_audit_log(
+def test_delete_segment_creates_audit_log(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -134,7 +134,7 @@ def test_delete_segment_creates_audit_log(
     assert audit_log.related_object_uuid == segment_uuid
 
 
-def test_delete_segment_deletes_all_versions(
+def test_delete_segment_deletes_all_versions(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -152,7 +152,7 @@ def test_delete_segment_deletes_all_versions(
     assert revision.deleted_at is not None
 
 
-def test_delete_segment_query_count_is_constant(
+def test_delete_segment_query_count_is_constant(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -180,7 +180,7 @@ def test_delete_segment_query_count_is_constant(
     assert small_query_count == large_query_count == 26
 
 
-def test_delete_segment_without_rules_works(
+def test_delete_segment_without_rules_works(  # noqa: FT003
     project: Project, admin_user: FFAdminUser
 ) -> None:
     # Given
@@ -195,7 +195,7 @@ def test_delete_segment_without_rules_works(
     assert segment.deleted_at is not None
 
 
-def test_delete_segment_with_master_api_key_records_api_key_in_audit_log(
+def test_delete_segment_with_master_api_key_records_api_key_in_audit_log(  # noqa: FT003
     project: Project, organisation: Organisation
 ) -> None:
     # Given
@@ -221,7 +221,7 @@ def test_delete_segment_with_master_api_key_records_api_key_in_audit_log(
     assert audit_log.author is None
 
 
-def test_delete_segment_deletes_feature_segments(
+def test_delete_segment_deletes_feature_segments(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,
@@ -242,7 +242,7 @@ def test_delete_segment_deletes_feature_segments(
     assert not FeatureSegment.objects.filter(id=feature_segment_id).exists()
 
 
-def test_delete_segment_cascades_to_feature_states(
+def test_delete_segment_cascades_to_feature_states(  # noqa: FT003
     project: Project,
     environment: Environment,
     feature: Feature,
@@ -268,7 +268,7 @@ def test_delete_segment_cascades_to_feature_states(
     assert not FeatureState.objects.filter(id=feature_state_id).exists()
 
 
-def test_copy_segment_rules_and_conditions_copies_rules(project: Project) -> None:
+def test_copy_segment_rules_and_conditions_copies_rules(project: Project) -> None:  # noqa: FT003
     # Given
     source = _create_segment_with_nested_rules(
         project, num_rules=2, num_nested=2, num_conditions=3
@@ -292,7 +292,7 @@ def test_copy_segment_rules_and_conditions_copies_rules(project: Project) -> Non
     assert target_condition_count == source_condition_count
 
 
-def test_copy_segment_rules_and_conditions_replaces_existing_rules(
+def test_copy_segment_rules_and_conditions_replaces_existing_rules(  # noqa: FT003
     project: Project,
 ) -> None:
     # Given
@@ -322,7 +322,7 @@ def test_copy_segment_rules_and_conditions_replaces_existing_rules(
     assert target_rule_count == source_rule_count
 
 
-def test_copy_segment_rules_and_conditions_query_count_is_constant(
+def test_copy_segment_rules_and_conditions_query_count_is_constant(  # noqa: FT003
     project: Project,
 ) -> None:
     # Given

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -43,7 +43,7 @@ User = get_user_model()
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_filter_by_identity_to_get_only_matching_segments(  # type: ignore[no-untyped-def]
+def test_can_filter_by_identity_to_get_only_matching_segments(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, client, environment, identity, trait, identity_matching_segment, segment
 ):
     # Given
@@ -61,7 +61,7 @@ def test_can_filter_by_identity_to_get_only_matching_segments(  # type: ignore[n
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_cannot_create_segments_without_rules(project, client):  # type: ignore[no-untyped-def]
+def test_cannot_create_segments_without_rules(project, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {"name": "New segment name", "project": project.id, "rules": []}
@@ -77,7 +77,7 @@ def test_cannot_create_segments_without_rules(project, client):  # type: ignore[
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_create_segments_with_boolean_condition(project, client):  # type: ignore[no-untyped-def]
+def test_can_create_segments_with_boolean_condition(project, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {
@@ -105,7 +105,7 @@ def test_can_create_segments_with_boolean_condition(project, client):  # type: i
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_not_create_system_segment(project: Project, client: APIClient):  # type: ignore[no-untyped-def]
+def test_can_not_create_system_segment(project: Project, client: APIClient):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {
@@ -139,7 +139,7 @@ def test_can_not_create_system_segment(project: Project, client: APIClient):  # 
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_create_segments_with_condition_that_has_null_value(project, client):  # type: ignore[no-untyped-def]
+def test_can_create_segments_with_condition_that_has_null_value(project, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {
@@ -165,7 +165,7 @@ def test_can_create_segments_with_condition_that_has_null_value(project, client)
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_segments_reaching_max_limit(project, client, settings):  # type: ignore[no-untyped-def]
+def test_create_segments_reaching_max_limit(project, client, settings):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     # let's reduce the max segments allowed to 1
     project.max_segments_allowed = 1
@@ -198,7 +198,7 @@ def test_create_segments_reaching_max_limit(project, client, settings):  # type:
     assert project.segments.count() == 1
 
 
-def test_segments_limit_ignores_old_segment_versions(
+def test_segments_limit_ignores_old_segment_versions(  # noqa: FT003
     project: Project,
     segment: Segment,
     staff_client: APIClient,
@@ -240,7 +240,7 @@ def test_segments_limit_ignores_old_segment_versions(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_audit_log_created_when_segment_updated(
+def test_audit_log_created_when_segment_updated(  # noqa: FT003
     client: APIClient,
     project: Project,
     segment: Segment,
@@ -272,7 +272,7 @@ def test_audit_log_created_when_segment_updated(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_patch_segment(project, segment, client):  # type: ignore[no-untyped-def]
+def test_can_patch_segment(project, segment, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     segment = Segment.objects.create(name="Test segment", project=project)
     url = reverse(
@@ -295,7 +295,7 @@ def test_can_patch_segment(project, segment, client):  # type: ignore[no-untyped
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_audit_log_created_when_segment_deleted(project, segment, client):  # type: ignore[no-untyped-def]
+def test_audit_log_created_when_segment_deleted(project, segment, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     segment = Segment.objects.create(name="Test segment", project=project)
     url = reverse(
@@ -321,7 +321,7 @@ def test_audit_log_created_when_segment_deleted(project, segment, client):  # ty
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_cannot_delete_system_segment(
+def test_cannot_delete_system_segment(  # noqa: FT003
     project: Project, system_segment: Segment, client: APIClient
 ) -> None:
     # Given
@@ -341,7 +341,7 @@ def test_cannot_delete_system_segment(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_audit_log_created_when_segment_created(project, client):  # type: ignore[no-untyped-def]
+def test_audit_log_created_when_segment_created(project, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {
@@ -368,7 +368,7 @@ def test_audit_log_created_when_segment_created(project, client):  # type: ignor
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_filter_by_edge_identity_to_get_only_matching_segments(  # type: ignore[no-untyped-def]
+def test_can_filter_by_edge_identity_to_get_only_matching_segments(  # type: ignore[no-untyped-def]  # noqa: FT003
     project,
     environment,
     identity,
@@ -403,7 +403,7 @@ def test_can_filter_by_edge_identity_to_get_only_matching_segments(  # type: ign
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_associated_features_returns_all_the_associated_features(  # type: ignore[no-untyped-def]
+def test_associated_features_returns_all_the_associated_features(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, environment, feature, segment, segment_featurestate, client
 ):
     # Given
@@ -430,7 +430,7 @@ def test_associated_features_returns_all_the_associated_features(  # type: ignor
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_associated_features_returns_only_latest_versions_of_associated_features(
+def test_associated_features_returns_only_latest_versions_of_associated_features(  # noqa: FT003
     project: Project,
     segment: Segment,
     environment_v2_versioning: Environment,
@@ -499,7 +499,7 @@ def test_associated_features_returns_only_latest_versions_of_associated_features
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_can_create_feature_based_segment(project, client, feature):  # type: ignore[no-untyped-def]
+def test_can_create_feature_based_segment(project, client, feature):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {
@@ -521,7 +521,7 @@ def test_can_create_feature_based_segment(project, client, feature):  # type: ig
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_get_segment_by_uuid(client, project, segment):  # type: ignore[no-untyped-def]
+def test_get_segment_by_uuid(client, project, segment):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:segments:get-segment-by-uuid", args=[segment.uuid])
 
@@ -546,7 +546,7 @@ def test_get_segment_by_uuid(client, project, segment):  # type: ignore[no-untyp
         (lazy_fixture("admin_client"), 14),
     ],
 )
-def test_list_segments_num_queries_without_rbac(
+def test_list_segments_num_queries_without_rbac(  # noqa: FT003
     django_assert_num_queries: DjangoAssertNumQueries,
     project: Project,
     client: APIClient,
@@ -574,7 +574,7 @@ def test_list_segments_num_queries_without_rbac(
     assert response_json["count"] == num_segments
 
 
-def test_system_segment_is_not_part_of_list_segments(
+def test_system_segment_is_not_part_of_list_segments(  # noqa: FT003,FT004
     project: Project,
     admin_client: APIClient,
     system_segment: Segment,
@@ -603,7 +603,7 @@ def test_system_segment_is_not_part_of_list_segments(
         (lazy_fixture("admin_client"), 15),
     ],
 )
-def test_list_segments_num_queries_with_rbac(
+def test_list_segments_num_queries_with_rbac(  # noqa: FT003
     django_assert_num_queries: DjangoAssertNumQueries,
     project: Project,
     client: APIClient,
@@ -653,7 +653,7 @@ def _list_segment_setup_data(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_search_segments(django_assert_num_queries, project, client):  # type: ignore[no-untyped-def]
+def test_search_segments(django_assert_num_queries, project, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     segments = []
     segment_names = ["segment one", "segment two"]
@@ -689,7 +689,7 @@ def test_search_segments(django_assert_num_queries, project, client):  # type: i
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_segments_with_description_condition(project, client):  # type: ignore[no-untyped-def]
+def test_create_segments_with_description_condition(project, client):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse("api-v1:projects:project-segments-list", args=[project.id])
     data = {
@@ -721,7 +721,7 @@ def test_create_segments_with_description_condition(project, client):  # type: i
     assert segment_condition_description_value == "test-description"
 
 
-def test_update_segment_add_new_root_rule(
+def test_update_segment_add_new_root_rule(  # noqa: FT003
     project: Project, admin_client_new: APIClient, segment: Segment
 ) -> None:
     # Given
@@ -762,7 +762,7 @@ def test_update_segment_add_new_root_rule(
     assert response.json()["rules"][0]["rules"][0]["conditions"][0]["value"] == "bar"
 
 
-def test_update_segment_add_new_rule(
+def test_update_segment_add_new_rule(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     segment: Segment,
@@ -835,7 +835,7 @@ def test_update_segment_add_new_rule(
     assert segment_rule.rules.count() == 2
 
 
-def test_update_segment_add_new_condition(
+def test_update_segment_add_new_condition(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     segment: Segment,
@@ -905,7 +905,7 @@ def test_update_segment_add_new_condition(
     assert expected_new_condition.value == new_condition_value
 
 
-def test_update_segment_delete_and_update_existing_condition(
+def test_update_segment_delete_and_update_existing_condition(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     segment: Segment,
@@ -978,7 +978,7 @@ def test_update_segment_delete_and_update_existing_condition(
     assert expected_new_condition.value == new_condition_updated_value
 
 
-def test_can_not_update_system_segment(
+def test_can_not_update_system_segment(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     system_segment: Segment,
@@ -1003,7 +1003,7 @@ def test_can_not_update_system_segment(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_update_segment_versioned_segment(
+def test_update_segment_versioned_segment(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     segment: Segment,
@@ -1082,7 +1082,7 @@ def test_update_segment_versioned_segment(
     assert versioned_condition.property == existing_condition.property
 
 
-def test_update_segment_versioned_segment_with_thrown_exception(
+def test_update_segment_versioned_segment_with_thrown_exception(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     segment: Segment,
@@ -1158,7 +1158,7 @@ def test_update_segment_versioned_segment_with_thrown_exception(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_update_segment_delete_existing_condition(  # type: ignore[no-untyped-def]
+def test_update_segment_delete_existing_condition(  # type: ignore[no-untyped-def]  # noqa: FT003
     project, client, segment, segment_rule
 ):
     # Given
@@ -1212,7 +1212,7 @@ def test_update_segment_delete_existing_condition(  # type: ignore[no-untyped-de
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_update_segment_delete_existing_rule(project, client, segment, segment_rule):  # type: ignore[no-untyped-def]
+def test_update_segment_delete_existing_rule(project, client, segment, segment_rule):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     url = reverse(
         "api-v1:projects:project-segments-detail", args=[project.id, segment.id]
@@ -1254,7 +1254,7 @@ def test_update_segment_delete_existing_rule(project, client, segment, segment_r
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_update_segment_metadata_create_correct_number_of_metadata(
+def test_update_segment_metadata_create_correct_number_of_metadata(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_segment_metadata_field: MetadataModelField,
@@ -1317,7 +1317,7 @@ def test_update_segment_metadata_create_correct_number_of_metadata(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_segment_with_required_metadata_returns_201(
+def test_create_segment_with_required_metadata_returns_201(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_segment_metadata_field: MetadataModelField,
@@ -1355,7 +1355,7 @@ def test_create_segment_with_required_metadata_returns_201(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_segment_with_required_metadata_using_organisation_content_type_returns_201(
+def test_create_segment_with_required_metadata_using_organisation_content_type_returns_201(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_segment_metadata_field_using_organisation_content_type: MetadataModelField,
@@ -1393,7 +1393,7 @@ def test_create_segment_with_required_metadata_using_organisation_content_type_r
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_segment_without_required_metadata_returns_400(
+def test_create_segment_without_required_metadata_returns_400(  # noqa: FT003
     project: Project,
     client: APIClient,
     required_a_segment_metadata_field: MetadataModelField,
@@ -1415,7 +1415,7 @@ def test_create_segment_without_required_metadata_returns_400(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_update_segment_obeys_max_conditions(
+def test_update_segment_obeys_max_conditions(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
     segment: Segment,
@@ -1496,7 +1496,7 @@ def test_update_segment_obeys_max_conditions(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
-def test_create_segment_with_optional_metadata_returns_201(
+def test_create_segment_with_optional_metadata_returns_201(  # noqa: FT003
     project: Project,
     client: APIClient,
     optional_b_segment_metadata_field: MetadataModelField,
@@ -1530,7 +1530,7 @@ def test_create_segment_with_optional_metadata_returns_201(
     assert response.json()["metadata"][0]["field_value"] == str(field_value)
 
 
-def test_create_multiple_segments_with_metadata_keeps_metadata_isolated(
+def test_create_multiple_segments_with_metadata_keeps_metadata_isolated(  # noqa: FT003
     project: Project,
     admin_client_new: APIClient,
     optional_b_segment_metadata_field: MetadataModelField,
@@ -1626,7 +1626,7 @@ def test_create_multiple_segments_with_metadata_keeps_metadata_isolated(
     assert second_segment_metadata_after[0]["id"] != first_metadata_id
 
 
-def test_update_segment_evades_max_conditions_when_whitelisted(
+def test_update_segment_evades_max_conditions_when_whitelisted(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
     segment: Segment,
@@ -1700,7 +1700,7 @@ def test_update_segment_evades_max_conditions_when_whitelisted(
     assert nested_rule.conditions.count() == 11
 
 
-def test_create_segment_obeys_max_conditions(
+def test_create_segment_obeys_max_conditions(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
     settings: SettingsWrapper,
@@ -1757,7 +1757,7 @@ def test_create_segment_obeys_max_conditions(
     assert Segment.objects.count() == 0
 
 
-def test_include_feature_specific_query_filter__true(
+def test_include_feature_specific_query_filter__true(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -1781,7 +1781,7 @@ def test_include_feature_specific_query_filter__true(
     ]
 
 
-def test_include_feature_specific_query_filter__false(
+def test_include_feature_specific_query_filter__false(  # noqa: FT003
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -1802,7 +1802,7 @@ def test_include_feature_specific_query_filter__false(
     assert [res["id"] for res in response.json()["results"]] == [segment.id]
 
 
-def test_clone_endpoint_uses_segment_clone_service(
+def test_clone_endpoint_uses_segment_clone_service(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
     segment: Segment,
@@ -1830,7 +1830,7 @@ def test_clone_endpoint_uses_segment_clone_service(
     assert response_data["id"] != segment.id
 
 
-def test_clone_segment_without_name_should_fail(
+def test_clone_segment_without_name_should_fail(  # noqa: FT003
     project: Project,
     admin_client: APIClient,
     segment: Segment,

--- a/api/tests/unit/sse/test_sse_service.py
+++ b/api/tests/unit/sse/test_sse_service.py
@@ -14,7 +14,7 @@ from sse.sse_service import (
 )
 
 
-def test_send_environment_update_message_for_project_schedules_task_correctly(  # type: ignore[no-untyped-def]
+def test_send_environment_update_message_for_project_schedules_task_correctly(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     sse_enabled_settings,
     realtime_enabled_project,
@@ -44,7 +44,7 @@ def test_send_environment_update_message_for_project_schedules_task_correctly(  
         ),
     ],
 )
-def test_send_environment_update_message_for_project_exits_early_without_scheduling_task(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_send_environment_update_message_for_project_exits_early_without_scheduling_task(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker,
     test_settings,
     test_project,
@@ -72,7 +72,7 @@ def test_send_environment_update_message_for_project_exits_early_without_schedul
         ),
     ],
 )
-def test_send_environment_update_message_for_environment_exits_early_without_scheduling_task(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_send_environment_update_message_for_environment_exits_early_without_scheduling_task(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker, test_settings, test_environment
 ):
     # Given
@@ -85,7 +85,7 @@ def test_send_environment_update_message_for_environment_exits_early_without_sch
     mocked_tasks.send_environment_update_message.delay.assert_not_called()
 
 
-def test_send_environment_update_message_for_environment_schedules_task_correctly(  # type: ignore[no-untyped-def]
+def test_send_environment_update_message_for_environment_schedules_task_correctly(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker, sse_enabled_settings, realtime_enabled_project_environment_one
 ):
     # Given
@@ -106,7 +106,7 @@ def test_send_environment_update_message_for_environment_schedules_task_correctl
 
 
 @mock_s3  # type: ignore[misc]
-def test_stream_access_logs(mocker: MockerFixture, aws_credentials: None) -> None:
+def test_stream_access_logs(mocker: MockerFixture, aws_credentials: None) -> None:  # noqa: FT003
     # Given - Some test data
     first_log = SSEAccessLogs("2023-11-27T06:42:47+0000", "key_one")
     second_log = SSEAccessLogs("2023-11-27T06:42:47+0000", "key_two")
@@ -163,7 +163,7 @@ def test_stream_access_logs(mocker: MockerFixture, aws_credentials: None) -> Non
     assert "Contents" not in s3_client.list_objects(Bucket=bucket_name)
 
 
-def test_stream_access_logs_handles_deleted_files(
+def test_stream_access_logs_handles_deleted_files(  # noqa: FT003
     mocker: MockerFixture, aws_credentials: None
 ) -> None:
     # Given - Mock bucket with objects where first raises NoSuchKey
@@ -200,7 +200,7 @@ def test_stream_access_logs_handles_deleted_files(
     )
 
 
-def test_stream_access_logs_reraises_non_nosuchkey_errors(
+def test_stream_access_logs_reraises_non_nosuchkey_errors(  # noqa: FT003
     mocker: MockerFixture, aws_credentials: None
 ) -> None:
     # Given - Mock bucket with object that raises AccessDenied error
@@ -225,7 +225,7 @@ def test_stream_access_logs_reraises_non_nosuchkey_errors(
     assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
 
 
-def test_stream_access_logs_respects_timeout(
+def test_stream_access_logs_respects_timeout(  # noqa: FT003
     mocker: MockerFixture, aws_credentials: None
 ) -> None:
     # Given - Mock bucket with multiple objects

--- a/api/tests/unit/sse/test_tasks.py
+++ b/api/tests/unit/sse/test_tasks.py
@@ -17,7 +17,7 @@ from sse.tasks import (
 )
 
 
-def test_send_environment_update_message_for_project_make_correct_request(  # type: ignore[no-untyped-def]
+def test_send_environment_update_message_for_project_make_correct_request(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker,
     settings,
     realtime_enabled_project,
@@ -59,7 +59,7 @@ def test_send_environment_update_message_for_project_make_correct_request(  # ty
     )
 
 
-def test_send_environment_update_message_make_correct_request(mocker, settings):  # type: ignore[no-untyped-def]
+def test_send_environment_update_message_make_correct_request(mocker, settings):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     base_url = "http://localhost:8000"
     token = "token"
@@ -82,7 +82,7 @@ def test_send_environment_update_message_make_correct_request(mocker, settings):
     )
 
 
-def test_auth_header_raises_exception_if_token_not_set(settings):  # type: ignore[no-untyped-def]
+def test_auth_header_raises_exception_if_token_not_set(settings):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # Given
     settings.SSE_AUTHENTICATION_TOKEN = None
 
@@ -91,7 +91,7 @@ def test_auth_header_raises_exception_if_token_not_set(settings):  # type: ignor
         get_auth_header()  # type: ignore[no-untyped-call]
 
 
-def test_track_sse_usage(  # type: ignore[no-untyped-def]
+def test_track_sse_usage(  # type: ignore[no-untyped-def]  # noqa: FT003
     mocker: MockerFixture,
     environment: Environment,
     django_assert_num_queries: DjangoAssertNumQueries,

--- a/api/tests/unit/telemetry/test_unit_telemetry_models.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_models.py
@@ -7,7 +7,7 @@ debug_enabled = True
 
 
 @override_settings(ENV=env, DEBUG=debug_enabled)
-def test_get_install_stats(  # type: ignore[no-untyped-def]
+def test_get_install_stats(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation_one,
     organisation_two,
     organisation_one_project_one,

--- a/api/tests/unit/telemetry/test_unit_telemetry_serializers.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_serializers.py
@@ -9,7 +9,7 @@ from tests.unit.telemetry.helpers import get_example_telemetry_data
 @override_settings(INFLUXDB_TOKEN="some-token")
 @mock.patch("telemetry.serializers.get_ip_address_from_request")
 @mock.patch("telemetry.serializers.InfluxDBWrapper")
-def test_telemetry_serializer_save(MockInfluxDBWrapper, mock_get_ip_address):  # type: ignore[no-untyped-def]
+def test_telemetry_serializer_save(MockInfluxDBWrapper, mock_get_ip_address):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     data = get_example_telemetry_data()
     serializer = TelemetrySerializer(data=data, context={"request": mock.MagicMock()})

--- a/api/tests/unit/telemetry/test_unit_telemetry_telemetry.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_telemetry.py
@@ -9,7 +9,7 @@ from tests.unit.telemetry.helpers import get_example_telemetry_data
 
 @responses.activate
 @mock.patch("telemetry.telemetry.TelemetryData")
-def test_self_hosted_telemetry_wrapper_send_heartbeat(MockTelemetryData):  # type: ignore[no-untyped-def]
+def test_self_hosted_telemetry_wrapper_send_heartbeat(MockTelemetryData):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     # we mock the response from the API
     responses.add(

--- a/api/tests/unit/users/test_unit_users_forms.py
+++ b/api/tests/unit/users/test_unit_users_forms.py
@@ -1,7 +1,7 @@
 from users.forms import CustomUserAdminForm
 
 
-def test_custom_user_admin_form_empty_value_of_username_is_none(db):  # type: ignore[no-untyped-def]
+def test_custom_user_admin_form_empty_value_of_username_is_none(db):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     form = CustomUserAdminForm({"email": "test@mail.com"})
     # When

--- a/api/tests/unit/users/test_unit_users_login.py
+++ b/api/tests/unit/users/test_unit_users_login.py
@@ -4,7 +4,7 @@ from pytest_django.fixtures import SettingsWrapper
 from rest_framework.test import APIClient
 
 
-def test_brute_force_access_attempts(
+def test_brute_force_access_attempts(  # noqa: FT003,FT004
     db: None, settings: SettingsWrapper, api_client: APIClient
 ) -> None:
     invalid_user_name = "invalid_user@mail.com"

--- a/api/tests/unit/users/test_unit_users_migrations.py
+++ b/api/tests/unit/users/test_unit_users_migrations.py
@@ -1,7 +1,7 @@
 from django_test_migrations.migrator import Migrator
 
 
-def test_remove_users_from_groups_in_orgs_the_do_not_belong_to(
+def test_remove_users_from_groups_in_orgs_the_do_not_belong_to(  # noqa: FT003
     migrator: Migrator,
 ) -> None:
     # Given

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -12,7 +12,7 @@ from tests.types import WithProjectPermissionsCallable
 from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_user_belongs_to_success(
+def test_user_belongs_to_success(  # noqa: FT003,FT004
     admin_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -22,12 +22,12 @@ def test_user_belongs_to_success(
     assert admin_user.belongs_to(organisation.id)
 
 
-def test_user_belongs_to_fail(admin_user: FFAdminUser) -> None:
+def test_user_belongs_to_fail(admin_user: FFAdminUser) -> None:  # noqa: FT003,FT004
     unaffiliated_organisation = Organisation.objects.create(name="Unaffiliated")
     assert not admin_user.belongs_to(unaffiliated_organisation.id)
 
 
-def test_get_permitted_projects_for_org_admin_returns_all_projects(
+def test_get_permitted_projects_for_org_admin_returns_all_projects(  # noqa: FT003
     admin_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -41,7 +41,7 @@ def test_get_permitted_projects_for_org_admin_returns_all_projects(
     assert projects.count() == 2
 
 
-def test_get_permitted_projects_for_user_returns_only_projects_matching_permission(
+def test_get_permitted_projects_for_user_returns_only_projects_matching_permission(  # noqa: FT003
     staff_user: FFAdminUser,
     with_project_permissions: WithProjectPermissionsCallable,
     project: Project,
@@ -57,7 +57,7 @@ def test_get_permitted_projects_for_user_returns_only_projects_matching_permissi
     assert projects.first() == project
 
 
-def test_get_admin_organisations(
+def test_get_admin_organisations(  # noqa: FT003
     admin_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -73,7 +73,7 @@ def test_get_admin_organisations(
     assert non_admin_organisation not in admin_orgs
 
 
-def test_get_permitted_environments_for_org_admin_returns_all_environments_for_project(
+def test_get_permitted_environments_for_org_admin_returns_all_environments_for_project(  # noqa: FT003,FT004
     admin_user: FFAdminUser,
     organisation: Organisation,
     project: Project,
@@ -87,7 +87,7 @@ def test_get_permitted_environments_for_org_admin_returns_all_environments_for_p
     assert environments.count() == project.environments.count()
 
 
-def test_get_permitted_environments_for_user_returns_only_environments_matching_permission(
+def test_get_permitted_environments_for_user_returns_only_environments_matching_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     project: Project,
 ) -> None:
@@ -100,7 +100,7 @@ def test_get_permitted_environments_for_user_returns_only_environments_matching_
     assert len(list(environments)) == 0
 
 
-def test_unique_user_organisation(
+def test_unique_user_organisation(  # noqa: FT003,FT004
     admin_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -108,7 +108,7 @@ def test_unique_user_organisation(
         admin_user.add_organisation(organisation, OrganisationRole.USER)
 
 
-def test_has_organisation_permission_is_true_for_organisation_admin(
+def test_has_organisation_permission_is_true_for_organisation_admin(  # noqa: FT003,FT004
     admin_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -121,7 +121,7 @@ def test_has_organisation_permission_is_true_for_organisation_admin(
     )
 
 
-def test_has_organisation_permission_is_true_when_user_has_permission(
+def test_has_organisation_permission_is_true_when_user_has_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -144,7 +144,7 @@ def test_has_organisation_permission_is_true_when_user_has_permission(
     )
 
 
-def test_has_organisation_permission_is_false_when_user_does_not_have_permission(
+def test_has_organisation_permission_is_false_when_user_does_not_have_permission(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
@@ -156,7 +156,7 @@ def test_has_organisation_permission_is_false_when_user_does_not_have_permission
     )
 
 
-def test_user_add_organisation_adds_user_to_the_default_user_permission_group(
+def test_user_add_organisation_adds_user_to_the_default_user_permission_group(  # noqa: FT003
     organisation: Organisation,
     default_user_permission_group: UserPermissionGroup,
     user_permission_group: UserPermissionGroup,
@@ -172,7 +172,7 @@ def test_user_add_organisation_adds_user_to_the_default_user_permission_group(
     assert user_permission_group not in user.permission_groups.all()
 
 
-def test_user_remove_organisation_removes_user_from_the_user_permission_group(  # type: ignore[no-untyped-def]
+def test_user_remove_organisation_removes_user_from_the_user_permission_group(  # type: ignore[no-untyped-def]  # noqa: FT003
     user_permission_group, admin_user, organisation, default_user_permission_group
 ):
     # Given - two groups that belongs to the same organisation, but user
@@ -187,7 +187,7 @@ def test_user_remove_organisation_removes_user_from_the_user_permission_group(  
 
 
 @pytest.mark.django_db
-def test_delete_user():  # type: ignore[no-untyped-def]
+def test_delete_user():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # create a couple of users
     email1 = "test1@example.com"
     email2 = "test2@example.com"
@@ -241,5 +241,5 @@ def test_delete_user():  # type: ignore[no-untyped-def]
     assert Organisation.objects.filter(name="org1").count() == 1
 
 
-def test_user_email_domain_property():  # type: ignore[no-untyped-def]
+def test_user_email_domain_property():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert FFAdminUser(email="test@example.com").email_domain == "example.com"

--- a/api/tests/unit/users/test_unit_users_serializers.py
+++ b/api/tests/unit/users/test_unit_users_serializers.py
@@ -11,7 +11,7 @@ from users.serializers import (
 )
 
 
-def test_user_ids_serializer_raises_exception_for_invalid_user_id(db: None) -> None:
+def test_user_ids_serializer_raises_exception_for_invalid_user_id(db: None) -> None:  # noqa: FT003,FT004
     # Given
     serializer = UserIdsSerializer(data={"user_ids": [99999]})
 
@@ -21,7 +21,7 @@ def test_user_ids_serializer_raises_exception_for_invalid_user_id(db: None) -> N
 
 
 @freeze_time("2025-01-01T12:00:00Z")
-def test_onboarding_task_serializer_list_returns_correct_format() -> None:
+def test_onboarding_task_serializer_list_returns_correct_format() -> None:  # noqa: FT003
     # Given
     data = [
         {"name": "task-1"},
@@ -44,7 +44,7 @@ def test_onboarding_task_serializer_list_returns_correct_format() -> None:
 
 
 @pytest.mark.parametrize("tools_completed", [True, False, None])
-def test_patch_onboarding_serializer_returns_correct_format(
+def test_patch_onboarding_serializer_returns_correct_format(  # noqa: FT003
     tools_completed: bool | None,
 ) -> None:
     # Given

--- a/api/tests/unit/users/test_unit_users_signals.py
+++ b/api/tests/unit/users/test_unit_users_signals.py
@@ -4,7 +4,7 @@ from users.signals import warn_insecure
 
 
 @pytest.mark.django_db
-def test_warn_insecure_emits_a_warning_when_no_user_exists(recwarn, django_user_model):  # type: ignore[no-untyped-def]  # noqa: E501
+def test_warn_insecure_emits_a_warning_when_no_user_exists(recwarn, django_user_model):  # type: ignore[no-untyped-def]  # noqa: E501,FT003,FT004
     # When
     warn_insecure(django_user_model)  # type: ignore[no-untyped-call]
 
@@ -15,7 +15,7 @@ def test_warn_insecure_emits_a_warning_when_no_user_exists(recwarn, django_user_
 
 
 @pytest.mark.django_db
-def test_warn_insecure_emits_no_warning_when_user_exists(  # type: ignore[no-untyped-def]
+def test_warn_insecure_emits_no_warning_when_user_exists(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     admin_user, recwarn, django_user_model
 ):
     # When

--- a/api/tests/unit/users/test_unit_users_tasks.py
+++ b/api/tests/unit/users/test_unit_users_tasks.py
@@ -5,7 +5,7 @@ from users.tasks import (
 )
 
 
-def test_send_email_changed_notification():  # type: ignore[no-untyped-def]
+def test_send_email_changed_notification():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # When
     send_email_changed_notification_email(
         first_name="first_name",

--- a/api/tests/unit/users/test_unit_users_views.py
+++ b/api/tests/unit/users/test_unit_users_views.py
@@ -28,7 +28,7 @@ from users.models import (
 )
 
 
-def test_join_organisation(
+def test_join_organisation(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -45,7 +45,7 @@ def test_join_organisation(
     assert organisation in staff_user.organisations.all()
 
 
-def test_join_organisation_via_link(
+def test_join_organisation_via_link(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -63,7 +63,7 @@ def test_join_organisation_via_link(
     assert organisation in staff_user.organisations.all()
 
 
-def test_cannot_join_organisation_via_expired_link(
+def test_cannot_join_organisation_via_expired_link(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -84,7 +84,7 @@ def test_cannot_join_organisation_via_expired_link(
     assert organisation not in staff_user.organisations.all()
 
 
-def test_user_can_join_second_organisation(  # type: ignore[no-untyped-def]
+def test_user_can_join_second_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation: Organisation,
     staff_user: FFAdminUser,
     staff_client: APIClient,
@@ -108,7 +108,7 @@ def test_user_can_join_second_organisation(  # type: ignore[no-untyped-def]
     )
 
 
-def test_cannot_join_organisation_with_different_email_address_than_invite(
+def test_cannot_join_organisation_with_different_email_address_than_invite(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -127,7 +127,7 @@ def test_cannot_join_organisation_with_different_email_address_than_invite(
     assert organisation not in staff_user.organisations.all()
 
 
-def test_can_join_organisation_as_admin_if_invite_role_is_admin(
+def test_can_join_organisation_as_admin_if_invite_role_is_admin(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -147,7 +147,7 @@ def test_can_join_organisation_as_admin_if_invite_role_is_admin(
     assert staff_user.is_organisation_admin(organisation)
 
 
-def test_admin_can_update_role_for_a_user_in_organisation(  # type: ignore[no-untyped-def]
+def test_admin_can_update_role_for_a_user_in_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
 ):
@@ -173,7 +173,7 @@ def test_admin_can_update_role_for_a_user_in_organisation(  # type: ignore[no-un
     )
 
 
-def test_admin_can_get_users_in_organisation(
+def test_admin_can_get_users_in_organisation(  # noqa: FT003
     admin_user: FFAdminUser,
     admin_client_new: APIClient,
     staff_user: FFAdminUser,
@@ -206,7 +206,7 @@ def test_admin_can_get_users_in_organisation(
     assert response.data[4]["email"] == additional_user2.email
 
 
-def test_org_user_can_get_users_in_organisation(
+def test_org_user_can_get_users_in_organisation(  # noqa: FT003
     staff_user: FFAdminUser,
     staff_client: APIClient,
     organisation: Organisation,
@@ -229,7 +229,7 @@ def test_org_user_can_get_users_in_organisation(
     assert response.data[2]["email"] == organisation_user.email
 
 
-def test_org_user_can_exclude_themself_when_getting_users_in_organisation(  # type: ignore[no-untyped-def]
+def test_org_user_can_exclude_themself_when_getting_users_in_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     staff_client: APIClient,
     staff_user: FFAdminUser,
     organisation: Organisation,
@@ -253,7 +253,7 @@ def test_org_user_can_exclude_themself_when_getting_users_in_organisation(  # ty
     assert response.data[1]["id"] == organisation_user.id
 
 
-def test_organisation_admin_can_interact_with_groups(
+def test_organisation_admin_can_interact_with_groups(  # noqa: FT003
     organisation: Organisation,
     admin_client_new: APIClient,
 ) -> None:
@@ -296,7 +296,7 @@ def test_organisation_admin_can_interact_with_groups(
     assert not UserPermissionGroup.objects.filter(name=update_data["name"]).exists()
 
 
-def test_staff_user_cannot_post_to_groups(
+def test_staff_user_cannot_post_to_groups(  # noqa: FT003,FT004
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -311,7 +311,7 @@ def test_staff_user_cannot_post_to_groups(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_staff_user_cannot_put_to_groups(
+def test_staff_user_cannot_put_to_groups(  # noqa: FT003,FT004
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -328,7 +328,7 @@ def test_staff_user_cannot_put_to_groups(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_staff_user_cannot_get_to_groups(
+def test_staff_user_cannot_get_to_groups(  # noqa: FT003,FT004
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -345,7 +345,7 @@ def test_staff_user_cannot_get_to_groups(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_staff_user_cannot_delete_to_groups(
+def test_staff_user_cannot_delete_to_groups(  # noqa: FT003,FT004
     staff_client: APIClient,
     organisation: Organisation,
 ) -> None:
@@ -363,7 +363,7 @@ def test_staff_user_cannot_delete_to_groups(
     assert UserPermissionGroup.objects.filter(name=group_name).exists()
 
 
-def test_can_add_multiple_users_including_current_user(
+def test_can_add_multiple_users_including_current_user(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_user: FFAdminUser,
@@ -389,7 +389,7 @@ def test_can_add_multiple_users_including_current_user(
     assert all(user in group.users.all() for user in [admin_user, staff_user])
 
 
-def test_can_add_users_with_master_api_key(
+def test_can_add_users_with_master_api_key(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_user: FFAdminUser,
@@ -415,7 +415,7 @@ def test_can_add_users_with_master_api_key(
     assert all(user in group.users.all() for user in [admin_user, staff_user])
 
 
-def test_cannot_add_user_from_another_organisation(  # type: ignore[no-untyped-def]
+def test_cannot_add_user_from_another_organisation(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new: APIClient,
     organisation: Organisation,
 ):
@@ -441,7 +441,7 @@ def test_cannot_add_user_from_another_organisation(  # type: ignore[no-untyped-d
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_cannot_add_same_user_twice(
+def test_cannot_add_same_user_twice(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_client_new: APIClient,
@@ -464,7 +464,7 @@ def test_cannot_add_same_user_twice(
     assert staff_user in group.users.all() and group.users.count() == 1
 
 
-def test_remove_users_from_group(
+def test_remove_users_from_group(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_user: FFAdminUser,
@@ -493,7 +493,7 @@ def test_remove_users_from_group(
     assert admin_user in group.users.all()
 
 
-def test_remove_users_silently_fails_if_user_not_in_group(
+def test_remove_users_silently_fails_if_user_not_in_group(  # noqa: FT003
     staff_user: FFAdminUser,
     organisation: Organisation,
     admin_client_new: APIClient,
@@ -522,7 +522,7 @@ def test_remove_users_silently_fails_if_user_not_in_group(
     assert admin_user in group.users.all()
 
 
-def test_user_permission_group_can_update_is_default(  # type: ignore[no-untyped-def]
+def test_user_permission_group_can_update_is_default(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new, organisation, user_permission_group
 ):
     # Given
@@ -543,7 +543,7 @@ def test_user_permission_group_can_update_is_default(  # type: ignore[no-untyped
     assert user_permission_group.is_default is True
 
 
-def test_user_permission_group_can_update_external_id(  # type: ignore[no-untyped-def]
+def test_user_permission_group_can_update_external_id(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new, organisation, user_permission_group
 ):
     # Given
@@ -561,7 +561,7 @@ def test_user_permission_group_can_update_external_id(  # type: ignore[no-untype
     assert response.json()["external_id"] == external_id
 
 
-def test_users_in_organisation_have_last_login(  # type: ignore[no-untyped-def]
+def test_users_in_organisation_have_last_login(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new, organisation, rf, mocker, admin_user
 ):
     # Given
@@ -582,7 +582,7 @@ def test_users_in_organisation_have_last_login(  # type: ignore[no-untyped-def]
     assert res.status_code == status.HTTP_200_OK
 
 
-def test_retrieve_user_permission_group_includes_group_admin(  # type: ignore[no-untyped-def]
+def test_retrieve_user_permission_group_includes_group_admin(  # type: ignore[no-untyped-def]  # noqa: FT003
     admin_client_new, admin_user, organisation, user_permission_group
 ):
     # Given
@@ -613,7 +613,7 @@ def test_retrieve_user_permission_group_includes_group_admin(  # type: ignore[no
     )
 
 
-def test_group_admin_can_retrieve_group(  # type: ignore[no-untyped-def]
+def test_group_admin_can_retrieve_group(  # type: ignore[no-untyped-def]  # noqa: FT003
     organisation: Organisation,
     django_user_model: typing.Type[AbstractUser],
     api_client: APIClient,
@@ -657,7 +657,7 @@ def delete_user(  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.django_db
-def test_delete_user():  # type: ignore[no-untyped-def]
+def test_delete_user():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     # create a couple of users
     email1 = "test1@example.com"
     email2 = "test2@example.com"
@@ -717,7 +717,7 @@ def test_delete_user():  # type: ignore[no-untyped-def]
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("password", [None, "", "random"])
-def test_delete_user_social_auth_with_no_password(password):  # type: ignore[no-untyped-def]
+def test_delete_user_social_auth_with_no_password(password):  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     google_auth_user_email = "google@example.com"
     github_auth_user_email = "github@example.com"
 
@@ -752,7 +752,7 @@ def test_delete_user_social_auth_with_no_password(password):  # type: ignore[no-
 
 
 @pytest.mark.django_db
-def test_change_email_address_api(mocker):  # type: ignore[no-untyped-def]
+def test_change_email_address_api(mocker):  # type: ignore[no-untyped-def]  # noqa: FT003
     # Given
     mocked_task = mocker.patch("users.tasks.send_email_changed_notification_email")
     # create an user
@@ -788,7 +788,7 @@ def test_change_email_address_api(mocker):  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.django_db
-def test_send_reset_password_emails_rate_limit(
+def test_send_reset_password_emails_rate_limit(  # noqa: FT003
     settings: SettingsWrapper,
     client: APIClient,
     staff_user: FFAdminUser,
@@ -827,7 +827,7 @@ def test_send_reset_password_emails_rate_limit(
 
 
 @pytest.mark.django_db
-def test_send_reset_password_emails_rate_limit_resets_after_password_reset(  # type: ignore[no-untyped-def]
+def test_send_reset_password_emails_rate_limit_resets_after_password_reset(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     settings: SettingsWrapper,
     client: APIClient,
     staff_user: FFAdminUser,
@@ -874,7 +874,7 @@ def test_send_reset_password_emails_rate_limit_resets_after_password_reset(  # t
     assert len(mail.outbox) == 1
 
 
-def test_list_user_groups(
+def test_list_user_groups(  # noqa: FT003
     organisation: Organisation,
     admin_client: APIClient,
     django_assert_num_queries: DjangoAssertNumQueries,
@@ -947,7 +947,7 @@ def test_list_user_groups(
         ),
     ],
 )
-def test_get_me_view_updates_last_login(
+def test_get_me_view_updates_last_login(  # noqa: FT003
     api_client: APIClient,
     staff_user: FFAdminUser,
     last_login: datetime | None,

--- a/api/tests/unit/util/engine_models/identities/traits/test_unit_traits_types.py
+++ b/api/tests/unit/util/engine_models/identities/traits/test_unit_traits_types.py
@@ -21,7 +21,7 @@ from util.engine_models.identities.traits.types import (
         ({"a": "dict"}, "{'a': 'dict'}"),
     ],
 )
-def test_map_any_value_to_trait_value(value: object, expected: object) -> None:
+def test_map_any_value_to_trait_value(value: object, expected: object) -> None:  # noqa: FT003,FT004
     # When
     result = map_any_value_to_trait_value(value)
 

--- a/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from features.models import FeatureState
 
 
-def test_map_environment_to_environment_document__call_expected(
+def test_map_environment_to_environment_document__call_expected(  # noqa: FT003
     environment: "Environment",
     feature_state: "FeatureState",
 ) -> None:
@@ -83,7 +83,7 @@ def test_map_environment_to_environment_document__call_expected(
     }
 
 
-def test_map_environment_api_key_to_environment_api_key_document__call_expected(
+def test_map_environment_api_key_to_environment_api_key_document__call_expected(  # noqa: FT003
     environment_api_key: "EnvironmentAPIKey",
 ) -> None:
     # Given
@@ -108,7 +108,7 @@ def test_map_environment_api_key_to_environment_api_key_document__call_expected(
     }
 
 
-def test_map_identity_to_identity_document__call_expected(
+def test_map_identity_to_identity_document__call_expected(  # noqa: FT003
     identity: "Identity",
     trait: "Trait",
     mocker: "MockerFixture",
@@ -137,7 +137,7 @@ def test_map_identity_to_identity_document__call_expected(
     assert uuid.UUID(result["identity_uuid"])  # type: ignore[arg-type]
 
 
-def test_map_environment_to_environment_v2_document__call_expected(
+def test_map_environment_to_environment_v2_document__call_expected(  # noqa: FT003
     environment: "Environment",
     feature_state: "FeatureState",
 ) -> None:
@@ -233,7 +233,7 @@ def test_map_identity_override_to_identity_override_document__decimal_feature_st
     assert feature_state_value == expected_feature_state_value
 
 
-def test_map_environment_to_compressed_environment_document__returns_expected(
+def test_map_environment_to_compressed_environment_document__returns_expected(  # noqa: FT003
     environment: "Environment",
     feature_state: "FeatureState",
 ) -> None:
@@ -263,7 +263,7 @@ def test_map_environment_to_compressed_environment_document__returns_expected(
     )
 
 
-def test_map_environment_to_compressed_environment_v2_document__returns_expected(
+def test_map_environment_to_compressed_environment_v2_document__returns_expected(  # noqa: FT003
     environment: "Environment",
     feature_state: "FeatureState",
 ) -> None:

--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -100,7 +100,7 @@ def versioned_segment_feature_state(
     )
 
 
-def test_map_segment_rule_to_engine__return_expected(
+def test_map_segment_rule_to_engine__return_expected(  # noqa: FT003
     segment_rule: SegmentRule,
     identity_matching_segment: "Segment",
 ) -> None:
@@ -131,7 +131,7 @@ def test_map_segment_rule_to_engine__return_expected(
     )
 
 
-def test_map_integration_to_engine__return_expected() -> None:
+def test_map_integration_to_engine__return_expected() -> None:  # noqa: FT003
     # Given
     class TestIntegration(IntegrationsModel):
         class Meta:
@@ -150,7 +150,7 @@ def test_map_integration_to_engine__return_expected() -> None:
     assert result == expected_result
 
 
-def test_map_integration_to_engine__none__return_expected() -> None:
+def test_map_integration_to_engine__none__return_expected() -> None:  # noqa: FT004
     # When
     result = engine.map_integration_to_engine(None)
 
@@ -182,7 +182,7 @@ def test_map_integration_to_engine__dynatrace__return_expected() -> None:
     assert result == expected_result
 
 
-def test_map_webhook_config_to_engine__return_expected() -> None:
+def test_map_webhook_config_to_engine__return_expected() -> None:  # noqa: FT003
     # Given
     url = "http://someurl"
     secret = "test"
@@ -203,7 +203,7 @@ def test_map_webhook_config_to_engine__return_expected() -> None:
     assert result == expected_result
 
 
-def test_map_webhook_config_to_engine__none__return_expected() -> None:
+def test_map_webhook_config_to_engine__none__return_expected() -> None:  # noqa: FT004
     # When
     result = engine.map_webhook_config_to_engine(None)
 
@@ -211,7 +211,7 @@ def test_map_webhook_config_to_engine__none__return_expected() -> None:
     assert result is None
 
 
-def test_map_feature_state_to_engine__return_expected(
+def test_map_feature_state_to_engine__return_expected(  # noqa: FT003
     feature: "Feature",
     feature_state: FeatureState,
 ) -> None:
@@ -284,7 +284,7 @@ def test_map_feature_state_to_engine__feature_segment__return_expected(
     assert result == expected_result
 
 
-def test_map_environment_to_engine__return_expected(
+def test_map_environment_to_engine__return_expected(  # noqa: FT003
     environment: Environment,
     feature: "Feature",
     feature_state: FeatureState,
@@ -425,7 +425,7 @@ def test_map_environment_to_engine__return_expected(
     assert segment_featurestate.uuid not in segment_feature_state_uuids
 
 
-def test_map_environment_api_key_to_engine__return_expected(
+def test_map_environment_api_key_to_engine__return_expected(  # noqa: FT003
     environment: Environment,
     environment_api_key: "EnvironmentAPIKey",
 ) -> None:
@@ -447,7 +447,7 @@ def test_map_environment_api_key_to_engine__return_expected(
     )
 
 
-def test_map_identity_to_engine__return_expected(
+def test_map_identity_to_engine__return_expected(  # noqa: FT003
     environment: Environment,
     identity: "Identity",
     feature: "Feature",
@@ -496,7 +496,7 @@ def test_map_identity_to_engine__return_expected(
     assert result == expected_result
 
 
-def test_map_environment_to_engine__returns_correct_feature_state_for_different_versions(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_map_environment_to_engine__returns_correct_feature_state_for_different_versions(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     feature, environment
 ):
     # Given
@@ -541,7 +541,7 @@ def test_map_environment_to_engine__returns_correct_feature_state_for_different_
     assert result.feature_states[0].django_id == v15_feature_state.id
 
 
-def test_map_environment_to_engine_following_migration_to_v2_versioning(
+def test_map_environment_to_engine_following_migration_to_v2_versioning(  # noqa: FT003
     environment: Environment,
     feature: "Feature",
     feature_state: FeatureState,
@@ -604,7 +604,7 @@ def test_map_environment_to_engine_following_migration_to_v2_versioning(
     assert mapped_segment_override.feature_state_value == v2_segment_override_value
 
 
-def test_map_environment_to_engine_v2_versioning_segment_overrides(
+def test_map_environment_to_engine_v2_versioning_segment_overrides(  # noqa: FT003
     environment_v2_versioning: Environment,
     segment: Segment,
     feature: "Feature",
@@ -663,7 +663,7 @@ def test_map_environment_to_engine_v2_versioning_segment_overrides(
 def test_map_environment_to_evaluation_context__no_identity__returns_environment_only(
     environment: Environment,
 ) -> None:
-    # When
+    # Given / When
     result = engine.map_environment_to_evaluation_context(environment=environment)
 
     # Then
@@ -679,7 +679,7 @@ def test_map_environment_to_evaluation_context__with_identity__returns_identity_
     environment: Environment,
     identity: Identity,
 ) -> None:
-    # When
+    # Given / When
     result = engine.map_environment_to_evaluation_context(
         environment=environment,
         identity=identity,
@@ -706,7 +706,7 @@ def test_map_environment_to_evaluation_context__with_explicit_traits__returns_gi
     identity: Identity,
     trait: Trait,
 ) -> None:
-    # When
+    # Given / When
     result = engine.map_environment_to_evaluation_context(
         environment=environment,
         identity=identity,
@@ -734,7 +734,7 @@ def test_map_environment_to_evaluation_context__no_explicit_traits__returns_iden
     identity: Identity,
     trait: Trait,
 ) -> None:
-    # When
+    # Given / When
     result = engine.map_environment_to_evaluation_context(
         environment=environment,
         identity=identity,
@@ -760,7 +760,7 @@ def test_map_environment_to_evaluation_context__with_segments__returns_segment_c
     environment: Environment,
     identity_matching_segment: Segment,
 ) -> None:
-    # When
+    # Given / When
     result = engine.map_environment_to_evaluation_context(
         environment=environment,
         segments=[identity_matching_segment],

--- a/api/tests/unit/util/mappers/test_unit_mappers_sdk.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_sdk.py
@@ -19,7 +19,7 @@ def identity_without_overrides(environment):  # type: ignore[no-untyped-def]
     )
 
 
-def test_map_environment_to_sdk_document__return_expected(
+def test_map_environment_to_sdk_document__return_expected(  # noqa: FT003
     mocker: "MockerFixture",
     environment: "Environment",
     feature_state: "FeatureState",
@@ -110,7 +110,7 @@ def test_map_environment_to_sdk_document__return_expected(
     }
 
 
-def test_map_environment_to_sdk_document__for_environment_with_identity_overrides_in_local_eval_disabled(
+def test_map_environment_to_sdk_document__for_environment_with_identity_overrides_in_local_eval_disabled(  # noqa: FT003
     mocker: "MockerFixture",
     environment: "Environment",
     feature_state: "FeatureState",

--- a/api/tests/unit/util/test_logging.py
+++ b/api/tests/unit/util/test_logging.py
@@ -12,7 +12,7 @@ from util.logging import GunicornAccessLogJsonFormatter, JsonFormatter
 
 
 @pytest.mark.freeze_time("2023-12-08T06:05:47.000000+00:00")
-def test_json_formatter__outputs_expected(
+def test_json_formatter__outputs_expected(  # noqa: FT003
     inspecting_handler: logging.Handler,
     request: pytest.FixtureRequest,
 ) -> None:
@@ -66,7 +66,7 @@ def test_json_formatter__outputs_expected(
 
 
 @pytest.mark.freeze_time("2023-12-08T06:05:47.000000+00:00")
-def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:
+def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:  # noqa: FT003
     # Given
     gunicorn_access_log_json_formatter = GunicornAccessLogJsonFormatter()
     log_record = logging.LogRecord(

--- a/api/tests/unit/util/test_util.py
+++ b/api/tests/unit/util/test_util.py
@@ -3,11 +3,11 @@ import pytest
 from util.util import iter_chunked_concat, iter_paired_chunks
 
 
-def test__iter_paired_chunks__empty():  # type: ignore[no-untyped-def]
+def test__iter_paired_chunks__empty():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert list(iter_paired_chunks([], [], chunk_size=1)) == []
 
 
-def test__iter_paired_chunks__first_empty():  # type: ignore[no-untyped-def]
+def test__iter_paired_chunks__first_empty():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert list(iter_paired_chunks([], [1, 2, 3], chunk_size=1)) == [
         ([], [1]),
         ([], [2]),
@@ -15,7 +15,7 @@ def test__iter_paired_chunks__first_empty():  # type: ignore[no-untyped-def]
     ]
 
 
-def test__iter_paired_chunks__second_empty():  # type: ignore[no-untyped-def]
+def test__iter_paired_chunks__second_empty():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert list(iter_paired_chunks([1, 2, 3], [], chunk_size=1)) == [
         ([1], []),
         ([2], []),
@@ -23,7 +23,7 @@ def test__iter_paired_chunks__second_empty():  # type: ignore[no-untyped-def]
     ]
 
 
-def test__iter_paired_chunks__first_shorter():  # type: ignore[no-untyped-def]
+def test__iter_paired_chunks__first_shorter():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert list(iter_paired_chunks([1, 2, 3], [4, 5, 6, 7, 8], chunk_size=3)) == [
         ([1, 2], [4]),
         ([3], [5, 6]),
@@ -31,7 +31,7 @@ def test__iter_paired_chunks__first_shorter():  # type: ignore[no-untyped-def]
     ]
 
 
-def test__iter_pair_chunks__second_shorter():  # type: ignore[no-untyped-def]
+def test__iter_pair_chunks__second_shorter():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert list(iter_paired_chunks([1, 2, 3, 4, 5], [6, 7, 8], chunk_size=3)) == [
         ([1, 2], [6]),
         ([3, 4], [7]),
@@ -39,7 +39,7 @@ def test__iter_pair_chunks__second_shorter():  # type: ignore[no-untyped-def]
     ]
 
 
-def test__iter_pair_chunks__same_length():  # type: ignore[no-untyped-def]
+def test__iter_pair_chunks__same_length():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     assert list(iter_paired_chunks([1, 2, 3], [4, 5, 6], chunk_size=3)) == [
         ([1, 2], [4]),
         ([3], [5, 6]),
@@ -82,7 +82,7 @@ def test__iter_pair_chunks__same_length():  # type: ignore[no-untyped-def]
         (["a", "b", "c"], ",", 5, ["a,b,c"]),
     ],
 )
-def test_iter_chunked_concat(
+def test_iter_chunked_concat(  # noqa: FT003,FT004
     values: list[str],
     delimiter: str,
     max_len: int,

--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -32,7 +32,7 @@ from webhooks.webhooks import (
 
 
 @mock.patch("webhooks.webhooks.requests")
-def test_webhooks_requests_made_to_all_urls_for_environment(
+def test_webhooks_requests_made_to_all_urls_for_environment(  # noqa: FT003
     mock_requests: MagicMock,
     environment: Environment,
 ) -> None:
@@ -62,7 +62,7 @@ def test_webhooks_requests_made_to_all_urls_for_environment(
 
 
 @mock.patch("webhooks.webhooks.requests")
-def test_webhooks_request_not_made_to_disabled_webhook(
+def test_webhooks_request_not_made_to_disabled_webhook(  # noqa: FT003
     mock_requests: MagicMock,
     environment: Environment,
 ) -> None:
@@ -84,7 +84,7 @@ def test_webhooks_request_not_made_to_disabled_webhook(
 
 @mock.patch("webhooks.webhooks.WebhookSerializer")
 @mock.patch("webhooks.webhooks.requests")
-def test_request_made_with_correct_signature(
+def test_request_made_with_correct_signature(  # noqa: FT003
     mock_requests: MagicMock,
     webhook_serializer: MagicMock,
     environment: Environment,
@@ -119,7 +119,7 @@ def test_request_made_with_correct_signature(
 
 
 @mock.patch("webhooks.webhooks.requests")
-def test_request_does_not_have_signature_header_if_secret_is_not_set(
+def test_request_does_not_have_signature_header_if_secret_is_not_set(  # noqa: FT003
     mock_requests: MagicMock,
     environment: Environment,
 ) -> None:
@@ -141,7 +141,7 @@ def test_request_does_not_have_signature_header_if_secret_is_not_set(
 
 @pytest.mark.parametrize("expected_error", [ConnectionError, Timeout])
 @pytest.mark.django_db
-def test_call_environment_webhooks__multiple_webhooks__failure__calls_expected(
+def test_call_environment_webhooks__multiple_webhooks__failure__calls_expected(  # noqa: FT003
     mocker: MockerFixture,
     expected_error: Type[Exception],
     environment: Environment,
@@ -205,7 +205,7 @@ def test_call_environment_webhooks__multiple_webhooks__failure__calls_expected(
 
 @pytest.mark.parametrize("expected_error", [ConnectionError, Timeout])
 @pytest.mark.django_db
-def test_call_organisation_webhooks__multiple_webhooks__failure__calls_expected(
+def test_call_organisation_webhooks__multiple_webhooks__failure__calls_expected(  # noqa: FT003
     mocker: MockerFixture,
     expected_error: Type[Exception],
     organisation: Organisation,
@@ -296,13 +296,13 @@ def test_call_webhook_with_failure_mail_after_retries__non_2xx_response__logs_wa
     )
 
 
-def test_call_webhook_with_failure_mail_after_retries_raises_error_on_invalid_args():  # type: ignore[no-untyped-def]
+def test_call_webhook_with_failure_mail_after_retries_raises_error_on_invalid_args():  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     try_count = 10
     with pytest.raises(ValueError):
         call_webhook_with_failure_mail_after_retries(0, {}, "", try_count=try_count)
 
 
-def test_call_webhook_with_failure_mail_after_retries_does_not_retry_if_not_using_processor(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_call_webhook_with_failure_mail_after_retries_does_not_retry_if_not_using_processor(  # type: ignore[no-untyped-def]  # noqa: E501,FT003
     mocker: MockerFixture, organisation: Organisation, settings: SettingsWrapper
 ):
     # Given
@@ -332,7 +332,7 @@ def test_call_webhook_with_failure_mail_after_retries_does_not_retry_if_not_usin
 
 
 @responses.activate()
-def test_call_integration_webhook_does_not_raise_error_on_backoff_give_up(
+def test_call_integration_webhook_does_not_raise_error_on_backoff_give_up(  # noqa: FT003
     mocker: MockerFixture,
 ) -> None:
     """
@@ -391,7 +391,7 @@ def test_call_integration_webhook_does_not_raise_error_on_backoff_give_up(
         ),
     ],
 )
-def test_send_test_request_to_webhook_returns_correct_response(
+def test_send_test_request_to_webhook_returns_correct_response(  # noqa: FT003
     mocker: MockerFixture,
     admin_client: APIClient,
     external_api_response_status: int,
@@ -452,7 +452,7 @@ def test_send_test_request_to_webhook_returns_correct_response(
         ),
     ],
 )
-def test_send_test_request_to_webhook_returns_has_correct_payload(
+def test_send_test_request_to_webhook_returns_has_correct_payload(  # noqa: FT003
     mocker: MockerFixture,
     admin_client: APIClient,
     header_assertion: Callable[[dict[str, str], str], bool],
@@ -493,7 +493,7 @@ def test_send_test_request_to_webhook_returns_has_correct_payload(
     assert response.status_code == 200
 
 
-def test_send_test_request_to_webhook_handles_request_exception(
+def test_send_test_request_to_webhook_handles_request_exception(  # noqa: FT003
     mocker: MockerFixture,
     admin_client: APIClient,
     organisation: Organisation,
@@ -524,7 +524,7 @@ def test_send_test_request_to_webhook_handles_request_exception(
     }
 
 
-def test_should_return_bad_request_when_webhook_url_is_missing(
+def test_should_return_bad_request_when_webhook_url_is_missing(  # noqa: FT003
     admin_client: APIClient,
     organisation: Organisation,
 ) -> None:

--- a/api/tests/unit/webhooks/test_unit_webhooks_mappers.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks_mappers.py
@@ -5,7 +5,7 @@ from users.models import FFAdminUser
 from webhooks import mappers as webhook_mappers
 
 
-def test_datetime_to_webhook_timestamp() -> None:
+def test_datetime_to_webhook_timestamp() -> None:  # noqa: FT003
     # Given
     dt = datetime(2024, 1, 15, 14, 30, 45, 123456)
 
@@ -16,7 +16,7 @@ def test_datetime_to_webhook_timestamp() -> None:
     assert result == "2024-01-15T14:30:45.123456Z"
 
 
-def test_user_or_key_to_changed_by_with_user(
+def test_user_or_key_to_changed_by_with_user(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
 ) -> None:
     # When
@@ -26,7 +26,7 @@ def test_user_or_key_to_changed_by_with_user(
     assert result == staff_user.email
 
 
-def test_user_or_key_to_changed_by_with_api_key(
+def test_user_or_key_to_changed_by_with_api_key(  # noqa: FT003,FT004
     master_api_key_object: MasterAPIKey,
 ) -> None:
     # When
@@ -38,7 +38,7 @@ def test_user_or_key_to_changed_by_with_api_key(
     assert result == master_api_key_object.name
 
 
-def test_user_or_key_to_changed_by_with_both_user_and_api_key_prefers_user(
+def test_user_or_key_to_changed_by_with_both_user_and_api_key_prefers_user(  # noqa: FT003,FT004
     staff_user: FFAdminUser,
     master_api_key_object: MasterAPIKey,
 ) -> None:
@@ -51,7 +51,7 @@ def test_user_or_key_to_changed_by_with_both_user_and_api_key_prefers_user(
     assert result == staff_user.email
 
 
-def test_user_or_key_to_changed_by_with_neither_returns_empty_string() -> None:
+def test_user_or_key_to_changed_by_with_neither_returns_empty_string() -> None:  # noqa: FT003,FT004
     # When
     result = webhook_mappers.user_or_key_to_changed_by(user=None, api_key=None)
 

--- a/api/tests/unit/webhooks/test_unit_webhooks_permissions.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks_permissions.py
@@ -10,7 +10,7 @@ from users.models import FFAdminUser
 from webhooks.permissions import TriggerSampleWebhookPermission
 
 
-def test_has_permission_returns_false_for_org_webhook_if_user_is_not_an_admin(  # type: ignore[no-untyped-def]
+def test_has_permission_returns_false_for_org_webhook_if_user_is_not_an_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, django_user_model, rf
 ):
     # Given
@@ -27,7 +27,7 @@ def test_has_permission_returns_false_for_org_webhook_if_user_is_not_an_admin(  
     assert permission_class.has_permission(mock_request, mock_view) is False  # type: ignore[no-untyped-call]
 
 
-def test_has_permission_returns_true_for_org_webhook_if_user_is_an_admin(  # type: ignore[no-untyped-def]
+def test_has_permission_returns_true_for_org_webhook_if_user_is_an_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, django_user_model, rf
 ):
     # Given
@@ -45,7 +45,7 @@ def test_has_permission_returns_true_for_org_webhook_if_user_is_an_admin(  # typ
     assert permission_class.has_permission(mock_request, mock_view) is True  # type: ignore[no-untyped-call]
 
 
-def test_has_permission_returns_false_for_env_webhook_if_user_is_not_an_admin(  # type: ignore[no-untyped-def]
+def test_has_permission_returns_false_for_env_webhook_if_user_is_not_an_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     environment, django_user_model, rf
 ):
     # Given
@@ -62,7 +62,7 @@ def test_has_permission_returns_false_for_env_webhook_if_user_is_not_an_admin(  
     assert permission_class.has_permission(mock_request, mock_view) is False  # type: ignore[no-untyped-call]
 
 
-def test_has_permission_returns_true_for_env_webhook_if_user_is_an_admin(
+def test_has_permission_returns_true_for_env_webhook_if_user_is_an_admin(  # noqa: FT003,FT004
     environment: Environment,
     staff_user: FFAdminUser,
     rf: RequestFactory,
@@ -84,7 +84,7 @@ def test_has_permission_returns_true_for_env_webhook_if_user_is_an_admin(
     assert permission_class.has_permission(mock_request, mock_view) is True  # type: ignore[no-untyped-call]
 
 
-def test_has_permission_ignores_payload_scope_if_not_webhook_test(  # type: ignore[no-untyped-def]
+def test_has_permission_ignores_payload_scope_if_not_webhook_test(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, django_user_model, rf
 ):
     # Given
@@ -106,7 +106,7 @@ def test_has_permission_ignores_payload_scope_if_not_webhook_test(  # type: igno
     assert permission_class.has_permission(mock_request, mock_view) is False  # type: ignore[no-untyped-call]
 
 
-def test_has_permission_returns_true_for_webhook_test_if_user_is_an_organisation_admin(  # type: ignore[no-untyped-def]
+def test_has_permission_returns_true_for_webhook_test_if_user_is_an_organisation_admin(  # type: ignore[no-untyped-def]  # noqa: FT003,FT004
     organisation, django_user_model, rf
 ):
     # Given
@@ -128,7 +128,7 @@ def test_has_permission_returns_true_for_webhook_test_if_user_is_an_organisation
     assert permission_class.has_permission(mock_request, mock_view) is True  # type: ignore[no-untyped-call]
 
 
-def test_has_permission_returns_true_for_webhook_test_if_user_is_an_environment_admin(
+def test_has_permission_returns_true_for_webhook_test_if_user_is_an_environment_admin(  # noqa: FT003,FT004
     environment: Environment,
     staff_user: FFAdminUser,
     user_environment_permission: UserEnvironmentPermission,


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

- Add `flagsmith-lint-tests` pre-commit hook from flagsmith-common (fv3.4.0)
- Add `# noqa` comments to all existing violations (2052 FT003, 341 FT004)

## How did you test this code?

`pre-commit run flagsmith-lint-tests --all-files` passes.