### PR TITLE
fix: align organisation dropdown on responsive viewports

### DIFF
--- a/frontend/web/styles/project/_project-nav.scss
+++ b/frontend/web/styles/project/_project-nav.scss
@@ -146,7 +146,7 @@ nav a {
     }
   }
   .nav-modal {
-    left: -50px;
+    left: 0;
     width: calc(100vw);
   }
 }


### PR DESCRIPTION
## Summary
Fix the organisation selector dropdown overflowing to the left on responsive/small screen viewports, which hid organisation names.

## Issue
Fixes #6607

## Changes
- Changed `left: -50px` to `left: 0` for `.nav-modal` at the `md` breakpoint in `_project-nav.scss`. At this breakpoint, the `.inline-modal` is already `position: fixed` with `left: 0; right: 0` (set at the `lg` breakpoint), so the `-50px` offset was shifting the fullscreen modal off-screen to the left.

## Testing
- Resize browser window to a small/responsive viewport (below `md` breakpoint)
- Click the organisation selector dropdown in the top navbar
- Verify the dropdown stays within the viewport and all org names are visible