### PR TITLE
fix(tabs): alignment issues with 'unsaved changes' badge in Tabs component

### DIFF
--- a/frontend/web/components/modals/CreateGroup.tsx
+++ b/frontend/web/components/modals/CreateGroup.tsx
@@ -456,15 +456,15 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
     <Tabs uncontrolled className='px-0'>
       <TabItem
         tabLabel={
-          <div>
+          <>
             General
             {!!edited && <span className='unread'>*</span>}
-          </div>
+          </>
         }
       >
         {editGroupEl}
       </TabItem>
-      <TabItem tabLabel={<div>Permissions</div>}>{editPermissionsEl}</TabItem>
+      <TabItem tabLabel='Permissions'>{editPermissionsEl}</TabItem>
     </Tabs>
   ) : (
     editGroupEl

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -503,10 +503,10 @@ const CreateSegment: FC<CreateSegmentType> = ({
           <TabItem
             tabLabelString='General'
             tabLabel={
-              <Row className='justify-content-center flex-nowrap'>
-                General{' '}
-                {valueChanged && <div className='unread ml-2 px-1'>{'*'}</div>}
-              </Row>
+              <>
+                General
+                {valueChanged && <span className='unread'>{'*'}</span>}
+              </>
             }
           >
             <div className='my-4'>
@@ -564,12 +564,12 @@ const CreateSegment: FC<CreateSegmentType> = ({
             <TabItem
               tabLabelString='Custom Fields'
               tabLabel={
-                <Row className='justify-content-center flex-nowrap'>
+                <>
                   Custom Fields
                   {metadataValueChanged && (
-                    <div className='unread ml-2 px-1 pt-2'>{'*'}</div>
+                    <span className='unread'>{'*'}</span>
                   )}
-                </Row>
+                </>
               }
             >
               <div className='my-4'>{MetadataTab}</div>
@@ -579,10 +579,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
       )}
       {!(isEdit && !condensed) && metadataEnable && segmentContentType?.id && (
         <Tabs value={tab} onChange={(tab: UserTabs) => setTab(tab)}>
-          <TabItem
-            tabLabelString='Basic configuration'
-            tabLabel={'Basic configuration'}
-          >
+          <TabItem tabLabel='Basic configuration'>
             <div className={className || 'my-3 mx-4'}>
               <CreateSegmentRulesTabForm
                 save={save}
@@ -610,12 +607,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               />
             </div>
           </TabItem>
-          <TabItem
-            tabLabelString='Custom Fields'
-            tabLabel={
-              <Row className='justify-content-center'>Custom Fields</Row>
-            }
-          >
+          <TabItem tabLabel='Custom Fields'>
             <div className={className || 'my-3 mx-4'}>{MetadataTab}</div>
           </TabItem>
         </Tabs>

--- a/frontend/web/components/modals/create-experiment/index.js
+++ b/frontend/web/components/modals/create-experiment/index.js
@@ -468,14 +468,12 @@ const Index = class extends Component {
                                     data-test='value'
                                     tabLabelString='Value'
                                     tabLabel={
-                                      <Row className='justify-content-center'>
-                                        Value{' '}
+                                      <>
+                                        Value
                                         {this.state.valueChanged && (
-                                          <div className='unread ml-2 px-1'>
-                                            {'*'}
-                                          </div>
+                                          <span className='unread'>{'*'}</span>
                                         )}
-                                      </Row>
+                                      </>
                                     }
                                   >
                                     <FeatureValueTab
@@ -540,12 +538,7 @@ const Index = class extends Component {
                                   </TabItem>
                                   <TabItem
                                     data-test='results'
-                                    tabLabelString='Results'
-                                    tabLabel={
-                                      <Row className='justify-content-center'>
-                                        Results
-                                      </Row>
-                                    }
+                                    tabLabel='Results'
                                   >
                                     <ExperimentResultsTab
                                       environmentId={this.props.environmentId}

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -571,12 +571,10 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                     data-test='value'
                     tabLabelString='Value'
                     tabLabel={
-                      <Row className='justify-content-center'>
-                        Value{' '}
-                        {valueChanged && (
-                          <div className='unread ml-2 px-1'>{'*'}</div>
-                        )}
-                      </Row>
+                      <>
+                        Value
+                        {valueChanged && <div className='unread'>*</div>}
+                      </>
                     }
                   >
                     <FeatureValueTab
@@ -615,16 +613,10 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                         data-test='segment_overrides'
                         tabLabelString='Segment Overrides'
                         tabLabel={
-                          <Row
-                            className={`justify-content-center ${
-                              segmentsChanged ? 'pr-1' : ''
-                            }`}
-                          >
-                            Segment Overrides{' '}
-                            {segmentsChanged && (
-                              <div className='unread ml-2 px-2'>*</div>
-                            )}
-                          </Row>
+                          <>
+                            Segment Overrides
+                            {segmentsChanged && <div className='unread'>*</div>}
+                          </>
                         }
                       >
                         <SegmentOverridesTab
@@ -660,12 +652,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                     </TabItem>
                   )}
                   {(!Project.disableAnalytics || hasCodeReferences) && (
-                    <TabItem
-                      tabLabelString='Usage'
-                      tabLabel={
-                        <Row className='justify-content-center'>Usage</Row>
-                      }
-                    >
+                    <TabItem tabLabelString='Usage' tabLabel='Usage'>
                       <UsageTab
                         projectId={projectId}
                         featureId={projectFlag.id}
@@ -691,9 +678,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                     <TabItem
                       data-test='external-resources-links'
                       tabLabelString='Links'
-                      tabLabel={
-                        <Row className='justify-content-center'>Links</Row>
-                      }
+                      tabLabel='Links'
                     >
                       <ExternalResourcesLinkTab
                         githubId={githubId}
@@ -719,12 +704,10 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       data-test='settings'
                       tabLabelString='Settings'
                       tabLabel={
-                        <Row className='justify-content-center'>
-                          Settings{' '}
-                          {settingsChanged && (
-                            <div className='unread ml-2 px-1'>{'*'}</div>
-                          )}
-                        </Row>
+                        <>
+                          Settings
+                          {settingsChanged && <div className='unread'>*</div>}
+                        </>
                       }
                     >
                       <FeatureSettings

--- a/frontend/web/components/navigation/TabMenu/TabButton.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabButton.tsx
@@ -27,7 +27,7 @@ const TabButton = React.forwardRef<HTMLButtonElement | null, TabButtonProps>(
           isSelected ? ' tab-active' : ''
         } ${className}`}
       >
-        {child.props.tabLabel}
+        <span className='btn-tab__label'>{child.props.tabLabel}</span>
       </Button>
     )
   },

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -159,6 +159,14 @@
 
 .btn-tab {
   position: relative;
+
+  .btn-tab__label {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 4px;
+  }
+
   .unread {
     padding-left: 0 !important;
     padding-right: 0 !important;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6935
Supersedes #6949 — thanks to @alveyworld for the initial investigation and for flagging the group editor issue.

- Replaced `<Row>` and `<div>` wrappers in tab labels with fragments, removing block-level elements that interfered with flex layout
- Added a `.btn-tab__label` wrapper in `TabButton` with `inline-flex` and `flex-wrap: nowrap` to keep text and badge on the same line
- Removed redundant `tabLabelString` where `tabLabel` is already a plain string

## Screenshots

<img width="644" height="277" alt="image" src="https://github.com/user-attachments/assets/b496ae76-592c-4f90-b002-e1a3757f8d3c" />
<img width="688" height="672" alt="image" src="https://github.com/user-attachments/assets/1204f236-e587-49b1-9b05-993a3ff16c31" />


## How did you test this code?

Manually verified the following:
- Feature modal — Value, Segment Overrides, and Settings tabs with unsaved changes (`*` badge stays inline)
- Edit Group modal — General tab with unsaved changes (`*` badge stays inline)
- Create Segment modal — General and Custom Fields tabs
- Pill tabs (e.g. Members/Groups/Roles) — still stretch to fill width
- Overflow dropdown tabs — still render correctly