### PR TITLE
refactor: Migrate react-select to semantic color tokens

### DIFF
--- a/frontend/web/components/base/select/multi-select/CustomMultiValue.tsx
+++ b/frontend/web/components/base/select/multi-select/CustomMultiValue.tsx
@@ -8,45 +8,23 @@ export const CustomMultiValue = ({
 }: MultiValueProps<MultiSelectOption> & { color?: string }) => {
   return (
     <div
-      className='d-flex align-items-center gap-x-1'
+      className='d-flex align-items-center gap-1 rounded-sm text-white overflow-hidden fs-small'
       style={{
         backgroundColor: color,
-        borderRadius: '4px',
-        color: 'white',
-        fontSize: '12px',
-        gap: '4px',
-        maxHeight: '24px',
-        maxWidth: '150px',
-        overflow: 'hidden',
+        maxHeight: 24,
+        maxWidth: 150,
         padding: '2px 6px',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
       }}
     >
-      <span
-        style={{
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <span className='text-nowrap overflow-hidden text-truncate'>
         {data.label}
       </span>
       <button
         {...removeProps}
-        style={{
-          backgroundColor: 'transparent',
-          border: 'none',
-          color: 'white',
-          cursor: 'pointer',
-          fontSize: '14px',
-          lineHeight: '1',
-          margin: 0,
-          padding: 0,
-        }}
-      >
-        ×
-      </button>
+        className='btn-close btn-close-white p-0 border-0'
+        style={{ fontSize: 10 }}
+        aria-label={`Remove ${data.label}`}
+      />
     </div>
   )
 }

--- a/frontend/web/components/base/select/multi-select/CustomOption.tsx
+++ b/frontend/web/components/base/select/multi-select/CustomOption.tsx
@@ -1,21 +1,9 @@
 import { OptionProps } from 'react-select'
 import { MultiSelectOption } from './MultiSelect'
 import Icon from 'components/icons/Icon'
+import ColorSwatch from 'components/ColorSwatch'
 import { useEffect, useRef } from 'react'
-import { getDarkMode } from 'project/darkMode'
-
-const getOptionColors = (isFocused: boolean) => {
-  const isDarkMode = getDarkMode()
-
-  const focusedBgColor = isDarkMode ? '#202839' : '#f0f0f0'
-  const backgroundColor = isFocused ? focusedBgColor : 'transparent'
-  const textColor = isDarkMode ? 'white' : 'inherit'
-
-  return {
-    backgroundColor,
-    textColor,
-  }
-}
+import classNames from 'classnames'
 
 export const CustomOption = ({
   children,
@@ -33,8 +21,6 @@ export const CustomOption = ({
     }
   }, [props.isFocused])
 
-  const { backgroundColor, textColor } = getOptionColors(props.isFocused)
-
   return (
     <div
       ref={ref}
@@ -42,47 +28,22 @@ export const CustomOption = ({
       role='option'
       aria-selected={props.isSelected}
       aria-disabled={props.isDisabled}
-      style={{
-        alignItems: 'center',
-        backgroundColor,
-        color: textColor,
-        cursor: props.isDisabled ? 'not-allowed' : 'pointer',
-        display: 'flex',
-        gap: '8px',
-        justifyContent: 'space-between',
-        padding: '8px 12px',
-      }}
+      className={classNames(
+        'd-flex align-items-center justify-content-between gap-2 px-3 py-2 cursor-pointer',
+        {
+          'bg-surface-hover': props.isFocused,
+          'cursor-not-allowed': props.isDisabled,
+        },
+      )}
     >
-      <div
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          flex: 1,
-          gap: '8px',
-          minWidth: 0,
-          wordWrap: 'break-word',
-        }}
-      >
-        {color && (
-          <div
-            aria-hidden='true'
-            style={{
-              backgroundColor: color,
-              borderRadius: '2px',
-              flexShrink: 0,
-              height: '12px',
-              width: '12px',
-            }}
-          />
-        )}
-        <span style={{ flex: 1, minWidth: 0, wordWrap: 'break-word' }}>
-          {children}
-        </span>
+      <div className='d-flex align-items-center flex-fill gap-2 overflow-hidden'>
+        {color && <ColorSwatch color={color} />}
+        <span className='flex-fill overflow-hidden text-break'>{children}</span>
       </div>
       {props.isSelected && (
-        <div aria-hidden='true'>
-          <Icon width={14} name='checkmark-circle' fill='#6837fc' />
-        </div>
+        <span className='icon-action' aria-hidden='true'>
+          <Icon width={14} name='checkmark-circle' />
+        </span>
       )}
     </div>
   )

--- a/frontend/web/styles/3rdParty/_react-select.scss
+++ b/frontend/web/styles/3rdParty/_react-select.scss
@@ -1,10 +1,14 @@
-@import '../variables';
+// =============================================================================
+// react-select Overrides
+// Uses semantic CSS custom properties for automatic light/dark mode support.
+// No separate .dark {} block needed — tokens resolve differently per theme.
+// =============================================================================
 
 .react-select .react-select {
   input[type='text'] {
     border: none;
+    color: var(--color-text-default) !important;
   }
-
 
   &__menu-list {
     overflow-y: auto;
@@ -12,7 +16,7 @@
     -ms-overflow-style: none;
 
     &::-webkit-scrollbar {
-      display: none; 
+      display: none;
     }
   }
 
@@ -22,11 +26,11 @@
       opacity: 0.5;
     }
     &__indicator {
-      color: $text-icon-light-grey;
+      color: var(--color-icon-secondary);
       padding: 0px 6px 0px 8px;
       cursor: pointer;
       &:hover {
-        color: $text-icon-light-grey;
+        color: var(--color-icon-secondary);
       }
       svg {
         width: 16px;
@@ -48,13 +52,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-weight: normal;
-    color: $input-placeholder-color;
+    color: var(--color-text-tertiary);
   }
   &__indicator {
-    color: $text-icon-light-grey;
+    color: var(--color-icon-secondary);
     padding: 0px 10px 0px 8px;
     &:hover {
-      color: $text-icon-light-grey;
+      color: var(--color-icon-secondary);
     }
     svg {
       width: 22px;
@@ -73,12 +77,13 @@
     padding: 0;
     line-height: $input-line-height;
     font-weight: 500;
+    color: var(--color-text-default);
     & + div {
       margin: 0;
       padding: 0;
     }
     &--is-disabled {
-      color: $text-icon-light-grey;
+      color: var(--color-text-disabled);
     }
   }
 
@@ -96,12 +101,12 @@
     }
   }
   &__control {
-    background: $input-bg;
+    background: var(--color-surface-default);
     height: $input-height;
     border-radius: $border-radius;
-    border: 1px solid $input-border-color;
+    border: 1px solid var(--color-border-default);
     &--is-disabled {
-      border: 1px solid $basic-alpha-8;
+      border: 1px solid var(--color-border-disabled);
       .react-select__indicators {
         opacity: $btn-disabled-opacity;
       }
@@ -198,78 +203,30 @@
 .react-select {
   font-weight: 500;
   line-height: $input-line-height;
-  color: $body-color;
+  color: var(--color-text-default);
   &.select-xsm {
     font-size: $font-size-sm;
   }
   &__option {
-    color: $body-color !important;
-    background: white !important;
+    color: var(--color-text-default) !important;
+    background: var(--color-surface-default) !important;
     padding: 9px 16px;
     cursor: pointer;
     &:hover {
-      background: $bg-light200 !important;
-      cursor:pointer;
+      background: var(--color-surface-hover) !important;
+      cursor: pointer;
     }
     &--is-focused {
-      background: $bg-light300 !important;
+      background: var(--color-surface-muted) !important;
     }
     &--is-selected {
-      background-color: $primary-alfa-8 !important;
+      background-color: var(--color-surface-action-subtle) !important;
     }
   }
   &__menu {
     font-weight: 500;
     margin: 3px;
-    box-shadow: 0px 10px 12px 0px rgba(100, 116, 139, 0.15) !important;
-    background: white !important;
-  }
-}
-.dark {
-  .react-select .react-select,.react-select {
-    input[type='text'] {
-      color: white !important;
-      border: none !important;
-    }
-    &__control {
-      background: $input-bg-dark;
-      border: none;
-      box-shadow: none;
-      border: 1px solid $input-border-color-dark;
-      &--is-disabled {
-        border: 1px solid $black-alpha-32;
-        .react-select__indicator {
-          opacity: $btn-disabled-opacity;
-        }
-      }
-    }
-    &__single-value {
-      color: $text-icon-light;
-      &--is-disabled {
-        color: $text-icon-light-grey;
-      }
-    }
-    &__menu {
-      background: $input-bg-dark !important;
-      margin: 3px;
-      color: $input-bg-dark;
-      box-shadow: 0px 8px 12px 0px rgba(0, 0, 0, 0.12) !important;
-    }
-    &__option {
-      color: white !important;
-      background: $input-bg-dark !important;
-      &:hover {
-        background: $bg-dark200 !important;
-        color: white !important;
-        cursor:pointer;
-      }
-      &--is-focused {
-        background: $bg-dark200 !important;
-        cursor:pointer;
-      }
-      &--is-selected {
-        background-color: $primary-alfa-16 !important;
-      }
-    }
+    box-shadow: var(--shadow-md) !important;
+    background: var(--color-surface-default) !important;
   }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to the design system migration — replaces SCSS variables with semantic CSS custom properties.

### Problem

`_react-select.scss` used SCSS variables (\$input-bg-dark, \$bg-dark200, etc.) with a separate `.dark {}` block for dark mode. `CustomOption` used `getDarkMode()` + hardcoded hex values. `CustomMultiValue` used all inline styles. Dark mode didn't work in Storybook because the `.dark` class wasn't always propagated.

### Solution

**_react-select.scss:**
- Replace all SCSS variables with semantic CSS custom properties (`var(--color-surface-default)`, `var(--color-surface-hover)`, `var(--color-text-default)`, etc.)
- Delete the entire `.dark {}` block — tokens resolve differently per theme automatically
- Net: -69 lines, +26 lines

**CustomOption:**
- Replace inline styles with Bootstrap utilities (`d-flex`, `align-items-center`, `gap-2`, `px-3`, `py-2`)
- Replace `getDarkMode()` + hardcoded colours with `bg-surface-hover` token class
- Use `ColorSwatch` for colour dot
- Remove `getDarkMode` import

**CustomMultiValue:**
- Replace all inline styles with Bootstrap utilities (`rounded-sm`, `text-white`, `text-nowrap`, `text-truncate`)
- Use `btn-close-white` for remove button

### Token mapping

| Before | After |
|--------|-------|
| \$input-bg / \$input-bg-dark | var(--color-surface-default) |
| \$input-border-color / \$input-border-color-dark | var(--color-border-default) |
| \$body-color | var(--color-text-default) |
| \$text-icon-light-grey | var(--color-icon-secondary) |
| \$bg-light200 / \$bg-dark200 | var(--color-surface-hover) |
| \$primary-alfa-8 | var(--color-surface-action-subtle) |
| box-shadow hardcoded | var(--shadow-md) |

## How did you test this code?

1. `npm run storybook` → Components/MultiSelect — all 7 variants render in light and dark mode
2. Dropdown menu, options, focus state, selected state all themed correctly
3. `ENV=local npm run dev` — Select dropdowns throughout the app look correct in both themes
4. Visual regression tests will catch any styling differences

> **Independent** — can merge to main separately from the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)