### PR TITLE
feat: Feature Analytics label grouping (#6067)

### DIFF
--- a/frontend/.storybook/DocsContainer.jsx
+++ b/frontend/.storybook/DocsContainer.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react'
+import { DocsContainer as BaseContainer } from '@storybook/addon-docs/blocks'
+import { create } from 'storybook/theming'
+import { addons } from 'storybook/preview-api'
+
+const darkTheme = create({
+  base: 'dark',
+  appBg: '#15192b',
+  appContentBg: '#161d30',
+  barBg: '#15192b',
+  colorPrimary: '#6837fc',
+  colorSecondary: '#6837fc',
+  textColor: '#e0e3e9',
+  textMutedColor: '#9da4ae',
+})
+
+const lightTheme = create({
+  base: 'light',
+  colorPrimary: '#6837fc',
+  colorSecondary: '#6837fc',
+})
+
+function getInitialTheme(context) {
+  try {
+    return context?.store?.globals?.globals?.theme === 'dark'
+  } catch {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+}
+
+export const DocsContainer = ({ children, context, ...props }) => {
+  const [isDark, setIsDark] = useState(() => getInitialTheme(context))
+
+  useEffect(() => {
+    const channel = addons.getChannel()
+    const handleGlobalsUpdate = ({ globals }) => {
+      if (globals?.theme !== undefined) {
+        setIsDark(globals.theme === 'dark')
+      }
+    }
+    channel.on('globalsUpdated', handleGlobalsUpdate)
+    return () => channel.off('globalsUpdated', handleGlobalsUpdate)
+  }, [])
+
+  return (
+    <BaseContainer {...props} context={context} theme={isDark ? darkTheme : lightTheme}>
+      {children}
+    </BaseContainer>
+  )
+}

--- a/frontend/.storybook/docs-theme.scss
+++ b/frontend/.storybook/docs-theme.scss
@@ -74,9 +74,66 @@
     border-color: var(--color-border-default, rgba(255, 255, 255, 0.16));
   }
 
-  // Canvas (story preview) background
+  // Canvas wrapper — emotion-styled div with no stable class, child of .sb-anchor
+  .sb-anchor > div {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  // Args/controls table
+  .docblock-argstable {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  .docblock-argstable th,
+  .docblock-argstable td {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Argstable description text, type badges, default values
+  .docblock-argstable td span,
+  .docblock-argstable td p,
+  .docblock-argstable td code,
+  .docblock-argstable td label {
+    color: var(--color-text-secondary, #9da4ae) !important;
+  }
+
+  // Prop names (first column)
+  .docblock-argstable td:first-child span {
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Control values, radio labels, object inspector text
+  .docblock-argstable [class*='css-'] {
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Control buttons (Set object, Set string, Set boolean, etc.)
+  .docblock-argstable button {
+    background-color: var(--color-surface-muted, #161d30) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  // Control inputs (text fields, textareas, number inputs)
+  .docblock-argstable input,
+  .docblock-argstable textarea,
+  .docblock-argstable select {
+    background-color: var(--color-surface-muted, #161d30) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
   .docs-story {
-    background-color: var(--color-surface-default, #101628);
+    background-color: var(--color-surface-subtle, #15192b) !important;
+  }
+
+  // Canvas toolbar (zoom, open in new tab icons)
+  .sbdocs-preview [role='toolbar'] {
+    background-color: var(--color-surface-subtle, #15192b) !important;
   }
 
   // Table borders

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -17,6 +17,15 @@ const config = {
     name: '@storybook/react-webpack5',
     options: {},
   },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
+    },
+  },
   swc: () => ({
     jsc: {
       transform: {
@@ -56,6 +65,21 @@ const config = {
         },
       ],
     })
+
+    // Stub modules that cause circular dependency crashes in Storybook.
+    // common/utils/utils → account-store → constants creates a webpack
+    // initialisation error. Ionic/stencil also triggers the same chain.
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      [path.resolve(__dirname, '../common/utils/utils')]: path.resolve(
+        __dirname,
+        'stubs/utils.js',
+      ),
+      '@stencil/core/internal/client': false,
+      '@stencil/core': false,
+      '@ionic/react': false,
+      'ionicons/icons': false,
+    }
 
     config.plugins = config.plugins || []
     config.plugins.push(

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,6 +1,53 @@
 import '../web/styles/styles.scss'
 import './docs-theme.scss'
 import { allModes } from './modes'
+import { DocsContainer } from './DocsContainer'
+
+// TODO: Remove these globals once legacy .js components (Input.js, etc.) are
+// migrated to TypeScript with proper imports. These replicate what
+// web/project/libs.js and web/project/project-components.js set at boot.
+// Utils is stubbed via webpack alias in main.js to avoid circular deps.
+import React from 'react'
+import PropTypes from 'prop-types'
+import Utils from 'common/utils/utils'
+import ReactSelect, { components as selectComponents } from 'react-select'
+import Tooltip from '../web/components/Tooltip'
+
+window.React = React
+window.propTypes = PropTypes
+window.OptionalString = PropTypes.string
+window.OptionalFunc = PropTypes.func
+window.OptionalBool = PropTypes.bool
+window.OptionalNumber = PropTypes.number
+window.OptionalObject = PropTypes.object
+window.OptionalArray = PropTypes.array
+window.OptionalNode = PropTypes.node
+window.OptionalElement = PropTypes.element
+window.RequiredString = PropTypes.string.isRequired
+window.RequiredFunc = PropTypes.func.isRequired
+window.RequiredBool = PropTypes.bool.isRequired
+window.RequiredNumber = PropTypes.number.isRequired
+window.RequiredObject = PropTypes.object.isRequired
+window.RequiredNode = PropTypes.node.isRequired
+window.Any = PropTypes.any
+window.oneOf = PropTypes.oneOf
+window.oneOfType = PropTypes.oneOfType
+window.Utils = Utils
+// Wrap ReactSelect to match the real app's global.Select (project-components.js)
+// which adds className="react-select" and classNamePrefix="react-select"
+// so _react-select.scss dark mode selectors work.
+global.Select = (props) =>
+  React.createElement(
+    'div',
+    { className: props.className, onClick: (e) => e.stopPropagation() },
+    React.createElement(ReactSelect, {
+      ...props,
+      className: `react-select ${props.size || ''}`,
+      classNamePrefix: 'react-select',
+      components: { ...props.components },
+    }),
+  )
+global.Tooltip = Tooltip
 
 /** @type { import('storybook').Preview } */
 const preview = {
@@ -45,6 +92,9 @@ const preview = {
       },
     },
     backgrounds: { disable: true },
+    docs: {
+      container: DocsContainer,
+    },
     chromatic: {
       modes: {
         light: allModes.light,

--- a/frontend/.storybook/stubs/utils.js
+++ b/frontend/.storybook/stubs/utils.js
@@ -1,0 +1,19 @@
+// Storybook stub for common/utils/utils.
+// The real Utils has circular dependencies (utils → account-store → constants)
+// that crash webpack in Storybook.
+// Only legacy .js components (Input.js) depend on this global.
+// New components should NOT import Utils — use dedicated utilities instead.
+// TODO: Remove once legacy .js files are migrated to TypeScript with imports.
+
+const Utils = {
+  getFlagsmithHasFeature: () => false,
+  getFlagsmithValue: () => '',
+  getPlansPermission: () => true,
+  keys: {
+    isEscape: (e) => e.key === 'Escape' || e.keyCode === 27,
+  },
+  safeParseEventValue: (e) =>
+    e?.target?.value !== undefined ? e.target.value : e,
+}
+
+export default Utils

--- a/frontend/common/theme/tokens.json
+++ b/frontend/common/theme/tokens.json
@@ -131,6 +131,18 @@
       "info": { "cssVar": "--color-icon-info", "light": "#0aaddf", "dark": "#0aaddf" }
     }
   },
+  "chart": {
+    "1": { "cssVar": "--color-chart-1", "light": "#0aaddf", "dark": "#45bce0", "description": "First series in charts. Blue." },
+    "2": { "cssVar": "--color-chart-2", "light": "#ef4d56", "dark": "#f57c78", "description": "Second series. Red." },
+    "3": { "cssVar": "--color-chart-3", "light": "#27ab95", "dark": "#56ccad", "description": "Third series. Green." },
+    "4": { "cssVar": "--color-chart-4", "light": "#ff9f43", "dark": "#ffc08a", "description": "Fourth series. Orange." },
+    "5": { "cssVar": "--color-chart-5", "light": "#7a4dfc", "dark": "#906af6", "description": "Fifth series. Purple." },
+    "6": { "cssVar": "--color-chart-6", "light": "#0b8bb2", "dark": "#7ecde2", "description": "Sixth series. Blue dark." },
+    "7": { "cssVar": "--color-chart-7", "light": "#e61b26", "dark": "#f5a5a2", "description": "Seventh series. Red dark." },
+    "8": { "cssVar": "--color-chart-8", "light": "#13787b", "dark": "#87d4c4", "description": "Eighth series. Green dark." },
+    "9": { "cssVar": "--color-chart-9", "light": "#fa810c", "dark": "#ffd7b5", "description": "Ninth series. Orange dark." },
+    "10": { "cssVar": "--color-chart-10", "light": "#6837fc", "dark": "#b794ff", "description": "Tenth series. Purple dark." }
+  },
   "radius": {
     "none": { "cssVar": "--radius-none", "value": "0px", "description": "Sharp corners. Tables, dividers." },
     "xs": { "cssVar": "--radius-xs", "value": "2px", "description": "Barely rounded. Badges, tags." },

--- a/frontend/common/theme/tokens.ts
+++ b/frontend/common/theme/tokens.ts
@@ -157,6 +157,20 @@ export const easing: Record<string, TokenEntry> = {
   },
 }
 
+// Chart colours — use with getCSSVar() for runtime resolution
+export const CHART_COLOURS = [
+  '--color-chart-1',
+  '--color-chart-10',
+  '--color-chart-2',
+  '--color-chart-3',
+  '--color-chart-4',
+  '--color-chart-5',
+  '--color-chart-6',
+  '--color-chart-7',
+  '--color-chart-8',
+  '--color-chart-9',
+] as const
+
 export type TokenCategory = keyof typeof tokens
 export type TokenName<C extends TokenCategory> = keyof (typeof tokens)[C]
 export type RadiusScale = keyof typeof radius

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1219,6 +1219,11 @@ export type Res = {
   environmentAnalytics: {
     day: string
     count: number
+    labels?: {
+      user_agent?: string | null
+      client_application_name?: string | null
+      client_application_version?: string | null
+    } | null
   }[]
   featureList: {
     results: ProjectFlag[]

--- a/frontend/common/utils/getCSSVar.ts
+++ b/frontend/common/utils/getCSSVar.ts
@@ -1,0 +1,26 @@
+/**
+ * Read the computed value of a CSS custom property from the document root.
+ * Use this when JS code needs actual colour strings (e.g. Recharts fills)
+ * rather than var() references.
+ *
+ * Respects dark mode — returns the currently resolved value.
+ *
+ * @example
+ *   import { getCSSVar } from 'common/utils/getCSSVar'
+ *   const fill = getCSSVar('--color-chart-1') // '#0aaddf' in light, '#45bce0' in dark
+ */
+export function getCSSVar(name: string): string {
+  if (typeof document === 'undefined') return ''
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim()
+}
+
+/**
+ * Read multiple CSS custom properties at once.
+ */
+export function getCSSVars(names: readonly string[]): string[] {
+  if (typeof document === 'undefined') return names.map(() => '')
+  const style = getComputedStyle(document.documentElement)
+  return names.map((name) => style.getPropertyValue(name).trim())
+}

--- a/frontend/documentation/TokenReference.generated.stories.tsx
+++ b/frontend/documentation/TokenReference.generated.stories.tsx
@@ -384,6 +384,108 @@ export const AllTokens: StoryObj = {
           </tr>
         </tbody>
       </table>
+      <h3>Chart colours</h3>
+      <table className='docs-table'>
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>Value</th>
+            <th>Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>--color-chart-1</code>
+            </td>
+            <td>
+              <code>#0aaddf</code>
+            </td>
+            <td>First series in charts. Blue.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-2</code>
+            </td>
+            <td>
+              <code>#ef4d56</code>
+            </td>
+            <td>Second series. Red.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-3</code>
+            </td>
+            <td>
+              <code>#27ab95</code>
+            </td>
+            <td>Third series. Green.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-4</code>
+            </td>
+            <td>
+              <code>#ff9f43</code>
+            </td>
+            <td>Fourth series. Orange.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-5</code>
+            </td>
+            <td>
+              <code>#7a4dfc</code>
+            </td>
+            <td>Fifth series. Purple.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-6</code>
+            </td>
+            <td>
+              <code>#0b8bb2</code>
+            </td>
+            <td>Sixth series. Blue dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-7</code>
+            </td>
+            <td>
+              <code>#e61b26</code>
+            </td>
+            <td>Seventh series. Red dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-8</code>
+            </td>
+            <td>
+              <code>#13787b</code>
+            </td>
+            <td>Eighth series. Green dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-9</code>
+            </td>
+            <td>
+              <code>#fa810c</code>
+            </td>
+            <td>Ninth series. Orange dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-10</code>
+            </td>
+            <td>
+              <code>#6837fc</code>
+            </td>
+            <td>Tenth series. Purple dark.</td>
+          </tr>
+        </tbody>
+      </table>
       <h3>Radius</h3>
       <table className='docs-table'>
         <thead>

--- a/frontend/documentation/components/BarChart.stories.tsx
+++ b/frontend/documentation/components/BarChart.stories.tsx
@@ -1,0 +1,181 @@
+import React, { useMemo, useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import BarChart, { ChartDataPoint } from 'components/charts/BarChart'
+import { MultiSelect } from 'components/base/select/multi-select'
+import { CHART_COLOURS } from 'common/theme/tokens'
+import { getCSSVars } from 'common/utils/getCSSVar'
+
+// ============================================================================
+// Fake data
+// ============================================================================
+
+const SDKS = [
+  'flagsmith-js-sdk',
+  'flagsmith-python-sdk',
+  'flagsmith-java-sdk',
+  'flagsmith-go-sdk',
+  'flagsmith-ruby-sdk',
+]
+
+function generateFakeData(days: number, labels: string[]): ChartDataPoint[] {
+  const data: ChartDataPoint[] = []
+  const now = new Date()
+
+  const baseMap: Record<string, number> = {
+    Development: 1200,
+    Production: 5000,
+    Staging: 2400,
+    'flagsmith-js-sdk': 4500,
+    'flagsmith-python-sdk': 2200,
+  }
+
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(now)
+    date.setDate(date.getDate() - i)
+    const dayStr = date.toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+    })
+
+    const point: ChartDataPoint = { day: dayStr }
+    labels.forEach((label) => {
+      const base = baseMap[label] || 800
+      const variance = Math.floor(Math.random() * base * 0.4)
+      const weekday = (now.getDay() - i + 7) % 7
+      const weekendDip = weekday === 0 || weekday === 6 ? 0.4 : 1
+      point[label] = Math.floor((base + variance) * weekendDip)
+    })
+    data.push(point)
+  }
+  return data
+}
+
+function buildColorMap(labels: string[]): Map<string, string> {
+  const resolved = getCSSVars(CHART_COLOURS)
+  const map = new Map<string, string>()
+  labels.forEach((label, i) => {
+    map.set(label, resolved[i % resolved.length])
+  })
+  return map
+}
+
+// ============================================================================
+// Stories
+// ============================================================================
+
+const meta: Meta<typeof BarChart> = {
+  component: BarChart,
+  tags: ['autodocs'],
+  title: 'Components/BarChart',
+}
+export default meta
+
+type Story = StoryObj<typeof BarChart>
+
+export const WithLabelledBuckets: Story = {
+  decorators: [
+    () => {
+      const labels = useMemo(() => SDKS.slice(0, 5), [])
+      const data = useMemo(() => generateFakeData(30, labels), [labels])
+      const colorMap = useMemo(() => buildColorMap(labels), [labels])
+      const [selectedLabels, setSelectedLabels] = useState<string[]>([])
+
+      const filteredLabels =
+        selectedLabels.length > 0
+          ? labels.filter((l) => selectedLabels.includes(l))
+          : labels
+
+      const labelOptions = labels.map((l) => ({ label: l, value: l }))
+
+      return (
+        <div style={{ maxWidth: 900 }}>
+          <p
+            style={{
+              color: 'var(--color-text-secondary)',
+              fontSize: 13,
+              marginBottom: 16,
+            }}
+          >
+            Stacked by SDK label — each color represents a different SDK sending
+            evaluations.
+          </p>
+          <div style={{ marginBottom: 16, maxWidth: 400 }}>
+            <MultiSelect
+              label='Filter by SDK'
+              options={labelOptions}
+              selectedValues={selectedLabels}
+              onSelectionChange={setSelectedLabels}
+              colorMap={colorMap}
+            />
+          </div>
+          <BarChart
+            data={data}
+            series={filteredLabels}
+            colorMap={colorMap}
+            xAxisInterval={2}
+          />
+        </div>
+      )
+    },
+  ],
+}
+
+export const WithoutLabels: Story = {
+  decorators: [
+    () => {
+      const labels = useMemo(() => ['Production', 'Staging', 'Development'], [])
+      const data = useMemo(() => generateFakeData(30, labels), [labels])
+      const colorMap = useMemo(() => buildColorMap(labels), [labels])
+
+      return (
+        <div style={{ maxWidth: 900 }}>
+          <p
+            style={{
+              color: 'var(--color-text-secondary)',
+              fontSize: 13,
+              marginBottom: 16,
+            }}
+          >
+            No labels — grouped by environment (current behaviour).
+          </p>
+          <BarChart
+            data={data}
+            series={labels}
+            colorMap={colorMap}
+            xAxisInterval={2}
+          />
+        </div>
+      )
+    },
+  ],
+}
+
+export const SingleSeries: Story = {
+  decorators: [
+    () => {
+      const labels = useMemo(() => ['flagsmith-js-sdk'], [])
+      const data = useMemo(() => generateFakeData(30, labels), [labels])
+      const colorMap = useMemo(() => buildColorMap(labels), [labels])
+
+      return (
+        <div style={{ maxWidth: 900 }}>
+          <p
+            style={{
+              color: 'var(--color-text-secondary)',
+              fontSize: 13,
+              marginBottom: 16,
+            }}
+          >
+            Single SDK — no filter needed when there's only one series.
+          </p>
+          <BarChart
+            data={data}
+            series={labels}
+            colorMap={colorMap}
+            xAxisInterval={2}
+          />
+        </div>
+      )
+    },
+  ],
+}

--- a/frontend/documentation/components/MultiSelect.stories.tsx
+++ b/frontend/documentation/components/MultiSelect.stories.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import { MultiSelect } from 'components/base/select/multi-select'
+
+const SDK_OPTIONS = [
+  { label: 'flagsmith-js-sdk', value: 'js' },
+  { label: 'flagsmith-python-sdk', value: 'python' },
+  { label: 'flagsmith-java-sdk', value: 'java' },
+  { label: 'flagsmith-go-sdk', value: 'go' },
+  { label: 'flagsmith-ruby-sdk', value: 'ruby' },
+]
+
+const COLOUR_MAP = new Map([
+  ['js', '#0aaddf'],
+  ['python', '#7a4dfc'],
+  ['java', '#ef4d56'],
+  ['go', '#27ab95'],
+  ['ruby', '#ff9f43'],
+])
+
+const meta: Meta<typeof MultiSelect> = {
+  component: MultiSelect,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 400, minHeight: 350 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  title: 'Components/MultiSelect',
+}
+export default meta
+
+type Story = StoryObj<typeof MultiSelect>
+
+export const Default: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<string[]>([])
+      return (
+        <MultiSelect
+          options={SDK_OPTIONS}
+          selectedValues={selected}
+          onSelectionChange={setSelected}
+          placeholder='Select SDKs...'
+        />
+      )
+    },
+  ],
+}
+
+export const WithLabel: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<string[]>([])
+      return (
+        <MultiSelect
+          label='Filter by SDK'
+          options={SDK_OPTIONS}
+          selectedValues={selected}
+          onSelectionChange={setSelected}
+        />
+      )
+    },
+  ],
+}
+
+export const WithColors: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<string[]>(['js', 'python'])
+      return (
+        <MultiSelect
+          label='Filter by SDK'
+          options={SDK_OPTIONS}
+          selectedValues={selected}
+          onSelectionChange={setSelected}
+          colorMap={COLOUR_MAP}
+        />
+      )
+    },
+  ],
+}
+
+export const PreSelected: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<string[]>([
+        'js',
+        'python',
+        'java',
+      ])
+      return (
+        <MultiSelect
+          label='Selected SDKs'
+          options={SDK_OPTIONS}
+          selectedValues={selected}
+          onSelectionChange={setSelected}
+          colorMap={COLOUR_MAP}
+        />
+      )
+    },
+  ],
+}
+
+export const Disabled: Story = {
+  decorators: [
+    () => (
+      <MultiSelect
+        label='Disabled'
+        options={SDK_OPTIONS}
+        selectedValues={['js']}
+        onSelectionChange={() => {}}
+        disabled
+      />
+    ),
+  ],
+}
+
+export const Inline: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<string[]>(['js', 'python'])
+      return (
+        <MultiSelect
+          label='Inline mode'
+          options={SDK_OPTIONS}
+          selectedValues={selected}
+          onSelectionChange={setSelected}
+          inline
+        />
+      )
+    },
+  ],
+}
+
+export const Small: Story = {
+  decorators: [
+    () => {
+      const [selected, setSelected] = useState<string[]>([])
+      return (
+        <MultiSelect
+          label='Small size'
+          options={SDK_OPTIONS}
+          selectedValues={selected}
+          onSelectionChange={setSelected}
+          size='small'
+        />
+      )
+    },
+  ],
+}

--- a/frontend/scripts/generate-tokens.mjs
+++ b/frontend/scripts/generate-tokens.mjs
@@ -39,6 +39,8 @@ const cap = (s) => s.charAt(0).toUpperCase() + s.slice(1)
 
 const NON_COLOUR = ['radius', 'shadow', 'duration', 'easing']
 const DESCRIBED = ['radius', 'shadow', 'duration', 'easing']
+// Chart colours are like colour tokens (light/dark) but not under "color"
+const CHART_CATEGORY = 'chart'
 
 // Build reverse lookups for primitives
 const hexToPrimitive = new Map()
@@ -125,6 +127,18 @@ function buildScssLines() {
   for (const [category, entries] of Object.entries(json.color)) {
     rootLines.push(`  // ${cap(category)}`)
     for (const [, e] of sorted(entries)) {
+      rootLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.light)};`)
+      if (e.dark && e.dark !== e.light) {
+        darkLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.dark)};`)
+      }
+    }
+    rootLines.push('')
+  }
+
+  // Chart colour tokens
+  if (json[CHART_CATEGORY]) {
+    rootLines.push('  // Chart')
+    for (const [, e] of sorted(json[CHART_CATEGORY])) {
       rootLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.light)};`)
       if (e.dark && e.dark !== e.light) {
         darkLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.dark)};`)
@@ -239,6 +253,18 @@ function generateTs() {
   const colourLines = buildTsColourLines()
   const describedBlocks = buildTsDescribedLines()
 
+  // Chart tokens as a flat array for JS chart libraries
+  const chartLines = []
+  if (json[CHART_CATEGORY]) {
+    chartLines.push('// Chart colours — use with getCSSVar() for runtime resolution')
+    chartLines.push(`export const CHART_COLOURS = [`)
+    for (const [, e] of sorted(json[CHART_CATEGORY])) {
+      chartLines.push(`  '${e.cssVar}',`)
+    }
+    chartLines.push('] as const')
+    chartLines.push('')
+  }
+
   const output = [
     '// =============================================================================',
     '// Design Tokens — AUTO-GENERATED from common/theme/tokens.json',
@@ -256,6 +282,7 @@ function generateTs() {
     '',
     ...describedBlocks,
     '',
+    ...chartLines,
     'export type TokenCategory = keyof typeof tokens',
     'export type TokenName<C extends TokenCategory> = keyof (typeof tokens)[C]',
     'export type RadiusScale = keyof typeof radius',
@@ -276,6 +303,16 @@ function generateMcpStory() {
       value: toPrimitiveRef(e.light),
     }))
     tables.push(...buildTableRows(`Colour: ${cat}`, data))
+  }
+
+  // Chart colours
+  if (json[CHART_CATEGORY]) {
+    const chartData = Object.values(json[CHART_CATEGORY]).map((e) => ({
+      cssVar: e.cssVar,
+      value: e.light,
+      description: e.description || '',
+    }))
+    tables.push(...buildTableRows('Chart colours', chartData, { showDescription: true }))
   }
 
   for (const cat of DESCRIBED) {

--- a/frontend/web/components/ColorSwatch.tsx
+++ b/frontend/web/components/ColorSwatch.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+
+type ColorSwatchSize = 'sm' | 'md' | 'lg'
+
+type ColorSwatchProps = {
+  color: string
+  size?: ColorSwatchSize
+  className?: string
+}
+
+const SIZE_MAP: Record<ColorSwatchSize, number> = {
+  lg: 16,
+  md: 12,
+  sm: 8,
+}
+
+const ColorSwatch: FC<ColorSwatchProps> = ({
+  className,
+  color,
+  size = 'md',
+}) => (
+  <span
+    aria-hidden='true'
+    className={classNames('d-inline-block flex-shrink-0 rounded-xs', className)}
+    style={{
+      backgroundColor: color,
+      height: SIZE_MAP[size],
+      width: SIZE_MAP[size],
+    }}
+  />
+)
+
+ColorSwatch.displayName = 'ColorSwatch'
+export default ColorSwatch

--- a/frontend/web/components/base/select/multi-select/CustomMultiValue.tsx
+++ b/frontend/web/components/base/select/multi-select/CustomMultiValue.tsx
@@ -8,45 +8,23 @@ export const CustomMultiValue = ({
 }: MultiValueProps<MultiSelectOption> & { color?: string }) => {
   return (
     <div
-      className='d-flex align-items-center gap-x-1'
+      className='d-flex align-items-center gap-1 rounded-sm text-white overflow-hidden fs-small'
       style={{
         backgroundColor: color,
-        borderRadius: '4px',
-        color: 'white',
-        fontSize: '12px',
-        gap: '4px',
-        maxHeight: '24px',
-        maxWidth: '150px',
-        overflow: 'hidden',
+        maxHeight: 24,
+        maxWidth: 150,
         padding: '2px 6px',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
       }}
     >
-      <span
-        style={{
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <span className='text-nowrap overflow-hidden text-truncate'>
         {data.label}
       </span>
       <button
         {...removeProps}
-        style={{
-          backgroundColor: 'transparent',
-          border: 'none',
-          color: 'white',
-          cursor: 'pointer',
-          fontSize: '14px',
-          lineHeight: '1',
-          margin: 0,
-          padding: 0,
-        }}
-      >
-        ×
-      </button>
+        className='btn-close btn-close-white p-0 border-0'
+        style={{ fontSize: 10 }}
+        aria-label={`Remove ${data.label}`}
+      />
     </div>
   )
 }

--- a/frontend/web/components/base/select/multi-select/CustomOption.tsx
+++ b/frontend/web/components/base/select/multi-select/CustomOption.tsx
@@ -1,21 +1,9 @@
 import { OptionProps } from 'react-select'
 import { MultiSelectOption } from './MultiSelect'
 import Icon from 'components/icons/Icon'
+import ColorSwatch from 'components/ColorSwatch'
 import { useEffect, useRef } from 'react'
-import { getDarkMode } from 'project/darkMode'
-
-const getOptionColors = (isFocused: boolean) => {
-  const isDarkMode = getDarkMode()
-
-  const focusedBgColor = isDarkMode ? '#202839' : '#f0f0f0'
-  const backgroundColor = isFocused ? focusedBgColor : 'transparent'
-  const textColor = isDarkMode ? 'white' : 'inherit'
-
-  return {
-    backgroundColor,
-    textColor,
-  }
-}
+import classNames from 'classnames'
 
 export const CustomOption = ({
   children,
@@ -33,8 +21,6 @@ export const CustomOption = ({
     }
   }, [props.isFocused])
 
-  const { backgroundColor, textColor } = getOptionColors(props.isFocused)
-
   return (
     <div
       ref={ref}
@@ -42,47 +28,22 @@ export const CustomOption = ({
       role='option'
       aria-selected={props.isSelected}
       aria-disabled={props.isDisabled}
-      style={{
-        alignItems: 'center',
-        backgroundColor,
-        color: textColor,
-        cursor: props.isDisabled ? 'not-allowed' : 'pointer',
-        display: 'flex',
-        gap: '8px',
-        justifyContent: 'space-between',
-        padding: '8px 12px',
-      }}
+      className={classNames(
+        'd-flex align-items-center justify-content-between gap-2 px-3 py-2 cursor-pointer',
+        {
+          'bg-surface-hover': props.isFocused,
+          'cursor-not-allowed': props.isDisabled,
+        },
+      )}
     >
-      <div
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          flex: 1,
-          gap: '8px',
-          minWidth: 0,
-          wordWrap: 'break-word',
-        }}
-      >
-        {color && (
-          <div
-            aria-hidden='true'
-            style={{
-              backgroundColor: color,
-              borderRadius: '2px',
-              flexShrink: 0,
-              height: '12px',
-              width: '12px',
-            }}
-          />
-        )}
-        <span style={{ flex: 1, minWidth: 0, wordWrap: 'break-word' }}>
-          {children}
-        </span>
+      <div className='d-flex align-items-center flex-fill gap-2 overflow-hidden'>
+        {color && <ColorSwatch color={color} />}
+        <span className='flex-fill overflow-hidden text-break'>{children}</span>
       </div>
       {props.isSelected && (
-        <div aria-hidden='true'>
-          <Icon width={14} name='checkmark-circle' fill='#6837fc' />
-        </div>
+        <span className='icon-action' aria-hidden='true'>
+          <Icon width={14} name='checkmark-circle' />
+        </span>
       )}
     </div>
   )

--- a/frontend/web/components/charts/BarChart.tsx
+++ b/frontend/web/components/charts/BarChart.tsx
@@ -1,0 +1,74 @@
+import React, { FC } from 'react'
+import {
+  Bar,
+  BarChart as RawBarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import ChartTooltip from './ChartTooltip'
+
+export type ChartDataPoint = {
+  day: string
+} & Record<string, number>
+
+type BarChartProps = {
+  data: ChartDataPoint[]
+  series: string[]
+  colorMap: Map<string, string>
+  height?: number
+  xAxisInterval?: number
+  stacked?: boolean
+}
+
+const BarChart: FC<BarChartProps> = ({
+  colorMap,
+  data,
+  height = 400,
+  series,
+  stacked = true,
+  xAxisInterval = 0,
+}) => {
+  return (
+    <ResponsiveContainer height={height} width='100%'>
+      <RawBarChart data={data}>
+        <CartesianGrid strokeDasharray='3 5' strokeOpacity={0.4} />
+        <XAxis
+          dataKey='day'
+          padding='gap'
+          interval={xAxisInterval}
+          height={80}
+          angle={-90}
+          textAnchor='end'
+          tick={{ dx: -4, fill: '#656D7B', fontSize: 11 }}
+          tickLine={false}
+          axisLine={{ stroke: '#656D7B' }}
+        />
+        <YAxis
+          tick={{ fill: '#656D7B', fontSize: 11 }}
+          axisLine={{ stroke: '#656D7B' }}
+          tickFormatter={(v) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v)}
+        />
+        <Tooltip cursor={{ fill: 'transparent' }} content={<ChartTooltip />} />
+        <Legend wrapperStyle={{ paddingTop: 16 }} />
+        {series.map((label, index) => (
+          <Bar
+            key={label}
+            dataKey={label}
+            stackId={stacked ? 'series' : undefined}
+            fill={colorMap.get(label) || '#656D7B'}
+            animationBegin={index * 80}
+            animationDuration={600}
+            animationEasing='ease-out'
+          />
+        ))}
+      </RawBarChart>
+    </ResponsiveContainer>
+  )
+}
+
+BarChart.displayName = 'BarChart'
+export default BarChart

--- a/frontend/web/components/charts/ChartTooltip.tsx
+++ b/frontend/web/components/charts/ChartTooltip.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react'
+import { TooltipProps } from 'recharts'
+import {
+  NameType,
+  ValueType,
+} from 'recharts/types/component/DefaultTooltipContent'
+import ColorSwatch from 'components/ColorSwatch'
+
+const formatNumber = (n: number): string =>
+  typeof n === 'number' ? n.toLocaleString() : ''
+
+const ChartTooltip: FC<TooltipProps<ValueType, NameType>> = ({
+  active,
+  label,
+  payload,
+}) => {
+  if (!active || !payload || payload.length === 0) return null
+  const total = payload.reduce(
+    (sum: number, el: any) => sum + (el.value || 0),
+    0,
+  )
+
+  return (
+    <div className='bg-surface-default border-default rounded-md shadow-md py-2'>
+      <div className='px-3 py-1 fs-small fw-semibold text-default'>{label}</div>
+      <hr className='border-default my-0 mb-2' />
+      {payload.map((el: any) => (
+        <div
+          key={el.dataKey}
+          className='d-flex align-items-center gap-2 px-3 py-1 fs-small'
+        >
+          <ColorSwatch color={el.fill} size='sm' />
+          <span className='text-secondary'>{el.dataKey}:</span>
+          <span className='fw-medium'>{formatNumber(el.value)}</span>
+        </div>
+      ))}
+      <div className='border-top border-default mt-2 pt-2 px-3 fs-small fw-semibold'>
+        Total: {formatNumber(total)}
+      </div>
+    </div>
+  )
+}
+
+export default ChartTooltip

--- a/frontend/web/components/feature-page/FeatureNavTab/FeatureAnalytics.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/FeatureAnalytics.tsx
@@ -1,20 +1,18 @@
-import React, { FC, useState } from 'react'
-import { sortBy } from 'lodash'
-import Color from 'color'
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
+import React, { FC, useMemo, useState } from 'react'
 import InfoMessage from 'components/InfoMessage'
 import EnvironmentTagSelect from 'components/EnvironmentTagSelect'
-import { useGetFeatureAnalyticsQuery } from 'common/services/useFeatureAnalytics'
-import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
-import Utils from 'common/utils/utils'
+import BarChart from 'components/charts/BarChart'
+import { MultiSelect } from 'components/base/select/multi-select'
+import {
+  useGetEnvironmentAnalyticsQuery,
+  useGetFeatureAnalyticsQuery,
+} from 'common/services/useFeatureAnalytics'
+import { Res } from 'common/types/responses'
+import {
+  aggregateByLabels,
+  buildEnvColorMap,
+  hasLabelledData,
+} from './analyticsUtils'
 
 type FlagAnalyticsType = {
   projectId: string
@@ -28,6 +26,8 @@ const FlagAnalytics: FC<FlagAnalyticsType> = ({
   projectId,
 }) => {
   const [environmentIds, setEnvironmentIds] = useState(defaultEnvironmentIds)
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([])
+
   const { data, isLoading } = useGetFeatureAnalyticsQuery(
     {
       environment_ids: environmentIds,
@@ -39,45 +39,111 @@ const FlagAnalytics: FC<FlagAnalyticsType> = ({
       skip: !environmentIds?.length || !featureId || !projectId,
     },
   )
-  const { data: environments } = useGetEnvironmentsQuery({
-    projectId: `${projectId}`,
+
+  const rawResponses = environmentIds.map((envId) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { data: envData } = useGetEnvironmentAnalyticsQuery(
+      {
+        environment_id: envId,
+        feature_id: featureId,
+        period: 30,
+        project_id: projectId,
+      },
+      {
+        skip: !envId || !featureId || !projectId,
+      },
+    )
+    return envData
   })
 
+  const allRawData = useMemo(
+    (): Res['environmentAnalytics'] => rawResponses.filter(Boolean).flat(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(rawResponses)],
+  )
+
+  const isLabelled = hasLabelledData(allRawData)
+
+  const {
+    chartData: labelledChartData,
+    colorMap,
+    labelValues,
+  } = useMemo(
+    () =>
+      isLabelled
+        ? aggregateByLabels(allRawData)
+        : {
+            chartData: [],
+            colorMap: new Map<string, string>(),
+            labelValues: [],
+          },
+    [isLabelled, allRawData],
+  )
+
+  const envColorMap = useMemo(
+    () => buildEnvColorMap(environmentIds),
+    [environmentIds],
+  )
+
+  const labelOptions = useMemo(
+    () => labelValues.map((v) => ({ label: v, value: v })),
+    [labelValues],
+  )
+
+  const filteredLabels =
+    selectedLabels.length > 0
+      ? labelValues.filter((v) => selectedLabels.includes(v))
+      : labelValues
+
   const handleEnvironmentChange = (value: string[] | string | undefined) => {
-    // If cleared (empty array or undefined), revert to default environment IDs
     if (!value || (Array.isArray(value) && value.length === 0)) {
       setEnvironmentIds(defaultEnvironmentIds)
     } else {
-      setEnvironmentIds(value as string[])
+      setEnvironmentIds(Array.isArray(value) ? value : [value])
     }
   }
 
-  // Check if there's any actual data (non-zero counts) across all days and environments
-  const hasData =
-    data &&
-    Array.isArray(data) &&
-    data.length > 0 &&
-    data.some((dayData) =>
-      environmentIds.some((envId) => (dayData[envId] as number) > 0),
-    )
+  const hasData = isLabelled
+    ? labelledChartData.length > 0
+    : data &&
+      Array.isArray(data) &&
+      data.length > 0 &&
+      data.some((dayData) =>
+        environmentIds.some((envId) => Number(dayData[envId] || 0) > 0),
+      )
 
   return (
     <>
       <FormGroup className='mb-4'>
         <h5 className='mb-2'>Flag events for last 30 days</h5>
-        <EnvironmentTagSelect
-          projectId={projectId}
-          idField='id'
-          value={environmentIds}
-          multiple
-          onChange={handleEnvironmentChange}
-        />
+        <div className='d-flex gap-3 mb-3 flex-wrap'>
+          <div className='flex-fill'>
+            <EnvironmentTagSelect
+              projectId={projectId}
+              idField='id'
+              value={environmentIds}
+              multiple
+              onChange={handleEnvironmentChange}
+            />
+          </div>
+          {isLabelled && labelValues.length > 1 && (
+            <div className='flex-fill' style={{ maxWidth: 400 }}>
+              <MultiSelect
+                label='Filter by SDK'
+                options={labelOptions}
+                selectedValues={selectedLabels}
+                onSelectionChange={setSelectedLabels}
+                colorMap={colorMap}
+              />
+            </div>
+          )}
+        </div>
         {isLoading && (
           <div className='text-center'>
             <Loader />
           </div>
         )}
-        {!isLoading && data && !hasData && (
+        {!isLoading && !hasData && (
           <div
             style={{ height: 200 }}
             className='text-center justify-content-center align-items-center text-muted mt-4 d-flex'
@@ -87,50 +153,12 @@ const FlagAnalytics: FC<FlagAnalyticsType> = ({
           </div>
         )}
         {hasData && (
-          <div>
-            <ResponsiveContainer height={400} width='100%' className='mt-4'>
-              <BarChart data={data}>
-                <CartesianGrid strokeDasharray='3 5' strokeOpacity={0.4} />
-                <XAxis
-                  dataKey='day'
-                  padding='gap'
-                  interval={0}
-                  height={100}
-                  angle={-90}
-                  textAnchor='end'
-                  tick={{ dx: -4, fill: '#656D7B' }}
-                  tickLine={false}
-                  axisLine={{ stroke: '#656D7B' }}
-                />
-                <YAxis
-                  tick={{ fill: '#656D7B' }}
-                  axisLine={{ stroke: '#656D7B' }}
-                />
-                <Tooltip
-                  cursor={{ fill: 'transparent' }}
-                  labelStyle={{ color: '#1a1a1a' }}
-                />
-                {sortBy(environmentIds, (id) =>
-                  environments?.results?.findIndex((env) => `${env.id}` === id),
-                ).map((id) => {
-                  let index = environments?.results.findIndex(
-                    (env) => `${env.id}` === id,
-                  )
-                  if (index === -1) index = 0
-                  return (
-                    <Bar
-                      key={id}
-                      dataKey={id}
-                      stackId='1'
-                      fill={`${Color(Utils.getTagColour(index))
-                        .alpha(0.75)
-                        .rgb()}`}
-                    />
-                  )
-                })}
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
+          <BarChart
+            data={isLabelled ? labelledChartData : data || []}
+            series={isLabelled ? filteredLabels : environmentIds}
+            colorMap={isLabelled ? colorMap : envColorMap}
+            xAxisInterval={2}
+          />
         )}
       </FormGroup>
       <InfoMessage>

--- a/frontend/web/components/feature-page/FeatureNavTab/analyticsUtils.ts
+++ b/frontend/web/components/feature-page/FeatureNavTab/analyticsUtils.ts
@@ -1,0 +1,74 @@
+import { ChartDataPoint } from 'components/charts/BarChart'
+import { Res } from 'common/types/responses'
+import { CHART_COLOURS } from 'common/theme/tokens'
+import { getCSSVars } from 'common/utils/getCSSVar'
+
+/**
+ * Check if the analytics data contains labelled buckets.
+ */
+export function hasLabelledData(
+  rawData: Res['environmentAnalytics'] | undefined,
+): boolean {
+  if (!rawData) return false
+  return rawData.some(
+    (entry) => entry.labels && Object.keys(entry.labels).length > 0,
+  )
+}
+
+/**
+ * Aggregate raw environment analytics into label-grouped chart data.
+ * Each unique label value becomes a series in the stacked chart.
+ */
+export function aggregateByLabels(rawData: Res['environmentAnalytics']): {
+  chartData: ChartDataPoint[]
+  colorMap: Map<string, string>
+  labelValues: string[]
+} {
+  const grouped: Record<string, ChartDataPoint> = {}
+  const labelSet = new Set<string>()
+  const labelList: string[] = []
+
+  rawData.forEach((entry) => {
+    const date = entry.day
+    const labelValue =
+      entry.labels?.user_agent ||
+      entry.labels?.client_application_name ||
+      'Unknown'
+
+    if (!labelSet.has(labelValue)) {
+      labelSet.add(labelValue)
+      labelList.push(labelValue)
+    }
+
+    if (!grouped[date]) {
+      grouped[date] = { day: date }
+    }
+    grouped[date][labelValue] = (grouped[date][labelValue] || 0) + entry.count
+  })
+
+  const resolvedColors = getCSSVars(CHART_COLOURS)
+  const colorMap = new Map<string, string>()
+  labelList.forEach((label, index) => {
+    colorMap.set(label, resolvedColors[index % resolvedColors.length])
+  })
+
+  return {
+    chartData: Object.values(grouped),
+    colorMap,
+    labelValues: labelList,
+  }
+}
+
+/**
+ * Build a color map for environment-based (non-labelled) chart mode.
+ */
+export function buildEnvColorMap(
+  environmentIds: string[],
+): Map<string, string> {
+  const resolvedColors = getCSSVars(CHART_COLOURS)
+  const map = new Map<string, string>()
+  environmentIds.forEach((id, index) => {
+    map.set(id, resolvedColors[index % resolvedColors.length])
+  })
+  return map
+}

--- a/frontend/web/styles/3rdParty/_react-select.scss
+++ b/frontend/web/styles/3rdParty/_react-select.scss
@@ -1,10 +1,14 @@
-@import '../variables';
+// =============================================================================
+// react-select Overrides
+// Uses semantic CSS custom properties for automatic light/dark mode support.
+// No separate .dark {} block needed — tokens resolve differently per theme.
+// =============================================================================
 
 .react-select .react-select {
   input[type='text'] {
     border: none;
+    color: var(--color-text-default) !important;
   }
-
 
   &__menu-list {
     overflow-y: auto;
@@ -12,7 +16,7 @@
     -ms-overflow-style: none;
 
     &::-webkit-scrollbar {
-      display: none; 
+      display: none;
     }
   }
 
@@ -22,11 +26,11 @@
       opacity: 0.5;
     }
     &__indicator {
-      color: $text-icon-light-grey;
+      color: var(--color-icon-secondary);
       padding: 0px 6px 0px 8px;
       cursor: pointer;
       &:hover {
-        color: $text-icon-light-grey;
+        color: var(--color-icon-secondary);
       }
       svg {
         width: 16px;
@@ -48,13 +52,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-weight: normal;
-    color: $input-placeholder-color;
+    color: var(--color-text-tertiary);
   }
   &__indicator {
-    color: $text-icon-light-grey;
+    color: var(--color-icon-secondary);
     padding: 0px 10px 0px 8px;
     &:hover {
-      color: $text-icon-light-grey;
+      color: var(--color-icon-secondary);
     }
     svg {
       width: 22px;
@@ -73,12 +77,13 @@
     padding: 0;
     line-height: $input-line-height;
     font-weight: 500;
+    color: var(--color-text-default);
     & + div {
       margin: 0;
       padding: 0;
     }
     &--is-disabled {
-      color: $text-icon-light-grey;
+      color: var(--color-text-disabled);
     }
   }
 
@@ -96,12 +101,12 @@
     }
   }
   &__control {
-    background: $input-bg;
+    background: var(--color-surface-default);
     height: $input-height;
     border-radius: $border-radius;
-    border: 1px solid $input-border-color;
+    border: 1px solid var(--color-border-default);
     &--is-disabled {
-      border: 1px solid $basic-alpha-8;
+      border: 1px solid var(--color-border-disabled);
       .react-select__indicators {
         opacity: $btn-disabled-opacity;
       }
@@ -198,78 +203,30 @@
 .react-select {
   font-weight: 500;
   line-height: $input-line-height;
-  color: $body-color;
+  color: var(--color-text-default);
   &.select-xsm {
     font-size: $font-size-sm;
   }
   &__option {
-    color: $body-color !important;
-    background: white !important;
+    color: var(--color-text-default) !important;
+    background: var(--color-surface-default) !important;
     padding: 9px 16px;
     cursor: pointer;
     &:hover {
-      background: $bg-light200 !important;
-      cursor:pointer;
+      background: var(--color-surface-hover) !important;
+      cursor: pointer;
     }
     &--is-focused {
-      background: $bg-light300 !important;
+      background: var(--color-surface-muted) !important;
     }
     &--is-selected {
-      background-color: $primary-alfa-8 !important;
+      background-color: var(--color-surface-action-subtle) !important;
     }
   }
   &__menu {
     font-weight: 500;
     margin: 3px;
-    box-shadow: 0px 10px 12px 0px rgba(100, 116, 139, 0.15) !important;
-    background: white !important;
-  }
-}
-.dark {
-  .react-select .react-select,.react-select {
-    input[type='text'] {
-      color: white !important;
-      border: none !important;
-    }
-    &__control {
-      background: $input-bg-dark;
-      border: none;
-      box-shadow: none;
-      border: 1px solid $input-border-color-dark;
-      &--is-disabled {
-        border: 1px solid $black-alpha-32;
-        .react-select__indicator {
-          opacity: $btn-disabled-opacity;
-        }
-      }
-    }
-    &__single-value {
-      color: $text-icon-light;
-      &--is-disabled {
-        color: $text-icon-light-grey;
-      }
-    }
-    &__menu {
-      background: $input-bg-dark !important;
-      margin: 3px;
-      color: $input-bg-dark;
-      box-shadow: 0px 8px 12px 0px rgba(0, 0, 0, 0.12) !important;
-    }
-    &__option {
-      color: white !important;
-      background: $input-bg-dark !important;
-      &:hover {
-        background: $bg-dark200 !important;
-        color: white !important;
-        cursor:pointer;
-      }
-      &--is-focused {
-        background: $bg-dark200 !important;
-        cursor:pointer;
-      }
-      &--is-selected {
-        background-color: $primary-alfa-16 !important;
-      }
-    }
+    box-shadow: var(--shadow-md) !important;
+    background: var(--color-surface-default) !important;
   }
 }

--- a/frontend/web/styles/_tokens.scss
+++ b/frontend/web/styles/_tokens.scss
@@ -134,6 +134,18 @@
   --color-icon-success: var(--green-500);
   --color-icon-warning: var(--orange-500);
 
+  // Chart
+  --color-chart-1: var(--blue-500);
+  --color-chart-10: var(--purple-600);
+  --color-chart-2: var(--red-500);
+  --color-chart-3: var(--green-500);
+  --color-chart-4: var(--orange-500);
+  --color-chart-5: var(--purple-500);
+  --color-chart-6: var(--blue-600);
+  --color-chart-7: var(--red-600);
+  --color-chart-8: var(--green-600);
+  --color-chart-9: var(--orange-600);
+
   // Radius
   --radius-2xl: 18px;
   --radius-full: 9999px;
@@ -191,6 +203,16 @@
   --color-icon-default: var(--slate-0);
   --color-icon-disabled: oklch(from var(--slate-0) l c h / 0.32);
   --color-icon-secondary: var(--slate-300);
+  --color-chart-1: var(--blue-400);
+  --color-chart-10: var(--purple-300);
+  --color-chart-2: var(--red-400);
+  --color-chart-3: var(--green-400);
+  --color-chart-4: var(--orange-300);
+  --color-chart-5: var(--purple-400);
+  --color-chart-6: var(--blue-300);
+  --color-chart-7: var(--red-300);
+  --color-chart-8: var(--green-300);
+  --color-chart-9: var(--orange-200);
   --shadow-lg: 0px 8px 16px oklch(from var(--slate-1000) l c h / 0.35);
   --shadow-md: 0px 4px 8px oklch(from var(--slate-1000) l c h / 0.30);
   --shadow-sm: 0px 1px 2px oklch(from var(--slate-1000) l c h / 0.20);


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6067

### Feature Analytics Label Grouping

When the API returns labelled evaluation buckets (e.g. different SDKs), the Feature Analytics chart now accumulates buckets for the same day into stacked bars with different colours per label value, with a MultiSelect filter to show/hide specific labels.

### New Reusable Components

- **`BarChart`** (`web/components/charts/BarChart.tsx`) — Reusable bar chart wrapping Recharts with our tooltip, colour tokens, legend, staggered entrance animation. Supports `stacked` and non-stacked modes via prop. Can serve all 4 chart consumers in the app.
- **`ColourSwatch`** (`web/components/ColourSwatch.tsx`) — Small coloured indicator with sm/md/lg sizes. Replaces inline colour dot patterns.
- **`getCSSVar` / `getCSSVars`** (`common/utils/getCSSVar.ts`) — Read resolved CSS custom property values at runtime for JS chart libraries. Respects dark mode.

### Chart Colour Tokens

10 new semantic tokens `--color-chart-1` through `--color-chart-10` with light/dark variants. Defined in `tokens.json`, auto-generated into `_tokens.scss` and `tokens.ts`. Exported as `CHART_COLOURS` array for JS consumption.

### Component Quality Improvements

- **react-select semantic tokens** — Migrated `_react-select.scss` from SCSS variables to CSS custom properties. Deleted entire `.dark {}` block — dark mode now works automatically via tokens.
- **CustomOption** — Replaced inline styles with Bootstrap utilities + `ColourSwatch`.
- **CustomMultiValue** — Replaced inline styles with Bootstrap utilities.
- **MultiSelect Storybook story** — 7 variants covering all states. Exposes dark mode for visual regression testing.
- **Storybook dark mode fixes** — globals, Utils stub, Select wrapper matching real app.

## How did you test this code?

### Storybook
1. `npm run storybook`
2. **Components/BarChart** — 3 stories: WithLabelledBuckets (interactive filter), WithoutLabels, SingleSeries
3. **Components/MultiSelect** — 7 stories: Default, WithLabel, WithColours, PreSelected, Disabled, Inline, Small
4. Toggle dark mode in toolbar — both components render correctly

### In the app
1. `ENV=local npm run dev`
2. Navigate to a feature flag → Usage tab → chart shows evaluation data
3. If labelled data exists, bars stack by SDK with filter dropdown

### Automated
- `npx eslint` — 0 errors
- `npm run typecheck` — 0 new errors
- Visual regression tests will catch react-select styling changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)