### PR TITLE
fix: add null validation for environment in FeatureStateSerializerBasic

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -588,7 +588,7 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
 
         except django.core.exceptions.ValidationError as e:
             raise serializers.ValidationError(str(e))
-        
+
     def validate_feature(self, feature):  # type: ignore[no-untyped-def]
         if self.instance and self.instance.feature_id != feature.id:  # type: ignore[union-attr]
             raise serializers.ValidationError(
@@ -598,9 +598,7 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
 
     def validate_environment(self, environment):  # type: ignore[no-untyped-def]
         if environment is None:
-            raise serializers.ValidationError(
-                "Environment cannot be null"
-            )
+            raise serializers.ValidationError("Environment cannot be null")
 
         if self.instance and self.instance.environment_id != environment.id:  # type: ignore[union-attr]
             raise serializers.ValidationError(

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -588,7 +588,7 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
 
         except django.core.exceptions.ValidationError as e:
             raise serializers.ValidationError(str(e))
-
+        
     def validate_feature(self, feature):  # type: ignore[no-untyped-def]
         if self.instance and self.instance.feature_id != feature.id:  # type: ignore[union-attr]
             raise serializers.ValidationError(
@@ -597,6 +597,11 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
         return feature
 
     def validate_environment(self, environment):  # type: ignore[no-untyped-def]
+        if environment is None:
+            raise serializers.ValidationError(
+                "Environment cannot be null"
+            )
+
         if self.instance and self.instance.environment_id != environment.id:  # type: ignore[union-attr]
             raise serializers.ValidationError(
                 "Cannot change the environment of a feature state"


### PR DESCRIPTION
## Summary
- Added validation in `FeatureStateSerializerBasic.validate_environment` to raise a `ValidationError` when the environment is `None`, preventing a 500 error response.

## Test plan
- [ ] Verify that sending a request with a null environment returns a 400 with a descriptive error message instead of a 500.
- [ ] Verify existing environment validation (cannot change environment of a feature state) still works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)