### PR TITLE
ci: integrate Qlty coverage reporting

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -2,7 +2,6 @@ name: API Pull Request
 
 permissions:
   contents: read # For actions/checkout
-  id-token: write # For Codecov OIDC
 
 on:
   pull_request:
@@ -80,9 +79,10 @@ jobs:
         run: make test
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
-        env:
-          PYTHON: ${{ matrix.python-version }}
+        if: matrix.python-version == '3.13'
+        uses: qltysh/qlty-action/coverage@v2
         with:
-          env_vars: PYTHON
-          use_oidc: true
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage.xml
+          tag: api
+          add-prefix: api/

--- a/.github/workflows/frontend-pull-request.yml
+++ b/.github/workflows/frontend-pull-request.yml
@@ -33,4 +33,12 @@ jobs:
         run: npm ci
 
       - name: Run unit tests
-        run: npm run test:unit -- --passWithNoTests
+        run: npm run test:unit -- --passWithNoTests --coverage
+
+      - name: Upload Coverage
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info
+          tag: frontend
+          add-prefix: frontend/


### PR DESCRIPTION
## Summary

- Replace Codecov with [Qlty](https://qlty.sh) for code coverage reporting in the API and frontend CI workflows
- API tests (pytest-cov, Cobertura XML) upload with the `api` coverage tag
- Frontend unit tests (Jest, LCOV) upload with the `frontend` coverage tag
- Coverage tags provide per-component visibility in the monorepo

## Changes

- **`.github/workflows/api-pull-request.yml`**: Replaced `codecov/codecov-action@v5` with `qltysh/qlty-action/coverage@v2`. Upload runs only on Python 3.13 matrix entry (avoids redundant uploads). Removed `id-token: write` permission (no longer needed without OIDC). Added `add-prefix: api/` to fix paths relative to repo root.
- **`.github/workflows/frontend-pull-request.yml`**: Added `--coverage` flag to Jest test command. Added Qlty coverage upload step with `add-prefix: frontend/`.

## Manual steps required

1. Add the `QLTY_COVERAGE_TOKEN` repository secret:
   - Go to **Qlty Cloud** → Workspace Settings → Code Coverage → copy the workspace coverage token
   - Go to **GitHub** → repo Settings → Secrets and variables → Actions → New repository secret
   - Name: `QLTY_COVERAGE_TOKEN`, Value: the token from Qlty

## Test plan

- [ ] Add the `QLTY_COVERAGE_TOKEN` secret to the repository
- [ ] Verify API workflow uploads coverage data successfully
- [ ] Verify frontend workflow uploads coverage data successfully
- [ ] Check Qlty Cloud dashboard shows coverage for both `api` and `frontend` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)