### PR TITLE
ci: Ensure workflows run on update flagsmith environment PRs

### DIFF
--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -36,10 +36,9 @@ jobs:
         run: poetry run python manage.py updateflagsmithenvironment
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Update API Flagsmith Defaults
-          branch: chore/update-api-flagsmith-environment
           delete-branch: true
           title: 'chore: Update Flagsmith environment document'
           labels: api

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 0 8 * * *
   workflow_dispatch:
+  push:
+    branches:
+      - ci/run-workflows-on-update-flagsmith-environment
 
 defaults:
   run:

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -42,4 +42,4 @@ jobs:
           delete-branch: true
           title: 'chore: Update Flagsmith environment document'
           labels: api
-          token: '${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}'
+          token: '${{ secrets.FLAGSMITH_BOT_GITHUB_TOKEN }}'

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -40,3 +40,4 @@ jobs:
           delete-branch: true
           title: 'chore: update Flagsmith environment document'
           labels: api
+          token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -41,6 +41,6 @@ jobs:
           commit-message: Update API Flagsmith Defaults
           branch: chore/update-api-flagsmith-environment
           delete-branch: true
-          title: 'chore: update Flagsmith environment document'
+          title: 'chore: Update Flagsmith environment document'
           labels: api
           token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -42,4 +42,4 @@ jobs:
           delete-branch: true
           title: 'chore: Update Flagsmith environment document'
           labels: api
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: '${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}'

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -42,4 +42,4 @@ jobs:
           delete-branch: true
           title: 'chore: Update Flagsmith environment document'
           labels: api
-          token: '${{ secrets.FLAGSMITH_BOT_GITHUB_TOKEN }}'
+          token: ${{ secrets.UPDATE_ENVIRONMENT_DOCUMENT_WORKFLOW_GH_PAT }}

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: 0 8 * * *
   workflow_dispatch:
-  push:
-    branches:
-      - ci/run-workflows-on-update-flagsmith-environment
 
 defaults:
   run:


### PR DESCRIPTION
## Changes

Ensures that workflows run on auto-generated PRs for updating flagsmith environment document. In order to do this, we have to define a custom GH token as per documentation [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs).

## How did you test this code?

Added a `push` trigger to the current branch to verify that the workflow triggers correctly. [This PR](https://github.com/Flagsmith/flagsmith/pull/6959) was created where you can see the correct workflows are running. 
