### PR TITLE
fix(account-dropdown):  fix contrast issues in dark mode

### DIFF
--- a/frontend/web/components/navigation/AccountDropdown.tsx
+++ b/frontend/web/components/navigation/AccountDropdown.tsx
@@ -56,7 +56,7 @@ const AccountDropdown: React.FC = () => {
   return (
     <div className='feature-action' tabIndex={-1}>
       <button
-        className='btn btn-link p-0 d-flex ps-3 lh-1 align-items-center'
+        className='account-dropdown-trigger d-flex ps-3 lh-1 align-items-center text-default'
         onClick={(e) => {
           e.stopPropagation()
           setIsOpen(!isOpen)
@@ -65,8 +65,8 @@ const AccountDropdown: React.FC = () => {
         id='account-settings-link'
         data-test='account-settings-link'
       >
-        <span className='mr-1'>
-          <Icon name='person' width={20} fill='#9DA4AE' />
+        <span className='mr-1 icon-secondary'>
+          <Icon name='person' width={20} />
         </span>
         <span className='d-none d-md-block'>Account</span>
       </button>

--- a/frontend/web/styles/project/_project-nav.scss
+++ b/frontend/web/styles/project/_project-nav.scss
@@ -13,6 +13,17 @@ nav a {
     font-weight: bold;
   }
 }
+.account-dropdown-trigger {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+
+  &:hover,
+  &:focus {
+    color: var(--color-text-action);
+  }
+}
 .nav-sub-link-disabled {
   cursor: not-allowed;
   span {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6902

Replace `btn btn-link` with scoped `.account-dropdown-trigger` styles using semantic design tokens:
- Uses `--color-text-default` for theme-aware text colour (dark in light mode, white in dark mode)
- Purple hover state (`--color-text-action`) on label text only, not the icon
- Removes dependency on Bootstrap button classes that forced low-contrast brand purple

## How did you test this code?

Manually verified in both light and dark mode:
- "Account" text is readable against the navbar background in both themes
- Hover state turns only the "Account" label purple, icon remains unchanged
- Button behaviour (click to open dropdown) unchanged