### PR TITLE
docs: Add project-level import/export specification

### DIFF
--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -154,7 +154,9 @@ overwritten, all of its rules, conditions, and associated feature overrides are 
 All entities are matched by name across instances, not by internal ID. This means exports are portable between Flagsmith
 instances. Specifically:
 
-- Features and segments are matched by name.
+- Features are matched by name (unique per project).
+- Segments are matched by name. If duplicates exist in the target project, the first match is used. If the export
+  contains duplicate segment names, all are imported.
 - Tags are matched by label.
 - Environments are matched by name. Missing environments are created with settings from the export. For existing
   environments, the Skip strategy leaves settings unchanged, while Overwrite Destructive updates settings to match the

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -6,8 +6,8 @@ sidebar_position: 30
 
 Flagsmith supports two levels of bulk import and export from the UI:
 
-- **[Environment-level](#environment-level-export)**: export and import default feature states for a single environment.
-  Useful for quickly copying feature values between environments or projects.
+- **[Environment-level](#environment-level-export)**: export features with one environment's values. Useful for copying
+  feature configuration between environments or projects.
 - **[Project-level](#project-level-export)**: export and import an entire project's feature configuration, including
   segments, segment overrides, and optionally identity overrides and tags. Useful for cloning a project or migrating
   between Flagsmith instances.

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -104,14 +104,17 @@ The following data can optionally be included in the export. You will be prompte
 | Custom fields and metadata | Off     |                                                           |
 | Integration configurations | Off     | Includes third-party integration settings per environment |
 
-The following data is **never** included in a project-level export:
+:::caution
 
+The following data is **never** included in a project-level export:
 - Users, owners, and group owners
 - Change requests and approvals
 - Scheduled flag changes
 - Version history (only the current live state is exported)
 - Audit logs
 - Flag analytics
+
+:::
 
 ### Export format
 

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -9,8 +9,8 @@ Flagsmith supports two levels of bulk import and export from the UI:
 - **[Environment-level](#environment-level-export)**: export and import default feature states for a single environment.
   Useful for quickly copying feature values between environments or projects.
 - **[Project-level](#project-level-export)**: export and import an entire project's feature configuration, including
-  segments, segment overrides, and optionally identity overrides, tags, and custom fields. Useful for cloning a project
-  or migrating between Flagsmith instances.
+  segments, segment overrides, and optionally identity overrides and tags. Useful for cloning a project or migrating
+  between Flagsmith instances.
 
 For exporting an entire organisation (including all projects), see
 [Organisation Import and Export](organisations-import-export).
@@ -93,20 +93,19 @@ Project-level export always includes the following data:
 | Multivariate options and weights                | Always   |                         |
 | Segments (rules and conditions)                 | Always   |                         |
 | Segment overrides per environment               | Always   |                         |
-| Environment names and keys                      | Always   |                         |
+| Environment names and settings                  | Always   | See below               |
 
 The following data can optionally be included in the export. You will be prompted to select these options in the UI:
 
-| Data                       | Default | Notes                                                     |
-| -------------------------- | ------- | --------------------------------------------------------- |
-| Identity overrides         | Off     | Can significantly increase export size                    |
-| Tags                       | On      |                                                           |
-| Custom fields and metadata | Off     |                                                           |
-| Integration configurations | Off     | Includes third-party integration settings per environment |
+| Data               | Default | Notes                                  |
+| ------------------ | ------- | -------------------------------------- |
+| Tags               | On      |                                        |
+| Identity overrides | Off     | Can significantly increase export size |
 
 :::caution
 
 The following data is **never** included in a project-level export:
+
 - Users, owners, and group owners
 - Change requests and approvals
 - Scheduled flag changes
@@ -115,6 +114,15 @@ The following data is **never** included in a project-level export:
 - Flag analytics
 
 :::
+
+#### Environment settings
+
+The following environment settings are included in the export: change request approval requirements, client trait
+permissions, banner text and colour, hide disabled flags, identity composite key hashing, hide sensitive data, feature
+versioning, and identity overrides in local evaluation.
+
+Environment API keys are **not** exported — new keys are generated automatically for any environments created during
+import.
 
 ### Exporting
 
@@ -145,13 +153,14 @@ overwritten, all of its rules, conditions, and associated feature overrides are 
 
 #### How entities are matched
 
-All entities are matched by name across instances, not by internal ID. This means exports are portable between
-Flagsmith instances. Specifically:
+All entities are matched by name across instances, not by internal ID. This means exports are portable between Flagsmith
+instances. Specifically:
 
 - Features and segments are matched by name.
 - Tags are matched by label.
-- Environments are matched by name. If the export contains environments that do not exist in the target project,
-  they are created automatically.
+- Environments are matched by name. Missing environments are created with settings from the export. For existing
+  environments, the Skip strategy leaves settings unchanged, while Overwrite Destructive updates settings to match the
+  export.
 
 #### Versioning
 

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -6,8 +6,8 @@ sidebar_position: 30
 
 Flagsmith supports two levels of bulk import and export from the UI:
 
-- **[Environment-level](#environment-level-export)**: export features with one environment's values. Useful for copying
-  feature configuration between environments or projects.
+- **[Environment-level](#environment-level-export)**: export and import default feature states for a single environment.
+  Useful for quickly copying feature values between environments or projects.
 - **[Project-level](#project-level-export)**: export and import an entire project's feature configuration, including
   segments, segment overrides, and optionally identity overrides and tags. Useful for cloning a project or migrating
   between Flagsmith instances.

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -136,9 +136,8 @@ overwritten, all of its rules, conditions, and associated feature overrides are 
 
 #### Versioning
 
-If the target project uses [V2 feature versioning](/managing-flags/version-history), importing with the Overwrite
-Destructive strategy will create new feature versions for any features that are modified. The Skip strategy does not
-create new versions.
+If the target project uses feature versioning, importing with the Overwrite Destructive strategy will create new
+feature versions for any features that are modified. The Skip strategy does not create new versions.
 
 #### Environments
 

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -77,8 +77,6 @@ Overwrite Destructive merge strategy.
 
 ## Project-level export
 
-<!-- TODO: confirm plan availability -->
-
 Project-level export captures the full feature configuration for a project, including segments and overrides. This is
 the recommended way to clone a project or migrate feature configuration between Flagsmith instances.
 

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -77,7 +77,7 @@ Overwrite Destructive merge strategy.
 
 ## Project-level export
 
-{/_ TODO: confirm plan availability _/}
+<!-- TODO: confirm plan availability -->
 
 Project-level export captures the full feature configuration for a project, including segments and overrides. This is
 the recommended way to clone a project or migrate feature configuration between Flagsmith instances.

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -154,9 +154,7 @@ overwritten, all of its rules, conditions, and associated feature overrides are 
 All entities are matched by name across instances, not by internal ID. This means exports are portable between Flagsmith
 instances. Specifically:
 
-- Features are matched by name (unique per project).
-- Segments are matched by name. If duplicates exist in the target project, the first match is used. If the export
-  contains duplicate segment names, all are imported.
+- Features and segments are matched by name.
 - Tags are matched by label.
 - Environments are matched by name. Missing environments are created with settings from the export. For existing
   environments, the Skip strategy leaves settings unchanged, while Overwrite Destructive updates settings to match the

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -116,12 +116,6 @@ The following data is **never** included in a project-level export:
 
 :::
 
-### Export format
-
-Project-level exports use a JSON format that is a superset of the
-[environment-level export format](#environment-level-export). An environment-level export file can be imported using
-project-level import (but not the other way around, since it contains additional data).
-
 ### Exporting
 
 On the Export tab of the project settings page, select **Project Export**. Choose which optional data to include, then
@@ -129,21 +123,37 @@ click Export Project.
 
 The export runs asynchronously. Once complete, you can download the export file from the list at the bottom of the page.
 
+:::info
+
+Exporting requires project administrator permissions.
+
+:::
+
 ### Importing
 
 On the Import tab of the project settings page, select **Project Import**. Upload the export file and select the merge
 strategy.
 
+:::info
+
+Importing requires organisation administrator permissions.
+
+:::
+
 When using Overwrite Destructive, segments and their overrides are treated as a single unit: if a segment is
 overwritten, all of its rules, conditions, and associated feature overrides are replaced.
 
+#### How entities are matched
+
+All entities are matched by name across instances, not by internal ID. This means exports are portable between
+Flagsmith instances. Specifically:
+
+- Features and segments are matched by name.
+- Tags are matched by label.
+- Environments are matched by name. If the export contains environments that do not exist in the target project,
+  they are created automatically.
+
 #### Versioning
 
-If the target project uses feature versioning, importing with the Overwrite Destructive strategy will create new
-feature versions for any features that are modified. The Skip strategy does not create new versions.
-
-#### Environments
-
-If the export contains environments that do not exist in the target project, they will be created automatically. If an
-environment with the same name already exists, the import will update feature states in that environment according to
-the selected merge strategy.
+If the target project uses feature versioning, importing with the Overwrite Destructive strategy will create new feature
+versions for any features that are modified. The Skip strategy does not create new versions.

--- a/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/bulk-import-and-export.md
@@ -4,9 +4,40 @@ sidebar_label: Bulk Import & Export
 sidebar_position: 30
 ---
 
-The bulk import and export of feature data associated with a given environment is possible in Flagsmith. The feature data that is exported includes multivariate features, but does not include other data such as tags, owners, group owners, etc. This functionality is useful for transferring features between any running instances of Flagsmith, even when only a subset of features (for example, importing features of a given tag) is needed.
+Flagsmith supports two levels of bulk import and export from the UI:
 
-## What is exported?
+- **[Environment-level](#environment-level-export)**: export and import default feature states for a single environment.
+  Useful for quickly copying feature values between environments or projects.
+- **[Project-level](#project-level-export)**: export and import an entire project's feature configuration, including
+  segments, segment overrides, and optionally identity overrides, tags, and custom fields. Useful for cloning a project
+  or migrating between Flagsmith instances.
+
+For exporting an entire organisation (including all projects), see
+[Organisation Import and Export](organisations-import-export).
+
+## Common concepts
+
+### Merge strategy
+
+When importing, you must select a merge strategy to handle entities that already exist in the target project:
+
+- **Skip**: existing entities are left unchanged. Only new entities from the export file are created. For example, if
+  you are importing ten features but two already exist, only eight will be added. This is the safest option and is best
+  for organisations that want to retain their existing data.
+- **Overwrite Destructive**: existing entities that match by name are deleted and recreated from the export file. **This
+  affects all environments.** Only use this when every entity in the export is known to be authoritative.
+
+### Retention
+
+Export files are available for download for two weeks. If an export is needed for a longer period, download it and store
+a local backup.
+
+## Environment-level export
+
+Environment-level export captures default feature states for a single environment. This is the simplest way to copy
+feature values between environments or projects.
+
+### What is exported?
 
 We **will** export the following data:
 
@@ -23,28 +54,94 @@ We **will not** export the following data:
 - Tags associated with Flags
 - Individual and group owners associated with Flags
 
-## Exporting
+### Exporting
 
-On the Export tab of the project settings page, it is possible to export the project's features using the environment's values. Simply select the source environment from the drop-down list and, if required, select one or more feature tags to filter the features.
+On the Export tab of the project settings page, select **Environment Export** and choose the source environment from the
+drop-down list. If required, select one or more feature tags to filter the features.
 
-By clicking the Export Features button, the feature export should quickly process and a list of processed feature exports is available at the bottom of the page.
+By clicking the Export Features button, the feature export should quickly process and a list of processed feature
+exports is available at the bottom of the page.
 
-:::tip
-Feature exports are available for only two weeks, so if an export is needed for a longer period, be sure to make a local backup.
-:::
+### Importing
 
-## Importing
-
-On the Import tab of the project settings page, you will find the feature import functionality, complete with file upload at the bottom of the page.
+On the Import tab of the project settings page, select **Environment Import**. You will find the feature import
+functionality, complete with file upload at the bottom of the page.
 
 :::caution
-The target environment is the environment to inherit the features of the exported environment. All other environments will be set to the values defined when the feature was initially created. Use with caution, especially when using the Overwrite Destructive merge strategy.
+
+The target environment is the environment to inherit the features of the exported environment. All other environments
+will be set to the values defined when the feature was initially created. Use with caution, especially when using the
+Overwrite Destructive merge strategy.
+
 :::
 
-### Merge Strategy
+## Project-level export
 
-Since a feature may have an identical name, it is important to carefully select a merge strategy during a feature import.
+{/_ TODO: confirm plan availability _/}
 
-The first option is the Skip strategy, which allows an import to process a feature export and, at any time a feature has a pre-existing feature present, it skips the import for that given feature. For example, if you are importing ten features but two of them were already there, only eight features will be added to the project. This strategy is best for organisations that want to retain their existing data as closely as possible.
+Project-level export captures the full feature configuration for a project, including segments and overrides. This is
+the recommended way to clone a project or migrate feature configuration between Flagsmith instances.
 
-The second option is the Overwrite Destructive strategy. In contrast to the Skip strategy, the Overwrite Destructive method overwrites your existing features, and it is important to remember that this is across all environments. This strategy is most useful only when every feature that was included in the export was vetted to be authoritative in the target project. 
+### What is exported?
+
+Project-level export always includes the following data:
+
+| Data                                            | Included | Notes                   |
+| ----------------------------------------------- | -------- | ----------------------- |
+| Features (name, type, default value)            | Always   |                         |
+| Feature states per environment (enabled, value) | Always   | Current live state only |
+| Multivariate options and weights                | Always   |                         |
+| Segments (rules and conditions)                 | Always   |                         |
+| Segment overrides per environment               | Always   |                         |
+| Environment names and keys                      | Always   |                         |
+
+The following data can optionally be included in the export. You will be prompted to select these options in the UI:
+
+| Data                       | Default | Notes                                                     |
+| -------------------------- | ------- | --------------------------------------------------------- |
+| Identity overrides         | Off     | Can significantly increase export size                    |
+| Tags                       | On      |                                                           |
+| Custom fields and metadata | Off     |                                                           |
+| Integration configurations | Off     | Includes third-party integration settings per environment |
+
+The following data is **never** included in a project-level export:
+
+- Users, owners, and group owners
+- Change requests and approvals
+- Scheduled flag changes
+- Version history (only the current live state is exported)
+- Audit logs
+- Flag analytics
+
+### Export format
+
+Project-level exports use a JSON format that is a superset of the
+[environment-level export format](#environment-level-export). An environment-level export file can be imported using
+project-level import (but not the other way around, since it contains additional data).
+
+### Exporting
+
+On the Export tab of the project settings page, select **Project Export**. Choose which optional data to include, then
+click Export Project.
+
+The export runs asynchronously. Once complete, you can download the export file from the list at the bottom of the page.
+
+### Importing
+
+On the Import tab of the project settings page, select **Project Import**. Upload the export file and select the merge
+strategy.
+
+When using Overwrite Destructive, segments and their overrides are treated as a single unit: if a segment is
+overwritten, all of its rules, conditions, and associated feature overrides are replaced.
+
+#### Versioning
+
+If the target project uses [V2 feature versioning](/managing-flags/version-history), importing with the Overwrite
+Destructive strategy will create new feature versions for any features that are modified. The Skip strategy does not
+create new versions.
+
+#### Environments
+
+If the export contains environments that do not exist in the target project, they will be created automatically. If an
+environment with the same name already exists, the import will update feature states in that environment according to
+the selected merge strategy.

--- a/docs/docs/administration-and-security/data-management/import-and-export.md
+++ b/docs/docs/administration-and-security/data-management/import-and-export.md
@@ -6,18 +6,19 @@ sidebar_position: 10
 
 You can import and export your data between Flagsmith organisations, instances, or other feature flagging services.
 
-We recommend understanding the [Flagsmith data model](/flagsmith-concepts/data-model) before importing or 
-exporting any data.
+We recommend understanding the [Flagsmith data model](/flagsmith-concepts/data-model) before importing or exporting any
+data.
 
 ## Flagsmith import/export
 
 There are several ways of importing or exporting Flagsmith data:
 
-* [Bulk feature import/export](bulk-import-and-export). Copy all or a subset of features 
-  between Flagsmith projects.
-* [Organisation import/export](organisations-import-export). Export an entire 
-  Flagsmith organisation and copy it to a different Flagsmith instance.
-* Use the [Admin API](/integrating-with-flagsmith/flagsmith-api-overview/admin-api) to manually manage your Flagsmith data.
+- [Bulk import/export](bulk-import-and-export). Copy features between Flagsmith projects at environment level (default
+  feature states) or project level (including segments and overrides).
+- [Organisation import/export](organisations-import-export). Export an entire Flagsmith organisation and copy it to a
+  different Flagsmith instance.
+- Use the [Admin API](/integrating-with-flagsmith/flagsmith-api-overview/admin-api) to manually manage your Flagsmith
+  data.
 
 ## Import from third-party services
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #6761

In this PR, we document the planned project-scoped export/import feature alongside the existing environment-level bulk import/export. This serves as the specification before implementation begins.

Key changes to `bulk-import-and-export.md`:
- Extract shared concepts (merge strategy, retention) into a common section to avoid repetition
- Restructure existing environment-level docs under a clear heading
- Add new project-level export section documenting:
  - What's always included
  - What's optionally included  (identity overrides, tags, custom fields, integrations)
  - What's never included
  - Export format compatibility with environment-level exports
  - Versioning behaviour on import (new versions created in Overwrite Destructive mode)
  - Environment creation behaviour on import

`import-and-export.md` index page now references both levels.

### Preview links

- [Bulk Import & Export](https://docs-git-docs-project-scoped-import-export-flagsmith.vercel.app/administration-and-security/data-management/bulk-import-and-export) (main changed page)
- [Import and Export index](https://docs-git-docs-project-scoped-import-export-flagsmith.vercel.app/administration-and-security/data-management/import-and-export)

## How did you test this code?

Documentation-only change. Verified formatting with `npx prettier --check` and Vercel preview build.