### PR TITLE
fix: pinned-flagsmith-to-exact-version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "@dnd-kit/abstract": "^0.3.2",
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
-        "@flagsmith/flagsmith": "^11.0.0-internal.6",
+        "@flagsmith/flagsmith": "11.0.0-internal.7",
         "@gram-ai/elements": "1.27.5",
         "@ionic/react": "^7.5.3",
         "@json-render/react": "0.2.0",
@@ -4340,9 +4340,9 @@
       }
     },
     "node_modules/@flagsmith/flagsmith": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-11.0.0.tgz",
-      "integrity": "sha512-jJB+1O/ctU7TCoIBsV2lgYAUOpShjcSqHkH4nlyqUGeQCGC0ZHto8IvGf+nZwpFAF5Czaphn/anm9MDoZIS3rw==",
+      "version": "11.0.0-internal.7",
+      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-11.0.0-internal.7.tgz",
+      "integrity": "sha512-LIEh63JEcFC1dQxgNw780iIPEL88BuZNuyra1W8eyeixl3v0dUTxDdTmCprtEAGVxQLECe3ElIaOtF0qVh3EKA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@floating-ui/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "@dnd-kit/abstract": "^0.3.2",
     "@dnd-kit/helpers": "^0.3.2",
     "@dnd-kit/react": "^0.3.2",
-    "@flagsmith/flagsmith": "^11.0.0-internal.6",
+    "@flagsmith/flagsmith": "11.0.0-internal.7",
     "@gram-ai/elements": "1.27.5",
     "@ionic/react": "^7.5.3",
     "@json-render/react": "0.2.0",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Pin to exact version otherwise it resolves to latest and `trackEvent` method does not exist

## How did you test this code?
With both versions 