### PR TITLE
fix(api): delegate concurrent deletion deadlocks to TaskBackoffError

### DIFF
--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -1,13 +1,11 @@
 from django.db import IntegrityError, OperationalError, transaction
-from django.db.transaction import TransactionManagementError
-from task_processor.exceptions import TaskBackoffError
-from django.db import transaction
-from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Prefetch, Q
+from django.db.transaction import TransactionManagementError
 from django.utils import timezone
 from task_processor.decorators import (
     register_task_handler,
 )
+from task_processor.exceptions import TaskBackoffError
 from task_processor.models import TaskPriority
 
 from audit.models import AuditLog
@@ -74,6 +72,7 @@ def delete_environment(environment_id: int) -> None:
     except (OperationalError, IntegrityError, TransactionManagementError):
         # Someone else is locking these rows, back off and retry
         raise TaskBackoffError()
+
 
 @register_task_handler()
 def clone_environment_feature_states(

--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -1,3 +1,8 @@
+from django.db import IntegrityError, OperationalError, transaction
+from django.db.transaction import TransactionManagementError
+from task_processor.exceptions import TaskBackoffError
+from django.db import transaction
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Prefetch, Q
 from django.utils import timezone
 from task_processor.decorators import (
@@ -59,8 +64,16 @@ def delete_environment_from_dynamo(api_key: str, environment_id: str):  # type: 
 
 @register_task_handler()
 def delete_environment(environment_id: int) -> None:
-    Environment.objects.get(id=environment_id).delete()
-
+    try:
+        # Wrap in atomic to safely catch DB-level errors
+        with transaction.atomic():
+            Environment.objects.get(id=environment_id).delete()
+    except Environment.DoesNotExist:
+        # If it's already gone, our job is done!
+        pass
+    except (OperationalError, IntegrityError, TransactionManagementError):
+        # Someone else is locking these rows, back off and retry
+        raise TaskBackoffError()
 
 @register_task_handler()
 def clone_environment_feature_states(

--- a/api/features/tasks.py
+++ b/api/features/tasks.py
@@ -1,13 +1,12 @@
-from django.db import IntegrityError, OperationalError, transaction
-from django.db.transaction import TransactionManagementError
-from task_processor.exceptions import TaskBackoffError
-
 import logging
 from typing import Any
 
+from django.db import IntegrityError, OperationalError, transaction
+from django.db.transaction import TransactionManagementError
 from task_processor.decorators import (
     register_task_handler,
 )
+from task_processor.exceptions import TaskBackoffError
 
 from environments.models import Webhook
 from features.models import Feature, FeatureState
@@ -166,9 +165,9 @@ def delete_feature(feature_id: int) -> None:
     try:
         with transaction.atomic():
             Feature.objects.get(pk=feature_id).delete()
-            
+
     except Feature.DoesNotExist:
         pass
-        
+
     except (OperationalError, IntegrityError, TransactionManagementError):
         raise TaskBackoffError()

--- a/api/features/tasks.py
+++ b/api/features/tasks.py
@@ -1,3 +1,7 @@
+from django.db import IntegrityError, OperationalError, transaction
+from django.db.transaction import TransactionManagementError
+from task_processor.exceptions import TaskBackoffError
+
 import logging
 from typing import Any
 
@@ -159,4 +163,12 @@ def _get_previous_multivariate_values(
 
 @register_task_handler()
 def delete_feature(feature_id: int) -> None:
-    Feature.objects.get(pk=feature_id).delete()
+    try:
+        with transaction.atomic():
+            Feature.objects.get(pk=feature_id).delete()
+            
+    except Feature.DoesNotExist:
+        pass
+        
+    except (OperationalError, IntegrityError, TransactionManagementError):
+        raise TaskBackoffError()

--- a/api/tests/unit/environments/test_unit_environments_tasks.py
+++ b/api/tests/unit/environments/test_unit_environments_tasks.py
@@ -1,12 +1,12 @@
-from pytest_mock import MockerFixture
 import pytest
 from django.db import OperationalError
+from pytest_mock import MockerFixture
 from task_processor.exceptions import TaskBackoffError
-from environments.models import Environment
-from environments.tasks import delete_environment
+
 from audit.models import AuditLog
 from environments.models import Environment
 from environments.tasks import (
+    delete_environment,
     delete_environment_from_dynamo,
     process_environment_update,
     rebuild_environment_document,
@@ -121,6 +121,8 @@ def test_delete_environment_from_dynamo__valid_environment__calls_all_wrappers(
     mocked_identity_wrapper.delete_all_identities.assert_called_once_with(
         environment_api_key
     )
+
+
 def test_delete_environment__environment_does_not_exist__succeeds_silently(
     mocker: MockerFixture,
 ) -> None:
@@ -149,7 +151,7 @@ def test_delete_environment__database_deadlock__raises_task_backoff_error(
 
     # Then
     # TaskBackoffError is raised to trigger the task-processor retry
-    mock_get_environment.assert_called_once_with(id=1)    # Given
+    mock_get_environment.assert_called_once_with(id=1)  # Given
     mock_get_environment = mocker.patch("environments.tasks.Environment.objects.get")
     mock_get_environment.side_effect = OperationalError
 

--- a/api/tests/unit/environments/test_unit_environments_tasks.py
+++ b/api/tests/unit/environments/test_unit_environments_tasks.py
@@ -1,5 +1,6 @@
 import pytest
-from django.db import OperationalError
+from django.db import IntegrityError, OperationalError
+from django.db.transaction import TransactionManagementError
 from pytest_mock import MockerFixture
 from task_processor.exceptions import TaskBackoffError
 
@@ -123,6 +124,7 @@ def test_delete_environment_from_dynamo__valid_environment__calls_all_wrappers(
     )
 
 
+@pytest.mark.django_db
 def test_delete_environment__environment_does_not_exist__succeeds_silently(
     mocker: MockerFixture,
 ) -> None:
@@ -134,10 +136,10 @@ def test_delete_environment__environment_does_not_exist__succeeds_silently(
     delete_environment(environment_id=1)
 
     # Then
-    # No exception is raised, confirming silent success
     mock_get_environment.assert_called_once_with(id=1)
 
 
+@pytest.mark.django_db
 def test_delete_environment__database_deadlock__raises_task_backoff_error(
     mocker: MockerFixture,
 ) -> None:
@@ -150,15 +152,37 @@ def test_delete_environment__database_deadlock__raises_task_backoff_error(
         delete_environment(environment_id=1)
 
     # Then
-    # TaskBackoffError is raised to trigger the task-processor retry
-    mock_get_environment.assert_called_once_with(id=1)  # Given
+    mock_get_environment.assert_called_once_with(id=1)
+
+
+@pytest.mark.django_db
+def test_delete_environment__integrity_error__raises_task_backoff_error(
+    mocker: MockerFixture,
+) -> None:
+    # Given
     mock_get_environment = mocker.patch("environments.tasks.Environment.objects.get")
-    mock_get_environment.side_effect = OperationalError
+    mock_get_environment.side_effect = IntegrityError
 
     # When
     with pytest.raises(TaskBackoffError):
         delete_environment(environment_id=1)
 
     # Then
-    # TaskBackoffError is raised to trigger the task-processor retry
     mock_get_environment.assert_called_once_with(id=1)
+
+
+@pytest.mark.django_db
+def test_delete_environment__transaction_management_error__raises_task_backoff_error(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_environment = mocker.patch("environments.tasks.Environment.objects.get")
+    mock_get_environment.side_effect = TransactionManagementError
+
+    # When
+    with pytest.raises(TaskBackoffError):
+        delete_environment(environment_id=1)
+
+    # Then
+    mock_get_environment.assert_called_once_with(id=1)
+

--- a/api/tests/unit/environments/test_unit_environments_tasks.py
+++ b/api/tests/unit/environments/test_unit_environments_tasks.py
@@ -1,5 +1,9 @@
 from pytest_mock import MockerFixture
-
+import pytest
+from django.db import OperationalError
+from task_processor.exceptions import TaskBackoffError
+from environments.models import Environment
+from environments.tasks import delete_environment
 from audit.models import AuditLog
 from environments.models import Environment
 from environments.tasks import (
@@ -117,3 +121,42 @@ def test_delete_environment_from_dynamo__valid_environment__calls_all_wrappers(
     mocked_identity_wrapper.delete_all_identities.assert_called_once_with(
         environment_api_key
     )
+def test_delete_environment__environment_does_not_exist__succeeds_silently(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_environment = mocker.patch("environments.tasks.Environment.objects.get")
+    mock_get_environment.side_effect = Environment.DoesNotExist
+
+    # When
+    delete_environment(environment_id=1)
+
+    # Then
+    # No exception is raised, confirming silent success
+    mock_get_environment.assert_called_once_with(id=1)
+
+
+def test_delete_environment__database_deadlock__raises_task_backoff_error(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_environment = mocker.patch("environments.tasks.Environment.objects.get")
+    mock_get_environment.side_effect = OperationalError
+
+    # When
+    with pytest.raises(TaskBackoffError):
+        delete_environment(environment_id=1)
+
+    # Then
+    # TaskBackoffError is raised to trigger the task-processor retry
+    mock_get_environment.assert_called_once_with(id=1)    # Given
+    mock_get_environment = mocker.patch("environments.tasks.Environment.objects.get")
+    mock_get_environment.side_effect = OperationalError
+
+    # When
+    with pytest.raises(TaskBackoffError):
+        delete_environment(environment_id=1)
+
+    # Then
+    # TaskBackoffError is raised to trigger the task-processor retry
+    mock_get_environment.assert_called_once_with(id=1)

--- a/api/tests/unit/environments/test_unit_environments_tasks.py
+++ b/api/tests/unit/environments/test_unit_environments_tasks.py
@@ -185,4 +185,3 @@ def test_delete_environment__transaction_management_error__raises_task_backoff_e
 
     # Then
     mock_get_environment.assert_called_once_with(id=1)
-

--- a/api/tests/unit/features/test_unit_features_tasks.py
+++ b/api/tests/unit/features/test_unit_features_tasks.py
@@ -1,14 +1,13 @@
 import pytest
+from django.db import OperationalError
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
-from unittest import mock
-from django.db import OperationalError
 from task_processor.exceptions import TaskBackoffError
-from features.tasks import delete_feature 
+
 from api_keys.models import MasterAPIKey
 from environments.models import Environment
 from features.models import Feature, FeatureState
-from features.tasks import trigger_feature_state_change_webhooks
+from features.tasks import delete_feature, trigger_feature_state_change_webhooks
 from organisations.models import Organisation
 from projects.models import Project
 from users.models import FFAdminUser
@@ -167,6 +166,7 @@ def test_trigger_feature_state_change_webhooks__deleted_flag_no_history__uses_fs
 
     assert data["previous_state"]["feature"]["id"] == feature_state.feature.id
     assert event_type == WebhookEventType.FLAG_DELETED.value
+
 
 @pytest.mark.django_db
 def test_delete_feature__feature_does_not_exist__succeeds_silently(

--- a/api/tests/unit/features/test_unit_features_tasks.py
+++ b/api/tests/unit/features/test_unit_features_tasks.py
@@ -1,5 +1,6 @@
 import pytest
-from django.db import OperationalError
+from django.db import IntegrityError, OperationalError
+from django.db.transaction import TransactionManagementError
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
 from task_processor.exceptions import TaskBackoffError
@@ -190,6 +191,38 @@ def test_delete_feature__database_deadlock__raises_task_backoff_error(
     # Given
     mock_get_feature = mocker.patch("features.tasks.Feature.objects.get")
     mock_get_feature.side_effect = OperationalError
+
+    # When
+    with pytest.raises(TaskBackoffError):
+        delete_feature(feature_id=1)
+
+    # Then
+    mock_get_feature.assert_called_once_with(pk=1)
+
+
+@pytest.mark.django_db
+def test_delete_feature__integrity_error__raises_task_backoff_error(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_feature = mocker.patch("features.tasks.Feature.objects.get")
+    mock_get_feature.side_effect = IntegrityError
+
+    # When
+    with pytest.raises(TaskBackoffError):
+        delete_feature(feature_id=1)
+
+    # Then
+    mock_get_feature.assert_called_once_with(pk=1)
+
+
+@pytest.mark.django_db
+def test_delete_feature__transaction_management_error__raises_task_backoff_error(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_feature = mocker.patch("features.tasks.Feature.objects.get")
+    mock_get_feature.side_effect = TransactionManagementError
 
     # When
     with pytest.raises(TaskBackoffError):

--- a/api/tests/unit/features/test_unit_features_tasks.py
+++ b/api/tests/unit/features/test_unit_features_tasks.py
@@ -1,7 +1,10 @@
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
-
+from unittest import mock
+from django.db import OperationalError
+from task_processor.exceptions import TaskBackoffError
+from features.tasks import delete_feature 
 from api_keys.models import MasterAPIKey
 from environments.models import Environment
 from features.models import Feature, FeatureState
@@ -164,3 +167,33 @@ def test_trigger_feature_state_change_webhooks__deleted_flag_no_history__uses_fs
 
     assert data["previous_state"]["feature"]["id"] == feature_state.feature.id
     assert event_type == WebhookEventType.FLAG_DELETED.value
+
+@pytest.mark.django_db
+def test_delete_feature__feature_does_not_exist__succeeds_silently(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_feature = mocker.patch("features.tasks.Feature.objects.get")
+    mock_get_feature.side_effect = Feature.DoesNotExist
+
+    # When
+    delete_feature(feature_id=1)
+
+    # Then
+    mock_get_feature.assert_called_once_with(pk=1)
+
+
+@pytest.mark.django_db
+def test_delete_feature__database_deadlock__raises_task_backoff_error(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_get_feature = mocker.patch("features.tasks.Feature.objects.get")
+    mock_get_feature.side_effect = OperationalError
+
+    # When
+    with pytest.raises(TaskBackoffError):
+        delete_feature(feature_id=1)
+
+    # Then
+    mock_get_feature.assert_called_once_with(pk=1)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ ] I have filled in the "How did you test this code" section below.

## Changes
Closes #6878 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._
1.Wrapped the deletion queries in `environments/tasks.py` and `features/tasks.py` with specific exception handlers for `OperationalError`, `IntegrityError`, and `TransactionManagementError`.
2. Delegated the retry mechanism by raising `TaskBackoffError`.
3. This allows the first worker to hold the lock and complete its softdelete cascade, while the colliding worker gracefully yields, backs off, and safely retries without polluting Sentry with unhandled DB exceptions.

## How did you test this code?


_Please describe._
