### PR TITLE
docs: Remove deny change request from docs

### DIFF
--- a/docs/docs/administration-and-security/access-control/rbac.md
+++ b/docs/docs/administration-and-security/access-control/rbac.md
@@ -183,7 +183,7 @@ Permissions can be assigned at four levels: user group, organisation, project, a
 | Manage identities        | Grants read and write access to identities in this environment.                                                          |               |
 | Manage segment overrides | Grants write access to segment overrides in this environment.                                                            |               |
 | Create change request    | Allows creating change requests for features in this environment.                                                        | Yes           |
-| Approve change request   | Allows approving or denying change requests in this environment.                                                         | Yes           |
+| Approve change request   | Allows approving change requests in this environment.                                                         | Yes           |
 | View identities          | Grants read-only access to identities in this environment.                                                               |               |
 
 ### Permission levels explained

--- a/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
+++ b/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
@@ -36,7 +36,7 @@ Change Requests awaiting approval are listed in the **Change Request** area.
 
 1.  Click on a **Change Request** to view its details.
 2.  Review the current and new Flag values.
-3.  Click **Approve** or **Deny** to record your decision.
+3.  Click **Approve** to record your decision.
 
 ## Publish a Change Request
 


### PR DESCRIPTION
## Changes

Removes references to unsupported 'Deny' option in docs. 

## How did you test this code?

Trivial wording change - test n/a
