### PR TITLE
fix: use bg-body on sign-up card for dark mode compatibility

### DIFF
--- a/frontend/web/components/pages/HomePage.tsx
+++ b/frontend/web/components/pages/HomePage.tsx
@@ -497,7 +497,7 @@ const HomePage: React.FC = () => {
                     ) : (
                       <>
                         <Card
-                          className='mb-3 bg-white p-3'
+                          className='mb-3 bg-body p-3'
                           contentClassName={classNames(
                             'd-flex flex-column gap-3',
                             { 'bg-light200': preventEmailPassword },


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6803

The sign-up page card uses `bg-white`, which in dark mode results in invisible labels (white text on white background) and no visual separation between the card and the page.

The login card already uses `bg-body` (which adapts to the current theme). This PR aligns the sign-up card with the same pattern.

## Screenshots

### Sign-up page (dark mode)

| Before | After |
|--------|-------|
| <img width="200" height="350" alt="image" src="https://github.com/user-attachments/assets/0df595ef-6b1b-4206-9eae-7bd7bae01d62" /> |  <img width="200" height="350" alt="image" src="https://github.com/user-attachments/assets/0bdf7a35-5cfb-4c1e-8fed-192065abbe37" /> |

## How did you test this code?

1. Enable dark mode
2. Log out and navigate to the sign-up page
3. Verify labels (First Name, Last Name, etc.) are visible
4. Verify SSO buttons are visible
5. Switch to light mode and verify no regression