### PR TITLE
fix: include specific IDs in owner validation errors

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -306,22 +306,32 @@ class CreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerializer):
 
     def validate_owners(self, owners: list[FFAdminUser]) -> list[FFAdminUser]:
         project: Project = self.context["project"]
-        for user in owners:
-            if not user.has_project_permission(VIEW_PROJECT, project):
-                raise serializers.ValidationError(
-                    "Some users do not have access to this project."
-                )
+        invalid_users = [
+            user
+            for user in owners
+            if not user.has_project_permission(VIEW_PROJECT, project)
+        ]
+        if invalid_users:
+            invalid_user_ids = [user.id for user in invalid_users]
+            raise serializers.ValidationError(
+                f"Users with ids {invalid_user_ids} do not have access to this project."
+            )
         return owners
 
     def validate_group_owners(
         self, group_owners: list[UserPermissionGroup]
     ) -> list[UserPermissionGroup]:
         project: Project = self.context["project"]
-        for group in group_owners:
-            if group.organisation_id != project.organisation_id:
-                raise serializers.ValidationError(
-                    "Some groups do not belong to this project's organisation."
-                )
+        invalid_groups = [
+            group
+            for group in group_owners
+            if group.organisation_id != project.organisation_id
+        ]
+        if invalid_groups:
+            invalid_group_ids = [group.id for group in invalid_groups]
+            raise serializers.ValidationError(
+                f"Groups with ids {invalid_group_ids} do not belong to this project's organisation."
+            )
         return group_owners
 
     def validate_name(self, name: str):  # type: ignore[no-untyped-def]

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -4750,6 +4750,7 @@ def test_create_feature__group_owner_from_different_org__returns_400(
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "group_owners" in response.json()
+    assert str(other_group.id) in response.json()["group_owners"][0]
 
 
 def test_create_feature__owner_without_project_access__returns_400(
@@ -4773,6 +4774,7 @@ def test_create_feature__owner_without_project_access__returns_400(
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "owners" in response.json()
+    assert str(other_user.id) in response.json()["owners"][0]
 
 
 def test_update_feature__owners_in_request_body__returns_200_without_changes(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Addresses 2 nit comments from @khvn26 on #7067:

- **`validate_owners`**: error message now includes the specific user IDs that lack project access (e.g. `"Users with ids [3, 7] do not have access to this project."`) instead of the generic `"Some users do not have access to this project."`
- **`validate_group_owners`**: error message now includes the specific group IDs that belong to the wrong organisation (e.g. `"Groups with ids [5] do not belong to this project's organisation."`) instead of the generic `"Some groups do not belong to this project's organisation."`

Both validators now collect all invalid entries before raising, so a single error reports every problematic ID at once.

## How did you test this code?

- Updated existing tests (`test_create_feature__group_owner_from_different_org__returns_400` and `test_create_feature__owner_without_project_access__returns_400`) to assert the specific IDs appear in the error response.