### PR TITLE
refactor: decouple Button from Constants import

### DIFF
--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import cn from 'classnames'
 import { ButtonHTMLAttributes, HTMLAttributeAnchorTarget } from 'react'
 import Icon, { IconName } from 'components/Icon'
-import Constants from 'common/constants'
+
+const iconColours = {
+  primary: '#6837fc',
+  white: '#ffffff',
+} as const
+
+export type IconColour = keyof typeof iconColours
 
 export const themeClassNames = {
   danger: 'btn btn-danger',
@@ -26,8 +32,8 @@ export const sizeClassNames = {
 
 export type ButtonType = ButtonHTMLAttributes<HTMLButtonElement> & {
   iconRight?: IconName
-  iconRightColour?: keyof typeof Constants.colours
-  iconLeftColour?: keyof typeof Constants.colours
+  iconRightColour?: IconColour
+  iconLeftColour?: IconColour
   iconLeft?: IconName
   href?: string
   target?: HTMLAttributeAnchorTarget
@@ -71,9 +77,7 @@ export const Button = React.forwardRef<
         <div className='d-flex h-100 align-items-center justify-content-center gap-2'>
           {!!iconLeft && (
             <Icon
-              fill={
-                iconLeftColour ? Constants.colours[iconLeftColour] : undefined
-              }
+              fill={iconLeftColour ? iconColours[iconLeftColour] : undefined}
               name={iconLeft}
               width={iconSize}
             />
@@ -82,9 +86,7 @@ export const Button = React.forwardRef<
         </div>
         {!!iconRight && (
           <Icon
-            fill={
-              iconRightColour ? Constants.colours[iconRightColour] : undefined
-            }
+            fill={iconRightColour ? iconColours[iconRightColour] : undefined}
             className='ml-2'
             name={iconRight}
             width={iconSize}
@@ -106,9 +108,7 @@ export const Button = React.forwardRef<
       >
         {!!iconLeft && (
           <Icon
-            fill={
-              iconLeftColour ? Constants.colours[iconLeftColour] : undefined
-            }
+            fill={iconLeftColour ? iconColours[iconLeftColour] : undefined}
             className='mr-2'
             name={iconLeft}
             width={iconSize}
@@ -117,9 +117,7 @@ export const Button = React.forwardRef<
         {children}
         {!!iconRight && (
           <Icon
-            fill={
-              iconRightColour ? Constants.colours[iconRightColour] : undefined
-            }
+            fill={iconRightColour ? iconColours[iconRightColour] : undefined}
             className='ml-2'
             name={iconRight}
             width={iconSize}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #6892

Replace `Constants.colours` lookup in `Button.tsx` with a local `iconColours` map, removing the transitive dependency chain: `common/constants` → `common/project.js` → `common/data/base/_data.js`.

Only two icon colours are used across all call sites: `'white'` and `'primary'`. The new local map provides exactly those values with no external imports.

This unblocks Button rendering in Storybook and other environments where those CJS modules are not available.

## How did you test this code?

- `npx eslint --fix` — no lint errors
- `npm run typecheck` — no new type errors (all 3 call sites type-safe: `iconLeftColour='white'`, `iconRightColour='primary'`)
- Verified the 3 existing usages in `JSONReference.tsx`, `EditIdentity.tsx`, and `CodeHelp.js` are unchanged in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)