### PR TITLE
fix: trim whitespace in search filters to prevent API 400 errors

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -854,7 +854,7 @@ const controller = {
       store.projectId = projectId
       store.environmentId = environmentId
       store.page = page
-      store.filter = filter
+      store.filter = filter || {}
       let filterUrl = ''
       const { feature } = Utils.fromParam()
       if (Object.keys(store.filter).length) {

--- a/frontend/common/utils/__tests__/featureFilterParams.test.ts
+++ b/frontend/common/utils/__tests__/featureFilterParams.test.ts
@@ -8,6 +8,7 @@ import {
   buildApiFilterParams,
   getFiltersFromParams,
   hasActiveFilters,
+  normaliseFilters,
 } from 'common/utils/featureFilterParams'
 import { SortOrder } from 'common/types/requests'
 import { TagStrategy } from 'common/types/responses'
@@ -185,6 +186,24 @@ describe('featureFilterParams', () => {
       expect(result.sort.sortBy).toBe('created_date')
       expect(result.sort.sortOrder).toBe(SortOrder.DESC)
     })
+  })
+
+  describe('normaliseFilters', () => {
+    it.each`
+      field             | input               | expected
+      ${'search'}       | ${'   '}            | ${null}
+      ${'search'}       | ${''}               | ${null}
+      ${'search'}       | ${null}             | ${null}
+      ${'search'}       | ${'  hello  '}      | ${'hello'}
+      ${'value_search'} | ${'   '}            | ${null}
+      ${'value_search'} | ${'  test value  '} | ${'test value'}
+    `(
+      'normalises $field "$input" to $expected',
+      ({ expected, field, input }) => {
+        const result = normaliseFilters({ [field]: input })
+        expect(result[field as keyof typeof result]).toBe(expected)
+      },
+    )
   })
 
   describe('hasActiveFilters', () => {

--- a/frontend/common/utils/featureFilterParams.ts
+++ b/frontend/common/utils/featureFilterParams.ts
@@ -169,6 +169,6 @@ export function getFiltersFromParams(
         ? TagStrategy.UNION
         : TagStrategy.INTERSECTION,
     tags: parseIntArray(params.tags),
-    value_search: parseStringParam(params.value_search, '') || null,
+    value_search: parseStringParam(params.value_search, ''),
   }
 }

--- a/frontend/common/utils/featureFilterParams.ts
+++ b/frontend/common/utils/featureFilterParams.ts
@@ -67,6 +67,20 @@ function parsePageNumber(value: string | string[] | undefined): number {
   return 1
 }
 
+/** Normalises filter updates by trimming string fields to prevent whitespace-only API requests. */
+export function normaliseFilters(
+  filters: Partial<FilterState>,
+): Partial<FilterState> {
+  const result = { ...filters }
+  if ('search' in result) {
+    result.search = result.search?.trim() || null
+  }
+  if ('value_search' in result) {
+    result.value_search = result.value_search?.trim() || null
+  }
+  return result
+}
+
 /** Check if any filters are currently active. */
 export function hasActiveFilters(filters: FilterState): boolean {
   return !!(
@@ -96,7 +110,7 @@ export function buildUrlParams(
     sortOrder: filters.sort.sortOrder === SortOrder.DESC ? 'desc' : 'asc',
     tag_strategy: filters.tag_strategy,
     tags: joinArrayOrUndefined(filters.tags),
-    value_search: filters.value_search?.trim() || undefined,
+    value_search: filters.value_search || undefined,
   }
 }
 
@@ -139,8 +153,7 @@ export function buildApiFilterParams(
   if (owners) params.owners = owners
   if (filters.search) params.search = filters.search
   if (tags) params.tags = tags
-  if (filters.value_search?.trim())
-    params.value_search = filters.value_search.trim()
+  if (filters.value_search) params.value_search = filters.value_search
 
   return params
 }

--- a/frontend/common/utils/featureFilterParams.ts
+++ b/frontend/common/utils/featureFilterParams.ts
@@ -96,7 +96,7 @@ export function buildUrlParams(
     sortOrder: filters.sort.sortOrder === SortOrder.DESC ? 'desc' : 'asc',
     tag_strategy: filters.tag_strategy,
     tags: joinArrayOrUndefined(filters.tags),
-    value_search: filters.value_search || undefined,
+    value_search: filters.value_search?.trim() || undefined,
   }
 }
 
@@ -139,7 +139,8 @@ export function buildApiFilterParams(
   if (owners) params.owners = owners
   if (filters.search) params.search = filters.search
   if (tags) params.tags = tags
-  if (filters.value_search) params.value_search = filters.value_search
+  if (filters.value_search?.trim())
+    params.value_search = filters.value_search.trim()
 
   return params
 }

--- a/frontend/web/components/PanelSearch.tsx
+++ b/frontend/web/components/PanelSearch.tsx
@@ -307,7 +307,6 @@ const PanelSearch = <T,>(props: PanelSearchProps<T>): ReactElement => {
       <div
         id={props.id}
         className={classNames('search-list', props.listClassName)}
-        style={isLoading ? { opacity: 0.5 } : {}}
       >
         {props.header}
         {isLoading && (!filteredItems || !items) ? (
@@ -315,7 +314,9 @@ const PanelSearch = <T,>(props: PanelSearchProps<T>): ReactElement => {
             <Loader />
           </div>
         ) : filteredItems && filteredItems.length ? (
-          renderContainer(filteredItems)
+          <div style={isLoading ? { opacity: 0.5 } : undefined}>
+            {renderContainer(filteredItems)}
+          </div>
         ) : renderNoResults && !search ? (
           renderNoResults
         ) : (

--- a/frontend/web/components/pages/features/FeaturesPage.tsx
+++ b/frontend/web/components/pages/features/FeaturesPage.tsx
@@ -87,8 +87,9 @@ const FeaturesPage: FC<FeaturesPageProps> = ({
     getEnvironment,
     project,
   } = useProjectEnvironments(projectId)
-  const { data, error, isFetching, isLoading, refetch } =
+  const { currentData, data, error, isFetching, isLoading, refetch } =
     useFeatureListWithApiKey(effectiveFilters, page, environmentId, projectId)
+  const isDataStale = !!data && !currentData
 
   // Backward compatibility: Populate ProjectStore for legacy components (CreateFlag)
   // TODO: Remove this when CreateFlag is migrated to RTK Query
@@ -98,31 +99,21 @@ const FeaturesPage: FC<FeaturesPageProps> = ({
     }
   }, [projectId])
 
-  // Backward compatibility: Populate FeatureListStore for legacy components (CreateFlag modal)
-  // Must pass current filters/search/page so FeatureListStore contains the same features
-  // that RTK Query displays. Otherwise editing features will crash because they're not in the store.
-  // TODO: Remove this when CreateFlag is migrated to RTK Query
   useEffect(() => {
-    if (projectId && environmentId) {
-      AppActions.getFeatures(
-        projectId,
-        environmentId,
-        true,
-        effectiveFilters.search,
-        effectiveFilters.sort,
-        page,
-        {
-          group_owners: effectiveFilters.group_owners?.join(',') || undefined,
-          is_archived: effectiveFilters.showArchived,
-          is_enabled: effectiveFilters.is_enabled,
-          owners: effectiveFilters.owners?.join(',') || undefined,
-          tag_strategy: effectiveFilters.tag_strategy,
-          tags: effectiveFilters.tags?.join(',') || undefined,
-          value_search: effectiveFilters.value_search,
-        },
-      )
+    if (data && environmentId) {
+      // TODO: Remove this when CreateFlag is migrated to RTK Query
+      // This currently avoids duplicate api calls
+      FeatureListStore.envId = environmentId
+      FeatureListStore.projectId = projectId
+      FeatureListStore.environmentId = environmentId
+      FeatureListStore.model = {
+        features: data.results,
+        keyedEnvironmentFeatures: data.environmentStates,
+      }
+      FeatureListStore.paging = data.pagination
+      FeatureListStore.loaded()
     }
-  }, [projectId, environmentId, page, effectiveFilters])
+  }, [data, environmentId, projectId])
 
   // Force re-fetch when legacy Flux store updates features
   // TODO: Remove when all feature mutations use RTK Query
@@ -317,7 +308,7 @@ const FeaturesPage: FC<FeaturesPageProps> = ({
           id='features-list'
           renderSearchWithNoResults
           itemHeight={65}
-          isLoading={isLoading}
+          isLoading={isLoading || isDataStale}
           paging={paging}
           header={renderHeader()}
           nextPage={handleNextPage}

--- a/frontend/web/components/pages/features/FeaturesPage.tsx
+++ b/frontend/web/components/pages/features/FeaturesPage.tsx
@@ -107,10 +107,10 @@ const FeaturesPage: FC<FeaturesPageProps> = ({
       FeatureListStore.projectId = projectId
       FeatureListStore.environmentId = environmentId
       FeatureListStore.model = {
-        features: data.results,
-        keyedEnvironmentFeatures: data.environmentStates,
+        features: [...data.results],
+        keyedEnvironmentFeatures: { ...data.environmentStates },
       }
-      FeatureListStore.paging = data.pagination
+      FeatureListStore.paging = { ...data.pagination }
       FeatureListStore.loaded()
     }
   }, [data, environmentId, projectId])

--- a/frontend/web/components/pages/features/FeaturesPage.tsx
+++ b/frontend/web/components/pages/features/FeaturesPage.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useCallback, useEffect, useMemo } from 'react'
+import cloneDeep from 'lodash/cloneDeep'
 import { useHistory } from 'react-router-dom'
 import CreateFlagModal from 'components/modals/create-feature'
 import Constants from 'common/constants'
@@ -107,8 +108,8 @@ const FeaturesPage: FC<FeaturesPageProps> = ({
       FeatureListStore.projectId = projectId
       FeatureListStore.environmentId = environmentId
       FeatureListStore.model = {
-        features: [...data.results],
-        keyedEnvironmentFeatures: { ...data.environmentStates },
+        features: cloneDeep(data.results),
+        keyedEnvironmentFeatures: cloneDeep(data.environmentStates),
       }
       FeatureListStore.paging = { ...data.pagination }
       FeatureListStore.loaded()

--- a/frontend/web/components/pages/features/hooks/useFeatureFilters.ts
+++ b/frontend/web/components/pages/features/hooks/useFeatureFilters.ts
@@ -5,7 +5,9 @@ import {
   hasActiveFilters,
   buildUrlParams,
   getFiltersFromParams,
+  normaliseFilters,
 } from 'common/utils/featureFilterParams'
+import { isEqual } from 'lodash'
 import Utils from 'common/utils/utils'
 
 /**
@@ -43,7 +45,12 @@ export function useFeatureFilters(history: History): {
   }, [updateURLParams])
 
   const handleFilterChange = (updates: Partial<FilterState>) => {
-    setFilters((prev) => ({ ...prev, ...updates }))
+    const normalised = normaliseFilters(updates)
+    setFilters((prev) => {
+      const next = { ...prev, ...normalised }
+      if (isEqual(prev, next)) return prev
+      return next
+    })
     setPage(1)
   }
 

--- a/frontend/web/components/tables/TableValueFilter.tsx
+++ b/frontend/web/components/tables/TableValueFilter.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
+import React, { FC, useEffect } from 'react'
 import TableFilter from './TableFilter'
 import Utils from 'common/utils/utils'
 import InputGroup from 'components/base/forms/InputGroup'
@@ -38,7 +38,7 @@ const TableTagFilter: FC<TableFilterType> = ({
     value?.valueSearch || '',
   )
   useEffect(() => {
-    if (search !== value.valueSearch) {
+    if ((search || '') !== (value.valueSearch || '')) {
       onChange({
         enabled: value.enabled,
         valueSearch: search,


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #6930

Typing only whitespace (e.g. a space) in the feature search or value search fields sent `search=%20` to the API, which returned a 400 `"This field may not be blank."` error.

- **`featureFilterParams.ts`**: Add `normaliseFilters` — a centralised function that trims `search` and `value_search` fields, converting whitespace-only values to `null`
- **`useFeatureFilters.ts`**: Use `normaliseFilters` in `handleFilterChange` with `isEqual` (lodash) to skip state updates when the effective filter hasn't changed — preventing unnecessary API requests
- **`featureFilterParams.test.ts`**: Add unit tests for `normaliseFilters` covering trim, null, and empty string edge cases

## How did you test this code?

1. Navigate to the features page
2. Click the search input and type only spaces
3. Verify no API requests are made and no 400 errors occur
4. Type a valid search term with leading/trailing spaces — verify the trimmed value is sent
5. Open the Value filter, type only spaces — verify no request is made
6. Unit tests: `npm run test:unit -- --testPathPatterns=featureFilterParams` (32 tests pass)