### PR TITLE
fix(environments): validate project field in environment creation

### DIFF
--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -6,7 +6,7 @@ from common.environments.permissions import (
 from common.projects.permissions import (
     CREATE_ENVIRONMENT,
 )
-from django.db.models import Model, Q
+from django.db.models import Model
 from rest_framework import exceptions
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
@@ -36,9 +36,12 @@ class EnvironmentPermissions(IsAuthenticated):
 
         if view.action == "create":
             try:
-                project_id = request.data.get("project")
-                project_lookup = Q(id=project_id)
-                project = Project.objects.get(project_lookup)
+                project_id = int(request.data.get("project"))
+            except (TypeError, ValueError):
+                return False
+
+            try:
+                project = Project.objects.get(id=project_id)
                 return request.user.has_project_permission(CREATE_ENVIRONMENT, project)
             except Project.DoesNotExist:
                 return False

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
@@ -158,7 +158,7 @@ def test_environment_permissions__user_without_create_permission__returns_false(
 )
 def test_environment_permissions__create_with_invalid_project__returns_false(
     staff_user: FFAdminUser,
-    request_data: dict,
+    request_data: dict[str, str],
     expected: bool,
 ) -> None:
     # Given

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from common.projects.permissions import (
     CREATE_ENVIRONMENT,
 )
@@ -148,36 +149,57 @@ def test_environment_permissions__user_without_create_permission__returns_false(
     assert result is False
 
 
-def test_environment_permissions__create_with_non_integer_project__returns_false(
+@pytest.mark.parametrize(
+    "request_data, expected",
+    [
+        ({"project": "<Project ID>", "name": "Test environment"}, False),
+        ({"name": "Test environment"}, False),
+    ],
+)
+def test_environment_permissions__create_with_invalid_project__returns_false(
     staff_user: FFAdminUser,
+    request_data: dict,
+    expected: bool,
 ) -> None:
     # Given
-    mock_view.action = "create"
-    mock_view.detail = False
-    mock_request.user = staff_user
-    mock_request.data = {"project": "<Project ID>", "name": "Test environment"}
+    view = mock.MagicMock()
+    request = mock.MagicMock()
+    view.action = "create"
+    view.detail = False
+    request.user = staff_user
+    request.data = request_data
 
     # When
-    result = environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+    result = environment_permissions.has_permission(request, view)  # type: ignore[no-untyped-call]
 
     # Then
-    assert result is False
+    assert result is expected
 
 
-def test_environment_permissions__create_with_none_project__returns_false(
+def test_environment_permissions__create_with_string_integer_project__returns_true(
     staff_user: FFAdminUser,
+    project: Project,
 ) -> None:
     # Given
-    mock_view.action = "create"
-    mock_view.detail = False
-    mock_request.user = staff_user
-    mock_request.data = {"name": "Test environment"}
+    create_environment_permission = ProjectPermissionModel.objects.get(
+        key=CREATE_ENVIRONMENT
+    )
+    user_project_permission = UserProjectPermission.objects.create(
+        user=staff_user, project=project
+    )
+    user_project_permission.permissions.set([create_environment_permission])
+    view = mock.MagicMock()
+    request = mock.MagicMock()
+    view.action = "create"
+    view.detail = False
+    request.user = staff_user
+    request.data = {"project": str(project.id), "name": "Test environment"}
 
     # When
-    result = environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+    result = environment_permissions.has_permission(request, view)  # type: ignore[no-untyped-call]
 
     # Then
-    assert result is False
+    assert result is True
 
 
 def test_environment_permissions__list_action__returns_true(

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
@@ -148,6 +148,38 @@ def test_environment_permissions__user_without_create_permission__returns_false(
     assert result is False
 
 
+def test_environment_permissions__create_with_non_integer_project__returns_false(
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    mock_view.action = "create"
+    mock_view.detail = False
+    mock_request.user = staff_user
+    mock_request.data = {"project": "<Project ID>", "name": "Test environment"}
+
+    # When
+    result = environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+
+    # Then
+    assert result is False
+
+
+def test_environment_permissions__create_with_none_project__returns_false(
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    mock_view.action = "create"
+    mock_view.detail = False
+    mock_request.user = staff_user
+    mock_request.data = {"name": "Test environment"}
+
+    # When
+    result = environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+
+    # Then
+    assert result is False
+
+
 def test_environment_permissions__list_action__returns_true(
     staff_user: FFAdminUser,
 ) -> None:


### PR DESCRIPTION
## Summary
- Validates the `project` field is a valid integer before querying the database in `EnvironmentPermissions.has_permission`
- Previously, passing a non-integer string (e.g. `<Project ID>`) caused an unhandled `ValueError` at `Project.objects.get()`, resulting in a 500 response
- Now returns 403 for invalid project values, consistent with how missing or non-existent projects are already handled

## Issue
Fixes #6599

## Changes
- `api/environments/permissions/permissions.py`: Added `int()` validation with `(TypeError, ValueError)` handling before the ORM query, following the same pattern used in `FeatureSegmentPermissions`
- Removed unused `Q` import
- Added two unit tests covering non-integer and missing project values