### PR TITLE
fix(e2e): skip SDK keys test when feature flag is off

### DIFF
--- a/frontend/e2e/tests/sdk-keys-test.pw.ts
+++ b/frontend/e2e/tests/sdk-keys-test.pw.ts
@@ -1,11 +1,17 @@
 import { test, expect } from '../test-setup'
-import { byId, log, createHelpers } from '../helpers'
+import { byId, log, createHelpers, getFlagsmith } from '../helpers'
 import { E2E_USER, PASSWORD, E2E_TEST_PROJECT } from '../config'
 
 test.describe('SDK Keys Tests', () => {
   test('Server-side SDK keys can be created and deleted @oss', async ({
     page,
   }) => {
+    const flagsmith = await getFlagsmith()
+    if (!flagsmith.hasFeature('rtk_server_side_sdk_keys')) {
+      log('Flag rtk_server_side_sdk_keys is off — skipping test')
+      return
+    }
+
     const {
       click,
       gotoProject,


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #7003

The SDK keys E2E test was written for the new refactored component, but CI doesn't have `rtk_server_side_sdk_keys` enabled. The legacy page renders with different selectors, causing `TimeoutError: locator.waitFor: Timeout 20000ms exceeded` on `[name="name"]`.

Adds a `getFlagsmith()` check at the start of the test — if the flag is off, early return. Follows the existing pattern used for `persona_based_views` in `gotoAccountSettings`.

## How did you test this code?

- Confirmed the timeout failure locally with flag off
- Verified early return triggers correctly when flag is disabled
- Existing E2E tests unaffected