### PR TITLE
fix(e2e): move data-test to visible wrapper in EnvironmentSelect

### DIFF
--- a/frontend/web/components/EnvironmentSelect.tsx
+++ b/frontend/web/components/EnvironmentSelect.tsx
@@ -16,6 +16,7 @@ export type EnvironmentSelectType = Partial<Omit<Props, 'value'>> & {
 }
 
 const EnvironmentSelect: FC<EnvironmentSelectType> = ({
+  'data-test': dataTestProp,
   idField = 'api_key',
   ignore,
   label,
@@ -54,7 +55,7 @@ const EnvironmentSelect: FC<EnvironmentSelectType> = ({
     return <div className='mb-2'>{foundValue?.label}</div>
   }
   return (
-    <div>
+    <div data-test={dataTestProp}>
       <Select
         {...rest}
         className='react-select select-xsm'


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes the ARM E2E timeout on the environment rename test.

React Select puts `...rest` props (including `data-test`) on the hidden `<input>` element. Playwright's `waitForElementVisible` finds the element but it's always hidden — causing a 20s timeout after 44 resolution attempts.

The fix: extract `data-test` from rest props and put it on the visible wrapping `<div>` instead.

```
// Before: data-test lands on hidden <input> inside React Select
<Select {...rest} />  // rest includes data-test

// After: data-test on visible <div> wrapper
<div data-test={dataTestProp}>
  <Select {...rest} />
</div>
```

## How did you test this code?

- Verified on PR #7142 — all 5 E2E jobs pass including ARM (was consistently failing before)
- Trace analysis confirmed the element was found 44 times but always hidden