### PR TITLE
fix: wrap long text in value editor to prevent horizontal overflow

### DIFF
--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -271,6 +271,8 @@
 }
 .value-editor pre code {
   height: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 code.txt {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6963

In the Segment Overrides tab, when a multivariate feature flag has a long value, the "Segment Control Value" input overflows horizontally, breaking the modal layout and causing a layout shift when clicking into the input.

The root cause is that `.value-editor pre code` uses the default `white-space: pre`, which prevents text from wrapping. This PR adds `white-space: pre-wrap` and `word-break: break-word` so long values wrap onto multiple lines instead of overflowing.

- `white-space: pre-wrap` — preserves whitespace/indentation (important for JSON, XML, YAML, TOML) while allowing line wrapping
- `word-break: break-word` — only breaks long unbroken strings that would otherwise overflow

Structured formats (JSON, XML, YAML, TOML) are unaffected since their natural line breaks and indentation are preserved by `pre-wrap`.

## Looms

Before
https://www.loom.com/share/3424c4a679b440e9b9be653ef8091586

After
https://www.loom.com/share/74867cebef69478984018fa997283e71

## How did you test this code?

1. Create or edit a multivariate feature flag
2. Go to the **Segment Overrides** tab
3. Add a segment override
4. Set the segment override value to a long string (e.g. repeated text without spaces)
5. Verify the value wraps within the modal instead of overflowing horizontally
6. Click into the input — verify no layout shift or horizontal scrollbar appears
7. Test with JSON/XML/YAML values — verify indentation is preserved