### PR TITLE
refactor: update GitHub installation completion message

### DIFF
--- a/frontend/web/components/pages/GitHubSetupPage.tsx
+++ b/frontend/web/components/pages/GitHubSetupPage.tsx
@@ -277,7 +277,12 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
           </Button>
         </>
       ) : (
-        <h1>Installation Completed</h1>
+        <div>
+          <strong>GitHub installation completed!</strong>
+          <p>
+            <small>You may close this window.</small>
+          </p>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Contributes to 7143 <!-- Replace with the actual issue number if different based on your branch name -->
Updated the GitHub integration setup completion view in `GitHubSetupPage` to correctly match the required UI acceptance criteria:
- Removed the old, un-styled `<h1>Installation Completed</h1>` layout.
- Added the emphasised text: **"GitHub installation completed!"** 
- Added the smaller print optional text beneath it: "You may close this window."
- Ensured the setup form inputs are properly hidden during the completion view.

## How did you test this code?
Tested manually on the local frontend dev server:
1. Ran the frontend via `ENV=local npm run dev`.
2. Bypassed the OAuth flow by setting the success state in the browser DevTools console: `localStorage.setItem('githubIntegrationSetupFromFlagsmith', 'install');`
3. Navigated directly to `/github-setup`.
4. Visually verified that the empty layout rendered correctly with the new emphasised text and smaller-print sub-text. 
5. Ran frontend linting and typechecking successfully.