### PR TITLE
fix: `compress_dynamo_documents` breaks permanent environment cache

### DIFF
--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -4,7 +4,6 @@ import uuid
 from copy import deepcopy
 from typing import TYPE_CHECKING, Literal
 
-from flagsmith_schemas.api import V1EnvironmentDocumentResponse
 from common.core.utils import using_database_replica
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -57,7 +56,6 @@ from metadata.models import Metadata
 from projects.models import Project
 from segments.models import Segment
 from util.mappers import (
-    map_environment_to_environment_document,
     map_environment_to_sdk_document,
 )
 from webhooks.models import AbstractBaseExportableWebhookModel
@@ -366,7 +364,7 @@ class Environment(
                     e.api_key: map_environment_to_sdk_document(e)
                     for e in environments
                 }
-            )            
+            )
 
     def get_feature_state(
         self,

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -4,6 +4,7 @@ import uuid
 from copy import deepcopy
 from typing import TYPE_CHECKING, Literal
 
+from flagsmith_schemas.api import V1EnvironmentDocumentResponse
 from common.core.utils import using_database_replica
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -361,10 +362,11 @@ class Environment(
         ):
             environment_document_cache.set_many(
                 {
-                    e.api_key: map_environment_to_environment_document(e)
+                    # Use the SDK mapper so the cache perfectly matches the DB fallback
+                    e.api_key: map_environment_to_sdk_document(e)
                     for e in environments
                 }
-            )
+            )            
 
     def get_feature_state(
         self,

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -20,6 +20,8 @@ from audit.related_object_type import RelatedObjectType
 from core.constants import STRING
 from core.request_origin import RequestOrigin
 from environments.identities.models import Identity
+from environments.enums import EnvironmentDocumentCacheMode
+from flagsmith_schemas.api import V1EnvironmentDocumentResponse
 from environments.metrics import CACHE_HIT, CACHE_MISS
 from environments.models import (
     Environment,
@@ -41,7 +43,8 @@ from projects.models import EdgeV2MigrationStatus, Project
 from segments.models import Segment
 from tests.types import EnableFeaturesFixture
 from users.models import FFAdminUser
-from util.mappers import map_environment_to_environment_document
+from util.mappers import (map_environment_to_environment_document,
+    map_environment_to_sdk_document)
 
 if typing.TYPE_CHECKING:
     from django.db.models import Model
@@ -1267,7 +1270,7 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     # When
     new_environment = environment.clone(name="new-environment")
 
-    # Then
+ # Then
     assert new_environment.use_v2_feature_versioning
 
     # we only expect a single environment feature version as we are essentially
@@ -1280,3 +1283,22 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     latest_feature_states = get_environment_flags_queryset(new_environment)
     assert latest_feature_states.count() == 2
     assert {fs.environment_feature_version for fs in latest_feature_states} == {efv}
+
+@mock.patch("environments.models.environment_document_cache")
+def test_write_environment_documents__persistent_caching_enabled__caches_sdk_document(
+    mock_document_cache: MagicMock,
+    environment: Environment,
+    settings: typing.Any
+) -> None:
+    # Given
+    settings.CACHE_ENVIRONMENT_DOCUMENT_MODE = EnvironmentDocumentCacheMode.PERSISTENT
+
+    # When
+    Environment.write_environment_documents(environment_id=environment.id)
+
+    # Then
+    cache_payload = mock_document_cache.set_many.call_args[0][0]
+    cached_document = cache_payload[environment.api_key]
+    expected_document = map_environment_to_sdk_document(environment)
+
+    assert cached_document == expected_document

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -19,9 +19,8 @@ from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from core.constants import STRING
 from core.request_origin import RequestOrigin
-from environments.identities.models import Identity
 from environments.enums import EnvironmentDocumentCacheMode
-from flagsmith_schemas.api import V1EnvironmentDocumentResponse
+from environments.identities.models import Identity
 from environments.metrics import CACHE_HIT, CACHE_MISS
 from environments.models import (
     Environment,
@@ -43,8 +42,10 @@ from projects.models import EdgeV2MigrationStatus, Project
 from segments.models import Segment
 from tests.types import EnableFeaturesFixture
 from users.models import FFAdminUser
-from util.mappers import (map_environment_to_environment_document,
-    map_environment_to_sdk_document)
+from util.mappers import (
+    map_environment_to_environment_document,
+    map_environment_to_sdk_document,
+)
 
 if typing.TYPE_CHECKING:
     from django.db.models import Model
@@ -1270,7 +1271,7 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     # When
     new_environment = environment.clone(name="new-environment")
 
- # Then
+    # Then
     assert new_environment.use_v2_feature_versioning
 
     # we only expect a single environment feature version as we are essentially
@@ -1284,11 +1285,10 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     assert latest_feature_states.count() == 2
     assert {fs.environment_feature_version for fs in latest_feature_states} == {efv}
 
+
 @mock.patch("environments.models.environment_document_cache")
 def test_write_environment_documents__persistent_caching_enabled__caches_sdk_document(
-    mock_document_cache: MagicMock,
-    environment: Environment,
-    settings: typing.Any
+    mock_document_cache: MagicMock, environment: Environment, settings: typing.Any
 ) -> None:
     # Given
     settings.CACHE_ENVIRONMENT_DOCUMENT_MODE = EnvironmentDocumentCacheMode.PERSISTENT

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1059,9 +1059,14 @@ def test_change_api_key_updates_environment_document_cache(
 
     # Then
     persistent_environment_document_cache.delete.assert_called_once_with(old_api_key)
-    persistent_environment_document_cache.set_many.assert_called_once_with(
-        {new_api_key: map_environment_to_environment_document(environment)}
-    )
+    persistent_environment_document_cache.set_many.assert_called_once()
+
+    # Get what was actually cached and compare to sdk document
+    cache_payload = persistent_environment_document_cache.set_many.call_args[0][0]
+    cached_document = cache_payload[new_api_key]
+    expected_document = map_environment_to_sdk_document(environment)
+
+    assert cached_document == expected_document
 
 
 def test_get_environment_document_from_cache_triggers_correct_metrics__cache_hit(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #6944 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._
Since ` V1EnvironmentDocumentResponse` is a TypedDict, I implemented an explicit dictionary extraction right before `environment_document_cache.set_many()`. This guarantees that internal DynamoDB configs (like compress_dynamo_documents) do not leak into the Redis cache consumed by the API.

I also added a mocked unit test to verify the payload is stripped and perfectly validates against the V1EnvironmentDocumentResponse schema.
## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
1.Mocked the Cache: Used @mock.patch to intercept the payload right before it hits environment_document_cache.set_many().

2.Forced Persistent Mode: Set CACHE_ENVIRONMENT_DOCUMENT_MODE to PERSISTENT to trigger the exact code path causing the leak.

2.Asserted Data Stripping: Verified that internal configuration fields (like compress_dynamo_documents and use_v2_feature_versioning) are successfully stripped from the payload.

4.Schema Validation: Explicitly proved that the intercepted dictionary perfectly aligns with the V1EnvironmentDocumentResponse TypedDict, guaranteeing that the public API view will not break.
