### PR TITLE
feat: Chart color tokens and getCSSVar utility

### DIFF
--- a/frontend/common/theme/tokens.json
+++ b/frontend/common/theme/tokens.json
@@ -131,6 +131,18 @@
       "info": { "cssVar": "--color-icon-info", "light": "#0aaddf", "dark": "#0aaddf" }
     }
   },
+  "chart": {
+    "1": { "cssVar": "--color-chart-1", "light": "#0aaddf", "dark": "#45bce0", "description": "First series in charts. Blue." },
+    "2": { "cssVar": "--color-chart-2", "light": "#ef4d56", "dark": "#f57c78", "description": "Second series. Red." },
+    "3": { "cssVar": "--color-chart-3", "light": "#27ab95", "dark": "#56ccad", "description": "Third series. Green." },
+    "4": { "cssVar": "--color-chart-4", "light": "#ff9f43", "dark": "#ffc08a", "description": "Fourth series. Orange." },
+    "5": { "cssVar": "--color-chart-5", "light": "#7a4dfc", "dark": "#906af6", "description": "Fifth series. Purple." },
+    "6": { "cssVar": "--color-chart-6", "light": "#0b8bb2", "dark": "#7ecde2", "description": "Sixth series. Blue dark." },
+    "7": { "cssVar": "--color-chart-7", "light": "#e61b26", "dark": "#f5a5a2", "description": "Seventh series. Red dark." },
+    "8": { "cssVar": "--color-chart-8", "light": "#13787b", "dark": "#87d4c4", "description": "Eighth series. Green dark." },
+    "9": { "cssVar": "--color-chart-9", "light": "#fa810c", "dark": "#ffd7b5", "description": "Ninth series. Orange dark." },
+    "10": { "cssVar": "--color-chart-10", "light": "#6837fc", "dark": "#b794ff", "description": "Tenth series. Purple dark." }
+  },
   "radius": {
     "none": { "cssVar": "--radius-none", "value": "0px", "description": "Sharp corners. Tables, dividers." },
     "xs": { "cssVar": "--radius-xs", "value": "2px", "description": "Barely rounded. Badges, tags." },

--- a/frontend/common/theme/tokens.ts
+++ b/frontend/common/theme/tokens.ts
@@ -157,6 +157,20 @@ export const easing: Record<string, TokenEntry> = {
   },
 }
 
+// Chart colours — use with getCSSVar() for runtime resolution
+export const CHART_COLOURS = [
+  '--color-chart-1',
+  '--color-chart-10',
+  '--color-chart-2',
+  '--color-chart-3',
+  '--color-chart-4',
+  '--color-chart-5',
+  '--color-chart-6',
+  '--color-chart-7',
+  '--color-chart-8',
+  '--color-chart-9',
+] as const
+
 export type TokenCategory = keyof typeof tokens
 export type TokenName<C extends TokenCategory> = keyof (typeof tokens)[C]
 export type RadiusScale = keyof typeof radius

--- a/frontend/common/utils/getCSSVar.ts
+++ b/frontend/common/utils/getCSSVar.ts
@@ -1,0 +1,26 @@
+/**
+ * Read the computed value of a CSS custom property from the document root.
+ * Use this when JS code needs actual colour strings (e.g. Recharts fills)
+ * rather than var() references.
+ *
+ * Respects dark mode — returns the currently resolved value.
+ *
+ * @example
+ *   import { getCSSVar } from 'common/utils/getCSSVar'
+ *   const fill = getCSSVar('--color-chart-1') // '#0aaddf' in light, '#45bce0' in dark
+ */
+export function getCSSVar(name: string): string {
+  if (typeof document === 'undefined') return ''
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim()
+}
+
+/**
+ * Read multiple CSS custom properties at once.
+ */
+export function getCSSVars(names: readonly string[]): string[] {
+  if (typeof document === 'undefined') return names.map(() => '')
+  const style = getComputedStyle(document.documentElement)
+  return names.map((name) => style.getPropertyValue(name).trim())
+}

--- a/frontend/documentation/TokenReference.generated.stories.tsx
+++ b/frontend/documentation/TokenReference.generated.stories.tsx
@@ -384,6 +384,108 @@ export const AllTokens: StoryObj = {
           </tr>
         </tbody>
       </table>
+      <h3>Chart colours</h3>
+      <table className='docs-table'>
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>Value</th>
+            <th>Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>--color-chart-1</code>
+            </td>
+            <td>
+              <code>#0aaddf</code>
+            </td>
+            <td>First series in charts. Blue.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-2</code>
+            </td>
+            <td>
+              <code>#ef4d56</code>
+            </td>
+            <td>Second series. Red.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-3</code>
+            </td>
+            <td>
+              <code>#27ab95</code>
+            </td>
+            <td>Third series. Green.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-4</code>
+            </td>
+            <td>
+              <code>#ff9f43</code>
+            </td>
+            <td>Fourth series. Orange.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-5</code>
+            </td>
+            <td>
+              <code>#7a4dfc</code>
+            </td>
+            <td>Fifth series. Purple.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-6</code>
+            </td>
+            <td>
+              <code>#0b8bb2</code>
+            </td>
+            <td>Sixth series. Blue dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-7</code>
+            </td>
+            <td>
+              <code>#e61b26</code>
+            </td>
+            <td>Seventh series. Red dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-8</code>
+            </td>
+            <td>
+              <code>#13787b</code>
+            </td>
+            <td>Eighth series. Green dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-9</code>
+            </td>
+            <td>
+              <code>#fa810c</code>
+            </td>
+            <td>Ninth series. Orange dark.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>--color-chart-10</code>
+            </td>
+            <td>
+              <code>#6837fc</code>
+            </td>
+            <td>Tenth series. Purple dark.</td>
+          </tr>
+        </tbody>
+      </table>
       <h3>Radius</h3>
       <table className='docs-table'>
         <thead>

--- a/frontend/scripts/generate-tokens.mjs
+++ b/frontend/scripts/generate-tokens.mjs
@@ -39,6 +39,8 @@ const cap = (s) => s.charAt(0).toUpperCase() + s.slice(1)
 
 const NON_COLOUR = ['radius', 'shadow', 'duration', 'easing']
 const DESCRIBED = ['radius', 'shadow', 'duration', 'easing']
+// Chart colours are like colour tokens (light/dark) but not under "color"
+const CHART_CATEGORY = 'chart'
 
 // Build reverse lookups for primitives
 const hexToPrimitive = new Map()
@@ -125,6 +127,18 @@ function buildScssLines() {
   for (const [category, entries] of Object.entries(json.color)) {
     rootLines.push(`  // ${cap(category)}`)
     for (const [, e] of sorted(entries)) {
+      rootLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.light)};`)
+      if (e.dark && e.dark !== e.light) {
+        darkLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.dark)};`)
+      }
+    }
+    rootLines.push('')
+  }
+
+  // Chart colour tokens
+  if (json[CHART_CATEGORY]) {
+    rootLines.push('  // Chart')
+    for (const [, e] of sorted(json[CHART_CATEGORY])) {
       rootLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.light)};`)
       if (e.dark && e.dark !== e.light) {
         darkLines.push(`  ${e.cssVar}: ${toPrimitiveRef(e.dark)};`)
@@ -239,6 +253,18 @@ function generateTs() {
   const colourLines = buildTsColourLines()
   const describedBlocks = buildTsDescribedLines()
 
+  // Chart tokens as a flat array for JS chart libraries
+  const chartLines = []
+  if (json[CHART_CATEGORY]) {
+    chartLines.push('// Chart colours — use with getCSSVar() for runtime resolution')
+    chartLines.push(`export const CHART_COLOURS = [`)
+    for (const [, e] of sorted(json[CHART_CATEGORY])) {
+      chartLines.push(`  '${e.cssVar}',`)
+    }
+    chartLines.push('] as const')
+    chartLines.push('')
+  }
+
   const output = [
     '// =============================================================================',
     '// Design Tokens — AUTO-GENERATED from common/theme/tokens.json',
@@ -256,6 +282,7 @@ function generateTs() {
     '',
     ...describedBlocks,
     '',
+    ...chartLines,
     'export type TokenCategory = keyof typeof tokens',
     'export type TokenName<C extends TokenCategory> = keyof (typeof tokens)[C]',
     'export type RadiusScale = keyof typeof radius',
@@ -276,6 +303,16 @@ function generateMcpStory() {
       value: toPrimitiveRef(e.light),
     }))
     tables.push(...buildTableRows(`Colour: ${cat}`, data))
+  }
+
+  // Chart colours
+  if (json[CHART_CATEGORY]) {
+    const chartData = Object.values(json[CHART_CATEGORY]).map((e) => ({
+      cssVar: e.cssVar,
+      value: e.light,
+      description: e.description || '',
+    }))
+    tables.push(...buildTableRows('Chart colours', chartData, { showDescription: true }))
   }
 
   for (const cat of DESCRIBED) {

--- a/frontend/web/styles/_tokens.scss
+++ b/frontend/web/styles/_tokens.scss
@@ -134,6 +134,18 @@
   --color-icon-success: var(--green-500);
   --color-icon-warning: var(--orange-500);
 
+  // Chart
+  --color-chart-1: var(--blue-500);
+  --color-chart-10: var(--purple-600);
+  --color-chart-2: var(--red-500);
+  --color-chart-3: var(--green-500);
+  --color-chart-4: var(--orange-500);
+  --color-chart-5: var(--purple-500);
+  --color-chart-6: var(--blue-600);
+  --color-chart-7: var(--red-600);
+  --color-chart-8: var(--green-600);
+  --color-chart-9: var(--orange-600);
+
   // Radius
   --radius-2xl: 18px;
   --radius-full: 9999px;
@@ -191,6 +203,16 @@
   --color-icon-default: var(--slate-0);
   --color-icon-disabled: oklch(from var(--slate-0) l c h / 0.32);
   --color-icon-secondary: var(--slate-300);
+  --color-chart-1: var(--blue-400);
+  --color-chart-10: var(--purple-300);
+  --color-chart-2: var(--red-400);
+  --color-chart-3: var(--green-400);
+  --color-chart-4: var(--orange-300);
+  --color-chart-5: var(--purple-400);
+  --color-chart-6: var(--blue-300);
+  --color-chart-7: var(--red-300);
+  --color-chart-8: var(--green-300);
+  --color-chart-9: var(--orange-200);
   --shadow-lg: 0px 8px 16px oklch(from var(--slate-1000) l c h / 0.35);
   --shadow-md: 0px 4px 8px oklch(from var(--slate-1000) l c h / 0.30);
   --shadow-sm: 0px 1px 2px oklch(from var(--slate-1000) l c h / 0.20);


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to chart infrastructure — provides semantic color tokens for data visualisation and a utility to read CSS custom properties at runtime.

### Chart color tokens

Adds `--color-chart-1` through `--color-chart-10` to the design token system with light and dark mode variants. Colours are derived from the existing palette primitives (blue, red, green, orange, purple in two shades each). Dark mode variants use lighter shades for better visibility on dark backgrounds.

- `common/theme/tokens.json` — 10 chart token definitions
- `scripts/generate-tokens.mjs` — Updated to generate chart tokens in SCSS, TypeScript, and Storybook MCP reference
- `common/theme/tokens.ts` — Auto-generated `CHART_COLOURS` array export (CSS var names)
- `web/styles/_tokens.scss` — Auto-generated CSS custom properties
- `documentation/TokenReference.generated.stories.tsx` — Auto-generated reference table

### getCSSVar utility

Recharts (and other JS chart libraries) need actual colour strings, not `var()` references. `getCSSVar`/`getCSSVars` reads the computed value of CSS custom properties from the document root at runtime — automatically resolves to the correct value for the current theme (light or dark).

- `common/utils/getCSSVar.ts`

## How did you test this code?

1. `npm run generate:tokens` — generates all files without errors
2. `npm run storybook` → Design System/Token Reference (MCP) — chart colours appear in the reference table
3. `npm run typecheck` — no type errors

> **Stack: 2/7** — depends on PR #7209

🤖 Generated with [Claude Code](https://claude.com/claude-code)