### PR TITLE
fix(ui): added optional chaining to getContentType to prevent undefin…

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -227,8 +227,8 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   flagsmithFeatureExists(flag: string) {
     return Object.prototype.hasOwnProperty.call(flagsmith.getAllFlags(), flag)
   },
-  getContentType(contentTypes: ContentType[], model: string, type: string) {
-    return contentTypes.find((c: ContentType) => c[model] === type) || null
+  getContentType(contentTypes: ContentType[] | undefined, model: string, type: string) {
+    return contentTypes?.find((c: ContentType) => c[model] === type) || null
   },
   getCreateProjectPermission(organisation: Organisation) {
     if (organisation?.restrict_project_create_to_admin) {


### PR DESCRIPTION
…ed crash

Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #6881 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
I tested this locally by verifying the 'Create Feature' modal UI. To ensure the specific Sentry bug was caught, I verified that calling `Utils.getContentType(undefined, 'my-model', 'my-type') `directly no longer throws a `TypeError` and correctly evaluates without breaking the render cycle. 
