### PR TITLE
fix: dissociated-code-references-gate-from-flag-response

### DIFF
--- a/frontend/web/components/feature-page/FeatureNavTab/FeatureAnalytics.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/FeatureAnalytics.tsx
@@ -106,7 +106,10 @@ const FlagAnalytics: FC<FlagAnalyticsType> = ({
                   tick={{ fill: '#656D7B' }}
                   axisLine={{ stroke: '#656D7B' }}
                 />
-                <Tooltip cursor={{ fill: 'transparent' }} />
+                <Tooltip
+                  cursor={{ fill: 'transparent' }}
+                  labelStyle={{ color: '#1a1a1a' }}
+                />
                 {sortBy(environmentIds, (id) =>
                   environments?.results?.findIndex((env) => `${env.id}` === id),
                 ).map((id) => {

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -380,7 +380,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
     controlValue < 0
   const isVersionedChangeRequest = existingChangeRequest && isVersioned
   const hideIdentityOverridesTab = Utils.getShouldHideIdentityOverridesTab()
-  const hasCodeReferences = projectFlag?.code_references_counts?.length > 0
+  const hasCodeReferenceCounts = projectFlag?.code_references_counts?.length > 0
 
   let regexValid = true
   try {
@@ -659,7 +659,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       />
                     </TabItem>
                   )}
-                  {(!Project.disableAnalytics || hasCodeReferences) && (
+                  {(!Project.disableAnalytics || hasCodeReferenceCounts) && (
                     <TabItem
                       tabLabelString='Usage'
                       tabLabel={
@@ -670,7 +670,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                         projectId={projectId}
                         featureId={projectFlag.id}
                         environmentId={environment.id}
-                        hasCodeReferences={hasCodeReferences}
+                        hasCodeReferences={true}
                       />
                     </TabItem>
                   )}

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -8,7 +8,6 @@ import FeatureListStore from 'common/stores/feature-list-store'
 import IdentityProvider from 'common/providers/IdentityProvider'
 import FeatureListProvider from 'common/providers/FeatureListProvider'
 import AppActions from 'common/dispatcher/app-actions'
-import Project from 'common/project'
 import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import ChangeRequestModal from 'components/modals/ChangeRequestModal'
@@ -380,7 +379,6 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
     controlValue < 0
   const isVersionedChangeRequest = existingChangeRequest && isVersioned
   const hideIdentityOverridesTab = Utils.getShouldHideIdentityOverridesTab()
-  const hasCodeReferenceCounts = projectFlag?.code_references_counts?.length > 0
 
   let regexValid = true
   try {
@@ -659,21 +657,18 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       />
                     </TabItem>
                   )}
-                  {(!Project.disableAnalytics || hasCodeReferenceCounts) && (
-                    <TabItem
-                      tabLabelString='Usage'
-                      tabLabel={
-                        <Row className='justify-content-center'>Usage</Row>
-                      }
-                    >
-                      <UsageTab
-                        projectId={projectId}
-                        featureId={projectFlag.id}
-                        environmentId={environment.id}
-                        hasCodeReferences={true}
-                      />
-                    </TabItem>
-                  )}
+                  <TabItem
+                    tabLabelString='Usage'
+                    tabLabel={
+                      <Row className='justify-content-center'>Usage</Row>
+                    }
+                  >
+                    <UsageTab
+                      projectId={projectId}
+                      featureId={projectFlag.id}
+                      environmentId={environment.id}
+                    />
+                  </TabItem>
                   {
                     <TabItem
                       data-test='feature_health'

--- a/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
@@ -7,13 +7,11 @@ type UsageTabProps = {
   projectId: number | string
   featureId: number
   environmentId: number
-  hasCodeReferences: boolean
 }
 
 const UsageTab: FC<UsageTabProps> = ({
   environmentId,
   featureId,
-  hasCodeReferences,
   projectId,
 }) => {
   if (!projectId) {
@@ -30,34 +28,32 @@ const UsageTab: FC<UsageTabProps> = ({
           />
         </div>
       )}
-      {hasCodeReferences && (
-        <FormGroup className='mb-4'>
-          <div className='d-flex align-items-center gap-2 mb-2'>
-            <h5 className='mb-0'>Code references</h5>
-            <span
-              className='chip chip--xs bg-primary text-white'
-              style={{ border: 'none' }}
-            >
-              New
-            </span>
-          </div>
-          <div className='text-muted mb-2'>
-            Code references allow you to track where feature flags are being
-            used within your code.{' '}
-            <a
-              target='_blank'
-              href='https://docs.flagsmith.com/managing-flags/code-references'
-              rel='noreferrer'
-            >
-              Learn more
-            </a>
-          </div>
-          <FeatureCodeReferencesContainer
-            featureId={featureId}
-            projectId={parseInt(`${projectId}`)}
-          />
-        </FormGroup>
-      )}
+      <FormGroup className='mb-4'>
+        <div className='d-flex align-items-center gap-2 mb-2'>
+          <h5 className='mb-0'>Code references</h5>
+          <span
+            className='chip chip--xs bg-primary text-white'
+            style={{ border: 'none' }}
+          >
+            New
+          </span>
+        </div>
+        <div className='text-muted mb-2'>
+          Code references allow you to track where feature flags are being used
+          within your code.{' '}
+          <a
+            target='_blank'
+            href='https://docs.flagsmith.com/managing-flags/code-references'
+            rel='noreferrer'
+          >
+            Learn more
+          </a>
+        </div>
+        <FeatureCodeReferencesContainer
+          featureId={featureId}
+          projectId={parseInt(`${projectId}`)}
+        />
+      </FormGroup>
     </>
   )
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Showing code references in feature flag modal was dependent on the data existing from `Get /flags`
- Always show code references in Usage (with empty message)
- Side fixed the dark mode in the Usage chart

## How did you test this code?
<img width="708" height="673" alt="image" src="https://github.com/user-attachments/assets/807c8d10-52f8-4389-886f-4b3db464b266" />

<img width="704" height="807" alt="image" src="https://github.com/user-attachments/assets/6b27a1f3-6f1b-4298-aac1-640c11283274" />

<img width="293" height="211" alt="image" src="https://github.com/user-attachments/assets/6a24e253-65c8-4e5e-88c4-27668d928a16" />
