### PR TITLE
fix: use .values("id").distinct().count() in platform_hub for Oracle compatibility

### DIFF
--- a/api/platform_hub/services.py
+++ b/api/platform_hub/services.py
@@ -48,7 +48,10 @@ def get_summary(
     ).count()
 
     total_users = (
-        FFAdminUser.objects.filter(organisations__in=organisations).distinct().count()
+        FFAdminUser.objects.filter(organisations__in=organisations)
+        .values("id")
+        .distinct()
+        .count()
     )
 
     total_projects = Project.objects.filter(organisation__in=organisations).count()
@@ -62,12 +65,16 @@ def get_summary(
             organisations__in=organisations,
             last_login__gte=cutoff,
         )
+        .values("id")
         .distinct()
         .count()
     )
 
     active_organisations = (
-        organisations.filter(users__last_login__gte=cutoff).distinct().count()
+        organisations.filter(users__last_login__gte=cutoff)
+        .values("id")
+        .distinct()
+        .count()
     )
 
     total_integrations = 0


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fix three `distinct().count()` queries in `platform_hub/services.py` that fail on Oracle with `ORA-00932: inconsistent datatypes: expected - got NCLOB`.

`FFAdminUser` has `TextField` columns (e.g. `onboarding_data`) which Oracle maps to NCLOB — Oracle cannot perform `SELECT DISTINCT` on NCLOB columns. Using `.values("id").distinct().count()` generates `SELECT DISTINCT "id"` instead of `SELECT DISTINCT *`, avoiding the NCLOB column while producing identical results since `id` is the primary key.

## How did you test this code?

- Oracle unit tests pass in flagsmith-ee CI (all 7 previously failing platform_hub tests now green)
- Postgres unit tests pass locally and in CI
- MySQL unit tests pass in CI