### PR TITLE
docs: Remove duplicate Prometheus metrics table from monitoring page

### DIFF
--- a/docs/docs/deployment-self-hosting/scaling-and-performance/monitoring.md
+++ b/docs/docs/deployment-self-hosting/scaling-and-performance/monitoring.md
@@ -3,9 +3,12 @@ title: Monitoring
 description: Setting up monitoring integrations like AppDynamics and StatsD.
 ---
 
-Monitoring your Flagsmith instance is crucial for keeping things running smoothly, spotting issues early, and making sure your platform is performing as expected. Whether you're running a small self-hosted setup or a large-scale deployment, having the right monitoring tools in place will help you keep tabs on system health, performance, and usage.
+Monitoring your Flagsmith instance is crucial for keeping things running smoothly, spotting issues early, and making
+sure your platform is performing as expected. Whether you're running a small self-hosted setup or a large-scale
+deployment, having the right monitoring tools in place will help you keep tabs on system health, performance, and usage.
 
-This page covers how to integrate Flagsmith with popular monitoring solutions like AppDynamics and StatsD. We'll walk you through the setup steps and share some tips for getting the most out of your monitoring stack.
+This page covers how to integrate Flagsmith with popular monitoring solutions like AppDynamics and StatsD. We'll walk
+you through the setup steps and share some tips for getting the most out of your monitoring stack.
 
 ## AppDynamics
 
@@ -15,7 +18,8 @@ AppDynamics is an Enterprise only feature.
 
 :::
 
-The application supports the use of AppDynamics for monitoring purposes. In order to set up AppDynamics for your environment, follow the steps below:
+The application supports the use of AppDynamics for monitoring purposes. In order to set up AppDynamics for your
+environment, follow the steps below:
 
 :::note
 
@@ -25,11 +29,14 @@ There is a bug in the AppDynamics wizard that sets the value `ssl = (on)` which 
 
 1. Set up your application in your AppDynamics dashboard using the "Getting Started Wizard - Python".
 2. In the wizard, you will need to select the "uWSGI with Emperor: Module Directive" when choosing a deployment method.
-3. On completing the wizard, you will be provided with a configuration file like the one seen here in the appdynamics.template.cfg provided, except with your application information. Make a copy of this information and place it in a file.
+3. On completing the wizard, you will be provided with a configuration file like the one seen here in the
+   appdynamics.template.cfg provided, except with your application information. Make a copy of this information and
+   place it in a file.
 
 ### Running with Docker
 
-When running with traditional Docker, you can use the code snippet below to inject the required information for running AppDynamics:
+When running with traditional Docker, you can use the code snippet below to inject the required information for running
+AppDynamics:
 
 ```shell
 docker run -t \{image_name\} -v \{config_file_path\}:/etc/appdynamics.cfg -e APP_DYNAMICS=on
@@ -42,7 +49,8 @@ Replacing the values for:
 
 ### Running with Docker Compose
 
-When running with the `docker-compose.yml` file provided, ensure the `APP_DYNAMICS` environment variable is set to `on` as seen below:
+When running with the `docker-compose.yml` file provided, ensure the `APP_DYNAMICS` environment variable is set to `on`
+as seen below:
 
 ```yaml
 api:
@@ -71,24 +79,14 @@ docker-compose -f docker-compose.yml up
 
 ### Additional Settings
 
-If you need additional AppDynamics setup options, you can find the other environment variables you can set [here](https://docs.appdynamics.com/display/PRO21/Python+Agent+Settings).
+If you need additional AppDynamics setup options, you can find the other environment variables you can set
+[here](https://docs.appdynamics.com/display/PRO21/Python+Agent+Settings).
 
 ## Prometheus
 
 To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` environment variable to `true`.
 
-The metrics provided by Flagsmith are described below.
-
-| Metric Name | Type | Description | Labels |
-|-------------|------|-------------|--------|
-| `flagsmith_build_info` | Gauge | Flagsmith version and build information | `ci_commit_sha`, `version` |
-| `flagsmith_environment_document_cache_queries` | Counter | Results of cache retrieval for environment document. `result` label is either `hit` or `miss` | `result` |
-| `flagsmith_http_server_request_duration_seconds` | Histogram | HTTP request duration in seconds | `route`, `method`, `response_status` |
-| `flagsmith_http_server_requests` | Counter | Total number of HTTP requests | `route`, `method`, `response_status` |
-| `flagsmith_http_server_response_size_bytes` | Histogram | HTTP response size in bytes | `route`, `method`, `response_status` |
-| `flagsmith_task_processor_enqueued_tasks` | Counter | Total number of enqueued tasks | `task_identifier` |
-| `flagsmith_task_processor_finished_tasks` | Counter | Total number of finished tasks. Only collected by Task Processor. `task_type` label is either `recurring` or `standard` | `task_identifier`, `task_type`, `result` |
-| `flagsmith_task_processor_task_duration_seconds` | Histogram | Task processor task duration in seconds. Only collected by Task Processor. `task_type` label is either `recurring` or `standard` | `task_identifier`, `task_type`, `result` |
+For the full list of metrics, see the [Metrics reference](/administration-and-security/platform-configuration/metrics).
 
 ## StatsD
 
@@ -100,14 +98,17 @@ There are a number of options for monitoring the task processor's health.
 
 ### Health Checks
 
-A task processor container exposes `/health/readiness` and `/health/liveness` endpoints for readiness and liveness probes. The endpoints run simple availability checks. To include a test that enqueues a task and makes sure it's run to your readiness probe, set `ENABLE_TASK_PROCESSOR_HEALTH_CHECK` environment variable to `True`.
+A task processor container exposes `/health/readiness` and `/health/liveness` endpoints for readiness and liveness
+probes. The endpoints run simple availability checks. To include a test that enqueues a task and makes sure it's run to
+your readiness probe, set `ENABLE_TASK_PROCESSOR_HEALTH_CHECK` environment variable to `True`.
 
 ### Task Statistics
 
-Both API and task processor expose an endpoint which returns task processor statistics in JSON format. This endpoint is available at `GET /processor/monitoring`. See an example response below:
+Both API and task processor expose an endpoint which returns task processor statistics in JSON format. This endpoint is
+available at `GET /processor/monitoring`. See an example response below:
 
 ```json
 {
- "waiting": 1  // The number of tasks waiting in the queue.
+ "waiting": 1 // The number of tasks waiting in the queue.
 }
 ```


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The [monitoring page](https://docs.flagsmith.com/deployment-self-hosting/scaling-and-performance/monitoring#prometheus) had a hand-maintained copy of the Prometheus metrics table. The authoritative, auto-generated reference lives at [/administration-and-security/platform-configuration/metrics](https://docs.flagsmith.com/administration-and-security/platform-configuration/metrics).

This PR replaces the stale table with a one-liner linking to the metrics reference page.

## How did you test this code?

Verified the cross-link resolves correctly in the Docusaurus build.