### PR TITLE
fix: Skip logout endpoint in e2e

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -357,7 +357,10 @@ const controller = {
         return
       }
 
-      data.post(`${Project.api}auth/logout/`, {}
+      //Skip logout in E2E since parallel sessions may be using a shared token
+      ;(E2E
+        ? Promise.resolve()
+        : data.post(`${Project.api}auth/logout/`, {})
       ).finally(() => {
         API.setCookie('t', '')
         data.setToken(null)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

https://github.com/Flagsmith/flagsmith/pull/7067 introduced calling the logout endpoint when a user clicks logout. The problem with this is that when a user logs in it reuses an existing token if one exists, meaning that logging out in 1 test invalidated existing sessions.

## How did you test this code?

E2E