### PR TITLE
fix: restore grid layout in PanelSearch broken by wrapper div

### DIFF
--- a/frontend/web/components/PanelSearch.tsx
+++ b/frontend/web/components/PanelSearch.tsx
@@ -12,7 +12,6 @@ import { AutoSizer, List } from 'react-virtualized'
 import Popover from './base/Popover'
 import Input from './base/forms/Input'
 import Icon from './Icon'
-import classNames from 'classnames'
 import { IonIcon } from '@ionic/react'
 import { chevronDown, chevronUp } from 'ionicons/icons'
 import Button from './base/forms/Button'
@@ -197,6 +196,58 @@ const PanelSearch = <T,>(props: PanelSearchProps<T>): ReactElement => {
     search = search.replace(/^"+|"+$/g, '')
   }
 
+  const renderListContent = (): ReactNode => {
+    if (isLoading && (!filteredItems || !items)) {
+      return (
+        <div className='text-center'>
+          <Loader />
+        </div>
+      )
+    }
+    if (filteredItems && filteredItems.length) {
+      return (
+        <div
+          className={props.listClassName}
+          style={isLoading ? { opacity: 0.5 } : undefined}
+        >
+          {renderContainer(filteredItems)}
+        </div>
+      )
+    }
+    if (renderNoResults && !search) {
+      return <>{renderNoResults}</>
+    }
+    return (
+      <Row className='list-item'>
+        {!isLoading && (
+          <>
+            {props.noResultsText ? (
+              props.noResultsText(search) || (
+                <div className='table-column'>
+                  No results{' '}
+                  {search && (
+                    <span>
+                      for <strong>{` "${search}"`}</strong>
+                    </span>
+                  )}
+                </div>
+              )
+            ) : (
+              <div className='table-column'>
+                No results{' '}
+                {search && (
+                  <span>
+                    for <strong>{` "${search}"`}</strong>
+                  </span>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </Row>
+    )
+  }
+
   if (
     !search &&
     (!filteredItems || filteredItems.length === 0) &&
@@ -304,50 +355,9 @@ const PanelSearch = <T,>(props: PanelSearchProps<T>): ReactElement => {
       }
     >
       {props.searchPanel}
-      <div
-        id={props.id}
-        className={classNames('search-list', props.listClassName)}
-      >
+      <div id={props.id} className='search-list'>
         {props.header}
-        {isLoading && (!filteredItems || !items) ? (
-          <div className='text-center'>
-            <Loader />
-          </div>
-        ) : filteredItems && filteredItems.length ? (
-          <div style={isLoading ? { opacity: 0.5 } : undefined}>
-            {renderContainer(filteredItems)}
-          </div>
-        ) : renderNoResults && !search ? (
-          renderNoResults
-        ) : (
-          <Row className='list-item'>
-            {!isLoading && (
-              <>
-                {props.noResultsText ? (
-                  props.noResultsText(search) || (
-                    <div className='table-column'>
-                      No results{' '}
-                      {search && (
-                        <span>
-                          for <strong>{` "${search}"`}</strong>
-                        </span>
-                      )}
-                    </div>
-                  )
-                ) : (
-                  <div className='table-column'>
-                    No results{' '}
-                    {search && (
-                      <span>
-                        for <strong>{` "${search}"`}</strong>
-                      </span>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
-          </Row>
-        )}
+        {renderListContent()}
         {paging && (
           <Paging
             paging={paging}

--- a/frontend/web/styles/project/_lists.scss
+++ b/frontend/web/styles/project/_lists.scss
@@ -31,12 +31,6 @@
   }
 }
 
-.search-list.row > div {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
 .overflow-visible .search-list,
 .overflow-visible .List {
   overflow-x: visible !important;

--- a/frontend/web/styles/project/_lists.scss
+++ b/frontend/web/styles/project/_lists.scss
@@ -31,6 +31,12 @@
   }
 }
 
+.search-list.row > div {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
 .overflow-visible .search-list,
 .overflow-visible .List {
   overflow-x: visible !important;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes a regression introduced in 362a9f8f6 (#6927).

The wrapper `<div>` added around `renderContainer(filteredItems)` to scope loading opacity to list items (not the header) broke Bootstrap grid layouts because `col-*` items were no longer direct children of the `row` container, causing the Organisations page, Projects page, and Import page to display cards vertically instead of in a horizontal grid.

**Fix:** Move `listClassName` from the outer `search-list` div to the items wrapper div, so that the `row` class and opacity live on the same element. This preserves Kyle's intended opacity scoping while restoring correct Bootstrap grid behaviour.

**Note:** The nested ternary in the render block was extracted into a `renderListContent` helper. This was required because touching the file triggered the pre-existing `no-nested-ternary` lint error, and we opted to fix it properly rather than adding `eslint-disable` comments.

## How did you test this code?

- Verified the Organisations and Projects pages render cards in a horizontal grid layout instead of a vertical stack.
- Verified loading opacity only applies to list items, not the header.