### PR TITLE
fix: convert feature_state_value after v2 segment save (#6962)

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -766,6 +766,9 @@ const controller = {
               store.model.keyedEnvironmentFeatures[projectFlag.id] = {
                 ...store.model.keyedEnvironmentFeatures[projectFlag.id],
                 ...environmentFeatureState,
+                feature_state_value: Utils.featureStateToValue(
+                  environmentFeatureState.feature_state_value,
+                ),
               }
             }
           })


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6962

After saving segment overrides on a v2 versioned environment, the `getVersionFeatureState` API returns `feature_state_value` as a `FeatureStateValue` object (e.g. `{type: "unicode", string_value: "hello", ...}`). The v2 segment save path in `feature-list-store.ts` was storing this raw object in the model, causing the UI to render `[object Object]` instead of the actual value.

The v2 **VALUE** save path (line 820) already converts correctly using `Utils.featureStateToValue()` — this PR aligns the **SEGMENT** path to do the same.

## How did you test this code?

1. Enable v2 feature versioning on an environment
2. Create a flag with a value
3. Add a segment override and save
4. Verify the feature value displays correctly (not `[object Object]`)