### PR TITLE
fix(ci): Docker compose migration race condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,23 @@ services:
       retries: 20
       start_period: 20s
 
+  init-db:
+    image: docker.flagsmith.com/flagsmith/flagsmith:latest
+    command:
+      - migrate
+    environment:
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
+      USE_POSTGRES_FOR_ANALYTICS: 'true' # Store API and Flag Analytics data in Postgres
+    healthcheck:
+      test: ["NONE"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   flagsmith:
     image: docker.flagsmith.com/flagsmith/flagsmith:latest
+    command:
+      - serve
     environment:
       # All environments variables are available here:
       # API: https://docs.flagsmith.com/deployment/locally-api#environment-variables
@@ -57,8 +72,8 @@ services:
     ports:
       - 8000:8000
     depends_on:
-      postgres:
-        condition: service_healthy
+      init-db:
+        condition: service_completed_successfully
 
   # The flagsmith_processor service is only needed if TASK_RUN_METHOD set to TASK_PROCESSOR
   # in the application environment
@@ -72,5 +87,6 @@ services:
     ports:
       - 8001:8000
     depends_on:
-      - flagsmith
+      init-db:
+        condition: service_completed_successfully
     command: run-task-processor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ x-flagsmith-env: &flagsmith-env
   # EMAIL_USE_TLS: 'true' # optional
 
 volumes:
-  pgdata-onboardingtest202603301212:
+  pgdata:
 
 services:
   postgres:
@@ -44,7 +44,7 @@ services:
       POSTGRES_DB: flagsmith
     container_name: flagsmith_postgres
     volumes:
-      - pgdata-onboardingtest202603301212:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -d flagsmith -U postgres']
       interval: 2s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     environment:
       <<: *flagsmith-env
     healthcheck:
-      test: ["NONE"]
+      disable: true
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       retries: 20
       start_period: 20s
 
-  init-db:
+  migrate-db:
     image: docker.flagsmith.com/flagsmith/flagsmith:latest
     command:
       - migrate
@@ -73,7 +73,7 @@ services:
     ports:
       - 8000:8000
     depends_on:
-      init-db:
+      migrate-db:
         condition: service_completed_successfully
 
   # The flagsmith_processor service is only needed if TASK_RUN_METHOD set to TASK_PROCESSOR
@@ -85,6 +85,6 @@ services:
     ports:
       - 8001:8000
     depends_on:
-      init-db:
+      migrate-db:
         condition: service_completed_successfully
     command: run-task-processor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,40 @@
 # See https://docs.flagsmith.com/deployment/docker for more information on running Flagsmith in Docker
 # This Docker Compose file will run the entire Flagsmith Platform
 
+x-flagsmith-env: &flagsmith-env
+  # All environments variables are available here:
+  # API: https://docs.flagsmith.com/deployment/locally-api#environment-variables
+  # UI: https://docs.flagsmith.com/deployment/locally-frontend#environment-variables
+
+  DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
+  USE_POSTGRES_FOR_ANALYTICS: 'true' # Store API and Flag Analytics data in Postgres
+  ENVIRONMENT: production # set to 'production' in production.
+  DJANGO_ALLOWED_HOSTS: '*' # Change this in production
+  FLAGSMITH_DOMAIN: localhost:8000 # Change this in production
+  DJANGO_SECRET_KEY: secret # Change this in production
+  # PREVENT_SIGNUP: 'true' # Uncomment to prevent any additional signups
+  # ALLOW_REGISTRATION_WITHOUT_INVITE: 'true' # Uncomment and set to false to only allow signups via invitations
+
+  # Enable Task Processor
+  TASK_RUN_METHOD: TASK_PROCESSOR # other options are: SYNCHRONOUSLY, SEPARATE_THREAD (default)
+  PROMETHEUS_ENABLED: 'true'
+
+  # Uncomment if you want to enable Google OAuth. Note this does not turn Google OAuth on. You still need to use
+  # Flagsmith on Flagsmith to enable it - https://docs.flagsmith.com/deployment/#oauth_google
+  # DJANGO_SECURE_CROSS_ORIGIN_OPENER_POLICY: 'same-origin-allow-popups'
+
+  # For more info on configuring E-Mails - https://docs.flagsmith.com/deployment/locally-api#environment-variables
+  # Example SMTP:
+  # EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+  # EMAIL_HOST: mail.example.com
+  # SENDER_EMAIL: flagsmith@example.com
+  # EMAIL_HOST_USER: flagsmith@example.com
+  # EMAIL_HOST_PASSWORD: smtp_account_password
+  # EMAIL_PORT: 587 # optional
+  # EMAIL_USE_TLS: 'true' # optional
+
 volumes:
-  pgdata:
+  pgdata-onboardingtest202603301212:
 
 services:
   postgres:
@@ -12,7 +44,7 @@ services:
       POSTGRES_DB: flagsmith
     container_name: flagsmith_postgres
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata-onboardingtest202603301212:/var/lib/postgresql/data
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -d flagsmith -U postgres']
       interval: 2s
@@ -25,8 +57,7 @@ services:
     command:
       - migrate
     environment:
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
-      USE_POSTGRES_FOR_ANALYTICS: 'true' # Store API and Flag Analytics data in Postgres
+      <<: *flagsmith-env
     healthcheck:
       test: ["NONE"]
     depends_on:
@@ -38,37 +69,7 @@ services:
     command:
       - serve
     environment:
-      # All environments variables are available here:
-      # API: https://docs.flagsmith.com/deployment/locally-api#environment-variables
-      # UI: https://docs.flagsmith.com/deployment/locally-frontend#environment-variables
-
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
-      USE_POSTGRES_FOR_ANALYTICS: 'true' # Store API and Flag Analytics data in Postgres
-
-      ENVIRONMENT: production # set to 'production' in production.
-      DJANGO_ALLOWED_HOSTS: '*' # Change this in production
-      FLAGSMITH_DOMAIN: localhost:8000 # Change this in production
-      DJANGO_SECRET_KEY: secret # Change this in production
-      # PREVENT_SIGNUP: 'true' # Uncomment to prevent any additional signups
-      # ALLOW_REGISTRATION_WITHOUT_INVITE: 'true' # Uncomment and set to false to only allow signups via invitations
-
-      # Enable Task Processor
-      TASK_RUN_METHOD: TASK_PROCESSOR # other options are: SYNCHRONOUSLY, SEPARATE_THREAD (default)
-      PROMETHEUS_ENABLED: 'true'
-
-      # Uncomment if you want to enable Google OAuth. Note this does not turn Google OAuth on. You still need to use
-      # Flagsmith on Flagsmith to enable it - https://docs.flagsmith.com/deployment/#oauth_google
-      # DJANGO_SECURE_CROSS_ORIGIN_OPENER_POLICY: 'same-origin-allow-popups'
-
-      # For more info on configuring E-Mails - https://docs.flagsmith.com/deployment/locally-api#environment-variables
-      # Example SMTP:
-      # EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
-      # EMAIL_HOST: mail.example.com
-      # SENDER_EMAIL: flagsmith@example.com
-      # EMAIL_HOST_USER: flagsmith@example.com
-      # EMAIL_HOST_PASSWORD: smtp_account_password
-      # EMAIL_PORT: 587 # optional
-      # EMAIL_USE_TLS: 'true' # optional
+      <<: *flagsmith-env
     ports:
       - 8000:8000
     depends_on:
@@ -80,10 +81,7 @@ services:
   flagsmith-task-processor:
     image: docker.flagsmith.com/flagsmith/flagsmith:latest
     environment:
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
-      USE_POSTGRES_FOR_ANALYTICS: 'true'
-      DJANGO_ALLOWED_HOSTS: '*'
-      PROMETHEUS_ENABLED: 'true'
+      <<: *flagsmith-env
     ports:
       - 8001:8000
     depends_on:


### PR DESCRIPTION
## Changes

Unsolicited improvement based on frustrations when using docker-compose. Currently on start up one of `flagsmith` or `flagsmith-task-processor` can fail based on a race condition when they both attempt to run the migrations. This change delegates the migrations to a new `init-db` service which the other 2 services rely on. 

It comes with a bonus DRY-ing up of the docker compose file to centralise the environment variables. I've shared all of the env vars between the different services since, while they are not all strictly necessary for each service, they are harmless when included in the services that don't strictly need them. We could, if we wanted to, clean this up to have service specific env vars in the relevant service if we want to. 

## How did you test this code?

`docker-compose up` 
