### PR TITLE
feat(gitlab): add frontend components for GitLab integration

### DIFF
--- a/api/tests/unit/integrations/gitlab/test_unit_gitlab_tasks.py
+++ b/api/tests/unit/integrations/gitlab/test_unit_gitlab_tasks.py
@@ -44,7 +44,15 @@ from projects.models import Project
             None,
         ),
     ],
-    ids=["mr", "issue", "work-item", "nested-group", "unknown-format", "no-iid", "no-project-path"],
+    ids=[
+        "mr",
+        "issue",
+        "work-item",
+        "nested-group",
+        "unknown-format",
+        "no-iid",
+        "no-project-path",
+    ],
 )
 def test_parse_resource_url__various_urls__returns_correct_tuple(
     url: str,

--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -492,6 +492,10 @@ const Constants = {
     githubIssue: 'GitHub Issue',
     githubPR: 'Github PR',
   },
+  gitlabType: {
+    gitlabIssue: 'GitLab Issue',
+    gitlabMR: 'GitLab MR',
+  },
   integrationCategoryDescriptions: {
     'All': 'Send data on what flags served to each identity.',
     'Analytics': 'Send data on what flags served to each identity.',
@@ -684,6 +688,18 @@ const Constants = {
       label: 'Pull Request',
       resourceType: 'pulls',
       type: 'GITHUB',
+    },
+    GITLAB_ISSUE: {
+      id: 3,
+      label: 'Issue',
+      resourceType: 'issues',
+      type: 'GITLAB',
+    },
+    GITLAB_MR: {
+      id: 4,
+      label: 'Merge Request',
+      resourceType: 'merge_requests',
+      type: 'GITLAB',
     },
   },
   roles: {

--- a/frontend/common/hooks/useHasGitlabIntegration.ts
+++ b/frontend/common/hooks/useHasGitlabIntegration.ts
@@ -1,0 +1,12 @@
+import { useGetGitlabIntegrationQuery } from 'common/services/useGitlabIntegration'
+
+export function useHasGitlabIntegration(projectId: number) {
+  const { data } = useGetGitlabIntegrationQuery(
+    { project_id: projectId },
+    { skip: !projectId },
+  )
+
+  return {
+    hasIntegration: !!data?.results?.length,
+  }
+}

--- a/frontend/common/services/useGitlab.ts
+++ b/frontend/common/services/useGitlab.ts
@@ -1,0 +1,73 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+import Utils from 'common/utils/utils'
+
+export const gitlabService = service
+  .enhanceEndpoints({ addTagTypes: ['Gitlab'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      getGitlabProjects: builder.query<
+        Res['gitlabProjects'],
+        Req['getGitlabProjects']
+      >({
+        providesTags: [{ id: 'LIST', type: 'Gitlab' }],
+        query: (query: Req['getGitlabProjects']) => ({
+          url: `projects/${query.project_id}/gitlab/projects/`,
+        }),
+      }),
+      getGitlabResources: builder.query<
+        Res['gitlabResources'],
+        Req['getGitlabResources']
+      >({
+        providesTags: [{ id: 'LIST', type: 'Gitlab' }],
+        query: (query: Req['getGitlabResources']) => ({
+          url:
+            `projects/${query.project_id}/gitlab/${query.gitlab_resource}/` +
+            `?${Utils.toParam({
+              gitlab_project_id: query.gitlab_project_id,
+              page: query.page,
+              page_size: query.page_size,
+              project_name: query.project_name,
+            })}`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function getGitlabResources(
+  store: any,
+  data: Req['getGitlabResources'],
+  options?: Parameters<
+    typeof gitlabService.endpoints.getGitlabResources.initiate
+  >[1],
+) {
+  return store.dispatch(
+    gitlabService.endpoints.getGitlabResources.initiate(data, options),
+  )
+}
+export async function getGitlabProjects(
+  store: any,
+  data: Req['getGitlabProjects'],
+  options?: Parameters<
+    typeof gitlabService.endpoints.getGitlabProjects.initiate
+  >[1],
+) {
+  return store.dispatch(
+    gitlabService.endpoints.getGitlabProjects.initiate(data, options),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useGetGitlabProjectsQuery,
+  useGetGitlabResourcesQuery,
+  // END OF EXPORTS
+} = gitlabService
+
+/* Usage examples:
+const { data, isLoading } = useGetGitlabResourcesQuery({ project_id: 2, gitlab_resource: 'issues', gitlab_project_id: 1, project_name: 'my-project' }, {}) //get hook
+const { data, isLoading } = useGetGitlabProjectsQuery({ project_id: 2 }, {}) //get hook
+gitlabService.endpoints.getGitlabProjects.select({ project_id: 2 })(store.getState()) //access data from any function
+*/

--- a/frontend/common/services/useGitlabIntegration.ts
+++ b/frontend/common/services/useGitlabIntegration.ts
@@ -1,0 +1,118 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const gitlabIntegrationService = service
+  .enhanceEndpoints({ addTagTypes: ['GitlabIntegration'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      createGitlabIntegration: builder.mutation<
+        Res['gitlabIntegrations'],
+        Req['createGitlabIntegration']
+      >({
+        invalidatesTags: [{ id: 'LIST', type: 'GitlabIntegration' }],
+        query: (query: Req['createGitlabIntegration']) => ({
+          body: query.body,
+          method: 'POST',
+          url: `projects/${query.project_id}/integrations/gitlab/`,
+        }),
+      }),
+      deleteGitlabIntegration: builder.mutation<
+        Res['gitlabIntegrations'],
+        Req['deleteGitlabIntegration']
+      >({
+        invalidatesTags: [{ id: 'LIST', type: 'GitlabIntegration' }],
+        query: (query: Req['deleteGitlabIntegration']) => ({
+          method: 'DELETE',
+          url: `projects/${query.project_id}/integrations/gitlab/${query.gitlab_integration_id}/`,
+        }),
+      }),
+      getGitlabIntegration: builder.query<
+        Res['gitlabIntegrations'],
+        Req['getGitlabIntegration']
+      >({
+        providesTags: [{ id: 'LIST', type: 'GitlabIntegration' }],
+        query: (query: Req['getGitlabIntegration']) => ({
+          url: `projects/${query.project_id}/integrations/gitlab/`,
+        }),
+      }),
+      updateGitlabIntegration: builder.mutation<
+        Res['gitlabIntegrations'],
+        Req['updateGitlabIntegration']
+      >({
+        invalidatesTags: [{ id: 'LIST', type: 'GitlabIntegration' }],
+        query: (query: Req['updateGitlabIntegration']) => ({
+          body: query.body,
+          method: 'PATCH',
+          url: `projects/${query.project_id}/integrations/gitlab/${query.gitlab_integration_id}/`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function createGitlabIntegration(
+  store: any,
+  data: Req['createGitlabIntegration'],
+  options?: Parameters<
+    typeof gitlabIntegrationService.endpoints.createGitlabIntegration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    gitlabIntegrationService.endpoints.createGitlabIntegration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function deleteGitlabIntegration(
+  store: any,
+  data: Req['deleteGitlabIntegration'],
+  options?: Parameters<
+    typeof gitlabIntegrationService.endpoints.deleteGitlabIntegration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    gitlabIntegrationService.endpoints.deleteGitlabIntegration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function getGitlabIntegration(
+  store: any,
+  data: Req['getGitlabIntegration'],
+  options?: Parameters<
+    typeof gitlabIntegrationService.endpoints.getGitlabIntegration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    gitlabIntegrationService.endpoints.getGitlabIntegration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function updateGitlabIntegration(
+  store: any,
+  data: Req['updateGitlabIntegration'],
+  options?: Parameters<
+    typeof gitlabIntegrationService.endpoints.updateGitlabIntegration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    gitlabIntegrationService.endpoints.updateGitlabIntegration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useCreateGitlabIntegrationMutation,
+  useDeleteGitlabIntegrationMutation,
+  useGetGitlabIntegrationQuery,
+  useUpdateGitlabIntegrationMutation,
+  // END OF EXPORTS
+} = gitlabIntegrationService

--- a/frontend/common/stores/default-flags.ts
+++ b/frontend/common/stores/default-flags.ts
@@ -87,6 +87,32 @@ const defaultFlags = {
       'tags': ['logging'],
       'title': 'Dynatrace',
     },
+    'gitlab': {
+      'description':
+        'View your Flagsmith flags inside GitLab issues and merge requests.',
+      'docs':
+        'https://docs.flagsmith.com/integrations/project-management/gitlab',
+      'fields': [
+        {
+          'default': 'https://gitlab.com',
+          'key': 'gitlab_instance_url',
+          'label': 'GitLab Instance URL',
+        },
+        {
+          'hidden': true,
+          'key': 'access_token',
+          'label': 'Access Token',
+        },
+        {
+          'key': 'webhook_secret',
+          'label': 'Webhook Secret',
+        },
+      ],
+      'image': '/static/images/integrations/gitlab.svg',
+      'isGitlabIntegration': true,
+      'perEnvironment': false,
+      'title': 'GitLab',
+    },
     'grafana': {
       'description':
         'Receive Flagsmith annotations to your Grafana instance on feature flag and segment changes.',

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -623,6 +623,36 @@ export type Req = {
     github_resource: string
   }>
   getGithubRepos: { installation_id: string; organisation_id: number }
+  // GitLab
+  getGitlabIntegration: { project_id: number; id?: number }
+  createGitlabIntegration: {
+    project_id: number
+    body: {
+      gitlab_instance_url: string
+      access_token: string
+      webhook_secret: string
+    }
+  }
+  updateGitlabIntegration: {
+    project_id: number
+    gitlab_integration_id: number
+    body: {
+      gitlab_project_id?: number
+      project_name?: string
+      tagging_enabled?: boolean
+    }
+  }
+  deleteGitlabIntegration: {
+    project_id: number
+    gitlab_integration_id: number
+  }
+  getGitlabResources: PagedRequest<{
+    project_id: number
+    gitlab_project_id: number
+    project_name: string
+    gitlab_resource: string
+  }>
+  getGitlabProjects: { project_id: number }
   getServersideEnvironmentKeys: { environmentId: string }
   deleteServersideEnvironmentKeys: { environmentId: string; id: string }
   createServersideEnvironmentKeys: {

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -321,6 +321,7 @@ export type IntegrationData = {
   image: string
   fields: IntegrationField[] | undefined
   isExternalInstallation: boolean
+  isGitlabIntegration?: boolean
   perEnvironment: boolean
   title?: string
   organisation?: string
@@ -1162,6 +1163,26 @@ export type Res = {
   githubRepository: PagedResponse<GithubRepository>
   githubResources: GitHubPagedResponse<GithubResource>
   githubRepos: GithubPaginatedRepos<Repository>
+  // GitLab
+  gitlabIntegration: {
+    id: number
+    gitlab_instance_url: string
+    webhook_secret: string
+    project: number
+  }
+  gitlabIntegrations: PagedResponse<Res['gitlabIntegration']>
+  GitlabResource: {
+    web_url: string
+    id: number
+    iid: number
+    title: string
+    state: string
+    merged: boolean
+    draft: boolean
+  }
+  gitlabResources: PagedResponse<Res['GitlabResource']>
+  GitlabProject: { id: number; name: string; path_with_namespace: string }
+  gitlabProjects: PagedResponse<Res['GitlabProject']>
   segmentPriorities: {}
   featureSegment: FeatureState['feature_segment']
   featureVersions: PagedResponse<FeatureVersion>

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -377,10 +377,12 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     return 'identities'
   },
   getIntegrationData() {
-    return Utils.getFlagsmithJSONValue(
+    const data = Utils.getFlagsmithJSONValue(
       'integration_data',
       defaultFlags.integration_data,
     )
+    // Merge default integration entries that may not be in the remote flag yet
+    return { ...defaultFlags.integration_data, ...data }
   },
   getIsEdge() {
     const model = ProjectStore.model as null | ProjectType

--- a/frontend/web/components/ExternalResourcesLinkTab.tsx
+++ b/frontend/web/components/ExternalResourcesLinkTab.tsx
@@ -1,44 +1,55 @@
 import React, { FC, useState } from 'react'
-import ExternalResourcesTable, {
-  ExternalResourcesTableBase,
-} from './ExternalResourcesTable'
-import { ExternalResource, GithubResource } from 'common/types/responses'
+import ExternalResourcesTable from './ExternalResourcesTable'
+import { ExternalResource, GithubResource, Res } from 'common/types/responses'
 import { useCreateExternalResourceMutation } from 'common/services/useExternalResource'
 import Constants from 'common/constants'
 import GitHubResourcesSelect from './GitHubResourcesSelect'
+import GitLabResourcesSelect from './GitLabResourcesSelect'
 import AppActions from 'common/dispatcher/app-actions'
+
+type VcsProvider = 'github' | 'gitlab'
 
 type ExternalResourcesLinkTabType = {
   githubId: string
+  hasIntegrationWithGitlab: boolean
   organisationId: number
   featureId: string
   projectId: number
   environmentId: string
 }
 
-type AddExternalResourceRowType = ExternalResourcesTableBase & {
-  selectedResources?: ExternalResource[]
-  environmentId: string
-  githubId: string
-}
-
 const ExternalResourcesLinkTab: FC<ExternalResourcesLinkTabType> = ({
   environmentId,
   featureId,
   githubId,
+  hasIntegrationWithGitlab,
   organisationId,
   projectId,
 }) => {
   const githubTypes = Object.values(Constants.resourceTypes).filter(
     (v) => v.type === 'GITHUB',
   )
+  const gitlabTypes = Object.values(Constants.resourceTypes).filter(
+    (v) => v.type === 'GITLAB',
+  )
 
+  const hasGithub = !!githubId
+  const hasGitlab = hasIntegrationWithGitlab
+
+  const defaultProvider: VcsProvider =
+    hasGitlab && !hasGithub ? 'gitlab' : 'github'
+  const defaultResourceType =
+    defaultProvider === 'gitlab'
+      ? gitlabTypes[0]?.resourceType
+      : githubTypes[0]?.resourceType
+
+  const [vcsProvider, setVcsProvider] = useState<VcsProvider>(defaultProvider)
   const [createExternalResource] = useCreateExternalResourceMutation()
-  const [resourceType, setResourceType] = useState(githubTypes[0].resourceType)
+  const [resourceType, setResourceType] = useState(defaultResourceType)
   const [selectedResources, setSelectedResources] =
     useState<ExternalResource[]>()
 
-  const addResource = (featureExternalResource: GithubResource) => {
+  const addGithubResource = (featureExternalResource: GithubResource) => {
     const type = Object.keys(Constants.resourceTypes).find(
       (key: string) =>
         Constants.resourceTypes[key as keyof typeof Constants.resourceTypes]
@@ -63,16 +74,90 @@ const ExternalResourcesLinkTab: FC<ExternalResourcesLinkTabType> = ({
       AppActions.refreshFeatures(projectId, environmentId)
     })
   }
+
+  const addGitlabResource = (
+    featureExternalResource: Res['GitlabResource'],
+  ) => {
+    const type = Object.keys(Constants.resourceTypes).find((key: string) => {
+      const rt =
+        Constants.resourceTypes[key as keyof typeof Constants.resourceTypes]
+      return rt.resourceType === resourceType && rt.type === 'GITLAB'
+    })
+    createExternalResource({
+      body: {
+        feature: parseInt(featureId),
+        metadata: {
+          'draft': featureExternalResource.draft,
+          'merged': featureExternalResource.merged,
+          'state': featureExternalResource.state,
+          'title': featureExternalResource.title,
+        },
+        type: type,
+        url: featureExternalResource.web_url,
+      },
+      feature_id: featureId,
+      project_id: projectId,
+    }).then((res) => {
+      if ('error' in res) {
+        toast(`Error adding resource: ${JSON.stringify(res.error)}`, 'danger')
+      } else {
+        toast('External Resource Added')
+      }
+      AppActions.refreshFeatures(projectId, environmentId)
+    })
+  }
+
+  const handleProviderChange = (provider: VcsProvider) => {
+    setVcsProvider(provider)
+    if (provider === 'gitlab') {
+      setResourceType(gitlabTypes[0]?.resourceType)
+    } else {
+      setResourceType(githubTypes[0]?.resourceType)
+    }
+  }
+
   return (
     <>
-      <GitHubResourcesSelect
-        githubId={githubId}
-        resourceType={resourceType}
-        setResourceType={setResourceType}
-        onChange={addResource as any}
-        value={selectedResources?.map((v) => v.url!)}
-        orgId={organisationId}
-      />
+      {hasGithub && hasGitlab && (
+        <div className='d-flex gap-2 mb-3'>
+          <button
+            className={`btn btn-sm ${
+              vcsProvider === 'github' ? 'btn-primary' : 'btn-outline-secondary'
+            }`}
+            onClick={() => handleProviderChange('github')}
+          >
+            GitHub
+          </button>
+          <button
+            className={`btn btn-sm ${
+              vcsProvider === 'gitlab' ? 'btn-primary' : 'btn-outline-secondary'
+            }`}
+            onClick={() => handleProviderChange('gitlab')}
+          >
+            GitLab
+          </button>
+        </div>
+      )}
+      {vcsProvider === 'gitlab' && hasGitlab ? (
+        <GitLabResourcesSelect
+          resourceType={resourceType}
+          setResourceType={setResourceType}
+          onChange={addGitlabResource as any}
+          value={selectedResources?.map((v) => v.url ?? '')}
+          projectId={`${projectId}`}
+          linkedExternalResources={selectedResources}
+        />
+      ) : (
+        <GitHubResourcesSelect
+          githubId={githubId}
+          resourceType={resourceType}
+          setResourceType={setResourceType}
+          onChange={addGithubResource as any}
+          value={selectedResources?.map((v) => v.url ?? '')}
+          orgId={organisationId as unknown as string}
+          linkedExternalResources={selectedResources}
+        />
+      )}
       <ExternalResourcesTable
         featureId={featureId}
         projectId={projectId}

--- a/frontend/web/components/ExternalResourcesTable.tsx
+++ b/frontend/web/components/ExternalResourcesTable.tsx
@@ -10,6 +10,13 @@ import { ExternalResource } from 'common/types/responses'
 import Constants from 'common/constants'
 import Tooltip from './Tooltip'
 
+const getResourceNumber = (url: string, type: string): string => {
+  const isGitlab = type?.startsWith('GITLAB')
+  const match = url.match(/\/(\d+)\/?$/)
+  const num = match ? match[1] : url.replace(/\D/g, '')
+  return isGitlab && type === 'GITLAB_MR' ? `!${num}` : `#${num}`
+}
+
 export type ExternalResourcesTableBase = {
   featureId: string
   projectId: string
@@ -61,9 +68,10 @@ const ExternalResourceRow: FC<ExternalResourceRowType> = ({
             <Tooltip
               title={
                 <Row>
-                  {`${
-                    externalResource?.metadata?.title
-                  } (#${externalResource?.url.replace(/\D/g, '')})`}{' '}
+                  {`${externalResource?.metadata?.title} (${getResourceNumber(
+                    externalResource?.url,
+                    externalResource?.type,
+                  )})`}{' '}
                   <div className='ml-1 mb-1'>
                     <Icon name='open-external-link' width={14} fill='#6837fc' />
                   </div>

--- a/frontend/web/components/GitLabResourcesSelect.tsx
+++ b/frontend/web/components/GitLabResourcesSelect.tsx
@@ -1,0 +1,152 @@
+import React, { FC, useState } from 'react'
+import { ExternalResource, Res } from 'common/types/responses'
+import Utils from 'common/utils/utils'
+import useInfiniteScroll from 'common/useInfiniteScroll'
+import { Req } from 'common/types/requests'
+import {
+  useGetGitlabProjectsQuery,
+  useGetGitlabResourcesQuery,
+} from 'common/services/useGitlab'
+import Constants from 'common/constants'
+
+export type GitLabResourcesSelectType = {
+  onChange: (value: string) => void
+  linkedExternalResources: ExternalResource[] | undefined
+  projectId: string
+  resourceType: string
+  value: string[] | undefined // an array of resource URLs
+  setResourceType: (value: string) => void
+}
+
+type GitLabResourcesValueType = {
+  value: string
+}
+
+const GitLabResourcesSelect: FC<GitLabResourcesSelectType> = ({
+  onChange,
+  projectId,
+  resourceType,
+  setResourceType,
+  value,
+}) => {
+  const gitlabTypes = Object.values(Constants.resourceTypes).filter(
+    (v) => v.type === 'GITLAB',
+  )
+  const [selectedProject, setSelectedProject] = useState<string>('')
+  const gitlabProjectId = selectedProject
+    ? parseInt(selectedProject.split('::')[0])
+    : undefined
+  const projectName = selectedProject
+    ? selectedProject.split('::')[1]
+    : undefined
+
+  const { data: gitlabProjects } = useGetGitlabProjectsQuery({
+    project_id: parseInt(projectId),
+  })
+
+  const { data, isFetching, isLoading, searchItems } = useInfiniteScroll<
+    Req['getGitlabResources'],
+    Res['gitlabResources']
+  >(
+    useGetGitlabResourcesQuery,
+    {
+      gitlab_project_id: gitlabProjectId || 0,
+      gitlab_resource: resourceType,
+      page_size: 100,
+      project_id: parseInt(projectId),
+      project_name: projectName || '',
+    },
+    100,
+    { skip: !resourceType || !projectId || !gitlabProjectId || !projectName },
+  )
+
+  const [searchText, setSearchText] = React.useState('')
+
+  return (
+    <>
+      <label className='cols-sm-2 control-label'>
+        Link new Issue / Merge Request
+      </label>
+      <div className='d-flex gap-2 mb-2'>
+        <div style={{ width: 300 }}>
+          <Select
+            className='react-select w-100'
+            size='select-md'
+            placeholder={'Select Your Repository'}
+            value={
+              gitlabProjects?.results
+                ?.map((p) => ({
+                  label: p.path_with_namespace,
+                  value: `${p.id}::${p.path_with_namespace}`,
+                }))
+                .find((v) => v.value === selectedProject) || null
+            }
+            onChange={(v: any) => setSelectedProject(v?.value)}
+            options={gitlabProjects?.results?.map((p) => ({
+              label: p.path_with_namespace,
+              value: `${p.id}::${p.path_with_namespace}`,
+            }))}
+          />
+        </div>
+        <div style={{ width: 200 }}>
+          <Select
+            autoSelect
+            className='w-100 react-select'
+            size='select-md'
+            placeholder={'Select Type'}
+            value={gitlabTypes.find((v) => v.resourceType === resourceType)}
+            onChange={(v: { resourceType: string }) =>
+              setResourceType(v.resourceType)
+            }
+            options={gitlabTypes.map((e) => {
+              return {
+                label: e.label,
+                resourceType: e.resourceType,
+                value: e.id,
+              }
+            })}
+          />
+        </div>
+      </div>
+      {!!gitlabProjectId && !!projectName && (
+        <div>
+          <Select
+            filterOption={(options: any[]) => {
+              return options
+            }}
+            value={null}
+            size='select-md'
+            placeholder={'Select Your Resource'}
+            onChange={(v: GitLabResourcesValueType) => {
+              onChange(v?.value)
+            }}
+            options={data?.results
+              .filter((v) => !value?.includes(v.web_url))
+              .map((i: Res['GitlabResource']) => {
+                return {
+                  label: `${i.title} !${i.iid}`,
+                  value: i,
+                }
+              })}
+            noOptionsMessage={() =>
+              isLoading || isFetching ? (
+                <div className='py-2'>
+                  <Loader />
+                </div>
+              ) : (
+                'No Results found'
+              )
+            }
+            onInputChange={(e: any) => {
+              setSearchText(e)
+              searchItems(Utils.safeParseEventValue(e))
+            }}
+            data={{ searchText }}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
+export default GitLabResourcesSelect

--- a/frontend/web/components/IntegrationList.tsx
+++ b/frontend/web/components/IntegrationList.tsx
@@ -17,6 +17,8 @@ import Button from './base/forms/Button'
 import Utils from 'common/utils/utils'
 import { useHistory } from 'react-router-dom'
 import each from 'lodash/each'
+import { useGetGitlabIntegrationQuery } from 'common/services/useGitlabIntegration'
+import GitLabSetupPage from './pages/GitLabSetupPage'
 
 const GITHUB_INSTALLATION_SETUP = 'install'
 
@@ -43,6 +45,7 @@ type IntegrationProps = {
     hasIntegrationWithGithub: boolean
     installationId: string
   }
+  hasIntegrationWithGitlab: boolean
 }
 
 const Integration: FC<IntegrationProps> = (props) => {
@@ -50,6 +53,14 @@ const Integration: FC<IntegrationProps> = (props) => {
   const [windowInstallationId, setWindowInstallationId] = useState<string>('')
 
   const add = () => {
+    if (props.integration.isGitlabIntegration && props.projectId) {
+      openModal(
+        'GitLab Integration',
+        <GitLabSetupPage projectId={props.projectId} />,
+        'side-modal',
+      )
+      return
+    }
     const isGithubIntegration =
       props.githubMeta.githubId && props.integration.isExternalInstallation
     if (isGithubIntegration) {
@@ -119,10 +130,12 @@ const Integration: FC<IntegrationProps> = (props) => {
     external,
     image,
     isExternalInstallation,
+    isGitlabIntegration,
     perEnvironment,
     title,
   } = props.integration
   const activeIntegrations = props.activeIntegrations
+  const hasIntegrationWithGitlab = props.hasIntegrationWithGitlab
   const showAdd = !(
     !perEnvironment &&
     activeIntegrations &&
@@ -168,56 +181,68 @@ const Integration: FC<IntegrationProps> = (props) => {
                     Delete Integration
                   </Button>
                 ))}
-              {showAdd && (
-                <>
-                  {external && !isExternalInstallation ? (
-                    <a
-                      href={docs}
-                      target={'_blank'}
-                      className='btn btn-primary btn-xsm ml-3'
-                      id='show-create-segment-btn'
-                      data-test='show-create-segment-btn'
-                      rel='noreferrer'
-                    >
-                      Add Integration
-                    </a>
-                  ) : external &&
-                    isExternalInstallation &&
-                    (windowInstallationId ||
-                      props.githubMeta.hasIntegrationWithGithub) ? (
-                    <Button
-                      className='ml-3'
-                      id='show-create-segment-btn'
-                      data-test='show-create-segment-btn'
-                      onClick={add}
-                      size='xSmall'
-                    >
-                      Manage Integration
-                    </Button>
-                  ) : external &&
-                    !props.githubMeta.hasIntegrationWithGithub &&
-                    isExternalInstallation ? (
-                    <Button
-                      className='ml-3'
-                      id='show-create-segment-btn'
-                      data-test='show-create-segment-btn'
-                      onClick={openChildWin}
-                      size='xSmall'
-                    >
-                      Add Integration
-                    </Button>
-                  ) : (
-                    <Button
-                      className='ml-3'
-                      id='show-create-segment-btn'
-                      data-test='show-create-segment-btn'
-                      onClick={add}
-                      size='xSmall'
-                    >
-                      Add Integration
-                    </Button>
-                  )}
-                </>
+              {isGitlabIntegration ? (
+                <Button
+                  className='ml-3'
+                  id='show-create-segment-btn'
+                  data-test='show-create-segment-btn'
+                  onClick={add}
+                  size='xSmall'
+                >
+                  {hasIntegrationWithGitlab
+                    ? 'Manage Integration'
+                    : 'Add Integration'}
+                </Button>
+              ) : showAdd && (
+                  <>
+                    {external && !isExternalInstallation ? (
+                      <a
+                        href={docs}
+                        target={'_blank'}
+                        className='btn btn-primary btn-xsm ml-3'
+                        id='show-create-segment-btn'
+                        data-test='show-create-segment-btn'
+                        rel='noreferrer'
+                      >
+                        Add Integration
+                      </a>
+                    ) : external &&
+                      isExternalInstallation &&
+                      (windowInstallationId ||
+                        props.githubMeta.hasIntegrationWithGithub) ? (
+                      <Button
+                        className='ml-3'
+                        id='show-create-segment-btn'
+                        data-test='show-create-segment-btn'
+                        onClick={add}
+                        size='xSmall'
+                      >
+                        Manage Integration
+                      </Button>
+                    ) : external &&
+                      !props.githubMeta.hasIntegrationWithGithub &&
+                      isExternalInstallation ? (
+                      <Button
+                        className='ml-3'
+                        id='show-create-segment-btn'
+                        data-test='show-create-segment-btn'
+                        onClick={openChildWin}
+                        size='xSmall'
+                      >
+                        Add Integration
+                      </Button>
+                    ) : (
+                      <Button
+                        className='ml-3'
+                        id='show-create-segment-btn'
+                        data-test='show-create-segment-btn'
+                        onClick={add}
+                        size='xSmall'
+                      >
+                        Add Integration
+                      </Button>
+                    )}
+                  </>
               )}
             </Row>
           </Row>
@@ -251,7 +276,7 @@ const Integration: FC<IntegrationProps> = (props) => {
 interface IntegrationListProps {
   integrations: string[]
   projectId?: string
-  organisationId: string
+  organisationId?: string
 }
 const IntegrationList: FC<IntegrationListProps> = (props) => {
   const [githubId, setGithubId] = useState<number>(0)
@@ -263,6 +288,14 @@ const IntegrationList: FC<IntegrationListProps> = (props) => {
   const history = useHistory()
 
   const organisationId = props.organisationId
+
+  const { data: gitlabIntegrationData } = useGetGitlabIntegrationQuery(
+    { project_id: parseInt(props.projectId || '0') },
+    { skip: !props.projectId },
+  )
+  const hasIntegrationWithGitlab = !!(
+    gitlabIntegrationData?.results?.length ?? 0
+  )
 
   useEffect(() => {
     fetch()
@@ -322,7 +355,7 @@ const IntegrationList: FC<IntegrationListProps> = (props) => {
               return allItems
             })
           }
-          if (key !== 'github') {
+          if (!integration.isExternalInstallation && !integration.isGitlabIntegration) {
             return _data
               .get(
                 `${Project.api}projects/${props.projectId}/integrations/${key}/`,
@@ -462,6 +495,7 @@ const IntegrationList: FC<IntegrationListProps> = (props) => {
                 hasIntegrationWithGithub: hasIntegrationWithGithub,
                 installationId: installationId,
               }}
+              hasIntegrationWithGitlab={hasIntegrationWithGitlab}
               activeIntegrations={activeIntegrations[index]}
               integration={Utils.getIntegrationData()[i]}
             />

--- a/frontend/web/components/modals/CreateEditIntegrationModal.tsx
+++ b/frontend/web/components/modals/CreateEditIntegrationModal.tsx
@@ -65,9 +65,17 @@ const CreateEditIntegration: FC<CreateEditIntegrationProps> = (props) => {
   } = props
   const [fields, setFields] = useState(cloneDeep(integration.fields || []))
 
-  const [formData, setFormData] = useState<Record<string, any>>(
-    data || { fields },
-  )
+  const [formData, setFormData] = useState<Record<string, any>>(() => {
+    if (data) return data
+    // Populate defaults from field definitions
+    const defaults: Record<string, any> = { fields }
+    for (const field of integration.fields || []) {
+      if (field.default !== undefined) {
+        defaults[field.key] = field.default
+      }
+    }
+    return defaults
+  })
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const [authorised, setAuthorised] = useState<boolean>(false)

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -4,6 +4,7 @@ import _ from 'lodash'
 import moment from 'moment'
 import { useProjectEnvironments } from 'common/hooks/useProjectEnvironments'
 import { useHasGithubIntegration } from 'common/hooks/useHasGithubIntegration'
+import { useHasGitlabIntegration } from 'common/hooks/useHasGitlabIntegration'
 import FeatureListStore from 'common/stores/feature-list-store'
 import IdentityProvider from 'common/providers/IdentityProvider'
 import FeatureListProvider from 'common/providers/FeatureListProvider'
@@ -346,6 +347,9 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
     organisationId,
   } = useHasGithubIntegration()
 
+  const { hasIntegration: hasIntegrationWithGitlab } =
+    useHasGitlabIntegration(projectId)
+
   const { permission: createFeaturePermission } = useHasPermission({
     id: projectId,
     level: 'project',
@@ -687,23 +691,25 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       />
                     </TabItem>
                   }
-                  {hasIntegrationWithGithub && projectFlag?.id && (
-                    <TabItem
-                      data-test='external-resources-links'
-                      tabLabelString='Links'
-                      tabLabel={
-                        <Row className='justify-content-center'>Links</Row>
-                      }
-                    >
-                      <ExternalResourcesLinkTab
-                        githubId={githubId}
-                        organisationId={organisationId}
-                        featureId={projectFlag.id}
-                        projectId={projectId}
-                        environmentId={`${environment.id}`}
-                      />
-                    </TabItem>
-                  )}
+                  {(hasIntegrationWithGithub || hasIntegrationWithGitlab) &&
+                    projectFlag?.id && (
+                      <TabItem
+                        data-test='external-resources-links'
+                        tabLabelString='Links'
+                        tabLabel={
+                          <Row className='justify-content-center'>Links</Row>
+                        }
+                      >
+                        <ExternalResourcesLinkTab
+                          githubId={githubId}
+                          hasIntegrationWithGitlab={hasIntegrationWithGitlab}
+                          organisationId={organisationId}
+                          featureId={projectFlag.id}
+                          projectId={projectId}
+                          environmentId={`${environment.id}`}
+                        />
+                      </TabItem>
+                    )}
                   {!existingChangeRequest && flagId && isVersioned && (
                     <TabItem data-test='change-history' tabLabel='History'>
                       <FeatureHistory

--- a/frontend/web/components/mv/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput.tsx
@@ -37,11 +37,7 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
             <>
               {Utils.renderWithPermission(
                 canCreateFeature,
-                readOnly
-                  ? 'Variation values are defined at the feature level and cannot be changed per segment.'
-                  : Constants.projectPermissions(
-                      ProjectPermission.CREATE_FEATURE,
-                    ),
+                Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
                 <ValueEditor
                   data-test={`featureVariationValue${
                     Utils.featureStateToValue(value) || index

--- a/frontend/web/components/pages/CreateGitLabIntegrationForm.tsx
+++ b/frontend/web/components/pages/CreateGitLabIntegrationForm.tsx
@@ -1,0 +1,80 @@
+import React, { FC, useState } from 'react'
+import InputGroup from 'components/base/forms/InputGroup'
+import Button from 'components/base/forms/Button'
+import Utils from 'common/utils/utils'
+
+type CreateGitLabIntegrationFormProps = {
+  projectId: string
+  onCreate: (args: any) => any
+  isCreating: boolean
+}
+
+const CreateGitLabIntegrationForm: FC<CreateGitLabIntegrationFormProps> = ({
+  isCreating,
+  onCreate,
+  projectId,
+}) => {
+  const [instanceUrl, setInstanceUrl] = useState('https://gitlab.com')
+  const [accessToken, setAccessToken] = useState('')
+  const [webhookSecret, setWebhookSecret] = useState(Utils.GUID())
+
+  const handleSubmit = async () => {
+    if (!instanceUrl || !accessToken) return
+    const res = await onCreate({
+      body: {
+        access_token: accessToken,
+        gitlab_instance_url: instanceUrl,
+        webhook_secret: webhookSecret,
+      },
+      project_id: parseInt(projectId),
+    })
+    if ('data' in res) {
+      toast('GitLab integration configured')
+    } else if ('error' in res) {
+      toast('Failed to save integration', 'danger')
+    }
+  }
+
+  return (
+    <div className='px-4 pt-4'>
+      <InputGroup
+        value={instanceUrl}
+        data-test='gitlab-instance-url'
+        inputProps={{ name: 'gitlabInstanceUrl' }}
+        onChange={(e: InputEvent) => setInstanceUrl(Utils.safeParseEventValue(e))}
+        type='text'
+        title='GitLab Instance URL'
+        tooltip='The base URL of your GitLab instance, e.g. https://gitlab.com'
+      />
+      <InputGroup
+        value={accessToken}
+        data-test='gitlab-access-token'
+        inputProps={{ name: 'gitlabAccessToken' }}
+        onChange={(e: InputEvent) => setAccessToken(Utils.safeParseEventValue(e))}
+        type='password'
+        title='Access Token'
+        tooltip='A group or project access token with api scope (Developer role minimum)'
+      />
+      <InputGroup
+        value={webhookSecret}
+        data-test='gitlab-webhook-secret'
+        inputProps={{ name: 'gitlabWebhookSecret' }}
+        onChange={(e: InputEvent) => setWebhookSecret(Utils.safeParseEventValue(e))}
+        type='text'
+        title='Webhook Secret (optional)'
+        tooltip='Custom secret for webhook validation. Leave as-is to use the auto-generated value.'
+      />
+      <div className='mt-3'>
+        <Button
+          theme='primary'
+          disabled={!instanceUrl || !accessToken || isCreating}
+          onClick={handleSubmit}
+        >
+          {isCreating ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default CreateGitLabIntegrationForm

--- a/frontend/web/components/pages/GitLabIntegrationDetails.tsx
+++ b/frontend/web/components/pages/GitLabIntegrationDetails.tsx
@@ -1,0 +1,173 @@
+import React, { FC, useState } from 'react'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/Icon'
+import { Res } from 'common/types/responses'
+
+type GitLabIntegrationDetailsProps = {
+  gitlabIntegration: Res['gitlabIntegration']
+  gitlabProjects: Res['gitlabProjects'] | undefined
+  projectId: string
+  webhookUrl: string
+  onUpdate: (args: any) => any
+  onDelete: (args: any) => any
+}
+
+const GitLabIntegrationDetails: FC<GitLabIntegrationDetailsProps> = ({
+  gitlabIntegration,
+  gitlabProjects,
+  onDelete,
+  onUpdate,
+  projectId,
+  webhookUrl,
+}) => {
+  const [showSecret, setShowSecret] = useState(false)
+  const [selectedGitlabProject, setSelectedGitlabProject] = useState<any>(null)
+
+  const handleLinkRepo = async (
+    gitlabProjectId: number,
+    pathWithNamespace: string,
+  ) => {
+    const res = await onUpdate({
+      body: {
+        gitlab_project_id: gitlabProjectId,
+        project_name: pathWithNamespace,
+      },
+      gitlab_integration_id: gitlabIntegration.id,
+      project_id: parseInt(projectId),
+    })
+    if ('error' in res) {
+      toast(`Error: ${JSON.stringify(res.error)}`, 'danger')
+    } else {
+      toast('GitLab repository linked')
+      setSelectedGitlabProject(null)
+    }
+  }
+
+  const handleDelete = () => {
+    openModal2(
+      'Delete GitLab Integration',
+      <div>
+        <p>
+          Are you sure you want to delete the GitLab integration? This will
+          remove all linked external resources.
+        </p>
+        <div className='text-right'>
+          <Button className='mr-2' onClick={() => closeModal2()}>
+            Cancel
+          </Button>
+          <Button
+            theme='danger'
+            onClick={async () => {
+              await onDelete({
+                gitlab_integration_id: gitlabIntegration.id,
+                project_id: parseInt(projectId),
+              })
+              toast('GitLab integration deleted')
+              closeModal2()
+            }}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>,
+    )
+  }
+
+  const copyToClipboard = (text: string, label: string) => {
+    navigator.clipboard.writeText(text)
+    toast(`${label} copied to clipboard`)
+  }
+
+  return (
+    <div className='px-4 pt-4'>
+      <div className='mb-4'>
+        <p className='text-muted'>
+          Connected to{' '}
+          <strong>{gitlabIntegration.gitlab_instance_url}</strong>
+        </p>
+      </div>
+
+      <div className='mb-4'>
+        <label className='fw-bold mb-1'>GitLab Repository</label>
+        {gitlabIntegration.project_name ? (
+          <div className='d-flex align-items-center'>
+            <code className='p-2 rounded flex-fill' style={{ backgroundColor: '#f0f1f3', color: '#1a2634' }}>
+              {gitlabIntegration.project_name}
+            </code>
+            <Button theme='text' size='small' className='ml-2' onClick={() => handleLinkRepo(0, '')}>
+              Change
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Select
+              size='select-md'
+              placeholder='Select a GitLab project to link'
+              value={selectedGitlabProject ? { label: selectedGitlabProject.path_with_namespace, value: selectedGitlabProject.id } : null}
+              onChange={(v: { value: number }) => {
+                const found = gitlabProjects?.results?.find((p) => p.id === v.value)
+                setSelectedGitlabProject(found || null)
+              }}
+              options={gitlabProjects?.results?.map((p) => ({ label: p.path_with_namespace, value: p.id }))}
+            />
+            {selectedGitlabProject && (
+              <Button theme='primary' className='mt-2' onClick={() => handleLinkRepo(selectedGitlabProject.id, selectedGitlabProject.path_with_namespace)}>
+                Save
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {gitlabIntegration.project_name && (
+        <div className='mb-4'>
+          <Row className='align-items-center'>
+            <Switch
+              checked={gitlabIntegration.tagging_enabled}
+              onChange={() => {
+                onUpdate({
+                  body: { tagging_enabled: !gitlabIntegration.tagging_enabled },
+                  gitlab_integration_id: gitlabIntegration.id,
+                  project_id: parseInt(projectId),
+                })
+              }}
+            />
+            <span className='ml-2'>Enable automatic tagging of features based on issue/MR state</span>
+          </Row>
+        </div>
+      )}
+
+      <div className='mb-4 p-3 rounded' style={{ backgroundColor: '#f8f9fa' }}>
+        <label className='fw-bold mb-1'>Webhook Configuration</label>
+        <p className='text-muted fs-small'>
+          Add this webhook URL to your GitLab project or group settings. Enable triggers for: Issues events, Merge request events.
+        </p>
+        <label className='mb-1'>Webhook URL</label>
+        <Row className='align-items-center mb-2'>
+          <code className='flex-fill p-2 rounded' style={{ backgroundColor: '#e9ecef', color: '#1a2634' }}>{webhookUrl}</code>
+          <Button theme='text' className='ml-2' onClick={() => copyToClipboard(webhookUrl, 'Webhook URL')}>
+            <Icon name='copy' width={16} />
+          </Button>
+        </Row>
+        <label className='mb-1'>Secret Token</label>
+        <Row className='align-items-center'>
+          <code className='flex-fill p-2 rounded' style={{ backgroundColor: '#e9ecef', color: '#1a2634' }}>
+            {showSecret ? gitlabIntegration.webhook_secret : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'}
+          </code>
+          <Button theme='text' className='ml-2' onClick={() => setShowSecret(!showSecret)}>
+            <Icon name={showSecret ? 'eye-off' : 'eye'} width={16} />
+          </Button>
+          <Button theme='text' className='ml-1' onClick={() => copyToClipboard(gitlabIntegration.webhook_secret, 'Webhook secret')}>
+            <Icon name='copy' width={16} />
+          </Button>
+        </Row>
+      </div>
+
+      <div className='text-right'>
+        <Button theme='danger' size='small' onClick={handleDelete}>Delete Integration</Button>
+      </div>
+    </div>
+  )
+}
+
+export default GitLabIntegrationDetails

--- a/frontend/web/components/pages/GitLabSetupPage.tsx
+++ b/frontend/web/components/pages/GitLabSetupPage.tsx
@@ -1,0 +1,62 @@
+import React, { FC } from 'react'
+import {
+  useCreateGitlabIntegrationMutation,
+  useDeleteGitlabIntegrationMutation,
+  useGetGitlabIntegrationQuery,
+  useUpdateGitlabIntegrationMutation,
+} from 'common/services/useGitlabIntegration'
+import { useGetGitlabProjectsQuery } from 'common/services/useGitlab'
+import Project from 'common/project'
+import GitLabIntegrationDetails from './GitLabIntegrationDetails'
+import CreateGitLabIntegrationForm from './CreateGitLabIntegrationForm'
+
+type GitLabSetupPageType = {
+  projectId: string
+}
+
+const GitLabSetupPage: FC<GitLabSetupPageType> = ({ projectId }) => {
+  const [createGitlabIntegration, { isLoading: isCreating }] =
+    useCreateGitlabIntegrationMutation()
+  const [updateGitlabIntegration] = useUpdateGitlabIntegrationMutation()
+  const [deleteGitlabIntegration] = useDeleteGitlabIntegrationMutation()
+
+  const { data: gitlabIntegrations } = useGetGitlabIntegrationQuery(
+    { project_id: parseInt(projectId) },
+    { skip: !projectId },
+  )
+
+  const gitlabIntegration = gitlabIntegrations?.results?.[0]
+
+  const { data: gitlabProjects } = useGetGitlabProjectsQuery(
+    { project_id: parseInt(projectId) },
+    { skip: !gitlabIntegration },
+  )
+
+  const apiHost = Project.api
+    ? Project.api.replace(/\/api\/v1\/?$/, '')
+    : window.location.origin
+  const webhookUrl = `${apiHost}/api/v1/gitlab-webhook/${projectId}/`
+
+  if (gitlabIntegration) {
+    return (
+      <GitLabIntegrationDetails
+        gitlabIntegration={gitlabIntegration}
+        gitlabProjects={gitlabProjects}
+        projectId={projectId}
+        webhookUrl={webhookUrl}
+        onUpdate={updateGitlabIntegration}
+        onDelete={deleteGitlabIntegration}
+      />
+    )
+  }
+
+  return (
+    <CreateGitLabIntegrationForm
+      projectId={projectId}
+      onCreate={createGitlabIntegration}
+      isCreating={isCreating}
+    />
+  )
+}
+
+export default GitLabSetupPage


### PR DESCRIPTION
Add all frontend components for the GitLab integration. Final PR in the stacked series splitting #7028.

## Changes

- [x] RTK Query services: `useGitlabIntegration.ts` (CRUD), `useGitlab.ts` (projects, resources)
- [x] `GitLabSetupPage.tsx` — data-fetching container, delegates to sub-components
- [x] `GitLabIntegrationDetails.tsx` — connected state: repo selection, tagging toggle, webhook config
- [x] `CreateGitLabIntegrationForm.tsx` — credentials input form
- [x] `GitLabResourcesSelect.tsx` — issue/MR search for Links tab
- [x] `useHasGitlabIntegration` hook
- [x] Types: request/response types for all GitLab endpoints
- [x] Constants: GitLab resource types, default integration flags
- [x] Modified: IntegrationList, ExternalResourcesLinkTab, ExternalResourcesTable, create-feature modal

Contributes to #7028
Stacks on #7122

Review effort: 3/5

## Review feedback addressed from #7028

- **Extracted connected-state block** into `GitLabIntegrationDetails` component (Zaimwa9)
- **Extracted setup form** into `CreateGitLabIntegrationForm` component (Zaimwa9)
- **`GitLabSetupPage` focused on data handling** only (Zaimwa9)
- **async/await** in `handleLinkRepo` and `handleDelete` (Zaimwa9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)