### PR TITLE
fix: make Feature.type writable on create

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -229,7 +229,6 @@ class CreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerializer):
             "created_date",
             "uuid",
             "project",
-            "type",
         )
 
     def to_internal_value(self, data):  # type: ignore[no-untyped-def]

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -4490,13 +4490,24 @@ def test_list_features__edge_v2_project__makes_one_dynamo_query(
     assert mock_table.query.call_count == 1
 
 
-def test_create_feature__type_provided__ignores_type_and_defaults_to_standard(
+@pytest.mark.parametrize(
+    "feature_type, expected_status",
+    [
+        (STANDARD, status.HTTP_201_CREATED),
+        (MULTIVARIATE, status.HTTP_201_CREATED),
+        ("boolean", status.HTTP_400_BAD_REQUEST),
+        ("FLAG", status.HTTP_400_BAD_REQUEST),
+    ],
+)
+def test_create_feature__type_provided__validates_and_sets_type(
     admin_client_new: APIClient,
     project: Project,
+    feature_type: str,
+    expected_status: int,
 ) -> None:
     # Given
     url = reverse("api-v1:projects:project-features-list", args=[project.id])
-    data = {"name": "test_feature_type_readonly", "type": "boolean"}
+    data = {"name": f"test_feature_{feature_type}", "type": feature_type}
 
     # When
     response = admin_client_new.post(
@@ -4504,8 +4515,9 @@ def test_create_feature__type_provided__ignores_type_and_defaults_to_standard(
     )
 
     # Then
-    assert response.status_code == status.HTTP_201_CREATED
-    assert response.json()["type"] == STANDARD
+    assert response.status_code == expected_status
+    if expected_status == status.HTTP_201_CREATED:
+        assert response.json()["type"] == feature_type
 
 
 def test_create_feature__multivariate_options_provided__sets_type_to_multivariate(

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -648,7 +648,7 @@ def test_create_feature_only_triggers_write_to_dynamodb_once_per_environment(
     project.save()
 
     url = reverse("api-v1:projects:project-features-list", args=[project.id])
-    data = {"name": "Test feature flag", "type": "FLAG", "project": project.id}
+    data = {"name": "Test feature flag", "type": STANDARD, "project": project.id}
 
     mock_dynamo_environment_wrapper.is_enabled = True
     mock_dynamo_environment_wrapper.reset_mock()
@@ -1748,7 +1748,7 @@ def test_create_feature_returns_201_if_name_matches_regex(
     feature_name = "valid_feature_name"
 
     url = reverse("api-v1:projects:project-features-list", args=[project.id])
-    data = {"name": feature_name, "type": "FLAG", "project": project.id}
+    data = {"name": feature_name, "type": STANDARD, "project": project.id}
 
     # When
     response = admin_client_new.post(url, data=data)
@@ -1766,7 +1766,7 @@ def test_create_feature_returns_400_if_name_does_not_matches_regex(
     feature_name = "not_a_valid_feature_name"
 
     url = reverse("api-v1:projects:project-features-list", args=[project.id])
-    data = {"name": feature_name, "type": "FLAG", "project": project.id}
+    data = {"name": feature_name, "type": STANDARD, "project": project.id}
 
     # When
     response = admin_client_new.post(url, data=data)
@@ -1784,7 +1784,7 @@ def test_audit_log_created_when_feature_created(
 ) -> None:
     # Given
     url = reverse("api-v1:projects:project-features-list", args=[project.id])
-    data = {"name": "Test feature flag", "type": "FLAG", "project": project.id}
+    data = {"name": "Test feature flag", "type": STANDARD, "project": project.id}
 
     # When
     response = admin_client_new.post(url, data=data)


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Reverts the `type` read-only change introduced in https://github.com/Flagsmith/flagsmith/pull/6888.

That PR added `type` to `read_only_fields` in `CreateFeatureSerializer`, which silently discards the `type` value from API requests. This breaks the Terraform provider — when it sends `"type": "MULTIVARIATE"` to create a feature, the API ignores it and returns `"type": "STANDARD"`, causing Terraform to error with "Provider produced inconsistent result after apply". See the failing `TestAccMultivariateFeatureOptionResource` test in https://github.com/Flagsmith/terraform-provider-flagsmith/pull/220.

The model-level `choices` constraint (also added in #6888) already validates that only `STANDARD` or `MULTIVARIATE` are accepted, so removing `type` from `read_only_fields` is safe — invalid values like `"boolean"` or `"FLAG"` still return a 400.

## How did you test this code?

Parametrised test covering valid types (`STANDARD` → 201, `MULTIVARIATE` → 201) and invalid types (`"boolean"` → 400, `"FLAG"` → 400). Existing lifecycle hook test for MV options still passes.