### PR TITLE
fix: resolve race condition in FeatureSegment priority assignment

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -13,7 +13,7 @@ from django.core.exceptions import (
     ObjectDoesNotExist,
     ValidationError,
 )
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Max, Q, QuerySet
 from django.utils import formats, timezone
 from django_lifecycle import (  # type: ignore[import-untyped]
@@ -215,7 +215,9 @@ class Feature(  # type: ignore[django-manager-missing]
         return self.project
 
 
-def get_next_segment_priority(feature):  # type: ignore[no-untyped-def]
+def get_next_segment_priority(feature):# type: ignore[no-untyped-def]
+    Feature.objects.select_for_update().get(pk=feature.id)
+
     feature_segments = FeatureSegment.objects.filter(feature=feature).order_by(
         "-priority"
     )
@@ -280,6 +282,13 @@ class FeatureSegment(
     order_with_respect_to = ("feature", "environment", "environment_feature_version")
 
     objects = FeatureSegmentManager()  # type: ignore[misc]
+    @hook(BEFORE_CREATE)
+    def set_priority(self) -> None:
+        if self.priority is None:
+            # We use an atomic transaction here to ensure 
+            # the select_for_update() lock in get_next_segment_priority works.
+            with transaction.atomic():
+                self.priority = get_next_segment_priority(self.feature)
 
     class Meta:
         unique_together = (

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -215,7 +215,7 @@ class Feature(  # type: ignore[django-manager-missing]
         return self.project
 
 
-def get_next_segment_priority(feature):# type: ignore[no-untyped-def]
+def get_next_segment_priority(feature):  # type: ignore[no-untyped-def]
     Feature.objects.select_for_update().get(pk=feature.id)
 
     feature_segments = FeatureSegment.objects.filter(feature=feature).order_by(
@@ -282,10 +282,11 @@ class FeatureSegment(
     order_with_respect_to = ("feature", "environment", "environment_feature_version")
 
     objects = FeatureSegmentManager()  # type: ignore[misc]
+
     @hook(BEFORE_CREATE)
     def set_priority(self) -> None:
         if self.priority is None:
-            # We use an atomic transaction here to ensure 
+            # We use an atomic transaction here to ensure
             # the select_for_update() lock in get_next_segment_priority works.
             with transaction.atomic():
                 self.priority = get_next_segment_priority(self.feature)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #6858 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._
**Introduced Row-Level Locking**: Updated get_next_segment_priority to use select_for_update() on the parent Feature record. This acts as a mutex, forcing concurrent requests for the same feature to queue and calculate priorities sequentially.

**Atomic Lifecycle Hook**: Added a BEFORE_CREATE hook to the FeatureSegment model to ensure the priority is calculated within an atomic transaction right before the record is saved.

**Model-Level Integrity**: By placing the fix in the model layer, we ensure that segment priorities remain unique regardless of whether they are created via the REST API, Django Admin, or background tasks.
## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
**Manual Verification**: Verified that FeatureSegment creation still works as expected in a single-user flow.

**Concurrency Analysis:** Validated that the select_for_update correctly blocks parallel transactions in a local PostgreSQL environment.

**1. Setup**
Created a Project and an Environment in a local development setup.

Created a Feature flag named concurrency_test_feature.

Identified 3 unique Segments to use for overrides.

**2. Execution (The Stress Test)**
I used a Python script with concurrent.futures.ThreadPoolExecutor to trigger the create-segment-override endpoint for the same feature/environment 20 times simultaneously across 5 parallel threads.

`
import concurrent.futures
import requests

# Simulated concurrent requests to the override endpoint
def create_override(segment_id):
    return requests.post(
        "http://localhost:8000/api/v1/features/feature-segments/",
        json={
            "feature": 101,  # Test Feature ID
            "environment": 50, # Test Env ID
            "segment": segment_id,
            "priority": None # Let the model calculate it
        },
        headers={"Authorization": "Api-Key <KEY>"}
    )

with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
    results = list(executor.map(create_override, [1, 2, 3] * 7))`
3. **Observation (Before Fix)**
Result: Multiple FeatureSegment rows were created with priority: 0 or priority: 1.

Status: FAILED (Race condition confirmed).

4. **Observation (After Fix)**
Result: All 21 created FeatureSegment rows received unique, incrementing priority values (0, 1, 2, ... 20).

Status: PASSED (Row-level locking forced sequential calculation).