### PR TITLE
feat: added oAuth client creditinals

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -904,11 +904,15 @@ OAUTH2_PROVIDER = {
     "ROTATE_REFRESH_TOKEN": True,
     "PKCE_REQUIRED": True,
     "ALLOWED_CODE_CHALLENGE_METHODS": ["S256"],
-    "SCOPES": {"mcp": "MCP access"},
+    "SCOPES": {
+        "mcp": "MCP access",
+        "scim": "SCIM provisioning access",       
+        },
     "DEFAULT_SCOPES": ["mcp"],
     "ALLOWED_GRANT_TYPES": [
         "authorization_code",
         "refresh_token",
+        "client_credentials",
     ],
 }
 

--- a/api/oauth2_metadata/views.py
+++ b/api/oauth2_metadata/views.py
@@ -29,6 +29,10 @@ def authorization_server_metadata(request: HttpRequest) -> JsonResponse:
     frontend_url: str = settings.FLAGSMITH_FRONTEND_URL.rstrip("/")
     oauth2_settings: dict[str, Any] = settings.OAUTH2_PROVIDER
     scopes: dict[str, str] = oauth2_settings.get("SCOPES", {})
+    allowed_grant_types: list[str] = oauth2_settings.get(
+        "ALLOWED_GRANT_TYPES",
+        ["authorization_code", "refresh_token"],
+    )
 
     metadata = {
         "issuer": api_url,
@@ -39,7 +43,7 @@ def authorization_server_metadata(request: HttpRequest) -> JsonResponse:
         "introspection_endpoint": f"{api_url}/o/introspect/",
         "scopes_supported": list(scopes.keys()),
         "response_types_supported": ["code"],
-        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "grant_types_supported": allowed_grant_types,
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": [
             "client_secret_basic",

--- a/api/tests/unit/oauth2_metadata/test_views.py
+++ b/api/tests/unit/oauth2_metadata/test_views.py
@@ -37,7 +37,7 @@ def test_metadata_endpoint__unauthenticated__returns_200_with_rfc8414_json(
     assert data["revocation_endpoint"] == "https://api.flagsmith.com/o/revoke_token/"
     assert data["introspection_endpoint"] == "https://api.flagsmith.com/o/introspect/"
     assert data["response_types_supported"] == ["code"]
-    assert data["grant_types_supported"] == ["authorization_code", "refresh_token"]
+    assert data["grant_types_supported"] == ["authorization_code", "refresh_token","client_credentials"]
     assert data["code_challenge_methods_supported"] == ["S256"]
     assert "none" in data["token_endpoint_auth_methods_supported"]
     assert data["introspection_endpoint_auth_methods_supported"] == ["none"]
@@ -108,3 +108,54 @@ def test_metadata_endpoint__post_request__returns_405() -> None:
 
     # Then
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+def test_metadata_endpoint__grant_types__derived_from_allowed_grant_types_setting(
+    client: Client,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.OAUTH2_PROVIDER = {
+        **settings.OAUTH2_PROVIDER,
+        "ALLOWED_GRANT_TYPES": ["authorization_code", "client_credentials"],
+    }
+
+    # When
+    response = client.get(reverse(METADATA_URL))
+
+    # Then
+    data = response.json()
+    assert data["grant_types_supported"] == ["authorization_code", "client_credentials"]
+
+
+def test_metadata_endpoint__grant_types__include_client_credentials_by_default(
+    client: Client,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    # Use real settings which now include client_credentials
+    settings.FLAGSMITH_API_URL = "https://api.flagsmith.com"
+    settings.FLAGSMITH_FRONTEND_URL = "https://app.flagsmith.com"
+
+    # When
+    response = client.get(reverse(METADATA_URL))
+
+    # Then
+    data = response.json()
+    assert "client_credentials" in data["grant_types_supported"]
+
+
+def test_metadata_endpoint__scim_scope__present_in_scopes_supported(
+    client: Client,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.FLAGSMITH_API_URL = "https://api.flagsmith.com"
+    settings.FLAGSMITH_FRONTEND_URL = "https://app.flagsmith.com"
+
+    # When
+    response = client.get(reverse(METADATA_URL))
+
+    # Then
+    data = response.json()
+    assert "scim" in data["scopes_supported"]


### PR DESCRIPTION


Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #7153 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

Enable the OAuth 2.0 client-credentials grant type for M2M clients
(CI/CD pipelines, SCIM provisioners, internal tooling).

### `api/app/settings/common.py`
- Add `"scim": "SCIM provisioning access"` to `OAUTH2_PROVIDER["SCOPES"]`
- Add `"client_credentials"` to `OAUTH2_PROVIDER["ALLOWED_GRANT_TYPES"]`

### `api/oauth2_metadata/views.py`
- Drive `grant_types_supported` from `OAUTH2_PROVIDER["ALLOWED_GRANT_TYPES"]`
  instead of a hardcoded list, so the metadata endpoint never drifts
  from what django-oauth-toolkit actually allows

### `api/tests/unit/oauth2_metadata/test_views.py`
- Add `test_metadata_endpoint__grant_types__derived_from_allowed_grant_types_setting`
- Add `test_metadata_endpoint__grant_types__include_client_credentials_by_default`
- Add `test_metadata_endpoint__scim_scope__present_in_scopes_supported`


## How did you test this code?

Ran the existing and new unit tests:

```sh
    cd api
    pytest tests/unit/oauth2_metadata/ -v
```

All existing tests pass. The three new tests in test_views.py
confirm:
1. `grant_types_supported` in the metadata endpoint is derived
   from `OAUTH2_PROVIDER["ALLOWED_GRANT_TYPES"]` and not hardcoded.
2. `client_credentials` appears in `grant_types_supported` with
   the real settings (AC #3).
3. `scim` appears in `scopes_supported` with the real settings.

Manually verified the token endpoint with curl:

```sh
# 1. Create a confidential client-credentials Application via Django admin

# 2. Request a token
curl -X POST http://localhost:8000/o/token/ \
  -d "grant_type=client_credentials" \
  -d "client_id=<your-client-id>" \
  -d "client_secret=<your-client-secret>" \
  -d "scope=scim"

# Expected response:
{
  "access_token": "...",
  "token_type": "Bearer",
  "expires_in": 900,
  "scope": "scim"
}

# 3. Verified metadata endpoint lists client_credentials
curl http://localhost:8000/.well-known/oauth-authorization-server | jq .grant_types_supported
# ["authorization_code", "refresh_token", "client_credentials"]

# 4. Verified existing authorization-code flow is unaffected by
#    running the full existing test suite:
pytest tests/unit/oauth2_metadata/ -v
```