### PR TITLE
refactor: Migrate users urls+page names to Identities

### DIFF
--- a/frontend/web/components/CompareIdentities.tsx
+++ b/frontend/web/components/CompareIdentities.tsx
@@ -127,7 +127,7 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
     window.open(
       `${
         document.location.origin
-      }/project/${projectId}/environment/${environmentId}/users/${encodeURIComponent(
+      }/project/${projectId}/environment/${environmentId}/identities/${encodeURIComponent(
         user.label,
       )}/${user.value}?flag=${encodeURIComponent(feature)}`,
       '_blank',

--- a/frontend/web/components/modals/create-feature/tabs/IdentityOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/IdentityOverridesTab.tsx
@@ -255,7 +255,7 @@ const IdentityOverridesTab: FC<IdentityOverridesTabProps> = ({
                   <div className='table-column d-flex align-items-center'>
                     <Button
                       target='_blank'
-                      href={`/project/${projectId}/environment/${environmentId}/users/${identity.identifier}/${identity.id}?flag=${projectFlag.name}`}
+                      href={`/project/${projectId}/environment/${environmentId}/identities/${identity.identifier}/${identity.id}?flag=${projectFlag.name}`}
                       className='btn btn-link fs-small lh-sm font-weight-medium me-4'
                     >
                       <Icon name='edit' width={20} fill='#6837FC' /> Edit

--- a/frontend/web/components/navigation/navbars/EnvironmentNavbar.tsx
+++ b/frontend/web/components/navigation/navbars/EnvironmentNavbar.tsx
@@ -117,7 +117,7 @@ const EnvironmentNavbar: FC<EnvironmentNavType> = ({
                 id={mobile ? undefined : 'users-link'}
                 exact
                 icon='people'
-                to={`/project/${projectId}/environment/${environmentId}/users`}
+                to={`/project/${projectId}/environment/${environmentId}/identities`}
               >
                 Identities
               </SidebarLink>

--- a/frontend/web/components/pages/IdentitiesPage.tsx
+++ b/frontend/web/components/pages/IdentitiesPage.tsx
@@ -71,7 +71,7 @@ export const removeIdentity = (
   })
 }
 
-const UsersPage: FC<{ props: any }> = (props) => {
+const IdentitiesPage: FC<{ props: any }> = (props) => {
   const { projectId } = useRouteContext()
   const match = useRouteMatch<RouteParams>()
   const [page, setPage] = useState<{
@@ -250,7 +250,7 @@ const UsersPage: FC<{ props: any }> = (props) => {
                   <Link
                     to={`/project/${projectId}/environment/${
                       props.match.params.environmentId
-                    }/users/${encodeURIComponent(identifier)}/${id}`}
+                    }/identities/${encodeURIComponent(identifier)}/${id}`}
                     className='flex-row flex flex-1 table-column'
                   >
                     <div>
@@ -358,4 +358,4 @@ const UsersPage: FC<{ props: any }> = (props) => {
   )
 }
 
-export default withRouter(ConfigProvider(UsersPage))
+export default withRouter(ConfigProvider(IdentitiesPage))

--- a/frontend/web/components/pages/IdentityIdPage.js
+++ b/frontend/web/components/pages/IdentityIdPage.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react'
 import data from 'common/data/base/_data'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import { withRouter } from 'react-router-dom'
-const UserPage = class extends Component {
-  static displayName = 'UserPage'
+const IdentityIdPage = class extends Component {
+  static displayName = 'IdentityIdPage'
 
   constructor(props, context) {
     super(props, context)
@@ -29,11 +29,11 @@ const UserPage = class extends Component {
           this.props.history.replace(
             `/project/${params.projectId}/environment/${
               params.environmentId
-            }/users/${params.identity}/${user.identity || user.identity_uuid}`,
+            }/identities/${params.identity}/${user.identity || user.identity_uuid}`,
           )
         } else {
           this.props.history.replace(
-            `/project/${params.projectId}/environment/${params.environmentId}/users/`,
+            `/project/${params.projectId}/environment/${params.environmentId}/identities/`,
           )
         }
       })
@@ -50,6 +50,6 @@ const UserPage = class extends Component {
   }
 }
 
-UserPage.propTypes = {}
+IdentityIdPage.propTypes = {}
 
-module.exports = withRouter(ConfigProvider(UserPage))
+module.exports = withRouter(ConfigProvider(IdentityIdPage))

--- a/frontend/web/components/pages/IdentityPage.tsx
+++ b/frontend/web/components/pages/IdentityPage.tsx
@@ -32,7 +32,7 @@ import PanelSearch from 'components/PanelSearch'
 import TryIt from 'components/TryIt'
 import Utils from 'common/utils/utils'
 import _data from 'common/data/base/_data'
-import { removeIdentity } from './UsersPage'
+import { removeIdentity } from './IdentitiesPage'
 import IdentityTraits from 'components/IdentityTraits'
 import { useGetIdentitySegmentsQuery } from 'common/services/useIdentitySegment'
 import useDebouncedSearch from 'common/useDebouncedSearch'
@@ -53,7 +53,7 @@ interface RouteParams {
   identity: string
 }
 
-const UserPage: FC = () => {
+const IdentityPage: FC = () => {
   const match = useRouteMatch<RouteParams>()
   const history = useHistory()
   const params = Utils.fromParam()
@@ -455,7 +455,7 @@ const UserPage: FC = () => {
                           integration again. You can also recreate it in the
                           dashboard from the{' '}
                           <Link
-                            to={`/project/${projectId}/environment/${environmentId}/users`}
+                            to={`/project/${projectId}/environment/${environmentId}/identities`}
                           >
                             Identities Page
                           </Link>
@@ -470,7 +470,7 @@ const UserPage: FC = () => {
                               environmentId,
                               () => {
                                 history.replace(
-                                  `/project/${projectId}/environment/${environmentId}/users`,
+                                  `/project/${projectId}/environment/${environmentId}/identities`,
                                 )
                               },
                             )
@@ -492,4 +492,4 @@ const UserPage: FC = () => {
   )
 }
 
-export default ConfigProvider(UserPage)
+export default ConfigProvider(IdentityPage)

--- a/frontend/web/components/pages/features/components/FeaturesEmptyState.tsx
+++ b/frontend/web/components/pages/features/components/FeaturesEmptyState.tsx
@@ -70,7 +70,7 @@ export const FeaturesEmptyState: FC<FeaturesEmptyStateProps> = ({
             the{' '}
             <Link
               className='btn-link'
-              to={`/project/${projectId}/environment/${environmentId}/users`}
+              to={`/project/${projectId}/environment/${environmentId}/identities`}
             >
               Identities page
             </Link>

--- a/frontend/web/routes.js
+++ b/frontend/web/routes.js
@@ -6,9 +6,9 @@ import HomePage from './components/pages/HomePage'
 import Maintenance from './components/Maintenance'
 import CreateOrganisationPage from './components/pages/CreateOrganisationPage'
 import CreateEnvironmentPage from './components/pages/CreateEnvironmentPage'
-import UsersPage from './components/pages/UsersPage'
-import UserPage from './components/pages/UserPage'
-import UserIdPage from './components/pages/UserIdPage'
+import IdentitiesPage from './components/pages/IdentitiesPage'
+import IdentityPage from './components/pages/IdentityPage'
+import IdentityIdPage from './components/pages/IdentityIdPage'
 import IntegrationsPage from './components/pages/IntegrationsPage'
 import FlagsPage from './components/pages/features'
 import SegmentsPage from './components/pages/SegmentsPage'
@@ -120,9 +120,12 @@ export const routes = {
   'segment': '/project/:projectId/segments/:id',
   'segments': '/project/:projectId/segments',
   'signup': '/signup',
-  'user': '/project/:projectId/environment/:environmentId/users/:identity/:id',
-  'user-id': '/project/:projectId/environment/:environmentId/users/:identity',
-  'users': '/project/:projectId/environment/:environmentId/users',
+  'identities': '/project/:projectId/environment/:environmentId/identities',
+  'identity': '/project/:projectId/environment/:environmentId/identities/:identity/:id',
+  'identity-id': '/project/:projectId/environment/:environmentId/identities/:identity',
+  'legacy-identities': '/project/:projectId/environment/:environmentId/users',
+  'legacy-identity': '/project/:projectId/environment/:environmentId/users/:identity/:id',
+  'legacy-identity-id': '/project/:projectId/environment/:environmentId/users/:identity',
   'widget': '/widget',
 }
 export default (
@@ -207,13 +210,21 @@ export default (
         exact
         component={OrganisationIntegrationsPage}
       />
-      <ParameterizedRoute path={routes.users} exact component={UsersPage} />
+      <ParameterizedRoute path={routes.identities} exact component={IdentitiesPage} />
       <ParameterizedRoute
-        path={routes['user-id']}
+        path={routes['identity-id']}
         exact
-        component={UserIdPage}
+        component={IdentityIdPage}
       />
-      <ParameterizedRoute path={routes.user} exact component={UserPage} />
+      <ParameterizedRoute path={routes.identity} exact component={IdentityPage} />
+      {/* Legacy /users routes for backward compatibility */}
+      <ParameterizedRoute path={routes['legacy-identities']} exact component={IdentitiesPage} />
+      <ParameterizedRoute
+        path={routes['legacy-identity-id']}
+        exact
+        component={IdentityIdPage}
+      />
+      <ParameterizedRoute path={routes['legacy-identity']} exact component={IdentityPage} />
       <ParameterizedRoute
         path={routes['create-environment']}
         exact


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Renames any usage of the word User where it should be identity in components and routes.

Note: I've purposely maintained support for old routes since teams use them from their own dashboards.

## How did you test this code?

E2E