### PR TITLE
fix: return null instead of empty string when clearing feature value

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -380,15 +380,17 @@ const controller = {
                 )
               environmentFlag.multivariate_feature_state_values =
                 multivariate_feature_state_values
+              const typedValue = Utils.getTypedValue(
+                flag.initial_value,
+                undefined,
+                true,
+              )
               return data.put(
                 `${Project.api}environments/${environmentId}/featurestates/${environmentFlag.id}/`,
                 Object.assign({}, environmentFlag, {
                   enabled: flag.default_enabled,
-                  feature_state_value: Utils.getTypedValue(
-                    flag.initial_value,
-                    undefined,
-                    true,
-                  ),
+                  feature_state_value:
+                    typedValue === '' ? null : typedValue,
                 }),
               )
             })
@@ -805,7 +807,8 @@ const controller = {
           ).then((res) => {
             const data = Object.assign({}, environmentFlag, {
               enabled: flag.default_enabled,
-              feature_state_value: flag.initial_value,
+              feature_state_value:
+                flag.initial_value === '' ? null : flag.initial_value,
             })
             return createAndSetFeatureVersion(getStore(), {
               environmentId: res,

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -841,7 +841,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     return {
       boolean_value: null,
       integer_value: null,
-      string_value: value === null ? null : val || '',
+      string_value: value === null || val === '' ? null : val,
       type: 'unicode',
     }
   },
@@ -869,7 +869,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     return {
       boolean_value: null,
       integer_value: null,
-      string_value: value === null ? null : val || '',
+      string_value: value === null || val === '' ? null : val,
       value_type: 'unicode',
     }
   },


### PR DESCRIPTION
## Summary
When removing a feature value, the value is set to an empty string `""` instead of `null`. This PR fixes the `valueToFeatureState` and `valueToTrait` utility functions to return `null` when the string value is empty.

## Issue
Fixes #6818

## Changes
- In `valueToFeatureState`: change `value === null ? null : val || ''` to `value === null || val === '' ? null : val`
- In `valueToTrait`: apply the same fix for consistency

The previous expression `val || ''` always produced `''` when `val` was an empty string (falsy), preventing the value from being set back to `null`. The new condition explicitly checks for empty string and returns `null`, matching the initial state of a feature created without a value.

## Testing
1. Create a feature without a value — value should be `null`
2. Set a string value (e.g., "hello")
3. Clear the value (remove all text)
4. The value should now be `null` (not `""`)