### PR TITLE
feat: experiments V2

### DIFF
--- a/frontend/.storybook/DocsContainer.jsx
+++ b/frontend/.storybook/DocsContainer.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react'
+import { DocsContainer as BaseContainer } from '@storybook/addon-docs/blocks'
+import { create } from 'storybook/theming'
+import { addons } from 'storybook/preview-api'
+
+const darkTheme = create({
+  base: 'dark',
+  appBg: '#15192b',
+  appContentBg: '#161d30',
+  barBg: '#15192b',
+  colorPrimary: '#6837fc',
+  colorSecondary: '#6837fc',
+  textColor: '#e0e3e9',
+  textMutedColor: '#9da4ae',
+})
+
+const lightTheme = create({
+  base: 'light',
+  colorPrimary: '#6837fc',
+  colorSecondary: '#6837fc',
+})
+
+function getInitialTheme(context) {
+  try {
+    return context?.store?.globals?.globals?.theme === 'dark'
+  } catch {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+}
+
+export const DocsContainer = ({ children, context, ...props }) => {
+  const [isDark, setIsDark] = useState(() => getInitialTheme(context))
+
+  useEffect(() => {
+    const channel = addons.getChannel()
+    const handleGlobalsUpdate = ({ globals }) => {
+      if (globals?.theme !== undefined) {
+        setIsDark(globals.theme === 'dark')
+      }
+    }
+    channel.on('globalsUpdated', handleGlobalsUpdate)
+    return () => channel.off('globalsUpdated', handleGlobalsUpdate)
+  }, [])
+
+  return (
+    <BaseContainer {...props} context={context} theme={isDark ? darkTheme : lightTheme}>
+      {children}
+    </BaseContainer>
+  )
+}

--- a/frontend/.storybook/docs-theme.scss
+++ b/frontend/.storybook/docs-theme.scss
@@ -74,9 +74,50 @@
     border-color: var(--color-border-default, rgba(255, 255, 255, 0.16));
   }
 
-  // Canvas (story preview) background
+  // Canvas wrapper — emotion-styled div with no stable class, child of .sb-anchor
+  .sb-anchor > div {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  // Args/controls table
+  .docblock-argstable {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  .docblock-argstable th,
+  .docblock-argstable td {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Argstable description text, type badges, default values
+  .docblock-argstable td span,
+  .docblock-argstable td p,
+  .docblock-argstable td code,
+  .docblock-argstable td label {
+    color: var(--color-text-secondary, #9da4ae) !important;
+  }
+
+  // Prop names (first column)
+  .docblock-argstable td:first-child span {
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Control values, radio labels, object inspector text
+  .docblock-argstable [class*='css-'] {
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
   .docs-story {
-    background-color: var(--color-surface-default, #101628);
+    background-color: var(--color-surface-subtle, #15192b) !important;
+  }
+
+  // Canvas toolbar (zoom, open in new tab icons)
+  .sbdocs-preview [role='toolbar'] {
+    background-color: var(--color-surface-subtle, #15192b) !important;
   }
 
   // Table borders

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -66,6 +66,21 @@ const config = {
       ],
     })
 
+    // Stub modules that cause circular dependency crashes in Storybook.
+    // common/utils/utils → account-store → constants creates a webpack
+    // initialisation error. Ionic/stencil also triggers the same chain.
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      [path.resolve(__dirname, '../common/utils/utils')]: path.resolve(
+        __dirname,
+        'stubs/utils.js',
+      ),
+      '@stencil/core/internal/client': false,
+      '@stencil/core': false,
+      '@ionic/react': false,
+      'ionicons/icons': false,
+    }
+
     config.plugins = config.plugins || []
     config.plugins.push(
       new webpack.DefinePlugin({

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -17,6 +17,15 @@ const config = {
     name: '@storybook/react-webpack5',
     options: {},
   },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
+    },
+  },
   swc: () => ({
     jsc: {
       transform: {

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -3,12 +3,17 @@ import './docs-theme.scss'
 import { allModes } from './modes'
 import { DocsContainer } from './DocsContainer'
 
-// Minimal globals needed for components that depend on project-components.js
-// Input.js uses window.Utils, SearchableSelect uses global.Select
-import Utils from '../common/utils/utils'
+// Minimal globals needed for components that depend on project-components.js.
+// We can't import the real Utils (circular deps with stores/constants),
+// so we provide only what Input.js actually calls: Utils.keys.isEscape.
 import ReactSelect from 'react-select'
 import Tooltip from '../web/components/Tooltip'
-window.Utils = Utils
+window.Utils = {
+  keys: {
+    isEscape: (e) => e.key === 'Escape' || e.keyCode === 27,
+  },
+  safeParseEventValue: (e) => (e?.target?.value !== undefined ? e.target.value : e),
+}
 global.Select = ReactSelect
 global.Tooltip = Tooltip
 

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -3,6 +3,13 @@ import './docs-theme.scss'
 import { allModes } from './modes'
 import { DocsContainer } from './DocsContainer'
 
+// Minimal globals needed for components that depend on project-components.js
+// (SearchableSelect uses global.Select, some components use global.Tooltip)
+import ReactSelect from 'react-select'
+import Tooltip from '../web/components/Tooltip'
+global.Select = ReactSelect
+global.Tooltip = Tooltip
+
 /** @type { import('storybook').Preview } */
 const preview = {
   globalTypes: {

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -4,9 +4,11 @@ import { allModes } from './modes'
 import { DocsContainer } from './DocsContainer'
 
 // Minimal globals needed for components that depend on project-components.js
-// (SearchableSelect uses global.Select, some components use global.Tooltip)
+// Input.js uses window.Utils, SearchableSelect uses global.Select
+import Utils from '../common/utils/utils'
 import ReactSelect from 'react-select'
 import Tooltip from '../web/components/Tooltip'
+window.Utils = Utils
 global.Select = ReactSelect
 global.Tooltip = Tooltip
 

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -3,17 +3,36 @@ import './docs-theme.scss'
 import { allModes } from './modes'
 import { DocsContainer } from './DocsContainer'
 
-// Minimal globals needed for components that depend on project-components.js.
-// We can't import the real Utils (circular deps with stores/constants),
-// so we provide only what Input.js actually calls: Utils.keys.isEscape.
+// TODO: Remove these globals once legacy .js components (Input.js, etc.) are
+// migrated to TypeScript with proper imports. These replicate what
+// web/project/libs.js and web/project/project-components.js set at boot.
+// Utils is stubbed via webpack alias in main.js to avoid circular deps.
+import React from 'react'
+import PropTypes from 'prop-types'
+import Utils from 'common/utils/utils'
 import ReactSelect from 'react-select'
 import Tooltip from '../web/components/Tooltip'
-window.Utils = {
-  keys: {
-    isEscape: (e) => e.key === 'Escape' || e.keyCode === 27,
-  },
-  safeParseEventValue: (e) => (e?.target?.value !== undefined ? e.target.value : e),
-}
+
+window.React = React
+window.propTypes = PropTypes
+window.OptionalString = PropTypes.string
+window.OptionalFunc = PropTypes.func
+window.OptionalBool = PropTypes.bool
+window.OptionalNumber = PropTypes.number
+window.OptionalObject = PropTypes.object
+window.OptionalArray = PropTypes.array
+window.OptionalNode = PropTypes.node
+window.OptionalElement = PropTypes.element
+window.RequiredString = PropTypes.string.isRequired
+window.RequiredFunc = PropTypes.func.isRequired
+window.RequiredBool = PropTypes.bool.isRequired
+window.RequiredNumber = PropTypes.number.isRequired
+window.RequiredObject = PropTypes.object.isRequired
+window.RequiredNode = PropTypes.node.isRequired
+window.Any = PropTypes.any
+window.oneOf = PropTypes.oneOf
+window.oneOfType = PropTypes.oneOfType
+window.Utils = Utils
 global.Select = ReactSelect
 global.Tooltip = Tooltip
 

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,6 +1,7 @@
 import '../web/styles/styles.scss'
 import './docs-theme.scss'
 import { allModes } from './modes'
+import { DocsContainer } from './DocsContainer'
 
 /** @type { import('storybook').Preview } */
 const preview = {
@@ -45,6 +46,9 @@ const preview = {
       },
     },
     backgrounds: { disable: true },
+    docs: {
+      container: DocsContainer,
+    },
     chromatic: {
       modes: {
         light: allModes.light,

--- a/frontend/.storybook/stubs/utils.js
+++ b/frontend/.storybook/stubs/utils.js
@@ -1,0 +1,16 @@
+// Storybook stub for common/utils/utils.
+// The real Utils has circular dependencies (utils → account-store → constants)
+// that crash webpack in Storybook. This provides the minimal API that
+// components actually call at runtime.
+const Utils = {
+  keys: {
+    isEscape: (e) => e.key === 'Escape' || e.keyCode === 27,
+  },
+  safeParseEventValue: (e) =>
+    e?.target?.value !== undefined ? e.target.value : e,
+  getFlagsmithHasFeature: () => false,
+  getFlagsmithValue: () => '',
+  getPlansPermission: () => true,
+}
+
+export default Utils

--- a/frontend/common/utils/motion.ts
+++ b/frontend/common/utils/motion.ts
@@ -1,0 +1,143 @@
+// =============================================================================
+// Motion Presets — Reusable animation variants for the motion library
+// Import these instead of defining raw values in components.
+//
+// Usage:
+//   import { motion, AnimatePresence } from 'motion/react'
+//   import { fadeIn, staggerContainer } from 'common/utils/motion'
+//
+//   <motion.div variants={fadeIn()} initial="hidden" animate="visible">
+//     ...
+//   </motion.div>
+// =============================================================================
+
+import type { Variants } from 'motion/react'
+
+// -----------------------------------------------------------------------------
+// Fade
+// -----------------------------------------------------------------------------
+
+/** Fade in with optional delay. Default 250ms. */
+export const fadeIn = (delay = 0): Variants => ({
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { delay, duration: 0.25, ease: [0.2, 0, 0.38, 0.9] },
+  },
+})
+
+/** Fade out. Matches --easing-exit. */
+export const fadeOut: Variants = {
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.2, ease: [0.2, 0, 1, 0.9] },
+  },
+  visible: { opacity: 1 },
+}
+
+// -----------------------------------------------------------------------------
+// Slide
+// -----------------------------------------------------------------------------
+
+/** Slide in from right. 320ms, matches --easing-entrance. */
+export const slideInRight: Variants = {
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.2, ease: [0.2, 0, 1, 0.9] },
+    x: -40,
+  },
+  hidden: { opacity: 0, x: 40 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.32, ease: [0.0, 0, 0.38, 0.9] },
+    x: 0,
+  },
+}
+
+/** Slide in from below. Subtler, for inline content. */
+export const slideInUp: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.25, ease: [0.0, 0, 0.38, 0.9] },
+    y: 0,
+  },
+}
+
+// -----------------------------------------------------------------------------
+// Stagger
+// -----------------------------------------------------------------------------
+
+/** Container that staggers its children's entrance. */
+export const staggerContainer = (staggerDelay = 0.1): Variants => ({
+  hidden: {},
+  visible: { transition: { staggerChildren: staggerDelay } },
+})
+
+/** Individual child item for use inside a stagger container. */
+export const staggerItem: Variants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.3, ease: [0.0, 0, 0.38, 0.9] },
+    y: 0,
+  },
+}
+
+// -----------------------------------------------------------------------------
+// Spring / Bounce
+// -----------------------------------------------------------------------------
+
+/** Spring bounce — success checkmarks, icons appearing. */
+export const springBounce: Variants = {
+  hidden: { opacity: 0, scale: 0 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { damping: 15, stiffness: 300, type: 'spring' },
+  },
+}
+
+// -----------------------------------------------------------------------------
+// Shake
+// -----------------------------------------------------------------------------
+
+/** Horizontal shake — error states, validation failures. */
+export const shakeX: Variants = {
+  idle: { x: 0 },
+  shake: {
+    transition: { duration: 0.4, ease: 'easeInOut' },
+    x: [0, -8, 8, -4, 4, 0],
+  },
+}
+
+// -----------------------------------------------------------------------------
+// Badge / Chip
+// -----------------------------------------------------------------------------
+
+/** Badge slides down from above with fade. 250ms with 400ms delay. */
+export const badgeEntrance: Variants = {
+  hidden: { opacity: 0, y: -12 },
+  visible: {
+    opacity: 1,
+    transition: { delay: 0.4, duration: 0.25, ease: [0.0, 0, 0.38, 0.9] },
+    y: 0,
+  },
+}
+
+// -----------------------------------------------------------------------------
+// Page Transition (for AnimatePresence)
+// -----------------------------------------------------------------------------
+
+/** Crossfade between pages/states. Use with AnimatePresence mode="wait". */
+export const pageCrossfade: Variants = {
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.15, ease: [0.2, 0, 1, 0.9] },
+  },
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.25, ease: [0.2, 0, 0.38, 0.9] },
+  },
+}

--- a/frontend/documentation/MotionPresets.stories.tsx
+++ b/frontend/documentation/MotionPresets.stories.tsx
@@ -1,0 +1,318 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import { motion, AnimatePresence } from 'motion/react'
+import {
+  fadeIn,
+  slideInRight,
+  slideInUp,
+  staggerContainer,
+  staggerItem,
+  springBounce,
+  shakeX,
+  badgeEntrance,
+  pageCrossfade,
+} from 'common/utils/motion'
+
+const meta: Meta = {
+  tags: ['autodocs'],
+  title: 'Design System/Motion Presets',
+}
+export default meta
+
+type Story = StoryObj
+
+const DemoBox = ({
+  children,
+  style,
+}: {
+  children: React.ReactNode
+  style?: React.CSSProperties
+}) => (
+  <div
+    style={{
+      alignItems: 'center',
+      background: 'var(--color-surface-subtle)',
+      border: '1px solid var(--color-border-default)',
+      borderRadius: 'var(--radius-lg)',
+      display: 'flex',
+      fontSize: 'var(--font-body-sm-size)',
+      justifyContent: 'center',
+      padding: '24px 32px',
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+)
+
+export const FadeIn: Story = {
+  decorators: [
+    () => {
+      const [key, setKey] = useState(0)
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <button
+            className='btn btn-primary btn-sm'
+            onClick={() => setKey((k) => k + 1)}
+          >
+            Replay
+          </button>
+          <motion.div
+            key={key}
+            variants={fadeIn()}
+            initial='hidden'
+            animate='visible'
+          >
+            <DemoBox>fadeIn()</DemoBox>
+          </motion.div>
+          <code style={{ color: 'var(--color-text-secondary)', fontSize: 12 }}>
+            {'variants={fadeIn()} initial="hidden" animate="visible"'}
+          </code>
+        </div>
+      )
+    },
+  ],
+}
+
+export const SlideInRight: Story = {
+  decorators: [
+    () => {
+      const [key, setKey] = useState(0)
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <button
+            className='btn btn-primary btn-sm'
+            onClick={() => setKey((k) => k + 1)}
+          >
+            Replay
+          </button>
+          <motion.div
+            key={key}
+            variants={slideInRight}
+            initial='hidden'
+            animate='visible'
+          >
+            <DemoBox>slideInRight — page transitions</DemoBox>
+          </motion.div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const SlideInUp: Story = {
+  decorators: [
+    () => {
+      const [key, setKey] = useState(0)
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <button
+            className='btn btn-primary btn-sm'
+            onClick={() => setKey((k) => k + 1)}
+          >
+            Replay
+          </button>
+          <motion.div
+            key={key}
+            variants={slideInUp}
+            initial='hidden'
+            animate='visible'
+          >
+            <DemoBox>slideInUp — inline content</DemoBox>
+          </motion.div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const StaggeredList: Story = {
+  decorators: [
+    () => {
+      const [key, setKey] = useState(0)
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <button
+            className='btn btn-primary btn-sm'
+            onClick={() => setKey((k) => k + 1)}
+          >
+            Replay
+          </button>
+          <motion.div
+            key={key}
+            variants={staggerContainer(0.15)}
+            initial='hidden'
+            animate='visible'
+            style={{ display: 'flex', flexDirection: 'column', gap: 8 }}
+          >
+            {[
+              'Resolving hostname...',
+              'Establishing TLS...',
+              'Authenticating...',
+              'Verifying schema...',
+            ].map((text) => (
+              <motion.div key={text} variants={staggerItem}>
+                <DemoBox>{text}</DemoBox>
+              </motion.div>
+            ))}
+          </motion.div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const SpringBounce: Story = {
+  decorators: [
+    () => {
+      const [key, setKey] = useState(0)
+      return (
+        <div
+          style={{
+            alignItems: 'flex-start',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+          }}
+        >
+          <button
+            className='btn btn-primary btn-sm'
+            onClick={() => setKey((k) => k + 1)}
+          >
+            Replay
+          </button>
+          <motion.div
+            key={key}
+            variants={springBounce}
+            initial='hidden'
+            animate='visible'
+          >
+            <DemoBox
+              style={{
+                background: 'var(--color-surface-success)',
+                borderColor: 'var(--color-border-success)',
+                color: 'var(--color-text-success)',
+                fontWeight: 600,
+              }}
+            >
+              ✓ Success
+            </DemoBox>
+          </motion.div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const ShakeError: Story = {
+  decorators: [
+    () => {
+      const [shaking, setShaking] = useState(false)
+      return (
+        <div
+          style={{
+            alignItems: 'flex-start',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+          }}
+        >
+          <button
+            className='btn btn-danger btn-sm'
+            onClick={() => {
+              setShaking(false)
+              requestAnimationFrame(() => setShaking(true))
+            }}
+          >
+            Trigger shake
+          </button>
+          <motion.div variants={shakeX} animate={shaking ? 'shake' : 'idle'}>
+            <DemoBox style={{ borderColor: 'var(--color-border-danger)' }}>
+              Error: Invalid credentials
+            </DemoBox>
+          </motion.div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const BadgeEntrance: Story = {
+  decorators: [
+    () => {
+      const [key, setKey] = useState(0)
+      return (
+        <div
+          style={{
+            alignItems: 'flex-start',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+          }}
+        >
+          <button
+            className='btn btn-primary btn-sm'
+            onClick={() => setKey((k) => k + 1)}
+          >
+            Replay
+          </button>
+          <motion.span
+            key={key}
+            variants={badgeEntrance}
+            initial='hidden'
+            animate='visible'
+            style={{
+              background: 'var(--color-surface-success)',
+              borderRadius: 'var(--radius-full)',
+              color: 'var(--color-text-success)',
+              fontSize: 'var(--font-caption-xs-size)',
+              fontWeight: 600,
+              padding: '4px 12px',
+            }}
+          >
+            Connected
+          </motion.span>
+        </div>
+      )
+    },
+  ],
+}
+
+export const PageCrossfade: Story = {
+  decorators: [
+    () => {
+      const [page, setPage] = useState(0)
+      const pages = ['Page A', 'Page B', 'Page C']
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {pages.map((label, i) => (
+              <button
+                key={label}
+                className={`btn btn-sm ${
+                  page === i ? 'btn-primary' : 'btn--outline'
+                }`}
+                onClick={() => setPage(i)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <AnimatePresence mode='wait'>
+            <motion.div
+              key={page}
+              variants={pageCrossfade}
+              initial='hidden'
+              animate='visible'
+              exit='exit'
+            >
+              <DemoBox style={{ minHeight: 100 }}>
+                {pages[page]} — crossfade transition
+              </DemoBox>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      )
+    },
+  ],
+}

--- a/frontend/documentation/experiments/AudienceTrafficStep.stories.tsx
+++ b/frontend/documentation/experiments/AudienceTrafficStep.stories.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import AudienceTrafficStep from 'components/experiments-v2/steps/AudienceTrafficStep'
+import {
+  AudienceConfig,
+  MOCK_VARIATIONS,
+} from 'components/experiments-v2/types'
+
+const meta: Meta<typeof AudienceTrafficStep> = {
+  component: AudienceTrafficStep,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 600 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Steps/AudienceTrafficStep',
+}
+export default meta
+
+type Story = StoryObj<typeof AudienceTrafficStep>
+
+export const Default: Story = {
+  args: {
+    audience: { segmentId: null, splits: [], trafficPercentage: 50 },
+    onChange: () => {},
+    variations: MOCK_VARIATIONS,
+  },
+}
+
+export const Interactive: Story = {
+  decorators: [
+    () => {
+      const [audience, setAudience] = useState<AudienceConfig>({
+        segmentId: 'seg-1',
+        splits: [],
+        trafficPercentage: 50,
+      })
+      return (
+        <AudienceTrafficStep
+          audience={audience}
+          variations={MOCK_VARIATIONS}
+          onChange={setAudience}
+        />
+      )
+    },
+  ],
+}

--- a/frontend/documentation/experiments/ExperimentDetailsStep.stories.tsx
+++ b/frontend/documentation/experiments/ExperimentDetailsStep.stories.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import ExperimentDetailsStep from 'components/experiments-v2/steps/ExperimentDetailsStep'
+import { ExperimentDetails } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof ExperimentDetailsStep> = {
+  component: ExperimentDetailsStep,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 600 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Steps/ExperimentDetailsStep',
+}
+export default meta
+
+type Story = StoryObj<typeof ExperimentDetailsStep>
+
+export const Empty: Story = {
+  args: {
+    details: { hypothesis: '', name: '', type: null },
+    onChange: () => {},
+  },
+}
+
+export const Filled: Story = {
+  args: {
+    details: {
+      hypothesis:
+        'Redesigning the checkout button with a clearer CTA will increase conversion rates by 15%',
+      name: 'Checkout Flow Redesign',
+      type: 'ab_test',
+    },
+    onChange: () => {},
+  },
+}
+
+export const Interactive: Story = {
+  decorators: [
+    () => {
+      const [details, setDetails] = useState<ExperimentDetails>({
+        hypothesis: '',
+        name: '',
+        type: null,
+      })
+      return <ExperimentDetailsStep details={details} onChange={setDetails} />
+    },
+  ],
+}

--- a/frontend/documentation/experiments/ExperimentStatCard.stories.tsx
+++ b/frontend/documentation/experiments/ExperimentStatCard.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import ExperimentStatCard from 'components/experiments-v2/shared/ExperimentStatCard'
+
+const meta: Meta<typeof ExperimentStatCard> = {
+  component: ExperimentStatCard,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 250 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/ExperimentStatCard',
+}
+export default meta
+
+type Story = StoryObj<typeof ExperimentStatCard>
+
+export const Default: Story = {
+  args: { label: 'Users Enrolled', value: 12847 },
+}
+
+export const Positive: Story = {
+  args: {
+    label: 'Winning Variation',
+    trend: 'positive',
+    value: 'Treatment B',
+  },
+}
+
+export const WithSubtitle: Story = {
+  args: {
+    label: 'Lift vs Control',
+    subtitle: 'vs control group',
+    trend: 'positive',
+    value: '+18.3%',
+  },
+}

--- a/frontend/documentation/experiments/FlagVariationsStep.stories.tsx
+++ b/frontend/documentation/experiments/FlagVariationsStep.stories.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import FlagVariationsStep from 'components/experiments-v2/steps/FlagVariationsStep'
+import { MOCK_VARIATIONS, Variation } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof FlagVariationsStep> = {
+  component: FlagVariationsStep,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 700 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Steps/FlagVariationsStep',
+}
+export default meta
+
+type Story = StoryObj<typeof FlagVariationsStep>
+
+export const Default: Story = {
+  args: {
+    featureFlagId: 'flag-1',
+    onFlagChange: () => {},
+    onVariationsChange: () => {},
+    variations: MOCK_VARIATIONS,
+  },
+}
+
+export const Interactive: Story = {
+  decorators: [
+    () => {
+      const [flagId, setFlagId] = useState<string | null>('flag-1')
+      const [variations, setVariations] = useState<Variation[]>(MOCK_VARIATIONS)
+      return (
+        <FlagVariationsStep
+          featureFlagId={flagId}
+          variations={variations}
+          onFlagChange={setFlagId}
+          onVariationsChange={setVariations}
+        />
+      )
+    },
+  ],
+}

--- a/frontend/documentation/experiments/LinkedExperimentSection.stories.tsx
+++ b/frontend/documentation/experiments/LinkedExperimentSection.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import LinkedExperimentSection from 'components/experiments-v2/flag-detail/LinkedExperimentSection'
+import { MOCK_LINKED_EXPERIMENT } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof LinkedExperimentSection> = {
+  component: LinkedExperimentSection,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 600 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/LinkedExperimentSection',
+}
+export default meta
+
+type Story = StoryObj<typeof LinkedExperimentSection>
+
+export const WithExperiment: Story = {
+  args: {
+    experiment: MOCK_LINKED_EXPERIMENT,
+    onViewResults: () => alert('View results'),
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    experiment: null,
+    onCreateExperiment: () => alert('Create experiment'),
+  },
+}

--- a/frontend/documentation/experiments/MetricsComparisonTable.stories.tsx
+++ b/frontend/documentation/experiments/MetricsComparisonTable.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from 'storybook'
+import MetricsComparisonTable from 'components/experiments-v2/shared/MetricsComparisonTable'
+import { MOCK_EXPERIMENT_RESULT } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof MetricsComparisonTable> = {
+  component: MetricsComparisonTable,
+  tags: ['autodocs'],
+  title: 'Experiments/MetricsComparisonTable',
+}
+export default meta
+
+type Story = StoryObj<typeof MetricsComparisonTable>
+
+export const WithSignificance: Story = {
+  args: { metrics: MOCK_EXPERIMENT_RESULT.metrics },
+}
+
+export const NoSignificance: Story = {
+  args: {
+    metrics: MOCK_EXPERIMENT_RESULT.metrics.map((m) => ({
+      ...m,
+      isSignificant: false,
+      liftDirection: 'neutral' as const,
+      significance: 'not significant',
+    })),
+  },
+}

--- a/frontend/documentation/experiments/ReviewLaunchStep.stories.tsx
+++ b/frontend/documentation/experiments/ReviewLaunchStep.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import ReviewLaunchStep from 'components/experiments-v2/steps/ReviewLaunchStep'
+import {
+  ExperimentWizardState,
+  MOCK_METRICS,
+  MOCK_VARIATIONS,
+} from 'components/experiments-v2/types'
+
+const MOCK_WIZARD_STATE: ExperimentWizardState = {
+  audience: {
+    segmentId: 'seg-1',
+    splits: [],
+    trafficPercentage: 50,
+  },
+  currentStep: 4,
+  details: {
+    hypothesis:
+      'Redesigning the checkout button will increase conversions by 15%',
+    name: 'Checkout Flow Redesign',
+    type: 'ab_test',
+  },
+  featureFlagId: 'flag-1',
+  metrics: [MOCK_METRICS[0], { ...MOCK_METRICS[1], role: 'secondary' }],
+  variations: MOCK_VARIATIONS,
+}
+
+const meta: Meta<typeof ReviewLaunchStep> = {
+  component: ReviewLaunchStep,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 600 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Steps/ReviewLaunchStep',
+}
+export default meta
+
+type Story = StoryObj<typeof ReviewLaunchStep>
+
+export const FullReview: Story = {
+  args: {
+    onEditStep: (step: number) => alert(`Edit step ${step}`),
+    wizardState: MOCK_WIZARD_STATE,
+  },
+}

--- a/frontend/documentation/experiments/SelectMetricsStep.stories.tsx
+++ b/frontend/documentation/experiments/SelectMetricsStep.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import SelectMetricsStep from 'components/experiments-v2/steps/SelectMetricsStep'
+import { Metric, MOCK_METRICS } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof SelectMetricsStep> = {
+  component: SelectMetricsStep,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 600 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Steps/SelectMetricsStep',
+}
+export default meta
+
+type Story = StoryObj<typeof SelectMetricsStep>
+
+export const NoneSelected: Story = {
+  args: {
+    onToggleMetric: () => {},
+    selectedMetrics: [],
+  },
+}
+
+export const WithMetrics: Story = {
+  args: {
+    onToggleMetric: () => {},
+    selectedMetrics: [
+      MOCK_METRICS[0],
+      { ...MOCK_METRICS[1], role: 'secondary' },
+    ],
+  },
+}
+
+export const Interactive: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<Metric[]>([])
+      const handleToggle = (metric: Metric) => {
+        const exists = selected.find((m) => m.id === metric.id)
+        if (exists) {
+          setSelected(selected.filter((m) => m.id !== metric.id))
+        } else {
+          const role = selected.length === 0 ? 'primary' : 'secondary'
+          setSelected([...selected, { ...metric, role }])
+        }
+      }
+      return (
+        <SelectMetricsStep
+          selectedMetrics={selected}
+          onToggleMetric={handleToggle}
+        />
+      )
+    },
+  ],
+}

--- a/frontend/documentation/experiments/SelectableCard.stories.tsx
+++ b/frontend/documentation/experiments/SelectableCard.stories.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import SelectableCard from 'components/experiments-v2/shared/SelectableCard'
+
+const meta: Meta<typeof SelectableCard> = {
+  component: SelectableCard,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 300 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/SelectableCard',
+}
+export default meta
+
+type Story = StoryObj<typeof SelectableCard>
+
+export const WithIcon: Story = {
+  args: {
+    description: 'Compare two variations',
+    icon: 'bar-chart',
+    onClick: () => {},
+    selected: true,
+    title: 'A/B Test',
+  },
+}
+
+export const WithBadge: Story = {
+  args: {
+    badge: { label: 'Primary', variant: 'primary' },
+    description: 'Percentage of users completing checkout',
+    onClick: () => {},
+    selected: true,
+    title: 'Checkout Conversion Rate',
+  },
+}
+
+export const Unselected: Story = {
+  args: {
+    description: 'Test multiple variables',
+    icon: 'layers',
+    onClick: () => {},
+    selected: false,
+    title: 'Multivariate',
+  },
+}
+
+export const SecondaryBadge: Story = {
+  args: {
+    badge: { label: 'Secondary', variant: 'secondary' },
+    description: 'Average revenue generated per user session',
+    onClick: () => {},
+    selected: true,
+    title: 'Revenue per User',
+  },
+}
+
+export const InteractiveGroup: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState(0)
+      const items = [
+        {
+          description: 'Compare two variations',
+          icon: 'bar-chart' as const,
+          title: 'A/B Test',
+        },
+        {
+          description: 'Test multiple variables',
+          icon: 'layers' as const,
+          title: 'Multivariate',
+        },
+        {
+          description: 'Toggle feature on/off',
+          icon: 'features' as const,
+          title: 'Feature Flag',
+        },
+      ]
+      return (
+        <div style={{ display: 'flex', gap: 12, maxWidth: 700 }}>
+          {items.map((item, i) => (
+            <SelectableCard
+              key={i}
+              icon={item.icon}
+              title={item.title}
+              description={item.description}
+              selected={selected === i}
+              onClick={() => setSelected(i)}
+            />
+          ))}
+        </div>
+      )
+    },
+  ],
+}

--- a/frontend/documentation/experiments/StatusBadge.stories.tsx
+++ b/frontend/documentation/experiments/StatusBadge.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from 'storybook'
+import StatusBadge from 'components/experiments-v2/shared/StatusBadge'
+
+const meta: Meta<typeof StatusBadge> = {
+  component: StatusBadge,
+  tags: ['autodocs'],
+  title: 'Experiments/StatusBadge',
+}
+export default meta
+
+type Story = StoryObj<typeof StatusBadge>
+
+export const Running: Story = { args: { status: 'running' } }
+export const Paused: Story = { args: { status: 'paused' } }
+export const Completed: Story = { args: { status: 'completed' } }

--- a/frontend/documentation/experiments/TrafficSplitBar.stories.tsx
+++ b/frontend/documentation/experiments/TrafficSplitBar.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import TrafficSplitBar from 'components/experiments-v2/shared/TrafficSplitBar'
+
+const meta: Meta<typeof TrafficSplitBar> = {
+  component: TrafficSplitBar,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 500 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/TrafficSplitBar',
+}
+export default meta
+
+type Story = StoryObj<typeof TrafficSplitBar>
+
+export const EvenSplit: Story = {
+  args: {
+    splits: [
+      { colour: 'var(--green-500)', name: 'Control', percentage: 50 },
+      { colour: 'var(--purple-500)', name: 'Treatment B', percentage: 50 },
+    ],
+  },
+}
+
+export const UnevenSplit: Story = {
+  args: {
+    splits: [
+      { colour: 'var(--green-500)', name: 'Control', percentage: 30 },
+      { colour: 'var(--purple-500)', name: 'Treatment B', percentage: 50 },
+      { colour: 'var(--orange-500)', name: 'Treatment C', percentage: 20 },
+    ],
+  },
+}

--- a/frontend/documentation/experiments/VariationTable.stories.tsx
+++ b/frontend/documentation/experiments/VariationTable.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import VariationTable from 'components/experiments-v2/shared/VariationTable'
+import { MOCK_VARIATIONS } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof VariationTable> = {
+  component: VariationTable,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 700 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/VariationTable',
+}
+export default meta
+
+type Story = StoryObj<typeof VariationTable>
+
+export const TwoVariations: Story = {
+  args: {
+    variations: MOCK_VARIATIONS,
+  },
+}
+
+export const ThreeVariations: Story = {
+  args: {
+    variations: [
+      ...MOCK_VARIATIONS,
+      {
+        colour: 'var(--orange-500)',
+        description: 'Alternative CTA text with urgency messaging',
+        id: 'var-3',
+        name: 'Treatment C',
+        value: 'false',
+      },
+    ],
+  },
+}
+
+export const Editable: Story = {
+  args: {
+    editable: true,
+    onRemove: (id: string) => alert(`Remove ${id}`),
+    variations: MOCK_VARIATIONS,
+  },
+}

--- a/frontend/documentation/experiments/Wizard.stories.tsx
+++ b/frontend/documentation/experiments/Wizard.stories.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import WizardLayout from 'components/experiments-v2/wizard/WizardLayout'
+import WizardSidebar from 'components/experiments-v2/wizard/WizardSidebar'
+import WizardHeader from 'components/experiments-v2/wizard/WizardHeader'
+import WizardNavButtons from 'components/experiments-v2/wizard/WizardNavButtons'
+import { EXPERIMENT_WIZARD_STEPS } from 'components/experiments-v2/types'
+
+const meta: Meta = {
+  tags: ['autodocs'],
+  title: 'Experiments/Wizard',
+}
+export default meta
+
+type Story = StoryObj
+
+export const FullWizard: Story = {
+  decorators: [
+    () => {
+      const [currentStep, setCurrentStep] = useState(2)
+
+      const stepsWithSummary = EXPERIMENT_WIZARD_STEPS.map((step, i) => {
+        if (i >= currentStep) return step
+        const summaries = [
+          'Checkout Flow Redesign · A/B Test',
+          '1 primary · 2 secondary',
+        ]
+        return { ...step, completeSummary: summaries[i] }
+      })
+
+      return (
+        <div style={{ maxWidth: 900 }}>
+          <WizardHeader
+            breadcrumbs={[
+              { label: 'Experiments' },
+              { label: 'Create Experiment' },
+            ]}
+            title='Create Experiment'
+            onCancel={() => alert('Cancel')}
+          />
+
+          <hr
+            style={{
+              border: 'none',
+              borderTop: '1px solid var(--color-border-default)',
+              margin: '24px 0',
+            }}
+          />
+
+          <WizardLayout
+            sidebar={
+              <WizardSidebar
+                steps={stepsWithSummary}
+                currentStep={currentStep}
+                onStepClick={setCurrentStep}
+              />
+            }
+          >
+            <div
+              style={{
+                background: 'var(--color-surface-subtle)',
+                border: '1px solid var(--color-border-default)',
+                borderRadius: 'var(--radius-lg)',
+                color: 'var(--color-text-secondary)',
+                fontSize: 14,
+                padding: 32,
+              }}
+            >
+              Step {currentStep + 1} content:{' '}
+              {EXPERIMENT_WIZARD_STEPS[currentStep].title}
+            </div>
+
+            <WizardNavButtons
+              isFirstStep={currentStep === 0}
+              isLastStep={currentStep === EXPERIMENT_WIZARD_STEPS.length - 1}
+              onBack={() => setCurrentStep(Math.max(0, currentStep - 1))}
+              onContinue={() =>
+                setCurrentStep(
+                  Math.min(EXPERIMENT_WIZARD_STEPS.length - 1, currentStep + 1),
+                )
+              }
+            />
+          </WizardLayout>
+        </div>
+      )
+    },
+  ],
+}

--- a/frontend/documentation/experiments/WizardHeader.stories.tsx
+++ b/frontend/documentation/experiments/WizardHeader.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from 'storybook'
+import WizardHeader from 'components/experiments-v2/wizard/WizardHeader'
+
+const meta: Meta<typeof WizardHeader> = {
+  args: {
+    onCancel: () => alert('Cancel clicked'),
+  },
+  component: WizardHeader,
+  tags: ['autodocs'],
+  title: 'Experiments/Wizard/WizardHeader',
+}
+export default meta
+
+type Story = StoryObj<typeof WizardHeader>
+
+export const Default: Story = {
+  args: {
+    breadcrumbs: [{ label: 'Experiments' }, { label: 'Create Experiment' }],
+    title: 'Create Experiment',
+  },
+}
+
+export const LongTitle: Story = {
+  args: {
+    breadcrumbs: [
+      { label: 'Experiments' },
+      { label: 'Checkout Button Redesign A/B Test' },
+    ],
+    title: 'Checkout Button Redesign A/B Test',
+  },
+}

--- a/frontend/documentation/experiments/WizardLayout.stories.tsx
+++ b/frontend/documentation/experiments/WizardLayout.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import WizardLayout from 'components/experiments-v2/wizard/WizardLayout'
+
+const meta: Meta<typeof WizardLayout> = {
+  component: WizardLayout,
+  tags: ['autodocs'],
+  title: 'Experiments/Wizard/WizardLayout',
+}
+export default meta
+
+type Story = StoryObj<typeof WizardLayout>
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div
+        style={{
+          background: 'var(--color-surface-subtle)',
+          borderRadius: 'var(--radius-lg)',
+          height: 400,
+          padding: 24,
+        }}
+      >
+        Main content area
+      </div>
+    ),
+    sidebar: (
+      <div
+        style={{
+          background: 'var(--color-surface-muted)',
+          borderRadius: 'var(--radius-lg)',
+          height: 400,
+          padding: 16,
+        }}
+      >
+        Sidebar content
+      </div>
+    ),
+  },
+}

--- a/frontend/documentation/experiments/WizardNavButtons.stories.tsx
+++ b/frontend/documentation/experiments/WizardNavButtons.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from 'storybook'
+import WizardNavButtons from 'components/experiments-v2/wizard/WizardNavButtons'
+
+const meta: Meta<typeof WizardNavButtons> = {
+  args: {
+    onBack: () => alert('Back clicked'),
+    onContinue: () => alert('Continue clicked'),
+  },
+  component: WizardNavButtons,
+  tags: ['autodocs'],
+  title: 'Experiments/Wizard/WizardNavButtons',
+}
+export default meta
+
+type Story = StoryObj<typeof WizardNavButtons>
+
+export const FirstStep: Story = {
+  args: {
+    isFirstStep: true,
+  },
+}
+
+export const MiddleStep: Story = {
+  args: {
+    isFirstStep: false,
+    isLastStep: false,
+  },
+}
+
+export const LastStep: Story = {
+  args: {
+    isLastStep: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    continueDisabled: true,
+  },
+}

--- a/frontend/documentation/experiments/WizardSidebar.stories.tsx
+++ b/frontend/documentation/experiments/WizardSidebar.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import WizardSidebar from 'components/experiments-v2/wizard/WizardSidebar'
+import { EXPERIMENT_WIZARD_STEPS } from 'components/experiments-v2/types'
+
+const meta: Meta<typeof WizardSidebar> = {
+  args: {
+    steps: EXPERIMENT_WIZARD_STEPS,
+  },
+  component: WizardSidebar,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Wizard/WizardSidebar',
+}
+export default meta
+
+type Story = StoryObj<typeof WizardSidebar>
+
+export const Step1Active: Story = {
+  args: { currentStep: 0 },
+}
+
+export const Step3Active: Story = {
+  args: {
+    currentStep: 2,
+    steps: EXPERIMENT_WIZARD_STEPS.map((s, i) => {
+      let completeSummary: string | undefined
+      if (i === 0) completeSummary = 'Checkout Flow Redesign · A/B Test'
+      else if (i === 1) completeSummary = '1 primary · 2 secondary'
+      return { ...s, completeSummary }
+    }),
+  },
+}
+
+export const AllDone: Story = {
+  args: {
+    currentStep: 5,
+    steps: EXPERIMENT_WIZARD_STEPS.map((s, i) => ({
+      ...s,
+      completeSummary: `Step ${i + 1} complete`,
+    })),
+  },
+}

--- a/frontend/documentation/experiments/WizardStepIndicator.stories.tsx
+++ b/frontend/documentation/experiments/WizardStepIndicator.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import WizardStepIndicator from 'components/experiments-v2/wizard/WizardStepIndicator'
+
+const meta: Meta<typeof WizardStepIndicator> = {
+  args: {
+    showConnector: true,
+    stepNumber: 1,
+    subtitle: 'Define the basics of your experiment',
+    title: 'Experiment Details',
+  },
+  component: WizardStepIndicator,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Experiments/Wizard/WizardStepIndicator',
+}
+export default meta
+
+type Story = StoryObj<typeof WizardStepIndicator>
+
+export const Done: Story = {
+  args: {
+    completeSummary: 'Checkout Flow Redesign · A/B Test',
+    onClick: () => alert('Step clicked'),
+    status: 'done',
+  },
+}
+
+export const Active: Story = {
+  args: {
+    status: 'active',
+    stepNumber: 2,
+    subtitle: 'Choose primary and secondary metrics to measure',
+    title: 'Select Metrics',
+  },
+}
+
+export const Upcoming: Story = {
+  args: {
+    showConnector: false,
+    status: 'upcoming',
+    stepNumber: 5,
+    subtitle: 'Review your configuration and launch',
+    title: 'Review & Launch',
+  },
+}

--- a/frontend/documentation/warehouse/ConfigForm.stories.tsx
+++ b/frontend/documentation/warehouse/ConfigForm.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import ConfigForm from 'components/warehouse/components/ConfigForm'
+
+const meta: Meta<typeof ConfigForm> = {
+  component: ConfigForm,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 700 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Warehouse/ConfigForm',
+}
+export default meta
+
+type Story = StoryObj<typeof ConfigForm>
+
+export const Default: Story = {
+  args: {
+    onCancel: () => alert('Cancel'),
+    onTestConnection: (config) => alert(`Test: ${config.accountUrl}`),
+  },
+}

--- a/frontend/documentation/warehouse/ConnectedState.stories.tsx
+++ b/frontend/documentation/warehouse/ConnectedState.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import ConnectedState from 'components/warehouse/components/ConnectedState'
+import { MOCK_CONNECTION_DETAILS, MOCK_STATS } from 'components/warehouse/types'
+
+const meta: Meta<typeof ConnectedState> = {
+  component: ConnectedState,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 800 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Warehouse/ConnectedState',
+}
+export default meta
+
+type Story = StoryObj<typeof ConnectedState>
+
+export const Default: Story = {
+  args: {
+    details: MOCK_CONNECTION_DETAILS,
+    onDisconnect: () => alert('Disconnect'),
+    onEdit: () => alert('Edit'),
+    stats: MOCK_STATS,
+  },
+}

--- a/frontend/documentation/warehouse/EmptyState.stories.tsx
+++ b/frontend/documentation/warehouse/EmptyState.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from 'storybook'
+import EmptyState from 'components/warehouse/components/EmptyState'
+
+const meta: Meta<typeof EmptyState> = {
+  component: EmptyState,
+  tags: ['autodocs'],
+  title: 'Warehouse/EmptyState',
+}
+export default meta
+
+type Story = StoryObj<typeof EmptyState>
+
+export const Default: Story = {
+  args: { onConnect: () => alert('Connect') },
+}

--- a/frontend/documentation/warehouse/ErrorState.stories.tsx
+++ b/frontend/documentation/warehouse/ErrorState.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import ErrorState from 'components/warehouse/components/ErrorState'
+import { MOCK_CONNECTION_DETAILS, MOCK_ERROR } from 'components/warehouse/types'
+
+const meta: Meta<typeof ErrorState> = {
+  component: ErrorState,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 800 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Warehouse/ErrorState',
+}
+export default meta
+
+type Story = StoryObj<typeof ErrorState>
+
+export const Default: Story = {
+  args: {
+    details: MOCK_CONNECTION_DETAILS,
+    error: MOCK_ERROR,
+    onEdit: () => alert('Edit'),
+    onRetry: () => alert('Retry'),
+  },
+}

--- a/frontend/documentation/warehouse/TestingState.stories.tsx
+++ b/frontend/documentation/warehouse/TestingState.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from 'storybook'
+import TestingState from 'components/warehouse/components/TestingState'
+
+const meta: Meta<typeof TestingState> = {
+  component: TestingState,
+  tags: ['autodocs'],
+  title: 'Warehouse/TestingState',
+}
+export default meta
+
+type Story = StoryObj<typeof TestingState>
+
+export const AllStepsComplete: Story = {
+  args: { currentStep: 4 },
+}
+
+export const MidProgress: Story = {
+  args: { currentStep: 2 },
+}

--- a/frontend/documentation/warehouse/WarehousePage.stories.tsx
+++ b/frontend/documentation/warehouse/WarehousePage.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from 'storybook'
+import WarehousePage from 'components/warehouse/WarehousePage'
+
+const meta: Meta<typeof WarehousePage> = {
+  component: WarehousePage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  title: 'Warehouse/WarehousePage',
+}
+export default meta
+
+type Story = StoryObj<typeof WarehousePage>
+
+export const Empty: Story = {
+  args: { initialState: 'empty' },
+}
+
+export const Configuring: Story = {
+  args: { initialState: 'configuring' },
+}
+
+export const Testing: Story = {
+  args: { initialState: 'testing' },
+}
+
+export const Connected: Story = {
+  args: { initialState: 'connected' },
+}
+
+export const Error: Story = {
+  args: { initialState: 'error' },
+}

--- a/frontend/web/components/experiments-v2/CreateExperimentPage.scss
+++ b/frontend/web/components/experiments-v2/CreateExperimentPage.scss
@@ -1,0 +1,12 @@
+.create-experiment-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px 48px;
+  min-height: 100vh;
+
+  &__divider {
+    height: 1px;
+    background: var(--color-border-default);
+  }
+}

--- a/frontend/web/components/experiments-v2/CreateExperimentPage.tsx
+++ b/frontend/web/components/experiments-v2/CreateExperimentPage.tsx
@@ -13,16 +13,26 @@ import {
   EXPERIMENT_WIZARD_STEPS,
   ExperimentWizardState,
   Metric,
+  MOCK_METRICS,
   MOCK_VARIATIONS,
 } from './types'
 import './CreateExperimentPage.scss'
 
 const INITIAL_STATE: ExperimentWizardState = {
-  audience: { segmentId: null, splits: [], trafficPercentage: 50 },
+  audience: { segmentId: 'seg-1', splits: [], trafficPercentage: 50 },
   currentStep: 0,
-  details: { hypothesis: '', name: '', type: null },
-  featureFlagId: null,
-  metrics: [],
+  details: {
+    hypothesis:
+      'Redesigning the checkout button with a clearer CTA will increase conversion rates by at least 15% within 30 days',
+    name: 'Checkout Button Redesign',
+    type: 'ab_test',
+  },
+  featureFlagId: 'flag-1',
+  metrics: [
+    MOCK_METRICS[0],
+    { ...MOCK_METRICS[1], role: 'secondary' },
+    { ...MOCK_METRICS[2], role: 'secondary' },
+  ],
   variations: MOCK_VARIATIONS,
 }
 

--- a/frontend/web/components/experiments-v2/CreateExperimentPage.tsx
+++ b/frontend/web/components/experiments-v2/CreateExperimentPage.tsx
@@ -1,0 +1,179 @@
+import React, { FC, useCallback, useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import WizardLayout from './wizard/WizardLayout'
+import WizardSidebar from './wizard/WizardSidebar'
+import WizardHeader from './wizard/WizardHeader'
+import WizardNavButtons from './wizard/WizardNavButtons'
+import ExperimentDetailsStep from './steps/ExperimentDetailsStep'
+import SelectMetricsStep from './steps/SelectMetricsStep'
+import FlagVariationsStep from './steps/FlagVariationsStep'
+import AudienceTrafficStep from './steps/AudienceTrafficStep'
+import ReviewLaunchStep from './steps/ReviewLaunchStep'
+import {
+  EXPERIMENT_WIZARD_STEPS,
+  ExperimentWizardState,
+  Metric,
+  MOCK_VARIATIONS,
+} from './types'
+import './CreateExperimentPage.scss'
+
+const INITIAL_STATE: ExperimentWizardState = {
+  audience: { segmentId: null, splits: [], trafficPercentage: 50 },
+  currentStep: 0,
+  details: { hypothesis: '', name: '', type: null },
+  featureFlagId: null,
+  metrics: [],
+  variations: MOCK_VARIATIONS,
+}
+
+const TOTAL_STEPS = EXPERIMENT_WIZARD_STEPS.length
+
+const CreateExperimentPage: FC = () => {
+  const history = useHistory()
+  const [state, setState] = useState<ExperimentWizardState>(INITIAL_STATE)
+
+  const goToStep = useCallback((step: number) => {
+    setState((prev) => ({ ...prev, currentStep: step }))
+  }, [])
+
+  const handleBack = useCallback(() => {
+    goToStep(Math.max(0, state.currentStep - 1))
+  }, [state.currentStep, goToStep])
+
+  const handleContinue = useCallback(() => {
+    if (state.currentStep < TOTAL_STEPS - 1) {
+      goToStep(state.currentStep + 1)
+    } else {
+      // Launch — for now just alert with mock data
+      alert('Experiment launched! (mock)')
+    }
+  }, [state.currentStep, goToStep])
+
+  const handleCancel = useCallback(() => {
+    history.goBack()
+  }, [history])
+
+  const handleToggleMetric = useCallback((metric: Metric) => {
+    setState((prev) => {
+      const exists = prev.metrics.find((m) => m.id === metric.id)
+      if (exists) {
+        return {
+          ...prev,
+          metrics: prev.metrics.filter((m) => m.id !== metric.id),
+        }
+      }
+      const role = prev.metrics.length === 0 ? 'primary' : 'secondary'
+      return { ...prev, metrics: [...prev.metrics, { ...metric, role }] }
+    })
+  }, [])
+
+  const stepsWithSummary = EXPERIMENT_WIZARD_STEPS.map((step, i) => {
+    if (i >= state.currentStep) return step
+
+    let completeSummary: string | undefined
+    switch (i) {
+      case 0:
+        completeSummary = [
+          state.details.name,
+          state.details.type?.replace('_', ' '),
+        ]
+          .filter(Boolean)
+          .join(' · ')
+        break
+      case 1:
+        completeSummary = `${
+          state.metrics.filter((m) => m.role === 'primary').length
+        } primary · ${
+          state.metrics.filter((m) => m.role === 'secondary').length
+        } secondary`
+        break
+      case 2:
+        completeSummary = `${state.variations.length} variations`
+        break
+      case 3:
+        completeSummary = `${state.audience.trafficPercentage}% traffic`
+        break
+      default:
+        break
+    }
+    return { ...step, completeSummary }
+  })
+
+  const renderStepContent = () => {
+    switch (state.currentStep) {
+      case 0:
+        return (
+          <ExperimentDetailsStep
+            details={state.details}
+            onChange={(details) => setState((prev) => ({ ...prev, details }))}
+          />
+        )
+      case 1:
+        return (
+          <SelectMetricsStep
+            selectedMetrics={state.metrics}
+            onToggleMetric={handleToggleMetric}
+          />
+        )
+      case 2:
+        return (
+          <FlagVariationsStep
+            featureFlagId={state.featureFlagId}
+            variations={state.variations}
+            onFlagChange={(flagId) =>
+              setState((prev) => ({ ...prev, featureFlagId: flagId }))
+            }
+            onVariationsChange={(variations) =>
+              setState((prev) => ({ ...prev, variations }))
+            }
+          />
+        )
+      case 3:
+        return (
+          <AudienceTrafficStep
+            audience={state.audience}
+            variations={state.variations}
+            onChange={(audience) => setState((prev) => ({ ...prev, audience }))}
+          />
+        )
+      case 4:
+        return <ReviewLaunchStep wizardState={state} onEditStep={goToStep} />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className='create-experiment-page'>
+      <WizardHeader
+        breadcrumbs={[{ label: 'Experiments' }, { label: 'Create Experiment' }]}
+        title='Create Experiment'
+        onCancel={handleCancel}
+      />
+
+      <div className='create-experiment-page__divider' />
+
+      <WizardLayout
+        sidebar={
+          <WizardSidebar
+            steps={stepsWithSummary}
+            currentStep={state.currentStep}
+            onStepClick={goToStep}
+          />
+        }
+      >
+        {renderStepContent()}
+
+        <WizardNavButtons
+          isFirstStep={state.currentStep === 0}
+          isLastStep={state.currentStep === TOTAL_STEPS - 1}
+          onBack={handleBack}
+          onContinue={handleContinue}
+        />
+      </WizardLayout>
+    </div>
+  )
+}
+
+CreateExperimentPage.displayName = 'CreateExperimentPage'
+export default CreateExperimentPage

--- a/frontend/web/components/experiments-v2/ExperimentResultsPage.scss
+++ b/frontend/web/components/experiments-v2/ExperimentResultsPage.scss
@@ -1,0 +1,70 @@
+.experiment-results-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px 32px 24px;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--color-text-default);
+    margin: 0;
+  }
+
+  &__days {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+  }
+
+  &__action-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__subtitle {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+
+    .btn svg {
+      margin-right: 4px;
+    }
+  }
+
+  &__cards {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__table-section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__section-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text-default);
+    margin: 0;
+  }
+}

--- a/frontend/web/components/experiments-v2/ExperimentResultsPage.scss
+++ b/frontend/web/components/experiments-v2/ExperimentResultsPage.scss
@@ -17,15 +17,15 @@
   }
 
   &__title {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 22px;
-    font-weight: 700;
+    font-family: var(--font-family);
+    font-size: var(--font-h4-size);
+    font-weight: var(--font-weight-bold);
     color: var(--color-text-default);
     margin: 0;
   }
 
   &__days {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
   }
 
@@ -36,7 +36,7 @@
   }
 
   &__subtitle {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
   }
 
@@ -51,6 +51,7 @@
 
   &__cards {
     display: flex;
+    flex-wrap: wrap;
     gap: 16px;
   }
 
@@ -61,9 +62,9 @@
   }
 
   &__section-title {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 16px;
-    font-weight: 700;
+    font-family: var(--font-family);
+    font-size: var(--font-h6-size);
+    font-weight: var(--font-weight-bold);
     color: var(--color-text-default);
     margin: 0;
   }

--- a/frontend/web/components/experiments-v2/ExperimentResultsPage.scss
+++ b/frontend/web/components/experiments-v2/ExperimentResultsPage.scss
@@ -7,7 +7,7 @@
   &__header {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 12px;
   }
 
   &__title-row {
@@ -17,16 +17,10 @@
   }
 
   &__title {
-    font-family: var(--font-family);
     font-size: var(--font-h4-size);
     font-weight: var(--font-weight-bold);
     color: var(--color-text-default);
     margin: 0;
-  }
-
-  &__days {
-    font-size: var(--font-body-sm-size);
-    color: var(--color-text-secondary);
   }
 
   &__action-row {
@@ -49,12 +43,90 @@
     }
   }
 
+  // Timeline progress
+  &__timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 16px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+  }
+
+  &__timeline-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__timeline-label {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__timeline-value {
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-default);
+  }
+
+  &__timeline-track {
+    height: 6px;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+  }
+
+  &__timeline-fill {
+    height: 100%;
+    background: var(--color-surface-action);
+    border-radius: var(--radius-full);
+    transition: width var(--duration-slow) var(--easing-standard);
+  }
+
+  // Stat cards
   &__cards {
     display: flex;
     flex-wrap: wrap;
     gap: 16px;
   }
 
+  // Recommendation callout
+  &__recommendation {
+    display: flex;
+    gap: 12px;
+    padding: 16px 20px;
+    background: var(--color-surface-success);
+    border: 1px solid var(--color-border-success);
+    border-radius: var(--radius-lg);
+
+    svg {
+      color: var(--color-icon-success);
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+  }
+
+  &__recommendation-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__recommendation-title {
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-success);
+  }
+
+  &__recommendation-text {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-default);
+    line-height: 1.5;
+  }
+
+  // Table section
   &__table-section {
     display: flex;
     flex-direction: column;
@@ -62,10 +134,47 @@
   }
 
   &__section-title {
-    font-family: var(--font-family);
     font-size: var(--font-h6-size);
     font-weight: var(--font-weight-bold);
     color: var(--color-text-default);
     margin: 0;
+  }
+
+  // Config summary
+  &__config {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__config-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+  }
+
+  &__config-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 16px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+  }
+
+  &__config-label {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__config-value {
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-default);
+
+    &--mono {
+      font-family: var(--font-family);
+    }
   }
 }

--- a/frontend/web/components/experiments-v2/ExperimentResultsPage.tsx
+++ b/frontend/web/components/experiments-v2/ExperimentResultsPage.tsx
@@ -1,0 +1,77 @@
+import React, { FC } from 'react'
+import Button from 'components/base/forms/Button'
+import StatusBadge from './shared/StatusBadge'
+import ExperimentStatCard from './shared/ExperimentStatCard'
+import MetricsComparisonTable from './shared/MetricsComparisonTable'
+import { MOCK_EXPERIMENT_RESULT } from './types'
+import './ExperimentResultsPage.scss'
+
+const ExperimentResultsPage: FC = () => {
+  const result = MOCK_EXPERIMENT_RESULT
+
+  return (
+    <div className='experiment-results-page'>
+      <div className='experiment-results-page__header'>
+        <div className='experiment-results-page__title-row'>
+          <h1 className='experiment-results-page__title'>{result.name}</h1>
+          <StatusBadge status={result.status} />
+          <span className='experiment-results-page__days'>
+            Day {result.daysCurrent} of {result.daysTotal}
+          </span>
+        </div>
+
+        <div className='experiment-results-page__action-row'>
+          <span className='experiment-results-page__subtitle'>
+            Primary metric: {result.primaryMetric} &middot; Last updated{' '}
+            {result.lastUpdated}
+          </span>
+          <div className='experiment-results-page__actions'>
+            <Button
+              theme='outline'
+              size='small'
+              iconLeft='open-external-link'
+              iconSize={14}
+            >
+              Export
+            </Button>
+            <Button theme='danger' size='small'>
+              Stop Experiment
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className='experiment-results-page__cards'>
+        <ExperimentStatCard
+          label='Users Enrolled'
+          value={result.usersEnrolled}
+        />
+        <ExperimentStatCard
+          label='Winning Variation'
+          value={result.winningVariation}
+          trend='positive'
+        />
+        <ExperimentStatCard
+          label='Probability to be Best'
+          value={`${result.probabilityToBest}%`}
+        />
+        <ExperimentStatCard
+          label='Lift vs Control'
+          value={`+${result.liftVsControl}%`}
+          trend='positive'
+          subtitle='vs control group'
+        />
+      </div>
+
+      <div className='experiment-results-page__table-section'>
+        <h2 className='experiment-results-page__section-title'>
+          Metrics Comparison
+        </h2>
+        <MetricsComparisonTable metrics={result.metrics} />
+      </div>
+    </div>
+  )
+}
+
+ExperimentResultsPage.displayName = 'ExperimentResultsPage'
+export default ExperimentResultsPage

--- a/frontend/web/components/experiments-v2/ExperimentResultsPage.tsx
+++ b/frontend/web/components/experiments-v2/ExperimentResultsPage.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
 import StatusBadge from './shared/StatusBadge'
 import ExperimentStatCard from './shared/ExperimentStatCard'
 import MetricsComparisonTable from './shared/MetricsComparisonTable'
@@ -8,6 +9,9 @@ import './ExperimentResultsPage.scss'
 
 const ExperimentResultsPage: FC = () => {
   const result = MOCK_EXPERIMENT_RESULT
+  const progressPercent = Math.round(
+    (result.daysCurrent / result.daysTotal) * 100,
+  )
 
   return (
     <div className='experiment-results-page'>
@@ -15,9 +19,6 @@ const ExperimentResultsPage: FC = () => {
         <div className='experiment-results-page__title-row'>
           <h1 className='experiment-results-page__title'>{result.name}</h1>
           <StatusBadge status={result.status} />
-          <span className='experiment-results-page__days'>
-            Day {result.daysCurrent} of {result.daysTotal}
-          </span>
         </div>
 
         <div className='experiment-results-page__action-row'>
@@ -37,6 +38,24 @@ const ExperimentResultsPage: FC = () => {
             <Button theme='danger' size='small'>
               Stop Experiment
             </Button>
+          </div>
+        </div>
+
+        {/* Timeline progress */}
+        <div className='experiment-results-page__timeline'>
+          <div className='experiment-results-page__timeline-header'>
+            <span className='experiment-results-page__timeline-label'>
+              Experiment Timeline
+            </span>
+            <span className='experiment-results-page__timeline-value'>
+              Day {result.daysCurrent} of {result.daysTotal}
+            </span>
+          </div>
+          <div className='experiment-results-page__timeline-track'>
+            <div
+              className='experiment-results-page__timeline-fill'
+              style={{ width: `${progressPercent}%` }}
+            />
           </div>
         </div>
       </div>
@@ -63,11 +82,65 @@ const ExperimentResultsPage: FC = () => {
         />
       </div>
 
+      {/* Recommendation callout */}
+      <div className='experiment-results-page__recommendation'>
+        <Icon name='checkmark-circle' width={20} />
+        <div className='experiment-results-page__recommendation-content'>
+          <span className='experiment-results-page__recommendation-title'>
+            Recommendation
+          </span>
+          <span className='experiment-results-page__recommendation-text'>
+            Treatment B is outperforming Control with 94.2% probability of being
+            the best variant. Consider rolling out Treatment B to 100% of
+            traffic after the experiment concludes on day {result.daysTotal}.
+          </span>
+        </div>
+      </div>
+
       <div className='experiment-results-page__table-section'>
         <h2 className='experiment-results-page__section-title'>
           Metrics Comparison
         </h2>
         <MetricsComparisonTable metrics={result.metrics} />
+      </div>
+
+      {/* Experiment config summary */}
+      <div className='experiment-results-page__config'>
+        <h2 className='experiment-results-page__section-title'>
+          Experiment Configuration
+        </h2>
+        <div className='experiment-results-page__config-grid'>
+          <div className='experiment-results-page__config-item'>
+            <span className='experiment-results-page__config-label'>Type</span>
+            <span className='experiment-results-page__config-value'>
+              A/B Test
+            </span>
+          </div>
+          <div className='experiment-results-page__config-item'>
+            <span className='experiment-results-page__config-label'>
+              Feature Flag
+            </span>
+            <span className='experiment-results-page__config-value experiment-results-page__config-value--mono'>
+              checkout_button_redesign
+            </span>
+          </div>
+          <div className='experiment-results-page__config-item'>
+            <span className='experiment-results-page__config-label'>
+              Audience
+            </span>
+            <span className='experiment-results-page__config-value'>
+              All Users
+            </span>
+          </div>
+          <div className='experiment-results-page__config-item'>
+            <span className='experiment-results-page__config-label'>
+              Traffic
+            </span>
+            <span className='experiment-results-page__config-value'>
+              50% / 50%
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/frontend/web/components/experiments-v2/flag-detail/LinkedExperimentSection.scss
+++ b/frontend/web/components/experiments-v2/flag-detail/LinkedExperimentSection.scss
@@ -1,0 +1,141 @@
+.linked-experiment-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .btn svg {
+      margin-right: 4px;
+    }
+  }
+
+  &__title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  // Experiment card (inlined from LinkedExperimentCard)
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-action);
+    border-radius: var(--radius-lg);
+  }
+
+  &__card-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__card-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  &__details {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  &__detail-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    svg,
+    .icon {
+      color: var(--color-icon-secondary);
+      flex-shrink: 0;
+    }
+  }
+
+  &__detail-label {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+  }
+
+  &__detail-value {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-default);
+  }
+
+  &__progress {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__progress-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__progress-label {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+
+  &__progress-value {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-default);
+  }
+
+  &__progress-track {
+    height: 6px;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+  }
+
+  &__progress-fill {
+    height: 100%;
+    background: var(--color-surface-action);
+    border-radius: var(--radius-full);
+    transition: width var(--duration-slow) var(--easing-standard);
+  }
+
+  // Empty state
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding: 40px 20px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    text-align: center;
+
+    svg,
+    .icon {
+      color: var(--color-icon-secondary);
+    }
+  }
+
+  &__empty-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  &__empty-desc {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    max-width: 400px;
+  }
+}

--- a/frontend/web/components/experiments-v2/flag-detail/LinkedExperimentSection.scss
+++ b/frontend/web/components/experiments-v2/flag-detail/LinkedExperimentSection.scss
@@ -14,8 +14,8 @@
   }
 
   &__title {
-    font-size: 16px;
-    font-weight: 600;
+    font-size: var(--font-h6-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
@@ -37,8 +37,8 @@
   }
 
   &__card-name {
-    font-size: 15px;
-    font-weight: 600;
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
@@ -61,13 +61,13 @@
   }
 
   &__detail-label {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
   }
 
   &__detail-value {
-    font-size: 13px;
-    font-weight: 500;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-default);
   }
 
@@ -84,13 +84,13 @@
   }
 
   &__progress-label {
-    font-size: 12px;
+    font-size: var(--font-caption-size);
     color: var(--color-text-secondary);
   }
 
   &__progress-value {
-    font-size: 12px;
-    font-weight: 500;
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-default);
   }
 
@@ -127,13 +127,13 @@
   }
 
   &__empty-title {
-    font-size: 15px;
-    font-weight: 600;
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
   &__empty-desc {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
     line-height: 1.5;
     max-width: 400px;

--- a/frontend/web/components/experiments-v2/flag-detail/LinkedExperimentSection.tsx
+++ b/frontend/web/components/experiments-v2/flag-detail/LinkedExperimentSection.tsx
@@ -1,0 +1,119 @@
+import React, { FC } from 'react'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
+import StatusBadge from 'components/experiments-v2/shared/StatusBadge'
+import { LinkedExperiment } from 'components/experiments-v2/types'
+import './LinkedExperimentSection.scss'
+
+type LinkedExperimentSectionProps = {
+  experiment?: LinkedExperiment | null
+  onCreateExperiment?: () => void
+  onViewResults?: () => void
+}
+
+const LinkedExperimentSection: FC<LinkedExperimentSectionProps> = ({
+  experiment,
+  onCreateExperiment,
+  onViewResults,
+}) => {
+  const progressPercent = experiment
+    ? Math.round((experiment.sampleProgress / experiment.sampleTarget) * 100)
+    : 0
+
+  return (
+    <div className='linked-experiment-section'>
+      <div className='linked-experiment-section__header'>
+        <span className='linked-experiment-section__title'>
+          Linked Experiment
+        </span>
+        {experiment && (
+          <Button
+            theme='primary'
+            size='xSmall'
+            iconLeft='open-external-link'
+            iconSize={14}
+            onClick={onViewResults}
+          >
+            View Results
+          </Button>
+        )}
+      </div>
+
+      {experiment ? (
+        <div className='linked-experiment-section__card'>
+          <div className='linked-experiment-section__card-top'>
+            <span className='linked-experiment-section__card-name'>
+              {experiment.name}
+            </span>
+            <StatusBadge status={experiment.status} />
+          </div>
+
+          <div className='linked-experiment-section__details'>
+            <div className='linked-experiment-section__detail-row'>
+              <Icon name='pie-chart' width={14} />
+              <span className='linked-experiment-section__detail-label'>
+                Primary Metric:
+              </span>
+              <span className='linked-experiment-section__detail-value'>
+                {experiment.primaryMetric}
+              </span>
+            </div>
+            <div className='linked-experiment-section__detail-row'>
+              <Icon name='clock' width={14} />
+              <span className='linked-experiment-section__detail-label'>
+                Running Since:
+              </span>
+              <span className='linked-experiment-section__detail-value'>
+                {experiment.runningSince}
+              </span>
+            </div>
+            <div className='linked-experiment-section__detail-row'>
+              <Icon name='people' width={14} />
+              <span className='linked-experiment-section__detail-label'>
+                Traffic:
+              </span>
+              <span className='linked-experiment-section__detail-value'>
+                {experiment.trafficSplit}
+              </span>
+            </div>
+          </div>
+
+          <div className='linked-experiment-section__progress'>
+            <div className='linked-experiment-section__progress-header'>
+              <span className='linked-experiment-section__progress-label'>
+                Sample Progress
+              </span>
+              <span className='linked-experiment-section__progress-value'>
+                {progressPercent}% ({experiment.sampleProgress.toLocaleString()}{' '}
+                / {experiment.sampleTarget.toLocaleString()})
+              </span>
+            </div>
+            <div className='linked-experiment-section__progress-track'>
+              <div
+                className='linked-experiment-section__progress-fill'
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className='linked-experiment-section__empty'>
+          <Icon name='flask' width={40} />
+          <span className='linked-experiment-section__empty-title'>
+            No experiment linked
+          </span>
+          <span className='linked-experiment-section__empty-desc'>
+            Create an experiment to test variations of this feature flag and
+            measure their impact on your key metrics.
+          </span>
+          <Button theme='primary' iconLeft='plus' onClick={onCreateExperiment}>
+            Create Experiment
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+LinkedExperimentSection.displayName = 'LinkedExperimentSection'
+export default LinkedExperimentSection

--- a/frontend/web/components/experiments-v2/shared/ExperimentStatCard.scss
+++ b/frontend/web/components/experiments-v2/shared/ExperimentStatCard.scss
@@ -1,0 +1,39 @@
+.experiment-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  flex: 1;
+
+  &__label {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+
+  &__value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--color-text-default);
+
+    &--positive {
+      color: var(--color-text-success);
+    }
+
+    &--negative {
+      color: var(--color-text-danger);
+    }
+
+    &--neutral {
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__subtitle {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+}

--- a/frontend/web/components/experiments-v2/shared/ExperimentStatCard.scss
+++ b/frontend/web/components/experiments-v2/shared/ExperimentStatCard.scss
@@ -6,17 +6,18 @@
   background: var(--color-surface-subtle);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
   flex: 1;
 
   &__label {
-    font-size: 12px;
+    font-size: var(--font-caption-size);
     color: var(--color-text-secondary);
   }
 
   &__value {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 28px;
-    font-weight: 700;
+    font-family: var(--font-family);
+    font-size: var(--font-h3-size);
+    font-weight: var(--font-weight-bold);
     color: var(--color-text-default);
 
     &--positive {
@@ -33,7 +34,7 @@
   }
 
   &__subtitle {
-    font-size: 12px;
+    font-size: var(--font-caption-size);
     color: var(--color-text-secondary);
   }
 }

--- a/frontend/web/components/experiments-v2/shared/ExperimentStatCard.tsx
+++ b/frontend/web/components/experiments-v2/shared/ExperimentStatCard.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react'
+import { LiftDirection } from 'components/experiments-v2/types'
+import './ExperimentStatCard.scss'
+
+type ExperimentStatCardProps = {
+  label: string
+  value: string | number
+  subtitle?: string
+  trend?: LiftDirection
+}
+
+const ExperimentStatCard: FC<ExperimentStatCardProps> = ({
+  label,
+  subtitle,
+  trend,
+  value,
+}) => {
+  return (
+    <div className='experiment-stat-card'>
+      <span className='experiment-stat-card__label'>{label}</span>
+      <span
+        className={`experiment-stat-card__value ${
+          trend ? `experiment-stat-card__value--${trend}` : ''
+        }`}
+      >
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </span>
+      {subtitle && (
+        <span className='experiment-stat-card__subtitle'>{subtitle}</span>
+      )}
+    </div>
+  )
+}
+
+ExperimentStatCard.displayName = 'ExperimentStatCard'
+export default ExperimentStatCard

--- a/frontend/web/components/experiments-v2/shared/MetricsComparisonTable.scss
+++ b/frontend/web/components/experiments-v2/shared/MetricsComparisonTable.scss
@@ -1,6 +1,7 @@
 .metrics-comparison-table {
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-sm);
   overflow: hidden;
 
   &__head {
@@ -11,8 +12,8 @@
   &__th {
     flex: 1;
     padding: 12px 16px;
-    font-size: 12px;
-    font-weight: 600;
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-secondary);
   }
 
@@ -29,21 +30,21 @@
   &__td {
     flex: 1;
     padding: 14px 16px;
-    font-size: 14px;
+    font-size: var(--font-body-size);
     color: var(--color-text-default);
 
     &--mono {
-      font-family: 'JetBrains Mono', monospace;
+      font-family: var(--font-family);
     }
 
     &--positive {
       color: var(--color-text-success);
-      font-weight: 600;
+      font-weight: var(--font-weight-semibold);
     }
 
     &--negative {
       color: var(--color-text-danger);
-      font-weight: 600;
+      font-weight: var(--font-weight-semibold);
     }
 
     &--neutral {

--- a/frontend/web/components/experiments-v2/shared/MetricsComparisonTable.scss
+++ b/frontend/web/components/experiments-v2/shared/MetricsComparisonTable.scss
@@ -1,0 +1,63 @@
+.metrics-comparison-table {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+
+  &__head {
+    display: flex;
+    background: var(--color-surface-emphasis);
+  }
+
+  &__th {
+    flex: 1;
+    padding: 12px 16px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+  }
+
+  &__row {
+    display: flex;
+    border-top: 1px solid var(--color-border-default);
+    transition: background var(--duration-fast) var(--easing-standard);
+
+    &:hover {
+      background: var(--color-surface-hover);
+    }
+  }
+
+  &__td {
+    flex: 1;
+    padding: 14px 16px;
+    font-size: 14px;
+    color: var(--color-text-default);
+
+    &--mono {
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    &--positive {
+      color: var(--color-text-success);
+      font-weight: 600;
+    }
+
+    &--negative {
+      color: var(--color-text-danger);
+      font-weight: 600;
+    }
+
+    &--neutral {
+      color: var(--color-text-secondary);
+    }
+
+    &--significance {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    &--significant {
+      color: var(--color-text-success);
+    }
+  }
+}

--- a/frontend/web/components/experiments-v2/shared/MetricsComparisonTable.tsx
+++ b/frontend/web/components/experiments-v2/shared/MetricsComparisonTable.tsx
@@ -1,0 +1,59 @@
+import React, { FC } from 'react'
+import Icon from 'components/icons/Icon'
+import { MetricComparison } from 'components/experiments-v2/types'
+import './MetricsComparisonTable.scss'
+
+type MetricsComparisonTableProps = {
+  metrics: MetricComparison[]
+}
+
+const MetricsComparisonTable: FC<MetricsComparisonTableProps> = ({
+  metrics,
+}) => {
+  return (
+    <div className='metrics-comparison-table'>
+      <div className='metrics-comparison-table__head'>
+        <span className='metrics-comparison-table__th'>Metric</span>
+        <span className='metrics-comparison-table__th'>Control</span>
+        <span className='metrics-comparison-table__th'>Treatment B</span>
+        <span className='metrics-comparison-table__th'>Lift</span>
+        <span className='metrics-comparison-table__th'>Significance</span>
+      </div>
+
+      {metrics.map((metric) => (
+        <div key={metric.name} className='metrics-comparison-table__row'>
+          <span className='metrics-comparison-table__td'>{metric.name}</span>
+          <span className='metrics-comparison-table__td metrics-comparison-table__td--mono'>
+            {metric.control}
+          </span>
+          <span className='metrics-comparison-table__td metrics-comparison-table__td--mono'>
+            {metric.treatment}
+          </span>
+          <span
+            className={`metrics-comparison-table__td metrics-comparison-table__td--mono metrics-comparison-table__td--${metric.liftDirection}`}
+          >
+            {metric.lift}
+          </span>
+          <span
+            className={`metrics-comparison-table__td metrics-comparison-table__td--significance ${
+              metric.isSignificant
+                ? 'metrics-comparison-table__td--significant'
+                : ''
+            }`}
+          >
+            {metric.significance}
+            {metric.isSignificant && (
+              <>
+                {' '}
+                <Icon name='checkmark' width={14} />
+              </>
+            )}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+MetricsComparisonTable.displayName = 'MetricsComparisonTable'
+export default MetricsComparisonTable

--- a/frontend/web/components/experiments-v2/shared/SelectableCard.scss
+++ b/frontend/web/components/experiments-v2/shared/SelectableCard.scss
@@ -1,0 +1,71 @@
+.selectable-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition:
+    border-color var(--duration-fast) var(--easing-standard),
+    background var(--duration-fast) var(--easing-standard);
+
+  &:hover {
+    border-color: var(--color-border-strong);
+  }
+
+  &--selected {
+    border-color: var(--color-border-action);
+    border-width: 2px;
+    background: var(--color-surface-action-subtle);
+
+    svg,
+    .icon {
+      color: var(--color-icon-action);
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    svg,
+    .icon {
+      color: var(--color-icon-secondary);
+      margin-bottom: 4px;
+    }
+  }
+
+  &__title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  &__description {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+
+  &__badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+
+    &--primary {
+      background: var(--color-surface-action);
+      color: #ffffff;
+    }
+
+    &--secondary {
+      border: 1px solid var(--color-border-default);
+      color: var(--color-text-secondary);
+    }
+  }
+}

--- a/frontend/web/components/experiments-v2/shared/SelectableCard.scss
+++ b/frontend/web/components/experiments-v2/shared/SelectableCard.scss
@@ -4,22 +4,24 @@
   justify-content: space-between;
   padding: 16px;
   border-radius: var(--radius-xl);
-  border: 1px solid var(--color-border-default);
+  border: 2px solid transparent;
+  box-shadow: inset 0 0 0 1px var(--color-border-default);
   background: transparent;
   cursor: pointer;
   text-align: left;
   width: 100%;
   transition:
     border-color var(--duration-fast) var(--easing-standard),
+    box-shadow var(--duration-fast) var(--easing-standard),
     background var(--duration-fast) var(--easing-standard);
 
   &:hover {
-    border-color: var(--color-border-strong);
+    box-shadow: inset 0 0 0 1px var(--color-border-strong);
   }
 
   &--selected {
     border-color: var(--color-border-action);
-    border-width: 2px;
+    box-shadow: none;
     background: var(--color-surface-action-subtle);
 
     svg,
@@ -41,26 +43,26 @@
   }
 
   &__title {
-    font-size: 14px;
-    font-weight: 600;
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
   &__description {
-    font-size: 12px;
+    font-size: var(--font-caption-size);
     color: var(--color-text-secondary);
   }
 
   &__badge {
-    font-size: 11px;
-    font-weight: 600;
+    font-size: var(--font-caption-xs-size);
+    font-weight: var(--font-weight-semibold);
     padding: 4px 12px;
     border-radius: var(--radius-full);
     flex-shrink: 0;
 
     &--primary {
       background: var(--color-surface-action);
-      color: #ffffff;
+      color: var(--color-surface-default);
     }
 
     &--secondary {

--- a/frontend/web/components/experiments-v2/shared/SelectableCard.tsx
+++ b/frontend/web/components/experiments-v2/shared/SelectableCard.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import Icon, { IconName } from 'components/icons/Icon'
+import './SelectableCard.scss'
+
+type BadgeVariant = 'primary' | 'secondary'
+
+type SelectableCardProps = {
+  selected: boolean
+  onClick: () => void
+  icon?: IconName
+  title: string
+  description: string
+  badge?: { label: string; variant: BadgeVariant }
+}
+
+const SelectableCard: FC<SelectableCardProps> = ({
+  badge,
+  description,
+  icon,
+  onClick,
+  selected,
+  title,
+}) => {
+  return (
+    <button
+      className={`selectable-card ${
+        selected ? 'selectable-card--selected' : ''
+      }`}
+      onClick={onClick}
+      type='button'
+    >
+      <div className='selectable-card__content'>
+        {icon && <Icon name={icon} width={20} />}
+        <span className='selectable-card__title'>{title}</span>
+        <span className='selectable-card__description'>{description}</span>
+      </div>
+      {badge && (
+        <span
+          className={`selectable-card__badge selectable-card__badge--${badge.variant}`}
+        >
+          {badge.label}
+        </span>
+      )}
+    </button>
+  )
+}
+
+SelectableCard.displayName = 'SelectableCard'
+export default SelectableCard

--- a/frontend/web/components/experiments-v2/shared/StatusBadge.scss
+++ b/frontend/web/components/experiments-v2/shared/StatusBadge.scss
@@ -1,0 +1,42 @@
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-weight: 600;
+
+  &__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+  }
+
+  &--running {
+    background: var(--color-surface-success);
+    color: var(--color-text-success);
+
+    .status-badge__dot {
+      background: var(--color-text-success);
+    }
+  }
+
+  &--paused {
+    background: var(--color-surface-warning);
+    color: var(--color-text-warning);
+
+    .status-badge__dot {
+      background: var(--color-text-warning);
+    }
+  }
+
+  &--completed {
+    background: var(--color-surface-muted);
+    color: var(--color-text-secondary);
+
+    .status-badge__dot {
+      background: var(--color-text-secondary);
+    }
+  }
+}

--- a/frontend/web/components/experiments-v2/shared/StatusBadge.scss
+++ b/frontend/web/components/experiments-v2/shared/StatusBadge.scss
@@ -4,8 +4,8 @@
   gap: 4px;
   padding: 3px 10px;
   border-radius: var(--radius-full);
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-caption-xs-size);
+  font-weight: var(--font-weight-semibold);
 
   &__dot {
     width: 6px;

--- a/frontend/web/components/experiments-v2/shared/StatusBadge.tsx
+++ b/frontend/web/components/experiments-v2/shared/StatusBadge.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react'
+import { ExperimentStatus } from 'components/experiments-v2/types'
+import './StatusBadge.scss'
+
+type StatusBadgeProps = {
+  status: ExperimentStatus
+}
+
+const STATUS_LABELS: Record<ExperimentStatus, string> = {
+  completed: 'Completed',
+  paused: 'Paused',
+  running: 'Running',
+}
+
+const StatusBadge: FC<StatusBadgeProps> = ({ status }) => {
+  return (
+    <span className={`status-badge status-badge--${status}`}>
+      <span className='status-badge__dot' />
+      {STATUS_LABELS[status]}
+    </span>
+  )
+}
+
+StatusBadge.displayName = 'StatusBadge'
+export default StatusBadge

--- a/frontend/web/components/experiments-v2/shared/TrafficSplitBar.scss
+++ b/frontend/web/components/experiments-v2/shared/TrafficSplitBar.scss
@@ -1,0 +1,53 @@
+.traffic-split-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &__bar {
+    display: flex;
+    height: 8px;
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    background: var(--color-surface-muted);
+  }
+
+  &__segment {
+    height: 100%;
+    transition: width var(--duration-slow) var(--easing-standard);
+
+    &:first-child {
+      border-radius: var(--radius-full) 0 0 var(--radius-full);
+    }
+
+    &:last-child {
+      border-radius: 0 var(--radius-full) var(--radius-full) 0;
+    }
+
+    &:only-child {
+      border-radius: var(--radius-full);
+    }
+  }
+
+  &__labels {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  &__label-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+  }
+
+  &__label-text {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+  }
+}

--- a/frontend/web/components/experiments-v2/shared/TrafficSplitBar.scss
+++ b/frontend/web/components/experiments-v2/shared/TrafficSplitBar.scss
@@ -47,7 +47,7 @@
   }
 
   &__label-text {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
   }
 }

--- a/frontend/web/components/experiments-v2/shared/TrafficSplitBar.tsx
+++ b/frontend/web/components/experiments-v2/shared/TrafficSplitBar.tsx
@@ -1,0 +1,47 @@
+import React, { FC } from 'react'
+import './TrafficSplitBar.scss'
+
+type Split = {
+  name: string
+  percentage: number
+  colour: string
+}
+
+type TrafficSplitBarProps = {
+  splits: Split[]
+}
+
+const TrafficSplitBar: FC<TrafficSplitBarProps> = ({ splits }) => {
+  return (
+    <div className='traffic-split-bar'>
+      <div className='traffic-split-bar__bar'>
+        {splits.map((split, index) => (
+          <div
+            key={index}
+            className='traffic-split-bar__segment'
+            style={{
+              background: split.colour,
+              width: `${split.percentage}%`,
+            }}
+          />
+        ))}
+      </div>
+      <div className='traffic-split-bar__labels'>
+        {splits.map((split, index) => (
+          <div key={index} className='traffic-split-bar__label'>
+            <span
+              className='traffic-split-bar__label-dot'
+              style={{ background: split.colour }}
+            />
+            <span className='traffic-split-bar__label-text'>
+              {split.name}: {split.percentage}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+TrafficSplitBar.displayName = 'TrafficSplitBar'
+export default TrafficSplitBar

--- a/frontend/web/components/experiments-v2/shared/VariationTable.scss
+++ b/frontend/web/components/experiments-v2/shared/VariationTable.scss
@@ -1,6 +1,7 @@
 .variation-table {
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-sm);
   overflow: hidden;
 
   &__head {
@@ -11,8 +12,8 @@
   }
 
   &__th {
-    font-size: 12px;
-    font-weight: 600;
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.02em;
@@ -75,14 +76,14 @@
   }
 
   &__name-text {
-    font-size: 14px;
-    font-weight: 600;
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
   &__control-tag {
-    font-size: 11px;
-    font-weight: 500;
+    font-size: var(--font-caption-xs-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-secondary);
     background: var(--color-surface-muted);
     padding: 2px 8px;
@@ -90,14 +91,14 @@
   }
 
   &__desc-text {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
     line-height: 1.4;
   }
 
   &__value-badge {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 13px;
+    font-family: var(--font-family);
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-default);
     background: var(--color-surface-muted);
     padding: 6px 12px;

--- a/frontend/web/components/experiments-v2/shared/VariationTable.scss
+++ b/frontend/web/components/experiments-v2/shared/VariationTable.scss
@@ -1,0 +1,120 @@
+.variation-table {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+
+  &__head {
+    display: flex;
+    padding: 12px 20px;
+    background: var(--color-surface-muted);
+    gap: 16px;
+  }
+
+  &__th {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+
+    &--name,
+    &--desc {
+      flex: 1;
+    }
+
+    &--value {
+      width: 100px;
+    }
+
+    &--actions {
+      width: 40px;
+    }
+  }
+
+  &__row {
+    display: flex;
+    padding: 16px 20px;
+    gap: 16px;
+    border-top: 1px solid var(--color-border-default);
+    align-items: center;
+    transition: background var(--duration-fast) var(--easing-standard);
+
+    &:hover {
+      background: var(--color-surface-hover);
+    }
+  }
+
+  &__cell {
+    &--name {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 1;
+    }
+
+    &--desc {
+      flex: 1;
+    }
+
+    &--value {
+      width: 100px;
+    }
+
+    &--actions {
+      width: 40px;
+      display: flex;
+      justify-content: center;
+    }
+  }
+
+  &__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+  }
+
+  &__name-text {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  &__control-tag {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    background: var(--color-surface-muted);
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+  }
+
+  &__desc-text {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.4;
+  }
+
+  &__value-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    color: var(--color-text-default);
+    background: var(--color-surface-muted);
+    padding: 6px 12px;
+    border-radius: var(--radius-md);
+  }
+
+  &__action-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    color: var(--color-icon-secondary);
+    border-radius: var(--radius-sm);
+    transition: color var(--duration-fast) var(--easing-standard);
+
+    &:hover {
+      color: var(--color-icon-danger);
+    }
+  }
+}

--- a/frontend/web/components/experiments-v2/shared/VariationTable.tsx
+++ b/frontend/web/components/experiments-v2/shared/VariationTable.tsx
@@ -1,0 +1,75 @@
+import React, { FC } from 'react'
+import Icon from 'components/icons/Icon'
+import { Variation } from 'components/experiments-v2/types'
+import './VariationTable.scss'
+
+type VariationTableProps = {
+  variations: Variation[]
+  editable?: boolean
+  onRemove?: (id: string) => void
+}
+
+const VariationTable: FC<VariationTableProps> = ({
+  editable = false,
+  onRemove,
+  variations,
+}) => {
+  return (
+    <div className='variation-table'>
+      <div className='variation-table__head'>
+        <span className='variation-table__th variation-table__th--name'>
+          Name
+        </span>
+        <span className='variation-table__th variation-table__th--desc'>
+          Description
+        </span>
+        <span className='variation-table__th variation-table__th--value'>
+          Value
+        </span>
+        {editable && (
+          <span className='variation-table__th variation-table__th--actions' />
+        )}
+      </div>
+
+      {variations.map((variation) => (
+        <div key={variation.id} className='variation-table__row'>
+          <div className='variation-table__cell variation-table__cell--name'>
+            <span
+              className='variation-table__dot'
+              style={{ background: variation.colour }}
+            />
+            <span className='variation-table__name-text'>{variation.name}</span>
+            {variation.name === 'Control' && (
+              <span className='variation-table__control-tag'>control</span>
+            )}
+          </div>
+          <div className='variation-table__cell variation-table__cell--desc'>
+            <span className='variation-table__desc-text'>
+              {variation.description}
+            </span>
+          </div>
+          <div className='variation-table__cell variation-table__cell--value'>
+            <span className='variation-table__value-badge'>
+              {variation.value}
+            </span>
+          </div>
+          {editable && (
+            <div className='variation-table__cell variation-table__cell--actions'>
+              <button
+                className='variation-table__action-btn'
+                onClick={() => onRemove?.(variation.id)}
+                type='button'
+                aria-label={`Remove ${variation.name}`}
+              >
+                <Icon name='trash-2' width={18} />
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+VariationTable.displayName = 'VariationTable'
+export default VariationTable

--- a/frontend/web/components/experiments-v2/steps/AudienceTrafficStep.scss
+++ b/frontend/web/components/experiments-v2/steps/AudienceTrafficStep.scss
@@ -1,0 +1,81 @@
+.audience-traffic-step {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-default);
+  }
+
+  &__slider-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__slider {
+    flex: 1;
+    appearance: none;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: var(--color-surface-muted);
+    outline: none;
+    cursor: pointer;
+
+    &::-webkit-slider-thumb {
+      appearance: none;
+      width: 20px;
+      height: 20px;
+      border-radius: var(--radius-full);
+      background: var(--color-surface-action);
+      cursor: pointer;
+      border: 2px solid var(--color-surface-default);
+      box-shadow: var(--shadow-sm);
+    }
+
+    &::-moz-range-thumb {
+      width: 20px;
+      height: 20px;
+      border-radius: var(--radius-full);
+      background: var(--color-surface-action);
+      cursor: pointer;
+      border: 2px solid var(--color-surface-default);
+      box-shadow: var(--shadow-sm);
+    }
+  }
+
+  &__sample-estimate {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    font-size: 13px;
+    color: var(--color-text-secondary);
+
+    svg,
+    .icon {
+      color: var(--color-icon-action);
+      flex-shrink: 0;
+    }
+  }
+
+  &__percentage {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-text-default);
+    min-width: 48px;
+    text-align: right;
+  }
+}

--- a/frontend/web/components/experiments-v2/steps/AudienceTrafficStep.scss
+++ b/frontend/web/components/experiments-v2/steps/AudienceTrafficStep.scss
@@ -10,8 +10,8 @@
   }
 
   &__label {
-    font-size: 13px;
-    font-weight: 500;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-default);
   }
 
@@ -60,7 +60,7 @@
     background: var(--color-surface-subtle);
     border: 1px solid var(--color-border-default);
     border-radius: var(--radius-lg);
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
 
     svg,
@@ -71,9 +71,9 @@
   }
 
   &__percentage {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 16px;
-    font-weight: 600;
+    font-family: var(--font-family);
+    font-size: var(--font-h6-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
     min-width: 48px;
     text-align: right;

--- a/frontend/web/components/experiments-v2/steps/AudienceTrafficStep.tsx
+++ b/frontend/web/components/experiments-v2/steps/AudienceTrafficStep.tsx
@@ -1,0 +1,89 @@
+import React, { FC } from 'react'
+import SearchableSelect from 'components/base/select/SearchableSelect'
+import Icon from 'components/icons/Icon'
+import TrafficSplitBar from 'components/experiments-v2/shared/TrafficSplitBar'
+import { OptionType } from 'components/base/select/SearchableSelect'
+import {
+  AudienceConfig,
+  MOCK_SEGMENTS,
+  Variation,
+} from 'components/experiments-v2/types'
+import './AudienceTrafficStep.scss'
+
+type AudienceTrafficStepProps = {
+  audience: AudienceConfig
+  variations: Variation[]
+  onChange: (audience: AudienceConfig) => void
+}
+
+const AudienceTrafficStep: FC<AudienceTrafficStepProps> = ({
+  audience,
+  onChange,
+  variations,
+}) => {
+  const splitPerVariation = Math.round(
+    audience.trafficPercentage / Math.max(variations.length, 1),
+  )
+
+  const splits = variations.map((v) => ({
+    colour: v.colour,
+    name: v.name,
+    percentage: splitPerVariation,
+  }))
+
+  return (
+    <div className='audience-traffic-step'>
+      <div className='audience-traffic-step__field'>
+        <label className='audience-traffic-step__label'>Target Audience</label>
+        <SearchableSelect
+          value={audience.segmentId}
+          onChange={(opt: OptionType) => {
+            onChange({ ...audience, segmentId: opt.value })
+          }}
+          options={MOCK_SEGMENTS}
+          placeholder='Select a segment...'
+        />
+      </div>
+
+      <div className='audience-traffic-step__field'>
+        <label className='audience-traffic-step__label'>
+          Traffic Allocation
+        </label>
+        <div className='audience-traffic-step__slider-row'>
+          <input
+            type='range'
+            min={10}
+            max={100}
+            step={5}
+            value={audience.trafficPercentage}
+            onChange={(e) =>
+              onChange({
+                ...audience,
+                trafficPercentage: Number(e.target.value),
+              })
+            }
+            className='audience-traffic-step__slider'
+          />
+          <span className='audience-traffic-step__percentage'>
+            {audience.trafficPercentage}%
+          </span>
+        </div>
+      </div>
+
+      <div className='audience-traffic-step__field'>
+        <label className='audience-traffic-step__label'>Traffic Split</label>
+        <TrafficSplitBar splits={splits} />
+      </div>
+
+      <div className='audience-traffic-step__sample-estimate'>
+        <Icon name='people' width={20} />
+        <span>
+          ~6,200 users per variation &middot; Est. 14 days to significance
+        </span>
+      </div>
+    </div>
+  )
+}
+
+AudienceTrafficStep.displayName = 'AudienceTrafficStep'
+export default AudienceTrafficStep

--- a/frontend/web/components/experiments-v2/steps/ExperimentDetailsStep.scss
+++ b/frontend/web/components/experiments-v2/steps/ExperimentDetailsStep.scss
@@ -1,0 +1,53 @@
+.experiment-details-step {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-default);
+  }
+
+  &__required {
+    color: var(--color-text-danger);
+  }
+
+  &__textarea {
+    width: 100%;
+    min-height: 80px;
+    padding: 10px 14px;
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    background: transparent;
+    color: var(--color-text-default);
+    font-size: 14px;
+    font-family: inherit;
+    resize: vertical;
+    transition: border-color var(--duration-fast) var(--easing-standard);
+
+    &::placeholder {
+      color: var(--color-text-disabled);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--color-border-action);
+    }
+  }
+
+  &__type-cards {
+    display: flex;
+    gap: 12px;
+  }
+}

--- a/frontend/web/components/experiments-v2/steps/ExperimentDetailsStep.scss
+++ b/frontend/web/components/experiments-v2/steps/ExperimentDetailsStep.scss
@@ -14,8 +14,8 @@
   }
 
   &__label {
-    font-size: 13px;
-    font-weight: 500;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-default);
   }
 
@@ -31,7 +31,7 @@
     border-radius: var(--radius-lg);
     background: transparent;
     color: var(--color-text-default);
-    font-size: 14px;
+    font-size: var(--font-body-size);
     font-family: inherit;
     resize: vertical;
     transition: border-color var(--duration-fast) var(--easing-standard);

--- a/frontend/web/components/experiments-v2/steps/ExperimentDetailsStep.tsx
+++ b/frontend/web/components/experiments-v2/steps/ExperimentDetailsStep.tsx
@@ -1,0 +1,103 @@
+import React, { FC } from 'react'
+import Input from 'components/base/forms/Input'
+import { IconName } from 'components/icons/Icon'
+import SelectableCard from 'components/experiments-v2/shared/SelectableCard'
+import {
+  ExperimentDetails,
+  ExperimentType,
+} from 'components/experiments-v2/types'
+import './ExperimentDetailsStep.scss'
+
+type ExperimentDetailsStepProps = {
+  details: ExperimentDetails
+  onChange: (details: ExperimentDetails) => void
+}
+
+const TYPE_CONFIG: Record<
+  ExperimentType,
+  { icon: IconName; title: string; description: string }
+> = {
+  ab_test: {
+    description: 'Compare two variations',
+    icon: 'bar-chart',
+    title: 'A/B Test',
+  },
+  feature_flag: {
+    description: 'Toggle feature on/off',
+    icon: 'features',
+    title: 'Feature Flag',
+  },
+  multivariate: {
+    description: 'Test multiple variables',
+    icon: 'layers',
+    title: 'Multivariate',
+  },
+}
+
+const EXPERIMENT_TYPES: ExperimentType[] = [
+  'ab_test',
+  'multivariate',
+  'feature_flag',
+]
+
+const ExperimentDetailsStep: FC<ExperimentDetailsStepProps> = ({
+  details,
+  onChange,
+}) => {
+  return (
+    <div className='experiment-details-step'>
+      <div className='experiment-details-step__field'>
+        <label className='experiment-details-step__label'>
+          Experiment Name{' '}
+          <span className='experiment-details-step__required'>*</span>
+        </label>
+        <Input
+          value={details.name}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onChange({ ...details, name: e.target.value })
+          }
+          placeholder='e.g. Checkout Flow Redesign'
+        />
+      </div>
+
+      <div className='experiment-details-step__field'>
+        <label className='experiment-details-step__label'>
+          Hypothesis{' '}
+          <span className='experiment-details-step__required'>*</span>
+        </label>
+        <textarea
+          className='experiment-details-step__textarea'
+          value={details.hypothesis}
+          onChange={(e) => onChange({ ...details, hypothesis: e.target.value })}
+          placeholder='Describe what you expect to happen...'
+          rows={3}
+        />
+      </div>
+
+      <div className='experiment-details-step__field'>
+        <label className='experiment-details-step__label'>
+          Experiment Type{' '}
+          <span className='experiment-details-step__required'>*</span>
+        </label>
+        <div className='experiment-details-step__type-cards'>
+          {EXPERIMENT_TYPES.map((type) => {
+            const config = TYPE_CONFIG[type]
+            return (
+              <SelectableCard
+                key={type}
+                icon={config.icon}
+                title={config.title}
+                description={config.description}
+                selected={details.type === type}
+                onClick={() => onChange({ ...details, type })}
+              />
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+ExperimentDetailsStep.displayName = 'ExperimentDetailsStep'
+export default ExperimentDetailsStep

--- a/frontend/web/components/experiments-v2/steps/FlagVariationsStep.scss
+++ b/frontend/web/components/experiments-v2/steps/FlagVariationsStep.scss
@@ -10,8 +10,8 @@
   }
 
   &__label {
-    font-size: 13px;
-    font-weight: 500;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-default);
   }
 

--- a/frontend/web/components/experiments-v2/steps/FlagVariationsStep.scss
+++ b/frontend/web/components/experiments-v2/steps/FlagVariationsStep.scss
@@ -1,0 +1,33 @@
+.flag-variations-step {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-default);
+  }
+
+  &__add-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-surface-action-subtle);
+    border: 1px solid var(--color-border-action);
+    border-radius: var(--radius-lg);
+  }
+
+  &__add-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+}

--- a/frontend/web/components/experiments-v2/steps/FlagVariationsStep.tsx
+++ b/frontend/web/components/experiments-v2/steps/FlagVariationsStep.tsx
@@ -1,0 +1,123 @@
+import React, { FC, useState } from 'react'
+import Button from 'components/base/forms/Button'
+import Input from 'components/base/forms/Input'
+import SearchableSelect from 'components/base/select/SearchableSelect'
+import VariationTable from 'components/experiments-v2/shared/VariationTable'
+import { OptionType } from 'components/base/select/SearchableSelect'
+import { MOCK_FLAGS, Variation } from 'components/experiments-v2/types'
+import './FlagVariationsStep.scss'
+
+type FlagVariationsStepProps = {
+  featureFlagId: string | null
+  variations: Variation[]
+  onFlagChange: (flagId: string) => void
+  onVariationsChange: (variations: Variation[]) => void
+}
+
+const FlagVariationsStep: FC<FlagVariationsStepProps> = ({
+  featureFlagId,
+  onFlagChange,
+  onVariationsChange,
+  variations,
+}) => {
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newDescription, setNewDescription] = useState('')
+  const [newValue, setNewValue] = useState('')
+
+  const handleAddVariation = () => {
+    if (!newName) return
+
+    const newVariation: Variation = {
+      colour: 'var(--orange-500)',
+      description: newDescription,
+      id: `var-${Date.now()}`,
+      name: newName,
+      value: newValue || 'false',
+    }
+    onVariationsChange([...variations, newVariation])
+    setNewName('')
+    setNewDescription('')
+    setNewValue('')
+    setShowAddForm(false)
+  }
+
+  const handleRemove = (id: string) => {
+    onVariationsChange(variations.filter((v) => v.id !== id))
+  }
+
+  return (
+    <div className='flag-variations-step'>
+      <div className='flag-variations-step__field'>
+        <label className='flag-variations-step__label'>Feature Flag</label>
+        <SearchableSelect
+          value={featureFlagId}
+          onChange={(opt: OptionType) => {
+            onFlagChange(opt.value)
+          }}
+          options={MOCK_FLAGS}
+          placeholder='Select a feature flag...'
+        />
+      </div>
+
+      <div className='flag-variations-step__field'>
+        <label className='flag-variations-step__label'>Variations</label>
+        <VariationTable
+          variations={variations}
+          editable
+          onRemove={handleRemove}
+        />
+      </div>
+
+      {showAddForm ? (
+        <div className='flag-variations-step__add-form'>
+          <Input
+            value={newName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setNewName(e.target.value)
+            }
+            placeholder='Variation name'
+          />
+          <Input
+            value={newDescription}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setNewDescription(e.target.value)
+            }
+            placeholder='Description'
+          />
+          <Input
+            value={newValue}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setNewValue(e.target.value)
+            }
+            placeholder='Value'
+          />
+          <div className='flag-variations-step__add-actions'>
+            <Button
+              theme='outline'
+              size='small'
+              onClick={() => setShowAddForm(false)}
+            >
+              Cancel
+            </Button>
+            <Button theme='primary' size='small' onClick={handleAddVariation}>
+              Add
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          theme='outline'
+          size='small'
+          iconLeft='plus'
+          onClick={() => setShowAddForm(true)}
+        >
+          Add Variation
+        </Button>
+      )}
+    </div>
+  )
+}
+
+FlagVariationsStep.displayName = 'FlagVariationsStep'
+export default FlagVariationsStep

--- a/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.scss
+++ b/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.scss
@@ -26,7 +26,6 @@
   }
 
   &__section-title {
-    font-family: var(--font-family);
     font-size: var(--font-body-size);
     font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
@@ -37,6 +36,12 @@
     align-items: center;
     justify-content: space-between;
     gap: 16px;
+
+    &--block {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+    }
   }
 
   &__label {
@@ -55,12 +60,67 @@
     }
   }
 
+  &__hypothesis {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-default);
+    line-height: 1.5;
+    padding: 12px;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-md);
+    width: 100%;
+  }
+
+  &__type-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-action);
+    background: var(--color-surface-action-subtle);
+    padding: 4px 12px;
+    border-radius: var(--radius-full);
+
+    svg {
+      color: var(--color-icon-action);
+    }
+  }
+
+  // Metrics
+  &__metric-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 12px;
+    border-radius: var(--radius-md);
+    background: var(--color-surface-muted);
+  }
+
+  &__metric-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__metric-name {
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-default);
+  }
+
+  &__metric-desc {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
   &__badge {
     font-size: var(--font-caption-xs-size);
     font-weight: var(--font-weight-medium);
     padding: 2px 10px;
     border-radius: var(--radius-full);
     text-transform: capitalize;
+    flex-shrink: 0;
 
     &--primary {
       background: var(--color-surface-action);
@@ -71,6 +131,92 @@
       border: 1px solid var(--color-border-default);
       color: var(--color-text-secondary);
     }
+  }
+
+  // Variations
+  &__variations {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__variation {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: var(--radius-md);
+    background: var(--color-surface-muted);
+  }
+
+  &__variation-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+  }
+
+  &__variation-name {
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-default);
+    flex: 1;
+  }
+
+  &__variation-value {
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-secondary);
+    background: var(--color-surface-subtle);
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+  }
+
+  // Traffic split
+  &__traffic-split {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__traffic-bar {
+    display: flex;
+    height: 8px;
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    background: var(--color-surface-muted);
+  }
+
+  &__traffic-segment {
+    height: 100%;
+
+    &:first-child {
+      border-radius: var(--radius-full) 0 0 var(--radius-full);
+    }
+
+    &:last-child {
+      border-radius: 0 var(--radius-full) var(--radius-full) 0;
+    }
+  }
+
+  &__traffic-labels {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__traffic-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__traffic-label-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
   }
 
   &__empty {

--- a/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.scss
+++ b/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.scss
@@ -1,0 +1,80 @@
+.review-launch-step {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 20px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    transition: border-color var(--duration-fast) var(--easing-standard);
+
+    &:hover {
+      border-color: var(--color-border-strong);
+    }
+  }
+
+  &__section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__section-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  &__label {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+  }
+
+  &__value {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-default);
+    text-align: right;
+
+    &--mono {
+      font-family: 'JetBrains Mono', monospace;
+    }
+  }
+
+  &__badge {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: var(--radius-full);
+    text-transform: capitalize;
+
+    &--primary {
+      background: var(--color-surface-action);
+      color: #ffffff;
+    }
+
+    &--secondary {
+      border: 1px solid var(--color-border-default);
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__empty {
+    font-size: 13px;
+    color: var(--color-text-disabled);
+    font-style: italic;
+  }
+}

--- a/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.scss
+++ b/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.scss
@@ -11,6 +11,7 @@
     background: var(--color-surface-subtle);
     border: 1px solid var(--color-border-default);
     border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
     transition: border-color var(--duration-fast) var(--easing-standard);
 
     &:hover {
@@ -25,9 +26,9 @@
   }
 
   &__section-title {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 14px;
-    font-weight: 600;
+    font-family: var(--font-family);
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
@@ -39,31 +40,31 @@
   }
 
   &__label {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
   }
 
   &__value {
-    font-size: 13px;
-    font-weight: 500;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
     color: var(--color-text-default);
     text-align: right;
 
     &--mono {
-      font-family: 'JetBrains Mono', monospace;
+      font-family: var(--font-family);
     }
   }
 
   &__badge {
-    font-size: 11px;
-    font-weight: 500;
+    font-size: var(--font-caption-xs-size);
+    font-weight: var(--font-weight-medium);
     padding: 2px 10px;
     border-radius: var(--radius-full);
     text-transform: capitalize;
 
     &--primary {
       background: var(--color-surface-action);
-      color: #ffffff;
+      color: var(--color-surface-default);
     }
 
     &--secondary {
@@ -73,7 +74,7 @@
   }
 
   &__empty {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-disabled);
     font-style: italic;
   }

--- a/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.tsx
+++ b/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.tsx
@@ -1,0 +1,139 @@
+import React, { FC } from 'react'
+import Button from 'components/base/forms/Button'
+import {
+  ExperimentWizardState,
+  MOCK_FLAGS,
+  MOCK_SEGMENTS,
+} from 'components/experiments-v2/types'
+import './ReviewLaunchStep.scss'
+
+type ReviewLaunchStepProps = {
+  wizardState: ExperimentWizardState
+  onEditStep: (step: number) => void
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  ab_test: 'A/B Test',
+  feature_flag: 'Feature Flag',
+  multivariate: 'Multivariate',
+}
+
+const ReviewLaunchStep: FC<ReviewLaunchStepProps> = ({
+  onEditStep,
+  wizardState,
+}) => {
+  const flagLabel =
+    MOCK_FLAGS.find((f) => f.value === wizardState.featureFlagId)?.label ?? '—'
+  const segmentLabel =
+    MOCK_SEGMENTS.find((s) => s.value === wizardState.audience.segmentId)
+      ?.label ?? 'All Users'
+
+  return (
+    <div className='review-launch-step'>
+      {/* Step 1: Experiment Details */}
+      <div className='review-launch-step__section'>
+        <div className='review-launch-step__section-header'>
+          <span className='review-launch-step__section-title'>
+            Experiment Details
+          </span>
+          <Button theme='text' size='xSmall' onClick={() => onEditStep(0)}>
+            Edit
+          </Button>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Name</span>
+          <span className='review-launch-step__value'>
+            {wizardState.details.name || '—'}
+          </span>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Hypothesis</span>
+          <span className='review-launch-step__value'>
+            {wizardState.details.hypothesis || '—'}
+          </span>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Type</span>
+          <span className='review-launch-step__value'>
+            {wizardState.details.type
+              ? TYPE_LABELS[wizardState.details.type]
+              : '—'}
+          </span>
+        </div>
+      </div>
+
+      {/* Step 2: Metrics */}
+      <div className='review-launch-step__section'>
+        <div className='review-launch-step__section-header'>
+          <span className='review-launch-step__section-title'>Metrics</span>
+          <Button theme='text' size='xSmall' onClick={() => onEditStep(1)}>
+            Edit
+          </Button>
+        </div>
+        {wizardState.metrics.length > 0 ? (
+          wizardState.metrics.map((m) => (
+            <div key={m.id} className='review-launch-step__row'>
+              <span className='review-launch-step__label'>{m.name}</span>
+              <span
+                className={`review-launch-step__badge review-launch-step__badge--${m.role}`}
+              >
+                {m.role}
+              </span>
+            </div>
+          ))
+        ) : (
+          <span className='review-launch-step__empty'>No metrics selected</span>
+        )}
+      </div>
+
+      {/* Step 3: Flag & Variations */}
+      <div className='review-launch-step__section'>
+        <div className='review-launch-step__section-header'>
+          <span className='review-launch-step__section-title'>
+            Flag & Variations
+          </span>
+          <Button theme='text' size='xSmall' onClick={() => onEditStep(2)}>
+            Edit
+          </Button>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Feature Flag</span>
+          <span className='review-launch-step__value review-launch-step__value--mono'>
+            {flagLabel}
+          </span>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Variations</span>
+          <span className='review-launch-step__value'>
+            {wizardState.variations.map((v) => v.name).join(', ')}
+          </span>
+        </div>
+      </div>
+
+      {/* Step 4: Audience & Traffic */}
+      <div className='review-launch-step__section'>
+        <div className='review-launch-step__section-header'>
+          <span className='review-launch-step__section-title'>
+            Audience & Traffic
+          </span>
+          <Button theme='text' size='xSmall' onClick={() => onEditStep(3)}>
+            Edit
+          </Button>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Segment</span>
+          <span className='review-launch-step__value'>{segmentLabel}</span>
+        </div>
+        <div className='review-launch-step__row'>
+          <span className='review-launch-step__label'>Traffic</span>
+          <span className='review-launch-step__value'>
+            {wizardState.audience.trafficPercentage}%
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+ReviewLaunchStep.displayName = 'ReviewLaunchStep'
+export default ReviewLaunchStep

--- a/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.tsx
+++ b/frontend/web/components/experiments-v2/steps/ReviewLaunchStep.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
 import {
   ExperimentWizardState,
   MOCK_FLAGS,
@@ -12,10 +13,10 @@ type ReviewLaunchStepProps = {
   onEditStep: (step: number) => void
 }
 
-const TYPE_LABELS: Record<string, string> = {
-  ab_test: 'A/B Test',
-  feature_flag: 'Feature Flag',
-  multivariate: 'Multivariate',
+const TYPE_CONFIG: Record<string, { icon: string; label: string }> = {
+  ab_test: { icon: 'bar-chart', label: 'A/B Test' },
+  feature_flag: { icon: 'features', label: 'Feature Flag' },
+  multivariate: { icon: 'layers', label: 'Multivariate' },
 }
 
 const ReviewLaunchStep: FC<ReviewLaunchStepProps> = ({
@@ -27,6 +28,13 @@ const ReviewLaunchStep: FC<ReviewLaunchStepProps> = ({
   const segmentLabel =
     MOCK_SEGMENTS.find((s) => s.value === wizardState.audience.segmentId)
       ?.label ?? 'All Users'
+  const typeConfig = wizardState.details.type
+    ? TYPE_CONFIG[wizardState.details.type]
+    : null
+  const splitPerVariation = Math.round(
+    wizardState.audience.trafficPercentage /
+      Math.max(wizardState.variations.length, 1),
+  )
 
   return (
     <div className='review-launch-step'>
@@ -46,34 +54,46 @@ const ReviewLaunchStep: FC<ReviewLaunchStepProps> = ({
             {wizardState.details.name || '—'}
           </span>
         </div>
-        <div className='review-launch-step__row'>
-          <span className='review-launch-step__label'>Hypothesis</span>
-          <span className='review-launch-step__value'>
-            {wizardState.details.hypothesis || '—'}
-          </span>
-        </div>
-        <div className='review-launch-step__row'>
-          <span className='review-launch-step__label'>Type</span>
-          <span className='review-launch-step__value'>
-            {wizardState.details.type
-              ? TYPE_LABELS[wizardState.details.type]
-              : '—'}
-          </span>
-        </div>
+        {wizardState.details.hypothesis && (
+          <div className='review-launch-step__row review-launch-step__row--block'>
+            <span className='review-launch-step__label'>Hypothesis</span>
+            <span className='review-launch-step__hypothesis'>
+              {wizardState.details.hypothesis}
+            </span>
+          </div>
+        )}
+        {typeConfig && (
+          <div className='review-launch-step__row'>
+            <span className='review-launch-step__label'>Type</span>
+            <span className='review-launch-step__type-badge'>
+              <Icon name={typeConfig.icon} width={14} />
+              {typeConfig.label}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Step 2: Metrics */}
       <div className='review-launch-step__section'>
         <div className='review-launch-step__section-header'>
-          <span className='review-launch-step__section-title'>Metrics</span>
+          <span className='review-launch-step__section-title'>
+            Metrics ({wizardState.metrics.length})
+          </span>
           <Button theme='text' size='xSmall' onClick={() => onEditStep(1)}>
             Edit
           </Button>
         </div>
         {wizardState.metrics.length > 0 ? (
           wizardState.metrics.map((m) => (
-            <div key={m.id} className='review-launch-step__row'>
-              <span className='review-launch-step__label'>{m.name}</span>
+            <div key={m.id} className='review-launch-step__metric-row'>
+              <div className='review-launch-step__metric-info'>
+                <span className='review-launch-step__metric-name'>
+                  {m.name}
+                </span>
+                <span className='review-launch-step__metric-desc'>
+                  {m.description}
+                </span>
+              </div>
               <span
                 className={`review-launch-step__badge review-launch-step__badge--${m.role}`}
               >
@@ -102,11 +122,21 @@ const ReviewLaunchStep: FC<ReviewLaunchStepProps> = ({
             {flagLabel}
           </span>
         </div>
-        <div className='review-launch-step__row'>
-          <span className='review-launch-step__label'>Variations</span>
-          <span className='review-launch-step__value'>
-            {wizardState.variations.map((v) => v.name).join(', ')}
-          </span>
+        <div className='review-launch-step__variations'>
+          {wizardState.variations.map((v) => (
+            <div key={v.id} className='review-launch-step__variation'>
+              <span
+                className='review-launch-step__variation-dot'
+                style={{ background: v.colour }}
+              />
+              <span className='review-launch-step__variation-name'>
+                {v.name}
+              </span>
+              <span className='review-launch-step__variation-value'>
+                {v.value}
+              </span>
+            </div>
+          ))}
         </div>
       </div>
 
@@ -125,10 +155,35 @@ const ReviewLaunchStep: FC<ReviewLaunchStepProps> = ({
           <span className='review-launch-step__value'>{segmentLabel}</span>
         </div>
         <div className='review-launch-step__row'>
-          <span className='review-launch-step__label'>Traffic</span>
+          <span className='review-launch-step__label'>Total Traffic</span>
           <span className='review-launch-step__value'>
             {wizardState.audience.trafficPercentage}%
           </span>
+        </div>
+        <div className='review-launch-step__traffic-split'>
+          <div className='review-launch-step__traffic-bar'>
+            {wizardState.variations.map((v) => (
+              <div
+                key={v.id}
+                className='review-launch-step__traffic-segment'
+                style={{
+                  background: v.colour,
+                  width: `${splitPerVariation}%`,
+                }}
+              />
+            ))}
+          </div>
+          <div className='review-launch-step__traffic-labels'>
+            {wizardState.variations.map((v) => (
+              <span key={v.id} className='review-launch-step__traffic-label'>
+                <span
+                  className='review-launch-step__traffic-label-dot'
+                  style={{ background: v.colour }}
+                />
+                {v.name}: {splitPerVariation}%
+              </span>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/web/components/experiments-v2/steps/SelectMetricsStep.scss
+++ b/frontend/web/components/experiments-v2/steps/SelectMetricsStep.scss
@@ -32,13 +32,13 @@
   }
 
   &__empty-title {
-    font-size: 14px;
-    font-weight: 600;
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-default);
   }
 
   &__empty-desc {
-    font-size: 12px;
+    font-size: var(--font-caption-size);
     color: var(--color-text-secondary);
   }
 }

--- a/frontend/web/components/experiments-v2/steps/SelectMetricsStep.scss
+++ b/frontend/web/components/experiments-v2/steps/SelectMetricsStep.scss
@@ -1,0 +1,44 @@
+.select-metrics-step {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 48px 24px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    text-align: center;
+
+    svg,
+    .icon {
+      color: var(--color-icon-disabled);
+    }
+  }
+
+  &__empty-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-default);
+  }
+
+  &__empty-desc {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+  }
+}

--- a/frontend/web/components/experiments-v2/steps/SelectMetricsStep.tsx
+++ b/frontend/web/components/experiments-v2/steps/SelectMetricsStep.tsx
@@ -1,0 +1,88 @@
+import React, { FC, useMemo, useState } from 'react'
+import Input from 'components/base/forms/Input'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
+import SelectableCard from 'components/experiments-v2/shared/SelectableCard'
+import { Metric, MOCK_METRICS } from 'components/experiments-v2/types'
+import './SelectMetricsStep.scss'
+
+type SelectMetricsStepProps = {
+  selectedMetrics: Metric[]
+  onToggleMetric: (metric: Metric) => void
+}
+
+const SelectMetricsStep: FC<SelectMetricsStepProps> = ({
+  onToggleMetric,
+  selectedMetrics,
+}) => {
+  const [search, setSearch] = useState('')
+
+  const filteredMetrics = useMemo(() => {
+    if (!search) return MOCK_METRICS
+    const lower = search.toLowerCase()
+    return MOCK_METRICS.filter(
+      (m) =>
+        m.name.toLowerCase().includes(lower) ||
+        m.description.toLowerCase().includes(lower),
+    )
+  }, [search])
+
+  const isSelected = (metric: Metric) =>
+    selectedMetrics.some((m) => m.id === metric.id)
+
+  const getRole = (metric: Metric) =>
+    selectedMetrics.find((m) => m.id === metric.id)?.role
+
+  const getBadge = (metric: Metric) => {
+    const role = getRole(metric)
+    if (!isSelected(metric) || !role) return undefined
+    return {
+      label: role === 'primary' ? 'Primary' : 'Secondary',
+      variant: role as 'primary' | 'secondary',
+    }
+  }
+
+  return (
+    <div className='select-metrics-step'>
+      <Input
+        value={search}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setSearch(e.target.value)
+        }
+        placeholder='Search metrics...'
+        search
+      />
+
+      {filteredMetrics.length > 0 ? (
+        <div className='select-metrics-step__list'>
+          {filteredMetrics.map((metric) => (
+            <SelectableCard
+              key={metric.id}
+              title={metric.name}
+              description={metric.description}
+              selected={isSelected(metric)}
+              badge={getBadge(metric)}
+              onClick={() => onToggleMetric(metric)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className='select-metrics-step__empty'>
+          <Icon name='search' width={36} />
+          <span className='select-metrics-step__empty-title'>
+            No metrics found for &ldquo;{search}&rdquo;
+          </span>
+          <span className='select-metrics-step__empty-desc'>
+            Try a different search term, or define a custom metric with SQL
+          </span>
+          <Button theme='primary' size='small'>
+            Define Custom Metric
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+SelectMetricsStep.displayName = 'SelectMetricsStep'
+export default SelectMetricsStep

--- a/frontend/web/components/experiments-v2/types.ts
+++ b/frontend/web/components/experiments-v2/types.ts
@@ -1,0 +1,276 @@
+// =============================================================================
+// Experiments V2 — Types & Mock Data
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Enums & Primitives
+// -----------------------------------------------------------------------------
+
+export type ExperimentType = 'ab_test' | 'multivariate' | 'feature_flag'
+
+export type ExperimentStatus = 'running' | 'paused' | 'completed'
+
+export type WizardStepStatus = 'done' | 'active' | 'upcoming'
+
+export type MetricRole = 'primary' | 'secondary'
+
+export type LiftDirection = 'positive' | 'negative' | 'neutral'
+
+// -----------------------------------------------------------------------------
+// Wizard State
+// -----------------------------------------------------------------------------
+
+export type ExperimentDetails = {
+  name: string
+  hypothesis: string
+  type: ExperimentType | null
+}
+
+export type Metric = {
+  id: string
+  name: string
+  description: string
+  role: MetricRole
+}
+
+export type Variation = {
+  id: string
+  name: string
+  description: string
+  value: string
+  colour: string
+}
+
+export type TrafficSplit = {
+  variationId: string
+  percentage: number
+}
+
+export type AudienceConfig = {
+  segmentId: string | null
+  trafficPercentage: number
+  splits: TrafficSplit[]
+}
+
+export type ExperimentWizardState = {
+  currentStep: number
+  details: ExperimentDetails
+  metrics: Metric[]
+  featureFlagId: string | null
+  variations: Variation[]
+  audience: AudienceConfig
+}
+
+// -----------------------------------------------------------------------------
+// Wizard Step Definition (for sidebar)
+// -----------------------------------------------------------------------------
+
+export type WizardStepDef = {
+  title: string
+  subtitle: string
+  completeSummary?: string
+}
+
+// -----------------------------------------------------------------------------
+// Results Page
+// -----------------------------------------------------------------------------
+
+export type MetricComparison = {
+  name: string
+  control: string
+  treatment: string
+  lift: string
+  liftDirection: LiftDirection
+  significance: string
+  isSignificant: boolean
+}
+
+export type ExperimentResultSummary = {
+  id: string
+  name: string
+  status: ExperimentStatus
+  daysCurrent: number
+  daysTotal: number
+  primaryMetric: string
+  lastUpdated: string
+  usersEnrolled: number
+  winningVariation: string
+  probabilityToBest: number
+  liftVsControl: number
+  metrics: MetricComparison[]
+}
+
+// -----------------------------------------------------------------------------
+// Flag Detail — Linked Experiment
+// -----------------------------------------------------------------------------
+
+export type LinkedExperiment = {
+  id: string
+  name: string
+  status: ExperimentStatus
+  primaryMetric: string
+  runningSince: string
+  trafficSplit: string
+  sampleProgress: number
+  sampleTarget: number
+}
+
+// -----------------------------------------------------------------------------
+// Dropdown Options
+// -----------------------------------------------------------------------------
+
+export type FlagOption = {
+  value: string
+  label: string
+}
+
+export type SegmentOption = {
+  value: string
+  label: string
+}
+
+// =============================================================================
+// Mock Data
+// =============================================================================
+
+export const MOCK_METRICS: Metric[] = [
+  {
+    description: 'Percentage of users completing checkout',
+    id: 'met-1',
+    name: 'Checkout Conversion Rate',
+    role: 'primary',
+  },
+  {
+    description: 'Average revenue generated per user session',
+    id: 'met-2',
+    name: 'Revenue per User',
+    role: 'secondary',
+  },
+  {
+    description: 'Average page load time in milliseconds',
+    id: 'met-3',
+    name: 'Page Load Time',
+    role: 'secondary',
+  },
+  {
+    description: 'Percentage of users who abandon the checkout flow',
+    id: 'met-4',
+    name: 'Cart Abandonment Rate',
+    role: 'secondary',
+  },
+  {
+    description: 'Average time users spend in a single session',
+    id: 'met-5',
+    name: 'Session Duration',
+    role: 'secondary',
+  },
+]
+
+export const MOCK_FLAGS: FlagOption[] = [
+  { label: 'checkout_button_redesign', value: 'flag-1' },
+  { label: 'new_pricing_page', value: 'flag-2' },
+  { label: 'search_algorithm_v2', value: 'flag-3' },
+  { label: 'onboarding_flow', value: 'flag-4' },
+]
+
+export const MOCK_SEGMENTS: SegmentOption[] = [
+  { label: 'All Users', value: 'seg-1' },
+  { label: 'Mobile Users', value: 'seg-2' },
+  { label: 'Premium Tier', value: 'seg-3' },
+]
+
+export const MOCK_VARIATIONS: Variation[] = [
+  {
+    colour: 'var(--green-500)',
+    description:
+      'Original checkout button design — serves as the baseline for comparison',
+    id: 'var-1',
+    name: 'Control',
+    value: 'true',
+  },
+  {
+    colour: 'var(--purple-500)',
+    description:
+      'New checkout button with updated styling and CTA copy for improved conversion',
+    id: 'var-2',
+    name: 'Treatment B',
+    value: 'false',
+  },
+]
+
+export const MOCK_EXPERIMENT_RESULT: ExperimentResultSummary = {
+  daysCurrent: 23,
+  daysTotal: 30,
+  id: 'exp-1',
+  lastUpdated: '2 min ago',
+  liftVsControl: 18.3,
+  metrics: [
+    {
+      control: '7.2%',
+      isSignificant: true,
+      lift: '+15.3%',
+      liftDirection: 'positive',
+      name: 'Conversion Rate',
+      significance: 'p<0.01',
+      treatment: '8.3%',
+    },
+    {
+      control: '$24.10',
+      isSignificant: true,
+      lift: '+14.1%',
+      liftDirection: 'positive',
+      name: 'Revenue per User',
+      significance: 'p<0.05',
+      treatment: '$27.50',
+    },
+    {
+      control: '2.4s',
+      isSignificant: false,
+      lift: '-4.2%',
+      liftDirection: 'neutral',
+      name: 'Page Load Time',
+      significance: 'not significant',
+      treatment: '2.3s',
+    },
+  ],
+  name: 'Checkout Button Redesign',
+  primaryMetric: 'Conversion Rate',
+  probabilityToBest: 94.2,
+  status: 'running',
+  usersEnrolled: 12847,
+  winningVariation: 'Treatment B',
+}
+
+export const MOCK_LINKED_EXPERIMENT: LinkedExperiment = {
+  id: 'exp-1',
+  name: 'Checkout Button A/B Test',
+  primaryMetric: 'Conversion Rate',
+  runningSince: 'Mar 15, 2026  (23 days)',
+  sampleProgress: 6800,
+  sampleTarget: 10000,
+  status: 'running',
+  trafficSplit: '50% / 50%',
+}
+
+export const EXPERIMENT_WIZARD_STEPS: WizardStepDef[] = [
+  {
+    subtitle: 'Define the basics of your experiment',
+    title: 'Experiment Details',
+  },
+  {
+    subtitle: 'Choose primary and secondary metrics to measure',
+    title: 'Select Metrics',
+  },
+  {
+    subtitle: 'Configure your feature flag and test variations',
+    title: 'Flag & Variations',
+  },
+  {
+    subtitle: 'Define who sees the experiment and traffic allocation',
+    title: 'Audience & Traffic',
+  },
+  {
+    subtitle: 'Review your configuration and launch',
+    title: 'Review & Launch',
+  },
+]

--- a/frontend/web/components/experiments-v2/wizard/WizardHeader.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardHeader.scss
@@ -10,7 +10,7 @@
   }
 
   &__breadcrumb-item {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
 
     &:last-child {
@@ -19,7 +19,7 @@
   }
 
   &__breadcrumb-separator {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-disabled);
   }
 
@@ -30,9 +30,9 @@
   }
 
   &__title {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 22px;
-    font-weight: 700;
+    font-family: var(--font-family);
+    font-size: var(--font-h4-size);
+    font-weight: var(--font-weight-bold);
     color: var(--color-text-default);
     margin: 0;
   }

--- a/frontend/web/components/experiments-v2/wizard/WizardHeader.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardHeader.scss
@@ -1,0 +1,39 @@
+.wizard-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &__breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  &__breadcrumb-item {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+
+    &:last-child {
+      color: var(--color-text-default);
+    }
+  }
+
+  &__breadcrumb-separator {
+    font-size: 13px;
+    color: var(--color-text-disabled);
+  }
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--color-text-default);
+    margin: 0;
+  }
+}

--- a/frontend/web/components/experiments-v2/wizard/WizardHeader.tsx
+++ b/frontend/web/components/experiments-v2/wizard/WizardHeader.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react'
+import Button from 'components/base/forms/Button'
+import './WizardHeader.scss'
+
+type BreadcrumbItem = {
+  label: string
+  href?: string
+}
+
+type WizardHeaderProps = {
+  breadcrumbs: BreadcrumbItem[]
+  title: string
+  onCancel: () => void
+}
+
+const WizardHeader: FC<WizardHeaderProps> = ({
+  breadcrumbs,
+  onCancel,
+  title,
+}) => {
+  return (
+    <div className='wizard-header'>
+      <div className='wizard-header__breadcrumb'>
+        {breadcrumbs.map((item, index) => (
+          <React.Fragment key={index}>
+            <span className='wizard-header__breadcrumb-item'>{item.label}</span>
+            {index < breadcrumbs.length - 1 && (
+              <span className='wizard-header__breadcrumb-separator'>/</span>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+      <div className='wizard-header__title-row'>
+        <h1 className='wizard-header__title'>{title}</h1>
+        <Button theme='outline' size='small' onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+WizardHeader.displayName = 'WizardHeader'
+export default WizardHeader

--- a/frontend/web/components/experiments-v2/wizard/WizardLayout.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardLayout.scss
@@ -1,0 +1,17 @@
+.wizard-layout {
+  display: flex;
+  gap: 48px;
+  width: 100%;
+
+  &__sidebar {
+    flex-shrink: 0;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    flex: 1;
+    min-width: 0;
+  }
+}

--- a/frontend/web/components/experiments-v2/wizard/WizardLayout.tsx
+++ b/frontend/web/components/experiments-v2/wizard/WizardLayout.tsx
@@ -1,0 +1,19 @@
+import React, { FC, ReactNode } from 'react'
+import './WizardLayout.scss'
+
+type WizardLayoutProps = {
+  sidebar: ReactNode
+  children: ReactNode
+}
+
+const WizardLayout: FC<WizardLayoutProps> = ({ children, sidebar }) => {
+  return (
+    <div className='wizard-layout'>
+      <aside className='wizard-layout__sidebar'>{sidebar}</aside>
+      <div className='wizard-layout__content'>{children}</div>
+    </div>
+  )
+}
+
+WizardLayout.displayName = 'WizardLayout'
+export default WizardLayout

--- a/frontend/web/components/experiments-v2/wizard/WizardNavButtons.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardNavButtons.scss
@@ -1,0 +1,13 @@
+.wizard-nav-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-border-default);
+
+  .btn svg {
+    margin-left: 4px;
+    margin-right: 4px;
+  }
+}

--- a/frontend/web/components/experiments-v2/wizard/WizardNavButtons.tsx
+++ b/frontend/web/components/experiments-v2/wizard/WizardNavButtons.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from 'react'
+import Button from 'components/base/forms/Button'
+import { IconName } from 'components/icons/Icon'
+import './WizardNavButtons.scss'
+
+type WizardNavButtonsProps = {
+  onBack?: () => void
+  onContinue: () => void
+  isFirstStep?: boolean
+  isLastStep?: boolean
+  continueDisabled?: boolean
+  continueLabel?: string
+  continueIcon?: IconName
+}
+
+const WizardNavButtons: FC<WizardNavButtonsProps> = ({
+  continueDisabled = false,
+  continueIcon,
+  continueLabel,
+  isFirstStep = false,
+  isLastStep = false,
+  onBack,
+  onContinue,
+}) => {
+  const label = continueLabel || (isLastStep ? 'Launch Experiment' : 'Continue')
+  const icon = continueIcon || (isLastStep ? 'rocket' : undefined)
+
+  return (
+    <div className='wizard-nav-buttons'>
+      {!isFirstStep && onBack && (
+        <Button
+          theme='outline'
+          onClick={onBack}
+          iconLeft='arrow-left'
+          iconSize={16}
+        >
+          Back
+        </Button>
+      )}
+      <Button
+        theme='primary'
+        onClick={onContinue}
+        disabled={continueDisabled}
+        iconRight={icon}
+        iconSize={16}
+      >
+        {label}
+      </Button>
+    </div>
+  )
+}
+
+WizardNavButtons.displayName = 'WizardNavButtons'
+export default WizardNavButtons

--- a/frontend/web/components/experiments-v2/wizard/WizardSidebar.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardSidebar.scss
@@ -1,0 +1,6 @@
+.wizard-sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 220px;
+  flex-shrink: 0;
+}

--- a/frontend/web/components/experiments-v2/wizard/WizardSidebar.tsx
+++ b/frontend/web/components/experiments-v2/wizard/WizardSidebar.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+import WizardStepIndicator from './WizardStepIndicator'
+import {
+  WizardStepDef,
+  WizardStepStatus,
+} from 'components/experiments-v2/types'
+import './WizardSidebar.scss'
+
+type WizardSidebarProps = {
+  steps: WizardStepDef[]
+  currentStep: number
+  onStepClick?: (step: number) => void
+}
+
+function getStepStatus(index: number, currentStep: number): WizardStepStatus {
+  if (index < currentStep) return 'done'
+  if (index === currentStep) return 'active'
+  return 'upcoming'
+}
+
+const WizardSidebar: FC<WizardSidebarProps> = ({
+  currentStep,
+  onStepClick,
+  steps,
+}) => {
+  return (
+    <nav className='wizard-sidebar'>
+      {steps.map((step, index) => (
+        <WizardStepIndicator
+          key={index}
+          stepNumber={index + 1}
+          title={step.title}
+          subtitle={step.subtitle}
+          status={getStepStatus(index, currentStep)}
+          completeSummary={step.completeSummary}
+          showConnector={index < steps.length - 1}
+          onClick={index < currentStep ? () => onStepClick?.(index) : undefined}
+        />
+      ))}
+    </nav>
+  )
+}
+
+WizardSidebar.displayName = 'WizardSidebar'
+export default WizardSidebar

--- a/frontend/web/components/experiments-v2/wizard/WizardStepIndicator.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardStepIndicator.scss
@@ -1,0 +1,121 @@
+.wizard-step-indicator {
+  display: flex;
+  gap: 20px;
+
+  &--done {
+    cursor: pointer;
+
+    .wizard-step-indicator__circle {
+      background: var(--color-surface-success);
+      border: 2px solid var(--green-500);
+      color: var(--color-text-success);
+    }
+
+    .wizard-step-indicator__title {
+      color: var(--color-text-default);
+    }
+  }
+
+  &--active {
+    .wizard-step-indicator__circle {
+      border: 2px solid var(--color-border-action);
+      color: var(--color-text-action);
+    }
+
+    .wizard-step-indicator__title {
+      color: var(--color-text-default);
+    }
+
+    .wizard-step-indicator__connector {
+      border-color: var(--color-border-default);
+    }
+  }
+
+  &--upcoming {
+    .wizard-step-indicator__circle {
+      border: 2px solid var(--color-border-default);
+      color: var(--color-text-disabled);
+    }
+
+    .wizard-step-indicator__title {
+      color: var(--color-text-disabled);
+    }
+  }
+
+  &__left {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 32px;
+    flex-shrink: 0;
+  }
+
+  &__circle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+  }
+
+  &__number {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  &__connector {
+    width: 2px;
+    flex: 1;
+    min-height: 24px;
+    background: var(--color-border-default);
+  }
+
+  &__right {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 0 24px;
+    flex: 1;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  &__badge {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-text-success);
+    background: var(--color-surface-success);
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+  }
+
+  &__summary {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+  }
+
+  &__description {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+
+  &__subtitle {
+    font-size: 13px;
+    color: var(--color-text-disabled);
+  }
+}

--- a/frontend/web/components/experiments-v2/wizard/WizardStepIndicator.scss
+++ b/frontend/web/components/experiments-v2/wizard/WizardStepIndicator.scss
@@ -61,9 +61,9 @@
   }
 
   &__number {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 13px;
-    font-weight: 600;
+    font-family: var(--font-family);
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-semibold);
   }
 
   &__connector {
@@ -89,14 +89,14 @@
   }
 
   &__title {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 16px;
-    font-weight: 600;
+    font-family: var(--font-family);
+    font-size: var(--font-h6-size);
+    font-weight: var(--font-weight-semibold);
   }
 
   &__badge {
-    font-size: 11px;
-    font-weight: 600;
+    font-size: var(--font-caption-xs-size);
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-success);
     background: var(--color-surface-success);
     padding: 3px 10px;
@@ -104,18 +104,18 @@
   }
 
   &__summary {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-secondary);
   }
 
   &__description {
-    font-size: 14px;
+    font-size: var(--font-body-size);
     color: var(--color-text-secondary);
     line-height: 1.5;
   }
 
   &__subtitle {
-    font-size: 13px;
+    font-size: var(--font-body-sm-size);
     color: var(--color-text-disabled);
   }
 }

--- a/frontend/web/components/experiments-v2/wizard/WizardStepIndicator.tsx
+++ b/frontend/web/components/experiments-v2/wizard/WizardStepIndicator.tsx
@@ -1,0 +1,76 @@
+import React, { FC } from 'react'
+import Icon from 'components/icons/Icon'
+import { WizardStepStatus } from 'components/experiments-v2/types'
+import './WizardStepIndicator.scss'
+
+type WizardStepIndicatorProps = {
+  stepNumber: number
+  title: string
+  subtitle?: string
+  status: WizardStepStatus
+  completeSummary?: string
+  showConnector?: boolean
+  onClick?: () => void
+}
+
+const WizardStepIndicator: FC<WizardStepIndicatorProps> = ({
+  completeSummary,
+  onClick,
+  showConnector = true,
+  status,
+  stepNumber,
+  subtitle,
+  title,
+}) => {
+  const isClickable = status === 'done' && !!onClick
+
+  return (
+    <div
+      className={`wizard-step-indicator wizard-step-indicator--${status}`}
+      onClick={isClickable ? onClick : undefined}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      onKeyDown={
+        isClickable
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') onClick?.()
+            }
+          : undefined
+      }
+    >
+      <div className='wizard-step-indicator__left'>
+        <div className='wizard-step-indicator__circle'>
+          {status === 'done' ? (
+            <Icon name='checkmark-circle' width={16} />
+          ) : (
+            <span className='wizard-step-indicator__number'>{stepNumber}</span>
+          )}
+        </div>
+        {showConnector && <div className='wizard-step-indicator__connector' />}
+      </div>
+
+      <div className='wizard-step-indicator__right'>
+        <div className='wizard-step-indicator__header'>
+          <span className='wizard-step-indicator__title'>{title}</span>
+          {status === 'done' && (
+            <span className='wizard-step-indicator__badge'>Complete</span>
+          )}
+        </div>
+        {status === 'done' && completeSummary && (
+          <span className='wizard-step-indicator__summary'>
+            {completeSummary}
+          </span>
+        )}
+        {status === 'active' && subtitle && (
+          <span className='wizard-step-indicator__description'>{subtitle}</span>
+        )}
+        {status === 'upcoming' && subtitle && (
+          <span className='wizard-step-indicator__subtitle'>{subtitle}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+WizardStepIndicator.displayName = 'WizardStepIndicator'
+export default WizardStepIndicator

--- a/frontend/web/components/warehouse/WarehousePage.scss
+++ b/frontend/web/components/warehouse/WarehousePage.scss
@@ -1,0 +1,61 @@
+.warehouse-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px 40px;
+  min-height: 100vh;
+
+  &__breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  &__breadcrumb-item {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__breadcrumb-sep {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-disabled);
+  }
+
+  &__breadcrumb-current {
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-default);
+  }
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  &__title-col {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__title {
+    font-size: var(--font-h4-size);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-default);
+    margin: 0;
+  }
+
+  &__subtitle {
+    font-size: var(--font-body-size);
+    color: var(--color-text-secondary);
+    margin: 0;
+    max-width: 600px;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+}

--- a/frontend/web/components/warehouse/WarehousePage.tsx
+++ b/frontend/web/components/warehouse/WarehousePage.tsx
@@ -1,0 +1,133 @@
+import React, { FC, useCallback, useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import EmptyState from './components/EmptyState'
+import ConfigForm from './components/ConfigForm'
+import TestingState from './components/TestingState'
+import ConnectedState from './components/ConnectedState'
+import ErrorState from './components/ErrorState'
+import { pageCrossfade } from 'common/utils/motion'
+import {
+  ConnectionState,
+  MOCK_CONNECTION_DETAILS,
+  MOCK_ERROR,
+  MOCK_STATS,
+  WarehouseConfig,
+} from './types'
+import './WarehousePage.scss'
+
+type WarehousePageProps = {
+  initialState?: ConnectionState
+}
+
+const WarehousePage: FC<WarehousePageProps> = ({ initialState = 'empty' }) => {
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>(initialState)
+
+  const handleConnect = useCallback(() => {
+    setConnectionState('configuring')
+  }, [])
+
+  const handleTestConnection = useCallback((_config: WarehouseConfig) => {
+    setConnectionState('testing')
+    // Simulate testing delay — in real app this would be an API call
+    setTimeout(() => {
+      // Randomly succeed or fail for demo purposes
+      setConnectionState(Math.random() > 0.3 ? 'connected' : 'error')
+    }, 3000)
+  }, [])
+
+  const handleEdit = useCallback(() => {
+    setConnectionState('configuring')
+  }, [])
+
+  const handleRetry = useCallback(() => {
+    setConnectionState('testing')
+    setTimeout(() => {
+      setConnectionState(Math.random() > 0.3 ? 'connected' : 'error')
+    }, 3000)
+  }, [])
+
+  const handleDisconnect = useCallback(() => {
+    setConnectionState('empty')
+  }, [])
+
+  const handleCancel = useCallback(() => {
+    setConnectionState('empty')
+  }, [])
+
+  const renderState = () => {
+    switch (connectionState) {
+      case 'empty':
+        return <EmptyState onConnect={handleConnect} />
+      case 'configuring':
+        return (
+          <ConfigForm
+            onTestConnection={handleTestConnection}
+            onCancel={handleCancel}
+          />
+        )
+      case 'testing':
+        return <TestingState />
+      case 'connected':
+        return (
+          <ConnectedState
+            stats={MOCK_STATS}
+            details={MOCK_CONNECTION_DETAILS}
+            onEdit={handleEdit}
+            onDisconnect={handleDisconnect}
+          />
+        )
+      case 'error':
+        return (
+          <ErrorState
+            error={MOCK_ERROR}
+            details={MOCK_CONNECTION_DETAILS}
+            onRetry={handleRetry}
+            onEdit={handleEdit}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className='warehouse-page'>
+      <div className='warehouse-page__breadcrumb'>
+        <span className='warehouse-page__breadcrumb-item'>Settings</span>
+        <span className='warehouse-page__breadcrumb-sep'>/</span>
+        <span className='warehouse-page__breadcrumb-current'>
+          Data Warehouse
+        </span>
+      </div>
+
+      <div className='warehouse-page__header'>
+        <div className='warehouse-page__title-col'>
+          <h1 className='warehouse-page__title'>Data Warehouse</h1>
+          {(connectionState === 'connected' || connectionState === 'error') && (
+            <p className='warehouse-page__subtitle'>
+              Stream flag evaluation and custom event data to your warehouse for
+              experimentation and analysis.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <AnimatePresence mode='wait'>
+        <motion.div
+          key={connectionState}
+          variants={pageCrossfade}
+          initial='hidden'
+          animate='visible'
+          exit='exit'
+          className='warehouse-page__content'
+        >
+          {renderState()}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  )
+}
+
+WarehousePage.displayName = 'WarehousePage'
+export default WarehousePage

--- a/frontend/web/components/warehouse/WarehousePage.tsx
+++ b/frontend/web/components/warehouse/WarehousePage.tsx
@@ -1,11 +1,9 @@
 import React, { FC, useCallback, useState } from 'react'
-import { AnimatePresence, motion } from 'motion/react'
 import EmptyState from './components/EmptyState'
 import ConfigForm from './components/ConfigForm'
 import TestingState from './components/TestingState'
 import ConnectedState from './components/ConnectedState'
 import ErrorState from './components/ErrorState'
-import { pageCrossfade } from 'common/utils/motion'
 import {
   ConnectionState,
   MOCK_CONNECTION_DETAILS,
@@ -113,18 +111,7 @@ const WarehousePage: FC<WarehousePageProps> = ({ initialState = 'empty' }) => {
         </div>
       </div>
 
-      <AnimatePresence mode='wait'>
-        <motion.div
-          key={connectionState}
-          variants={pageCrossfade}
-          initial='hidden'
-          animate='visible'
-          exit='exit'
-          className='warehouse-page__content'
-        >
-          {renderState()}
-        </motion.div>
-      </AnimatePresence>
+      <div className='warehouse-page__content'>{renderState()}</div>
     </div>
   )
 }

--- a/frontend/web/components/warehouse/components/ConfigForm.scss
+++ b/frontend/web/components/warehouse/components/ConfigForm.scss
@@ -1,0 +1,120 @@
+.wh-config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__section-label {
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-secondary);
+    letter-spacing: 0.5px;
+  }
+
+  &__type-row {
+    display: flex;
+    gap: 12px;
+  }
+
+  &__type-card {
+    position: relative;
+    width: 180px;
+
+    &--disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
+
+  &__coming-soon {
+    position: absolute;
+    bottom: 12px;
+    left: 16px;
+    font-size: var(--font-caption-xs-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-warning);
+    background: var(--color-surface-warning);
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+  }
+
+  &__label {
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-secondary);
+  }
+
+  &__row {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__divider {
+    height: 1px;
+    background: var(--color-border-default);
+  }
+
+  &__select-display {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 12px;
+    height: 36px;
+    background: var(--color-surface-muted);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-default);
+    cursor: pointer;
+
+    svg {
+      color: var(--color-icon-secondary);
+    }
+  }
+
+  &__textarea {
+    width: 100%;
+    min-height: 80px;
+    padding: 12px;
+    background: var(--color-surface-muted);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    color: var(--color-text-secondary);
+    font-family: var(--font-family);
+    font-size: var(--font-caption-size);
+    resize: vertical;
+    transition: border-color var(--duration-fast) var(--easing-standard);
+
+    &:focus {
+      @include focus-ring;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+}

--- a/frontend/web/components/warehouse/components/ConfigForm.scss
+++ b/frontend/web/components/warehouse/components/ConfigForm.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/animations';
+
 .wh-config-form {
   display: flex;
   flex-direction: column;
@@ -108,7 +110,7 @@
     transition: border-color var(--duration-fast) var(--easing-standard);
 
     &:focus {
-      @include focus-ring;
+      @include animations.focus-ring;
     }
   }
 

--- a/frontend/web/components/warehouse/components/ConfigForm.tsx
+++ b/frontend/web/components/warehouse/components/ConfigForm.tsx
@@ -1,10 +1,8 @@
 import React, { FC, useState } from 'react'
-import { motion } from 'motion/react'
 import Button from 'components/base/forms/Button'
 import Input from 'components/base/forms/Input'
 import Icon from 'components/icons/Icon'
 import SelectableCard from 'components/experiments-v2/shared/SelectableCard'
-import { slideInRight } from 'common/utils/motion'
 import {
   MOCK_CONFIG,
   WAREHOUSE_TYPES,
@@ -27,12 +25,7 @@ const ConfigForm: FC<ConfigFormProps> = ({ onCancel, onTestConnection }) => {
   }
 
   return (
-    <motion.div
-      className='wh-config-form'
-      variants={slideInRight}
-      initial='hidden'
-      animate='visible'
-    >
+    <div className='wh-config-form'>
       <div className='wh-config-form__section'>
         <span className='wh-config-form__section-label'>Warehouse Type</span>
         <div className='wh-config-form__type-row'>
@@ -151,7 +144,7 @@ const ConfigForm: FC<ConfigFormProps> = ({ onCancel, onTestConnection }) => {
           </Button>
         </div>
       </div>
-    </motion.div>
+    </div>
   )
 }
 

--- a/frontend/web/components/warehouse/components/ConfigForm.tsx
+++ b/frontend/web/components/warehouse/components/ConfigForm.tsx
@@ -1,0 +1,159 @@
+import React, { FC, useState } from 'react'
+import { motion } from 'motion/react'
+import Button from 'components/base/forms/Button'
+import Input from 'components/base/forms/Input'
+import Icon from 'components/icons/Icon'
+import SelectableCard from 'components/experiments-v2/shared/SelectableCard'
+import { slideInRight } from 'common/utils/motion'
+import {
+  MOCK_CONFIG,
+  WAREHOUSE_TYPES,
+  WarehouseConfig,
+  WarehouseType,
+} from 'components/warehouse/types'
+import './ConfigForm.scss'
+
+type ConfigFormProps = {
+  onTestConnection: (config: WarehouseConfig) => void
+  onCancel: () => void
+}
+
+const ConfigForm: FC<ConfigFormProps> = ({ onCancel, onTestConnection }) => {
+  const [config, setConfig] = useState<WarehouseConfig>(MOCK_CONFIG)
+  const [selectedType, setSelectedType] = useState<WarehouseType>('snowflake')
+
+  const updateField = (field: keyof WarehouseConfig, value: string) => {
+    setConfig((prev) => ({ ...prev, [field]: value }))
+  }
+
+  return (
+    <motion.div
+      className='wh-config-form'
+      variants={slideInRight}
+      initial='hidden'
+      animate='visible'
+    >
+      <div className='wh-config-form__section'>
+        <span className='wh-config-form__section-label'>Warehouse Type</span>
+        <div className='wh-config-form__type-row'>
+          {WAREHOUSE_TYPES.map((wh) => (
+            <div
+              key={wh.type}
+              className={`wh-config-form__type-card ${
+                !wh.available ? 'wh-config-form__type-card--disabled' : ''
+              }`}
+            >
+              <SelectableCard
+                icon={wh.type === 'snowflake' ? 'flash' : 'layers'}
+                title={wh.label}
+                description={wh.description}
+                selected={selectedType === wh.type}
+                onClick={() => {
+                  if (wh.available) setSelectedType(wh.type)
+                }}
+              />
+              {!wh.available && (
+                <span className='wh-config-form__coming-soon'>Coming Soon</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className='wh-config-form__card'>
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Account URL</label>
+          <Input
+            value={config.accountUrl}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              updateField('accountUrl', e.target.value)
+            }
+            placeholder='https://myorg.snowflakecomputing.com'
+          />
+        </div>
+
+        <div className='wh-config-form__row'>
+          <div className='wh-config-form__field'>
+            <label className='wh-config-form__label'>Database</label>
+            <Input
+              value={config.database}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                updateField('database', e.target.value)
+              }
+              placeholder='FLAGSMITH_PROD'
+            />
+          </div>
+          <div className='wh-config-form__field'>
+            <label className='wh-config-form__label'>Schema</label>
+            <Input
+              value={config.schema}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                updateField('schema', e.target.value)
+              }
+              placeholder='PUBLIC'
+            />
+          </div>
+        </div>
+
+        <div className='wh-config-form__row'>
+          <div className='wh-config-form__field'>
+            <label className='wh-config-form__label'>Warehouse</label>
+            <Input
+              value={config.warehouse}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                updateField('warehouse', e.target.value)
+              }
+              placeholder='COMPUTE_WH'
+            />
+          </div>
+          <div className='wh-config-form__field'>
+            <label className='wh-config-form__label'>User</label>
+            <Input
+              value={config.user}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                updateField('user', e.target.value)
+              }
+              placeholder='FLAGSMITH_SVC'
+            />
+          </div>
+        </div>
+
+        <div className='wh-config-form__divider' />
+
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Authentication Method</label>
+          <div className='wh-config-form__select-display'>
+            <span>{config.authMethod}</span>
+            <Icon name='chevron-down' width={16} />
+          </div>
+        </div>
+
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Private Key</label>
+          <textarea
+            className='wh-config-form__textarea'
+            value={config.privateKey}
+            onChange={(e) => updateField('privateKey', e.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className='wh-config-form__actions'>
+          <Button theme='outline' size='small' onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            theme='primary'
+            size='small'
+            onClick={() => onTestConnection(config)}
+          >
+            Test Connection
+          </Button>
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+ConfigForm.displayName = 'WarehouseConfigForm'
+export default ConfigForm

--- a/frontend/web/components/warehouse/components/ConnectedState.scss
+++ b/frontend/web/components/warehouse/components/ConnectedState.scss
@@ -1,0 +1,107 @@
+.wh-connected {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  &__status-card {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 24px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-success);
+    border-radius: var(--radius-lg);
+  }
+
+  &__status-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__icon-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-lg);
+
+    svg {
+      color: var(--color-icon-action);
+    }
+  }
+
+  &__name-col {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__name {
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-default);
+  }
+
+  &__account {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__divider {
+    height: 1px;
+    background: var(--color-border-default);
+  }
+
+  &__stats {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__stat {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 16px 20px;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-md);
+    flex: 1;
+  }
+
+  &__stat-label {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__stat-value {
+    font-size: var(--font-h5-size);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-default);
+  }
+
+  &__stat-sub {
+    font-size: var(--font-caption-xs-size);
+    color: var(--color-text-tertiary);
+
+    &--success {
+      color: var(--color-text-success);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: 10px;
+
+    .btn svg {
+      margin-right: 4px;
+    }
+  }
+}

--- a/frontend/web/components/warehouse/components/ConnectedState.tsx
+++ b/frontend/web/components/warehouse/components/ConnectedState.tsx
@@ -1,15 +1,8 @@
 import React, { FC } from 'react'
-import { motion } from 'motion/react'
 import Button from 'components/base/forms/Button'
 import Icon from 'components/icons/Icon'
 import StatusBadge from 'components/experiments-v2/shared/StatusBadge'
 import ConnectionDetailsGrid from './ConnectionDetailsGrid'
-import {
-  springBounce,
-  badgeEntrance,
-  staggerContainer,
-  staggerItem,
-} from 'common/utils/motion'
 import { ConnectionDetail, ConnectionStats } from 'components/warehouse/types'
 import './ConnectedState.scss'
 
@@ -32,14 +25,9 @@ const ConnectedState: FC<ConnectedStateProps> = ({
       <div className='wh-connected__status-card'>
         <div className='wh-connected__status-top'>
           <div className='wh-connected__info'>
-            <motion.div
-              className='wh-connected__icon-box'
-              variants={springBounce}
-              initial='hidden'
-              animate='visible'
-            >
+            <div className='wh-connected__icon-box'>
               <Icon name='flash' width={24} />
-            </motion.div>
+            </div>
             <div className='wh-connected__name-col'>
               <span className='wh-connected__name'>Snowflake</span>
               <span className='wh-connected__account'>
@@ -47,24 +35,13 @@ const ConnectedState: FC<ConnectedStateProps> = ({
               </span>
             </div>
           </div>
-          <motion.div
-            variants={badgeEntrance}
-            initial='hidden'
-            animate='visible'
-          >
-            <StatusBadge status='running' />
-          </motion.div>
+          <StatusBadge status='running' />
         </div>
 
         <div className='wh-connected__divider' />
 
-        <motion.div
-          className='wh-connected__stats'
-          variants={staggerContainer(0.1)}
-          initial='hidden'
-          animate='visible'
-        >
-          <motion.div className='wh-connected__stat' variants={staggerItem}>
+        <div className='wh-connected__stats'>
+          <div className='wh-connected__stat'>
             <span className='wh-connected__stat-label'>
               Last Successful Delivery
             </span>
@@ -74,8 +51,8 @@ const ConnectedState: FC<ConnectedStateProps> = ({
             <span className='wh-connected__stat-sub'>
               {stats.lastDeliveryDate}
             </span>
-          </motion.div>
-          <motion.div className='wh-connected__stat' variants={staggerItem}>
+          </div>
+          <div className='wh-connected__stat'>
             <span className='wh-connected__stat-label'>
               Flag Evaluations (24h)
             </span>
@@ -85,8 +62,8 @@ const ConnectedState: FC<ConnectedStateProps> = ({
             <span className='wh-connected__stat-sub wh-connected__stat-sub--success'>
               {stats.flagEvaluationsTrend}
             </span>
-          </motion.div>
-          <motion.div className='wh-connected__stat' variants={staggerItem}>
+          </div>
+          <div className='wh-connected__stat'>
             <span className='wh-connected__stat-label'>
               Custom Events (24h)
             </span>
@@ -96,8 +73,8 @@ const ConnectedState: FC<ConnectedStateProps> = ({
             <span className='wh-connected__stat-sub wh-connected__stat-sub--success'>
               {stats.customEventsTrend}
             </span>
-          </motion.div>
-        </motion.div>
+          </div>
+        </div>
       </div>
 
       {/* Connection details */}

--- a/frontend/web/components/warehouse/components/ConnectedState.tsx
+++ b/frontend/web/components/warehouse/components/ConnectedState.tsx
@@ -1,0 +1,126 @@
+import React, { FC } from 'react'
+import { motion } from 'motion/react'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
+import StatusBadge from 'components/experiments-v2/shared/StatusBadge'
+import ConnectionDetailsGrid from './ConnectionDetailsGrid'
+import {
+  springBounce,
+  badgeEntrance,
+  staggerContainer,
+  staggerItem,
+} from 'common/utils/motion'
+import { ConnectionDetail, ConnectionStats } from 'components/warehouse/types'
+import './ConnectedState.scss'
+
+type ConnectedStateProps = {
+  stats: ConnectionStats
+  details: ConnectionDetail[]
+  onEdit: () => void
+  onDisconnect: () => void
+}
+
+const ConnectedState: FC<ConnectedStateProps> = ({
+  details,
+  onDisconnect,
+  onEdit,
+  stats,
+}) => {
+  return (
+    <div className='wh-connected'>
+      {/* Status card */}
+      <div className='wh-connected__status-card'>
+        <div className='wh-connected__status-top'>
+          <div className='wh-connected__info'>
+            <motion.div
+              className='wh-connected__icon-box'
+              variants={springBounce}
+              initial='hidden'
+              animate='visible'
+            >
+              <Icon name='flash' width={24} />
+            </motion.div>
+            <div className='wh-connected__name-col'>
+              <span className='wh-connected__name'>Snowflake</span>
+              <span className='wh-connected__account'>
+                myorg.snowflakecomputing.com
+              </span>
+            </div>
+          </div>
+          <motion.div
+            variants={badgeEntrance}
+            initial='hidden'
+            animate='visible'
+          >
+            <StatusBadge status='running' />
+          </motion.div>
+        </div>
+
+        <div className='wh-connected__divider' />
+
+        <motion.div
+          className='wh-connected__stats'
+          variants={staggerContainer(0.1)}
+          initial='hidden'
+          animate='visible'
+        >
+          <motion.div className='wh-connected__stat' variants={staggerItem}>
+            <span className='wh-connected__stat-label'>
+              Last Successful Delivery
+            </span>
+            <span className='wh-connected__stat-value'>
+              {stats.lastDelivery}
+            </span>
+            <span className='wh-connected__stat-sub'>
+              {stats.lastDeliveryDate}
+            </span>
+          </motion.div>
+          <motion.div className='wh-connected__stat' variants={staggerItem}>
+            <span className='wh-connected__stat-label'>
+              Flag Evaluations (24h)
+            </span>
+            <span className='wh-connected__stat-value'>
+              {stats.flagEvaluations24h.toLocaleString()}
+            </span>
+            <span className='wh-connected__stat-sub wh-connected__stat-sub--success'>
+              {stats.flagEvaluationsTrend}
+            </span>
+          </motion.div>
+          <motion.div className='wh-connected__stat' variants={staggerItem}>
+            <span className='wh-connected__stat-label'>
+              Custom Events (24h)
+            </span>
+            <span className='wh-connected__stat-value'>
+              {stats.customEvents24h.toLocaleString()}
+            </span>
+            <span className='wh-connected__stat-sub wh-connected__stat-sub--success'>
+              {stats.customEventsTrend}
+            </span>
+          </motion.div>
+        </motion.div>
+      </div>
+
+      {/* Connection details */}
+      <ConnectionDetailsGrid details={details} />
+
+      {/* Actions */}
+      <div className='wh-connected__actions'>
+        <Button
+          theme='outline'
+          size='small'
+          iconLeft='edit'
+          iconSize={14}
+          onClick={onEdit}
+        >
+          Edit Connection
+        </Button>
+        <Button theme='danger' size='small' onClick={onDisconnect}>
+          Disconnect
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+ConnectedState.displayName = 'WarehouseConnectedState'
+export default ConnectedState

--- a/frontend/web/components/warehouse/components/ConnectionDetailsGrid.scss
+++ b/frontend/web/components/warehouse/components/ConnectionDetailsGrid.scss
@@ -1,0 +1,46 @@
+.wh-details-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+
+  &__title {
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-default);
+  }
+
+  &__rows {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 0;
+
+    &--bordered {
+      border-bottom: 1px solid var(--color-border-default);
+    }
+  }
+
+  &__label {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__value {
+    font-family: var(--font-family);
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-default);
+
+    &--masked {
+      color: var(--color-text-tertiary);
+    }
+  }
+}

--- a/frontend/web/components/warehouse/components/ConnectionDetailsGrid.tsx
+++ b/frontend/web/components/warehouse/components/ConnectionDetailsGrid.tsx
@@ -1,0 +1,37 @@
+import React, { FC } from 'react'
+import { ConnectionDetail } from 'components/warehouse/types'
+import './ConnectionDetailsGrid.scss'
+
+type ConnectionDetailsGridProps = {
+  details: ConnectionDetail[]
+}
+
+const ConnectionDetailsGrid: FC<ConnectionDetailsGridProps> = ({ details }) => {
+  return (
+    <div className='wh-details-grid'>
+      <span className='wh-details-grid__title'>Connection Details</span>
+      <div className='wh-details-grid__rows'>
+        {details.map((detail, index) => (
+          <div
+            key={detail.label}
+            className={`wh-details-grid__row ${
+              index < details.length - 1 ? 'wh-details-grid__row--bordered' : ''
+            }`}
+          >
+            <span className='wh-details-grid__label'>{detail.label}</span>
+            <span
+              className={`wh-details-grid__value ${
+                detail.masked ? 'wh-details-grid__value--masked' : ''
+              }`}
+            >
+              {detail.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+ConnectionDetailsGrid.displayName = 'ConnectionDetailsGrid'
+export default ConnectionDetailsGrid

--- a/frontend/web/components/warehouse/components/EmptyState.scss
+++ b/frontend/web/components/warehouse/components/EmptyState.scss
@@ -8,8 +8,8 @@
   text-align: center;
   flex: 1;
 
-  svg,
-  .icon {
+  > svg,
+  > .icon {
     color: var(--color-icon-secondary);
   }
 

--- a/frontend/web/components/warehouse/components/EmptyState.scss
+++ b/frontend/web/components/warehouse/components/EmptyState.scss
@@ -1,0 +1,30 @@
+.wh-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 80px 40px;
+  text-align: center;
+  flex: 1;
+
+  svg,
+  .icon {
+    color: var(--color-icon-secondary);
+  }
+
+  &__heading {
+    font-size: var(--font-h5-size);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-default);
+    margin: 0;
+  }
+
+  &__text {
+    font-size: var(--font-body-size);
+    color: var(--color-text-secondary);
+    max-width: 420px;
+    line-height: 1.5;
+    margin: 0;
+  }
+}

--- a/frontend/web/components/warehouse/components/EmptyState.tsx
+++ b/frontend/web/components/warehouse/components/EmptyState.tsx
@@ -1,8 +1,6 @@
 import React, { FC } from 'react'
-import { motion } from 'motion/react'
 import Button from 'components/base/forms/Button'
 import Icon from 'components/icons/Icon'
-import { fadeIn } from 'common/utils/motion'
 import './EmptyState.scss'
 
 type EmptyStateProps = {
@@ -11,12 +9,7 @@ type EmptyStateProps = {
 
 const EmptyState: FC<EmptyStateProps> = ({ onConnect }) => {
   return (
-    <motion.div
-      className='wh-empty-state'
-      variants={fadeIn()}
-      initial='hidden'
-      animate='visible'
-    >
+    <div className='wh-empty-state'>
       <Icon name='layers' width={48} />
       <h2 className='wh-empty-state__heading'>No warehouse connected</h2>
       <p className='wh-empty-state__text'>
@@ -26,7 +19,7 @@ const EmptyState: FC<EmptyStateProps> = ({ onConnect }) => {
       <Button theme='primary' onClick={onConnect} iconLeft='plus' iconSize={16}>
         Connect Data Warehouse
       </Button>
-    </motion.div>
+    </div>
   )
 }
 

--- a/frontend/web/components/warehouse/components/EmptyState.tsx
+++ b/frontend/web/components/warehouse/components/EmptyState.tsx
@@ -1,0 +1,34 @@
+import React, { FC } from 'react'
+import { motion } from 'motion/react'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
+import { fadeIn } from 'common/utils/motion'
+import './EmptyState.scss'
+
+type EmptyStateProps = {
+  onConnect: () => void
+}
+
+const EmptyState: FC<EmptyStateProps> = ({ onConnect }) => {
+  return (
+    <motion.div
+      className='wh-empty-state'
+      variants={fadeIn()}
+      initial='hidden'
+      animate='visible'
+    >
+      <Icon name='layers' width={48} />
+      <h2 className='wh-empty-state__heading'>No warehouse connected</h2>
+      <p className='wh-empty-state__text'>
+        Stream flag evaluation and custom event data to your data warehouse for
+        experimentation and analysis.
+      </p>
+      <Button theme='primary' onClick={onConnect} iconLeft='plus' iconSize={16}>
+        Connect Data Warehouse
+      </Button>
+    </motion.div>
+  )
+}
+
+EmptyState.displayName = 'WarehouseEmptyState'
+export default EmptyState

--- a/frontend/web/components/warehouse/components/ErrorState.scss
+++ b/frontend/web/components/warehouse/components/ErrorState.scss
@@ -1,0 +1,147 @@
+.wh-error {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 24px;
+    background: var(--color-surface-subtle);
+    border: 1px solid var(--color-border-danger);
+    border-radius: var(--radius-lg);
+  }
+
+  &__top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__icon-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    background: var(--color-surface-danger);
+    border-radius: var(--radius-lg);
+
+    svg {
+      color: var(--color-icon-danger);
+    }
+  }
+
+  &__name-col {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__name {
+    font-size: var(--font-body-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-default);
+  }
+
+  &__account {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: var(--radius-full);
+    background: var(--color-surface-danger);
+    color: var(--color-text-danger);
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-semibold);
+
+    svg {
+      color: var(--color-icon-danger);
+    }
+  }
+
+  &__divider {
+    height: 1px;
+    background: var(--color-border-default);
+  }
+
+  &__message-box {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px 20px;
+    background: var(--color-surface-danger);
+    border-radius: var(--radius-md);
+  }
+
+  &__message-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__message-label {
+    font-size: var(--font-caption-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-danger);
+  }
+
+  &__message-date {
+    font-size: var(--font-caption-xs-size);
+    color: var(--color-text-tertiary);
+  }
+
+  &__message-text {
+    font-family: var(--font-family);
+    font-size: var(--font-caption-size);
+    color: var(--color-text-danger);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  &__last-ok {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__last-ok-label {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-secondary);
+  }
+
+  &__last-ok-value {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--font-body-sm-size);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-default);
+  }
+
+  &__last-ok-date {
+    font-size: var(--font-caption-size);
+    color: var(--color-text-tertiary);
+  }
+
+  &__actions {
+    display: flex;
+    gap: 10px;
+
+    .btn svg {
+      margin-right: 4px;
+    }
+  }
+}

--- a/frontend/web/components/warehouse/components/ErrorState.tsx
+++ b/frontend/web/components/warehouse/components/ErrorState.tsx
@@ -1,0 +1,98 @@
+import React, { FC } from 'react'
+import { motion } from 'motion/react'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
+import ConnectionDetailsGrid from './ConnectionDetailsGrid'
+import { shakeX } from 'common/utils/motion'
+import { ConnectionDetail, ConnectionError } from 'components/warehouse/types'
+import './ErrorState.scss'
+
+type ErrorStateProps = {
+  error: ConnectionError
+  details: ConnectionDetail[]
+  onRetry: () => void
+  onEdit: () => void
+}
+
+const ErrorState: FC<ErrorStateProps> = ({
+  details,
+  error,
+  onEdit,
+  onRetry,
+}) => {
+  return (
+    <div className='wh-error'>
+      {/* Error card */}
+      <motion.div
+        className='wh-error__card'
+        variants={shakeX}
+        initial='idle'
+        animate='shake'
+      >
+        <div className='wh-error__top'>
+          <div className='wh-error__info'>
+            <div className='wh-error__icon-box'>
+              <Icon name='warning' width={24} />
+            </div>
+            <div className='wh-error__name-col'>
+              <span className='wh-error__name'>Snowflake</span>
+              <span className='wh-error__account'>
+                myorg.snowflakecomputing.com
+              </span>
+            </div>
+          </div>
+          <span className='wh-error__badge'>
+            <Icon name='warning' width={14} />
+            Connection Failed
+          </span>
+        </div>
+
+        <div className='wh-error__divider' />
+
+        <div className='wh-error__message-box'>
+          <div className='wh-error__message-header'>
+            <span className='wh-error__message-label'>Last Error</span>
+            <span className='wh-error__message-date'>{error.timestamp}</span>
+          </div>
+          <p className='wh-error__message-text'>{error.message}</p>
+        </div>
+
+        <div className='wh-error__divider' />
+
+        <div className='wh-error__last-ok'>
+          <span className='wh-error__last-ok-label'>
+            Last successful delivery
+          </span>
+          <div className='wh-error__last-ok-value'>
+            <span>{error.lastSuccessful}</span>
+            <span className='wh-error__last-ok-date'>
+              {error.lastSuccessfulDate}
+            </span>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Connection details */}
+      <ConnectionDetailsGrid details={details} />
+
+      {/* Actions */}
+      <div className='wh-error__actions'>
+        <Button theme='primary' size='small' onClick={onRetry}>
+          Retry Connection
+        </Button>
+        <Button
+          theme='outline'
+          size='small'
+          iconLeft='edit'
+          iconSize={14}
+          onClick={onEdit}
+        >
+          Edit Connection
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+ErrorState.displayName = 'WarehouseErrorState'
+export default ErrorState

--- a/frontend/web/components/warehouse/components/ErrorState.tsx
+++ b/frontend/web/components/warehouse/components/ErrorState.tsx
@@ -1,9 +1,7 @@
 import React, { FC } from 'react'
-import { motion } from 'motion/react'
 import Button from 'components/base/forms/Button'
 import Icon from 'components/icons/Icon'
 import ConnectionDetailsGrid from './ConnectionDetailsGrid'
-import { shakeX } from 'common/utils/motion'
 import { ConnectionDetail, ConnectionError } from 'components/warehouse/types'
 import './ErrorState.scss'
 
@@ -23,12 +21,7 @@ const ErrorState: FC<ErrorStateProps> = ({
   return (
     <div className='wh-error'>
       {/* Error card */}
-      <motion.div
-        className='wh-error__card'
-        variants={shakeX}
-        initial='idle'
-        animate='shake'
-      >
+      <div className='wh-error__card'>
         <div className='wh-error__top'>
           <div className='wh-error__info'>
             <div className='wh-error__icon-box'>
@@ -70,7 +63,7 @@ const ErrorState: FC<ErrorStateProps> = ({
             </span>
           </div>
         </div>
-      </motion.div>
+      </div>
 
       {/* Connection details */}
       <ConnectionDetailsGrid details={details} />

--- a/frontend/web/components/warehouse/components/TestingState.scss
+++ b/frontend/web/components/warehouse/components/TestingState.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/animations';
+
 .wh-testing {
   display: flex;
   flex-direction: column;
@@ -8,7 +10,7 @@
   flex: 1;
 
   &__spinner {
-    @include spinner;
+    @include animations.spinner;
     color: var(--color-icon-action);
   }
 
@@ -52,6 +54,6 @@
     border-radius: var(--radius-full);
     border: 2px solid var(--color-border-default);
     flex-shrink: 0;
-    @include animate-pulse;
+    @include animations.animate-pulse;
   }
 }

--- a/frontend/web/components/warehouse/components/TestingState.scss
+++ b/frontend/web/components/warehouse/components/TestingState.scss
@@ -1,0 +1,57 @@
+.wh-testing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 80px 40px;
+  flex: 1;
+
+  &__spinner {
+    @include spinner;
+    color: var(--color-icon-action);
+  }
+
+  &__title {
+    font-size: var(--font-h6-size);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-default);
+  }
+
+  &__steps {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 280px;
+  }
+
+  &__step {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-secondary);
+
+    svg {
+      color: var(--color-icon-secondary);
+      flex-shrink: 0;
+    }
+
+    &--done {
+      color: var(--color-text-success);
+
+      svg {
+        color: var(--color-icon-success);
+      }
+    }
+  }
+
+  &__step-dot {
+    width: 16px;
+    height: 16px;
+    border-radius: var(--radius-full);
+    border: 2px solid var(--color-border-default);
+    flex-shrink: 0;
+    @include animate-pulse;
+  }
+}

--- a/frontend/web/components/warehouse/components/TestingState.tsx
+++ b/frontend/web/components/warehouse/components/TestingState.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react'
+import { motion } from 'motion/react'
+import Icon from 'components/icons/Icon'
+import { staggerContainer, staggerItem } from 'common/utils/motion'
+import { TESTING_STEPS } from 'components/warehouse/types'
+import './TestingState.scss'
+
+type TestingStateProps = {
+  currentStep?: number
+}
+
+const TestingState: FC<TestingStateProps> = ({
+  currentStep = TESTING_STEPS.length,
+}) => {
+  return (
+    <div className='wh-testing'>
+      <div className='wh-testing__spinner'>
+        <Icon name='refresh' width={32} />
+      </div>
+      <span className='wh-testing__title'>Testing connection...</span>
+
+      <motion.div
+        className='wh-testing__steps'
+        variants={staggerContainer(0.6)}
+        initial='hidden'
+        animate='visible'
+      >
+        {TESTING_STEPS.map((step, index) => (
+          <motion.div
+            key={step}
+            className={`wh-testing__step ${
+              index < currentStep ? 'wh-testing__step--done' : ''
+            }`}
+            variants={staggerItem}
+          >
+            {index < currentStep ? (
+              <Icon name='checkmark-circle' width={16} />
+            ) : (
+              <span className='wh-testing__step-dot' />
+            )}
+            <span>{step}</span>
+          </motion.div>
+        ))}
+      </motion.div>
+    </div>
+  )
+}
+
+TestingState.displayName = 'WarehouseTestingState'
+export default TestingState

--- a/frontend/web/components/warehouse/types.ts
+++ b/frontend/web/components/warehouse/types.ts
@@ -1,0 +1,125 @@
+// =============================================================================
+// Warehouse Connection — Types & Mock Data
+// =============================================================================
+
+export type WarehouseType = 'snowflake' | 'bigquery' | 'databricks'
+
+export type ConnectionState =
+  | 'empty'
+  | 'configuring'
+  | 'testing'
+  | 'connected'
+  | 'error'
+
+export type WarehouseConfig = {
+  type: WarehouseType
+  accountUrl: string
+  database: string
+  schema: string
+  warehouse: string
+  user: string
+  authMethod: string
+  privateKey: string
+}
+
+export type ConnectionStats = {
+  lastDelivery: string
+  lastDeliveryDate: string
+  flagEvaluations24h: number
+  flagEvaluationsTrend: string
+  customEvents24h: number
+  customEventsTrend: string
+}
+
+export type ConnectionError = {
+  message: string
+  timestamp: string
+  lastSuccessful: string
+  lastSuccessfulDate: string
+}
+
+export type ConnectionDetail = {
+  label: string
+  value: string
+  masked?: boolean
+}
+
+export type WarehouseTypeOption = {
+  type: WarehouseType
+  icon: string
+  label: string
+  description: string
+  available: boolean
+}
+
+// =============================================================================
+// Mock Data
+// =============================================================================
+
+export const WAREHOUSE_TYPES: WarehouseTypeOption[] = [
+  {
+    available: true,
+    description: 'Connected warehouse',
+    icon: 'snowflake',
+    label: 'Snowflake',
+    type: 'snowflake',
+  },
+  {
+    available: false,
+    description: 'Coming Soon',
+    icon: 'database',
+    label: 'BigQuery',
+    type: 'bigquery',
+  },
+  {
+    available: false,
+    description: 'Coming Soon',
+    icon: 'database',
+    label: 'Databricks',
+    type: 'databricks',
+  },
+]
+
+export const MOCK_CONFIG: WarehouseConfig = {
+  accountUrl: 'https://myorg.snowflakecomputing.com',
+  authMethod: 'Key Pair',
+  database: 'FLAGSMITH_PROD',
+  privateKey:
+    '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASC...',
+  schema: 'PUBLIC',
+  type: 'snowflake',
+  user: 'FLAGSMITH_SVC',
+  warehouse: 'COMPUTE_WH',
+}
+
+export const MOCK_STATS: ConnectionStats = {
+  customEvents24h: 84210,
+  customEventsTrend: '+5% vs yesterday',
+  flagEvaluations24h: 1284039,
+  flagEvaluationsTrend: '+12% vs yesterday',
+  lastDelivery: '2 minutes ago',
+  lastDeliveryDate: 'Apr 8, 2026 — 14:37 UTC',
+}
+
+export const MOCK_ERROR: ConnectionError = {
+  lastSuccessful: '3 hours ago',
+  lastSuccessfulDate: 'Apr 8, 2026 — 11:15 UTC',
+  message:
+    "JWT token authentication failed: Invalid private key format. Expected PKCS#8 PEM format but received PKCS#1. Please check your key pair configuration and ensure the private key begins with '-----BEGIN PRIVATE KEY-----'.",
+  timestamp: 'Apr 8, 2026 — 14:22 UTC',
+}
+
+export const MOCK_CONNECTION_DETAILS: ConnectionDetail[] = [
+  { label: 'Database', value: 'FLAGSMITH_PROD' },
+  { label: 'Schema', value: 'PUBLIC' },
+  { label: 'Warehouse', value: 'COMPUTE_WH' },
+  { label: 'User', value: 'FLAGSMITH_SVC' },
+  { label: 'Private Key', masked: true, value: '••••••••••••••••  ...a8f2' },
+]
+
+export const TESTING_STEPS = [
+  'Resolving hostname...',
+  'Establishing TLS connection...',
+  'Authenticating credentials...',
+  'Verifying schema access...',
+]

--- a/frontend/web/routes.js
+++ b/frontend/web/routes.js
@@ -48,6 +48,8 @@ import CreateReleasePipelinePage from './components/pages/CreateReleasePipelineP
 import ReleasePipelineDetailPage from './components/pages/ReleasePipelineDetailPage'
 import SegmentPage from './components/pages/SegmentPage'
 import ExperimentsPage from './components/pages/ExperimentsPage'
+import CreateExperimentPage from './components/experiments-v2/CreateExperimentPage'
+import ExperimentResultsPage from './components/experiments-v2/ExperimentResultsPage'
 import ReleaseManagerPage from './components/pages/ReleaseManagerPage'
 import FlagEnvironmentsPage from './components/pages/FlagEnvironmentsPage'
 import ExecutiveViewPage from './components/pages/ExecutiveViewPage'
@@ -78,7 +80,11 @@ export const routes = {
   'environment-settings':
     '/project/:projectId/environment/:environmentId/settings',
   'executive-view': '/organisation/:organisationId/executive-view',
+  'experiment-results':
+    '/project/:projectId/environment/:environmentId/experiments/:experimentId',
   'experiments': '/project/:projectId/environment/:environmentId/experiments',
+  'experiments-create':
+    '/project/:projectId/environment/:environmentId/experiments/create',
   'feature-history': '/project/:projectId/environment/:environmentId/history',
   'feature-history-detail':
     '/project/:projectId/environment/:environmentId/history/:id/',
@@ -111,25 +117,29 @@ export const routes = {
     '/project/:projectId/environment/:environmentId/project-settings',
   'release-manager': '/organisation/:organisationId/release-manager',
   'release-pipelines': '/project/:projectId/release-pipelines',
+  'identities': '/project/:projectId/environment/:environmentId/identities',
   'release-pipelines-detail': '/project/:projectId/release-pipelines/:id',
+  'identity':
+    '/project/:projectId/environment/:environmentId/identities/:identity/:id',
   'release-pipelines-detail-edit':
     '/project/:projectId/release-pipelines/:id/edit',
+  'identity-id':
+    '/project/:projectId/environment/:environmentId/identities/:identity',
   'root': '/',
+  'legacy-identities': '/project/:projectId/environment/:environmentId/users',
   'saml': '/saml',
+  'legacy-identity':
+    '/project/:projectId/environment/:environmentId/users/:identity/:id',
   'scheduled-change':
     '/project/:projectId/environment/:environmentId/scheduled-changes/:id',
+  'legacy-identity-id':
+    '/project/:projectId/environment/:environmentId/users/:identity',
   'scheduled-changes':
     '/project/:projectId/environment/:environmentId/scheduled-changes',
   'sdk-keys': '/project/:projectId/environment/:environmentId/sdk-keys',
   'segment': '/project/:projectId/segments/:id',
   'segments': '/project/:projectId/segments',
   'signup': '/signup',
-  'identities': '/project/:projectId/environment/:environmentId/identities',
-  'identity': '/project/:projectId/environment/:environmentId/identities/:identity/:id',
-  'identity-id': '/project/:projectId/environment/:environmentId/identities/:identity',
-  'legacy-identities': '/project/:projectId/environment/:environmentId/users',
-  'legacy-identity': '/project/:projectId/environment/:environmentId/users/:identity/:id',
-  'legacy-identity-id': '/project/:projectId/environment/:environmentId/users/:identity',
   'widget': '/widget',
 }
 export default (
@@ -161,6 +171,16 @@ export default (
           path={routes.features}
           exact
           component={FlagsPage}
+        />
+        <ParameterizedRoute
+          path={routes['experiments-create']}
+          exact
+          component={CreateExperimentPage}
+        />
+        <ParameterizedRoute
+          path={routes['experiment-results']}
+          exact
+          component={ExperimentResultsPage}
         />
         <ParameterizedRoute
           path={routes.experiments}
@@ -228,21 +248,37 @@ export default (
           exact
           component={OrganisationIntegrationsPage}
         />
-      <ParameterizedRoute path={routes.identities} exact component={IdentitiesPage} />
-      <ParameterizedRoute
-        path={routes['identity-id']}
-        exact
-        component={IdentityIdPage}
-      />
-      <ParameterizedRoute path={routes.identity} exact component={IdentityPage} />
-      {/* Legacy /users routes for backward compatibility */}
-      <ParameterizedRoute path={routes['legacy-identities']} exact component={IdentitiesPage} />
         <ParameterizedRoute
-        path={routes['legacy-identity-id']}
+          path={routes.identities}
           exact
-        component={IdentityIdPage}
+          component={IdentitiesPage}
         />
-      <ParameterizedRoute path={routes['legacy-identity']} exact component={IdentityPage} />
+        <ParameterizedRoute
+          path={routes['identity-id']}
+          exact
+          component={IdentityIdPage}
+        />
+        <ParameterizedRoute
+          path={routes.identity}
+          exact
+          component={IdentityPage}
+        />
+        {/* Legacy /users routes for backward compatibility */}
+        <ParameterizedRoute
+          path={routes['legacy-identities']}
+          exact
+          component={IdentitiesPage}
+        />
+        <ParameterizedRoute
+          path={routes['legacy-identity-id']}
+          exact
+          component={IdentityIdPage}
+        />
+        <ParameterizedRoute
+          path={routes['legacy-identity']}
+          exact
+          component={IdentityPage}
+        />
         <ParameterizedRoute
           path={routes['create-environment']}
           exact

--- a/frontend/web/routes.js
+++ b/frontend/web/routes.js
@@ -56,6 +56,7 @@ import ExecutiveViewPage from './components/pages/ExecutiveViewPage'
 import DevViewPage from './components/pages/DevViewPage'
 import AdminDashboardPage from './components/pages/admin-dashboard/AdminDashboardPage'
 import CleanupPage from './components/pages/feature-lifecycle'
+import WarehousePage from './components/warehouse/WarehousePage'
 import OAuthAuthorizePage from './components/pages/OAuthAuthorizePage'
 import { Provider } from 'react-redux'
 import { getStore } from 'common/store'
@@ -97,11 +98,21 @@ export const routes = {
   'invite': '/invite/:id',
   'invite-link': '/invite-link/:id',
   'lifecycle': '/project/:projectId/lifecycle/:section?',
+  'identities': '/project/:projectId/environment/:environmentId/identities',
   'login': '/login',
+  'identity':
+    '/project/:projectId/environment/:environmentId/identities/:identity/:id',
   'maintenance': '/maintenance',
+  'identity-id':
+    '/project/:projectId/environment/:environmentId/identities/:identity',
   'not-found': '/404',
+  'legacy-identities': '/project/:projectId/environment/:environmentId/users',
   'oauth': '/oauth/:type',
+  'legacy-identity':
+    '/project/:projectId/environment/:environmentId/users/:identity/:id',
   'oauth-authorize': '/oauth/authorize',
+  'legacy-identity-id':
+    '/project/:projectId/environment/:environmentId/users/:identity',
   'organisation-integrations': '/organisation/:organisationId/integrations',
   'organisation-permissions': '/organisation/:organisationId/permissions',
   'organisation-projects': '/organisation/:organisationId/projects',
@@ -117,23 +128,14 @@ export const routes = {
     '/project/:projectId/environment/:environmentId/project-settings',
   'release-manager': '/organisation/:organisationId/release-manager',
   'release-pipelines': '/project/:projectId/release-pipelines',
-  'identities': '/project/:projectId/environment/:environmentId/identities',
   'release-pipelines-detail': '/project/:projectId/release-pipelines/:id',
-  'identity':
-    '/project/:projectId/environment/:environmentId/identities/:identity/:id',
   'release-pipelines-detail-edit':
     '/project/:projectId/release-pipelines/:id/edit',
-  'identity-id':
-    '/project/:projectId/environment/:environmentId/identities/:identity',
   'root': '/',
-  'legacy-identities': '/project/:projectId/environment/:environmentId/users',
   'saml': '/saml',
-  'legacy-identity':
-    '/project/:projectId/environment/:environmentId/users/:identity/:id',
+  'warehouse': '/organisation/:organisationId/warehouse',
   'scheduled-change':
     '/project/:projectId/environment/:environmentId/scheduled-changes/:id',
-  'legacy-identity-id':
-    '/project/:projectId/environment/:environmentId/users/:identity',
   'scheduled-changes':
     '/project/:projectId/environment/:environmentId/scheduled-changes',
   'sdk-keys': '/project/:projectId/environment/:environmentId/sdk-keys',
@@ -323,6 +325,11 @@ export default (
           path={routes.segment}
           exact
           component={SegmentPage}
+        />
+        <ParameterizedRoute
+          path={routes.warehouse}
+          exact
+          component={WarehousePage}
         />
         <ParameterizedRoute
           path={routes['organisation-settings']}

--- a/frontend/web/styles/_animations.scss
+++ b/frontend/web/styles/_animations.scss
@@ -1,0 +1,107 @@
+// =============================================================================
+// Shared Keyframes & Mixins
+// Uses motion tokens from _tokens.scss. For CSS-only animations.
+// For orchestrated JS animations, use common/utils/motion.ts with the motion library.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Keyframes
+// -----------------------------------------------------------------------------
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-6px);
+  }
+  40% {
+    transform: translateX(6px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(3px);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Mixins
+// -----------------------------------------------------------------------------
+
+/// Focus ring for interactive elements (inputs, cards, buttons)
+@mixin focus-ring {
+  border: 2px solid var(--color-border-action);
+  box-shadow: 0 0 0 3px oklch(from var(--purple-600) l c h / 0.13);
+  outline: none;
+}
+
+/// Danger focus ring (validation errors)
+@mixin focus-ring-danger {
+  border: 2px solid var(--color-border-danger);
+  box-shadow: 0 0 0 3px oklch(from var(--red-500) l c h / 0.13);
+  outline: none;
+}
+
+/// Apply shake animation (form validation errors)
+@mixin input-error-shake {
+  animation: shake 350ms var(--easing-standard);
+}
+
+/// Spinner animation
+@mixin spinner {
+  animation: spin 800ms linear infinite;
+}
+
+/// Fade in with configurable duration
+@mixin animate-fade-in($duration: var(--duration-normal)) {
+  animation: fade-in $duration var(--easing-entrance);
+}
+
+/// Slide in from below with fade
+@mixin animate-slide-in-up($duration: var(--duration-normal)) {
+  animation: slide-in-up $duration var(--easing-entrance);
+}
+
+/// Pulse (loading skeletons, pending states)
+@mixin animate-pulse {
+  animation: pulse 1.5s var(--easing-standard) infinite;
+}

--- a/frontend/web/styles/styles.scss
+++ b/frontend/web/styles/styles.scss
@@ -1,6 +1,7 @@
 @import "variables";
 @import "tokens";
 @import "token-utilities";
+@import "animations";
 @import "3rdParty/index";
 @import "components/index";
 @import "flexbox/index";


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to the Experiments V2 and Data Warehouse features

---

### 1. Storybook Dark Mode Fixes

The Storybook docs page had white backgrounds in dark mode on the canvas preview, toolbar, and controls table.

- **Reactive DocsContainer** — switches theme when toggling light/dark in the toolbar
- **CSS overrides** for `.sb-anchor`, `.docblock-argstable`, and toolbar backgrounds
- **`react-docgen-typescript`** for proper prop name extraction in controls
- **Legacy globals** registered (`React`, `propTypes`, `OptionalString`, etc.) for `Input.js` compatibility
- **Utils stub** via webpack alias to break circular dependency (`utils → account-store → constants`)
- **Ionic/stencil stubbed** to prevent secondary circular dep chain

### 2. Experiments V2 — Wizard + Results Dashboard

Full frontend scaffolding for the new experiment creation wizard and results dashboard, built from Pencil designs with **mock data**.

**Architecture** — 4 layers under `web/components/experiments-v2/`:

| Layer | Components |
|-------|-----------|
| `wizard/` | WizardLayout, WizardSidebar, WizardStepIndicator, WizardHeader, WizardNavButtons — **reusable**, zero experiment knowledge |
| `shared/` | SelectableCard, VariationTable, TrafficSplitBar, StatusBadge, ExperimentStatCard, MetricsComparisonTable |
| `steps/` | ExperimentDetailsStep, SelectMetricsStep, FlagVariationsStep, AudienceTrafficStep, ReviewLaunchStep |
| `flag-detail/` | LinkedExperimentSection (experiment card + empty state for flag detail page) |

**Pages:**
- **Create Experiment** (`/experiments/create`) — 5-step wizard: Details → Metrics → Flags & Variations → Audience & Traffic → Review & Launch
- **Experiment Results** (`/experiments/:experimentId`) — Stat cards, recommendation callout, metrics comparison table, experiment config grid, timeline progress

**Routes** gated behind `experimental_flags` feature flag.

### 3. Data Warehouse Connection Settings

New settings page with 5 states, built from Pencil designs with **mock data**.

| State | Description |
|-------|-------------|
| **Empty** | "No warehouse connected" CTA |
| **Config Form** | Snowflake/BigQuery/Databricks type selector + connection fields (reuses `SelectableCard`) |
| **Testing** | Spinner + staggered progress steps (only `motion` library usage — functional, not cosmetic) |
| **Connected** | Status card with stats (Last Delivery, Flag Evaluations 24h, Custom Events 24h) + connection details grid |
| **Error** | Error message box with JWT failure example + retry + connection details |

**Route:** `/organisation/:organisationId/warehouse`

### 4. Shared Infrastructure

- **Motion presets** (`common/utils/motion.ts`) — 10 reusable animation variants (fadeIn, slideInRight, staggerContainer, springBounce, shakeX, etc.). Foundation for gradual motion adoption.
- **CSS animations** (`web/styles/_animations.scss`) — Shared keyframes (shake, spin, fade-in, pulse) + mixins (focus-ring, spinner, input-error-shake)
- **Storybook Motion demos** — Interactive playground under "Design System/Motion Presets"

### 5. Design Quality

- **All values tokenised** — no hardcoded font-size, font-weight, font-family, or colours. Uses `--font-body-size`, `--font-weight-semibold`, `--color-text-default`, etc.
- **`box-shadow: var(--shadow-sm)`** on cards and tables for depth
- **SelectableCard** border-width fix (no layout shift on selection)
- **`flex-wrap`** on stat cards for tablet responsiveness

---

## How to demo

### In the app

1. `ENV=local npm run dev`
2. **Experiments wizard:** Navigate to any project/environment → go to `/experiments/create` → step through the 5-step wizard (pre-populated with mock data)
3. **Experiment results:** Go to `/experiments/exp-1` → stat cards, recommendation, metrics table
4. **Warehouse:** Go to `/organisation/{orgId}/warehouse` → click "Connect Data Warehouse" → Config Form → "Test Connection" → Testing (3s) → Connected or Error (random)

### In Storybook

1. `npm run storybook`
2. **Experiments/** — 19 stories: Wizard (composed), Steps (interactive), SelectableCard, VariationTable, StatusBadge, etc.
3. **Warehouse/** — 6 stories: each state + full page
4. **Design System/Motion Presets** — click "Replay" to see each animation

### Automated

- `npx eslint` — 0 errors on all new files
- `npm run typecheck` — 0 type errors in experiments-v2 and warehouse
- `npx storybook build --test` — builds successfully

---

## Notes

- All data is **mock/fake** — no API calls. Mock data centralised in `types.ts` files for easy replacement with RTK Query hooks.
- Motion animations kept **minimal** — only functional stagger on warehouse testing steps. Cosmetic animations available in presets but not applied (app has no existing animations, would feel inconsistent).
- `SelectableCard` and `StatusBadge` are **shared** across both features.
- Sidebar nav links for Experiments and Warehouse are **not added** — planned as part of a future sidebar navigation refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)