### PR TITLE
feat(saas-billing): Invoice immediately for new seats

### DIFF
--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -232,7 +232,7 @@ def add_single_seat(subscription_id: str) -> None:
                     )
                 ],
                 prorate=True,
-                invoice_immediately=False,
+                invoice_immediately=True,
             ),
         )
 

--- a/api/organisations/chargebee/constants.py
+++ b/api/organisations/chargebee/constants.py
@@ -1,4 +1,4 @@
-ADDITIONAL_SEAT_ADDON_ID = "additional-team-members-scale-up-v2-monthly"
+ADDITIONAL_SEAT_ADDON_ID = "additional-team-members-scale-up-v2"
 
 ADDITIONAL_API_START_UP_ADDON_ID = "additional-api-start-up-monthly"
 ADDITIONAL_API_SCALE_UP_ADDON_ID = "additional-api-scale-up-monthly"

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -546,7 +546,7 @@ def test_add_single_seat__existing_addon__increments_quantity(mocker) -> None:  
                 )
             ],
             prorate=True,
-            invoice_immediately=False,
+            invoice_immediately=True,
         ),
     )
 
@@ -585,7 +585,7 @@ def test_add_single_seat__no_existing_addon__creates_addon_with_quantity_one(  #
                 )
             ],
             prorate=True,
-            invoice_immediately=False,
+            invoice_immediately=True,
         ),
     )
 
@@ -637,7 +637,7 @@ def test_add_single_seat__api_error__raises_upgrade_seats_error(  # type: ignore
                 )
             ],
             prorate=True,
-            invoice_immediately=False,
+            invoice_immediately=True,
         ),
     )
     assert len(caplog.records) == 1


### PR DESCRIPTION
## Changes

Resolves https://github.com/Flagsmith/flagsmith-private/issues/108

- Invoices scale-up customers immediately for new seats instead of pro-rating to the next billing cycle. 
- Uses a new addon which ensures that addons are billed according to the correct billing frequency

## How did you test this code?

Existing unit tests should cover the behaviour, but I will also test manually in staging. 
