### PR TITLE
fix(ui): replace misleading permission tooltip on segment override variations

### DIFF
--- a/frontend/web/components/mv/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput.tsx
@@ -37,7 +37,11 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
             <>
               {Utils.renderWithPermission(
                 canCreateFeature,
-                Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
+                readOnly
+                  ? 'Variation values are defined at the feature level and cannot be changed per segment.'
+                  : Constants.projectPermissions(
+                      ProjectPermission.CREATE_FEATURE,
+                    ),
                 <ValueEditor
                   data-test={`featureVariationValue${
                     Utils.featureStateToValue(value) || index


### PR DESCRIPTION
## Summary
- Fixes misleading "Create Feature permission" tooltip shown on read-only variation value inputs in segment overrides
- When variations are read-only due to being in a segment override context, the tooltip now shows: "Variation values are defined at the feature level and cannot be changed per segment."
- The original permission tooltip is preserved for cases where the user genuinely lacks Create Feature permission

## Issue
Fixes #6982

## Changes
- `frontend/web/components/mv/VariationValueInput.tsx`: When `readOnly` is true and `canCreateFeature` is falsy, show an informative tooltip instead of the permission-related one

## Testing
1. Create a multivariate feature with variations
2. Go to Segment Overrides tab
3. Add or view a segment override
4. Hover over a variation value input
5. Verify the tooltip now says "Variation values are defined at the feature level and cannot be changed per segment."
6. Verify that non-segment-override variation editing still shows the correct permission tooltip when the user lacks Create Feature permission