### PR TITLE
fix: storybook dark mode and component compatibility

### DIFF
--- a/frontend/.storybook/DocsContainer.jsx
+++ b/frontend/.storybook/DocsContainer.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react'
+import { DocsContainer as BaseContainer } from '@storybook/addon-docs/blocks'
+import { create } from 'storybook/theming'
+import { addons } from 'storybook/preview-api'
+
+const darkTheme = create({
+  base: 'dark',
+  appBg: '#15192b',
+  appContentBg: '#161d30',
+  barBg: '#15192b',
+  colorPrimary: '#6837fc',
+  colorSecondary: '#6837fc',
+  textColor: '#e0e3e9',
+  textMutedColor: '#9da4ae',
+})
+
+const lightTheme = create({
+  base: 'light',
+  colorPrimary: '#6837fc',
+  colorSecondary: '#6837fc',
+})
+
+function getInitialTheme(context) {
+  try {
+    return context?.store?.globals?.globals?.theme === 'dark'
+  } catch {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+}
+
+export const DocsContainer = ({ children, context, ...props }) => {
+  const [isDark, setIsDark] = useState(() => getInitialTheme(context))
+
+  useEffect(() => {
+    const channel = addons.getChannel()
+    const handleGlobalsUpdate = ({ globals }) => {
+      if (globals?.theme !== undefined) {
+        setIsDark(globals.theme === 'dark')
+      }
+    }
+    channel.on('globalsUpdated', handleGlobalsUpdate)
+    return () => channel.off('globalsUpdated', handleGlobalsUpdate)
+  }, [])
+
+  return (
+    <BaseContainer {...props} context={context} theme={isDark ? darkTheme : lightTheme}>
+      {children}
+    </BaseContainer>
+  )
+}

--- a/frontend/.storybook/docs-theme.scss
+++ b/frontend/.storybook/docs-theme.scss
@@ -74,9 +74,66 @@
     border-color: var(--color-border-default, rgba(255, 255, 255, 0.16));
   }
 
-  // Canvas (story preview) background
+  // Canvas wrapper — emotion-styled div with no stable class, child of .sb-anchor
+  .sb-anchor > div {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  // Args/controls table
+  .docblock-argstable {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  .docblock-argstable th,
+  .docblock-argstable td {
+    background-color: var(--color-surface-subtle, #15192b) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Argstable description text, type badges, default values
+  .docblock-argstable td span,
+  .docblock-argstable td p,
+  .docblock-argstable td code,
+  .docblock-argstable td label {
+    color: var(--color-text-secondary, #9da4ae) !important;
+  }
+
+  // Prop names (first column)
+  .docblock-argstable td:first-child span {
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Control values, radio labels, object inspector text
+  .docblock-argstable [class*='css-'] {
+    color: var(--color-text-default, #e0e3e9) !important;
+  }
+
+  // Control buttons (Set object, Set string, Set boolean, etc.)
+  .docblock-argstable button {
+    background-color: var(--color-surface-muted, #161d30) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
+  // Control inputs (text fields, textareas, number inputs)
+  .docblock-argstable input,
+  .docblock-argstable textarea,
+  .docblock-argstable select {
+    background-color: var(--color-surface-muted, #161d30) !important;
+    color: var(--color-text-default, #e0e3e9) !important;
+    border-color: var(--color-border-default, rgba(255, 255, 255, 0.16)) !important;
+  }
+
   .docs-story {
-    background-color: var(--color-surface-default, #101628);
+    background-color: var(--color-surface-subtle, #15192b) !important;
+  }
+
+  // Canvas toolbar (zoom, open in new tab icons)
+  .sbdocs-preview [role='toolbar'] {
+    background-color: var(--color-surface-subtle, #15192b) !important;
   }
 
   // Table borders

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -17,6 +17,15 @@ const config = {
     name: '@storybook/react-webpack5',
     options: {},
   },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
+    },
+  },
   swc: () => ({
     jsc: {
       transform: {
@@ -56,6 +65,21 @@ const config = {
         },
       ],
     })
+
+    // Stub modules that cause circular dependency crashes in Storybook.
+    // common/utils/utils → account-store → constants creates a webpack
+    // initialisation error. Ionic/stencil also triggers the same chain.
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      [path.resolve(__dirname, '../common/utils/utils')]: path.resolve(
+        __dirname,
+        'stubs/utils.js',
+      ),
+      '@stencil/core/internal/client': false,
+      '@stencil/core': false,
+      '@ionic/react': false,
+      'ionicons/icons': false,
+    }
 
     config.plugins = config.plugins || []
     config.plugins.push(

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,6 +1,53 @@
 import '../web/styles/styles.scss'
 import './docs-theme.scss'
 import { allModes } from './modes'
+import { DocsContainer } from './DocsContainer'
+
+// TODO: Remove these globals once legacy .js components (Input.js, etc.) are
+// migrated to TypeScript with proper imports. These replicate what
+// web/project/libs.js and web/project/project-components.js set at boot.
+// Utils is stubbed via webpack alias in main.js to avoid circular deps.
+import React from 'react'
+import PropTypes from 'prop-types'
+import Utils from 'common/utils/utils'
+import ReactSelect, { components as selectComponents } from 'react-select'
+import Tooltip from '../web/components/Tooltip'
+
+window.React = React
+window.propTypes = PropTypes
+window.OptionalString = PropTypes.string
+window.OptionalFunc = PropTypes.func
+window.OptionalBool = PropTypes.bool
+window.OptionalNumber = PropTypes.number
+window.OptionalObject = PropTypes.object
+window.OptionalArray = PropTypes.array
+window.OptionalNode = PropTypes.node
+window.OptionalElement = PropTypes.element
+window.RequiredString = PropTypes.string.isRequired
+window.RequiredFunc = PropTypes.func.isRequired
+window.RequiredBool = PropTypes.bool.isRequired
+window.RequiredNumber = PropTypes.number.isRequired
+window.RequiredObject = PropTypes.object.isRequired
+window.RequiredNode = PropTypes.node.isRequired
+window.Any = PropTypes.any
+window.oneOf = PropTypes.oneOf
+window.oneOfType = PropTypes.oneOfType
+window.Utils = Utils
+// Wrap ReactSelect to match the real app's global.Select (project-components.js)
+// which adds className="react-select" and classNamePrefix="react-select"
+// so _react-select.scss dark mode selectors work.
+global.Select = (props) =>
+  React.createElement(
+    'div',
+    { className: props.className, onClick: (e) => e.stopPropagation() },
+    React.createElement(ReactSelect, {
+      ...props,
+      className: `react-select ${props.size || ''}`,
+      classNamePrefix: 'react-select',
+      components: { ...props.components },
+    }),
+  )
+global.Tooltip = Tooltip
 
 /** @type { import('storybook').Preview } */
 const preview = {
@@ -45,6 +92,9 @@ const preview = {
       },
     },
     backgrounds: { disable: true },
+    docs: {
+      container: DocsContainer,
+    },
     chromatic: {
       modes: {
         light: allModes.light,

--- a/frontend/.storybook/stubs/utils.js
+++ b/frontend/.storybook/stubs/utils.js
@@ -1,0 +1,19 @@
+// Storybook stub for common/utils/utils.
+// The real Utils has circular dependencies (utils → account-store → constants)
+// that crash webpack in Storybook.
+// Only legacy .js components (Input.js) depend on this global.
+// New components should NOT import Utils — use dedicated utilities instead.
+// TODO: Remove once legacy .js files are migrated to TypeScript with imports.
+
+const Utils = {
+  getFlagsmithHasFeature: () => false,
+  getFlagsmithValue: () => '',
+  getPlansPermission: () => true,
+  keys: {
+    isEscape: (e) => e.key === 'Escape' || e.keyCode === 27,
+  },
+  safeParseEventValue: (e) =>
+    e?.target?.value !== undefined ? e.target.value : e,
+}
+
+export default Utils


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to Storybook infrastructure — enables component stories to render correctly in both light and dark mode.

### Problem

Storybook docs pages had multiple dark mode issues:
- Canvas preview wrapper rendered with white background
- Controls table (argstable) had white backgrounds and invisible text
- Toolbar had white background
- Theme didn't toggle reactively when switching via toolbar
- Components using legacy globals (`Select`, `React`, `propTypes`, `Utils`) crashed at runtime

### Solution

- **DocsContainer** (`.storybook/DocsContainer.jsx`) — Listens to `globalsUpdated` channel events and switches the Storybook docs theme reactively when toggling light/dark in the toolbar
- **Utils stub** (`.storybook/stubs/utils.js`) — Minimal stub for `common/utils/utils` to break the circular dependency chain (`utils → account-store → constants`) that crashes webpack in Storybook. Only provides the functions legacy `.js` components actually call (`keys.isEscape`, `safeParseEventValue`)
- **Legacy globals** — Registers `React`, `propTypes`, `OptionalString`, `OptionalFunc`, and all other prop-type helpers that `Input.js` and other legacy `.js` files use without importing
- **Global Select wrapper** — Wraps `ReactSelect` to match the real app's `global.Select` (`className="react-select"`, `classNamePrefix="react-select"`) so `_react-select.scss` dark mode selectors work
- **Dark mode CSS** (`.storybook/docs-theme.scss`) — Overrides for `.sb-anchor > div` (canvas wrapper), `.docblock-argstable` (controls table), `[role='toolbar']` (toolbar), and control button/input elements

## How did you test this code?

1. `npm run storybook`
2. Toggle theme via toolbar (moon/sun icon) — docs page, canvas, controls table, and toolbar all switch between light and dark
3. Verified existing component stories (Button, Banner, Icons, Switch) still render correctly
4. Verified no errors in browser console

> **Note:** This is PR 1 in a stacked series. Subsequent PRs add chart tokens, components, and feature analytics improvements that depend on these Storybook fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)