### PR TITLE
fix: Version endpoints not returning JSON in all-in-one Docker deployment

### DIFF
--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -76,6 +76,10 @@ app.get('/config/project-overrides', (req, res) => {
         ? '/api/v1/'
         : process.env.FLAGSMITH_API_URL,
     },
+    {
+      name: 'apiProxyEnabled',
+      value: !!process.env.FLAGSMITH_PROXY_API_URL,
+    },
     { name: 'maintenance', value: envToBool('ENABLE_MAINTENANCE_MODE', false) },
     {
       name: 'flagsmithClientAPI',

--- a/frontend/common/services/useBuildVersion.ts
+++ b/frontend/common/services/useBuildVersion.ts
@@ -13,10 +13,9 @@ export const buildVersionService = service
         providesTags: () => [{ id: 'BuildVersion', type: 'BuildVersion' }],
         queryFn: async (args, _, _2, baseQuery) => {
           try {
-            const backendVersionUrl =
-              Project.api === '/api/v1/'
-                ? '/_backend_version'
-                : `${Project.api.replace('api/v1/', '')}version/`
+            const backendVersionUrl = Project.apiProxyEnabled
+              ? '/_backend_version'
+              : `${Project.api.replace('api/v1/', '')}version/`
             const [frontendRes, backendRes] = await Promise.all([
               data.get(`/version`).catch(() => ({})),
               data.get(backendVersionUrl),


### PR DESCRIPTION
## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/7069

Uses a new attribute in projectOverrides to expose whether the FE proxy is enabled, instead of relying on the API URL being `/api/v1/` which is true in the case where the FE proxy is enabled, but also in the all-in-one image. This ensures that the FE calls the BE correctly to get the version endpoint. 

Note: what this still doesn't solve is the FE trying to get its own version in the all-in-one deployment scenario, but since it's a handled case, and the FE doesn't really _have_ a version in this scenario, it's not really worth worrying about. 

## How did you test this code?

Ran Flagsmith in all 3 deployment setups using docker compose and verified that the version endpoint is returned correctly.  

- [x] All-in-one
- [x] Separate FE / API no proxy
- [x] Separate FE / API with FE proxy