### PR TITLE
fix: Fix "unsaved changes" badge positioning on Edit Feature modal tabs

### DIFF
--- a/frontend/web/components/modals/create-feature/index.js
+++ b/frontend/web/components/modals/create-feature/index.js
@@ -924,7 +924,7 @@ const Index = class extends Component {
                                       tabLabelString='Segment Overrides'
                                       tabLabel={
                                         <Row
-                                          className={`justify-content-center ${
+                                          className={`justify-content-center align-items-center ${
                                             this.state.segmentsChanged
                                               ? 'pr-1'
                                               : ''

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -166,7 +166,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    bottom: 0;
   }
 
   &.btn-no-focus {

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -21,13 +21,12 @@
   }
   .hljs-container {
     code {
-
       padding-top: 80px;
     }
     .react-select {
       position: absolute;
-      top:16px;
-      left:16px;
+      top: 16px;
+      left: 16px;
     }
   }
 }
@@ -115,10 +114,9 @@
   }
 }
 
-
 .tabs {
   & .pill {
-    background-color:$pill-bg;
+    background-color: $pill-bg;
     border-radius: $border-radius-xlg;
     display: inline-block;
     button,
@@ -168,6 +166,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    bottom: 0;
   }
 
   &.btn-no-focus {


### PR DESCRIPTION
Fixes #6935

The "unsaved changes" badge on the Segment Overrides tab in the Edit Feature modal was rendered out of vertical alignment. The `Row` wrapper in `create-feature/index.js` only applied `justify-content-center`, leaving the badge offset vertically relative to the tab label text. Adding `align-items-center` to that `Row`'s className corrects the vertical alignment. Minor whitespace inconsistencies in `_tabs.scss` are cleaned up alongside the fix.