### PR TITLE
Fix 'unsaved changes' badge positioning on Edit Feature modal tabs

### DIFF
--- a/frontend/web/components/navigation/TabMenu/TabButton.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabButton.tsx
@@ -8,13 +8,12 @@ interface TabButtonProps {
   isSelected: boolean
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   buttonTheme?: string
-  className?: string
   child: React.ReactElement
   children: React.ReactNode
 }
 
 const TabButton = React.forwardRef<HTMLButtonElement | null, TabButtonProps>(
-  ({ buttonTheme, child, className, isSelected, noFocus, onClick }, ref) => {
+  ({ buttonTheme, child, isSelected, noFocus, onClick }, ref) => {
     return (
       <Button
         ref={ref as React.RefObject<HTMLButtonElement>}
@@ -25,7 +24,7 @@ const TabButton = React.forwardRef<HTMLButtonElement | null, TabButtonProps>(
         onClick={(e) => onClick?.(e)}
         className={`btn-tab px-2 ${noFocus ? 'btn-no-focus' : ''} ${
           isSelected ? ' tab-active' : ''
-        } ${className}`}
+        }`}
       >
         {child.props.tabLabel}
       </Button>

--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -104,8 +104,6 @@ const Tabs: React.FC<TabsProps> = ({
     () => (disableOverflow ? [] : tabChildren.slice(visibleCount)),
     [tabChildren, visibleCount, disableOverflow],
   )
-  const canGrow = !isMeasuring && visibleCount === tabChildren.length
-
   const handleChange = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>, tabLabel: string, i: number) => {
       e.stopPropagation()
@@ -138,9 +136,13 @@ const Tabs: React.FC<TabsProps> = ({
       >
         <div
           ref={itemsContainerRef}
-          className={classNames('d-flex align-items-center flex-1', 'gap-2', {
-            'opacity-0': isMeasuring,
-          })}
+          className={classNames(
+            'd-flex align-items-center justify-content-evenly flex-1',
+            'gap-2',
+            {
+              'opacity-0': isMeasuring,
+            },
+          )}
         >
           {(isMeasuring ? tabChildren : visible).map((child, i) => {
             const isSelected = !isMeasuring && value === i
@@ -148,7 +150,6 @@ const Tabs: React.FC<TabsProps> = ({
               <TabButton
                 key={`button-${i}`}
                 isSelected={isSelected}
-                className={canGrow ? 'tab-nav-full' : ''}
                 noFocus={noFocus}
                 onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
                   handleChange(

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -64,10 +64,6 @@
 }
 
 .tabs-nav {
-  .tab-nav-full {
-    flex: 1 !important;
-  }
-
   position: relative;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6935

The `.unread` badge (purple `*`) on the Edit Feature modal tabs was overflowing below the tab underline. The root cause was `.tab-nav-full` applying `flex: 1` to each tab button, stretching them and causing the badge to misalign.

**Fix:** Replace per-button `flex: 1` with `justify-content-evenly` on the tab container. Tabs still distribute evenly, but buttons keep their natural width so the badge aligns correctly.

- Remove `.tab-nav-full` CSS rule and `canGrow` logic from `Tabs.tsx`
- Add `justify-content-evenly` to the tab items container
- Clean up unused `className` prop from `TabButton`

### Before

<img width="651" height="358" alt="image" src="https://github.com/user-attachments/assets/bd1b6bf6-8950-4297-a29b-22a36b0bf889" />

### After

<img width="647" height="355" alt="image" src="https://github.com/user-attachments/assets/f7021a72-b9a2-40ec-90c6-29e10dc9d685" />

## How did you test this code?

1. Run `ENV=local npm run dev`
2. Open a feature with segment overrides
3. Toggle or edit a segment override to trigger the unsaved state
4. Verify the `*` badge aligns vertically with the tab text
5. Check other tab bars across the app (permissions, settings) for visual regressions