### PR TITLE
feat: support DJANGO_DB_CONN_HEALTH_CHECKS for persistent DB connections

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -175,12 +175,16 @@ SITE_ID = 1
 db_conn_max_age = env.int("DJANGO_DB_CONN_MAX_AGE", 60)
 DJANGO_DB_CONN_MAX_AGE = 0 if db_conn_max_age == -1 else db_conn_max_age
 
+DJANGO_DB_CONN_HEALTH_CHECKS = env.bool("DJANGO_DB_CONN_HEALTH_CHECKS", False)
+
 DATABASE_ROUTERS: list[str] = []
 # Allows collectstatic to run without a database, mainly for Docker builds to collectstatic at build time
 if "DATABASE_URL" in os.environ:
     DATABASES = {
         "default": dj_database_url.parse(
-            env("DATABASE_URL"), conn_max_age=DJANGO_DB_CONN_MAX_AGE
+            env("DATABASE_URL"),
+            conn_max_age=DJANGO_DB_CONN_MAX_AGE,
+            conn_health_checks=DJANGO_DB_CONN_HEALTH_CHECKS,
         ),
     }
     REPLICA_DATABASE_URLS_DELIMITER = env("REPLICA_DATABASE_URLS_DELIMITER", ",")
@@ -221,17 +225,23 @@ if "DATABASE_URL" in os.environ:
 
     for i, db_url in enumerate(REPLICA_DATABASE_URLS, start=1):
         DATABASES[f"replica_{i}"] = dj_database_url.parse(
-            db_url, conn_max_age=DJANGO_DB_CONN_MAX_AGE
+            db_url,
+            conn_max_age=DJANGO_DB_CONN_MAX_AGE,
+            conn_health_checks=DJANGO_DB_CONN_HEALTH_CHECKS,
         )
 
     for i, db_url in enumerate(CROSS_REGION_REPLICA_DATABASE_URLS, start=1):
         DATABASES[f"cross_region_replica_{i}"] = dj_database_url.parse(
-            db_url, conn_max_age=DJANGO_DB_CONN_MAX_AGE
+            db_url,
+            conn_max_age=DJANGO_DB_CONN_MAX_AGE,
+            conn_health_checks=DJANGO_DB_CONN_HEALTH_CHECKS,
         )
 
     if "ANALYTICS_DATABASE_URL" in os.environ:
         DATABASES["analytics"] = dj_database_url.parse(
-            env("ANALYTICS_DATABASE_URL"), conn_max_age=DJANGO_DB_CONN_MAX_AGE
+            env("ANALYTICS_DATABASE_URL"),
+            conn_max_age=DJANGO_DB_CONN_MAX_AGE,
+            conn_health_checks=DJANGO_DB_CONN_HEALTH_CHECKS,
         )
         DATABASE_ROUTERS.insert(0, "app.routers.AnalyticsRouter")
 elif "DJANGO_DB_NAME" in os.environ:
@@ -245,6 +255,7 @@ elif "DJANGO_DB_NAME" in os.environ:
             "HOST": os.environ["DJANGO_DB_HOST"],
             "PORT": os.environ["DJANGO_DB_PORT"],
             "CONN_MAX_AGE": DJANGO_DB_CONN_MAX_AGE,
+            "CONN_HEALTH_CHECKS": DJANGO_DB_CONN_HEALTH_CHECKS,
         },
     }
     if "DJANGO_DB_NAME_ANALYTICS" in os.environ:
@@ -256,6 +267,7 @@ elif "DJANGO_DB_NAME" in os.environ:
             "HOST": os.environ["DJANGO_DB_HOST_ANALYTICS"],
             "PORT": os.environ["DJANGO_DB_PORT_ANALYTICS"],
             "CONN_MAX_AGE": DJANGO_DB_CONN_MAX_AGE,
+            "CONN_HEALTH_CHECKS": DJANGO_DB_CONN_HEALTH_CHECKS,
         }
 
         DATABASE_ROUTERS.insert(0, "app.routers.AnalyticsRouter")

--- a/docs/docs/deployment-self-hosting/core-configuration/environment-variables.md
+++ b/docs/docs/deployment-self-hosting/core-configuration/environment-variables.md
@@ -14,6 +14,12 @@ relevant section below for more details.
 
 - `DJANGO_ALLOWED_HOSTS`: Comma-separated list of domains that can access the API. Alternatively `*` to allow any.
 - `DATABASE_URL`: The URL of your PostgreSQL database. Both `postgres://` and `postgresql://` schemas are supported.
+- `DJANGO_DB_CONN_MAX_AGE`: Lifetime of a database connection, in seconds. Defaults to `60`. Set to `-1` to close the
+  connection at the end of each request (Django's default behaviour). See
+  [Django's `CONN_MAX_AGE` docs](https://docs.djangoproject.com/en/stable/ref/databases/#persistent-connections).
+- `DJANGO_DB_CONN_HEALTH_CHECKS`: If `True`, persistent database connections are health checked before being reused.
+  Defaults to `False`. See
+  [Django's `CONN_HEALTH_CHECKS` docs](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-CONN_HEALTH_CHECKS).
 - `REDIS_URL`: The URL of your Redis instance.
 - `ENV`: The environment the application is running in, e.g. "prod".
 - `SENTRY_DSN`: If you want to send errors to Sentry, specify the DSN here.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds a `DJANGO_DB_CONN_HEALTH_CHECKS` env var (default `False`) that toggles Django's [`CONN_HEALTH_CHECKS`](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-CONN_HEALTH_CHECKS) on the API's database connections. Helps cases with e.g. hanging dead pgbouncer connections whenever it restarts.

The setting is wired into both database configuration paths:
- `DATABASE_URL` (via `dj_database_url.parse(..., conn_health_checks=...)`)
- The legacy `DJANGO_DB_NAME`-style config, for both the primary and analytics databases

While in the area, this PR also documents `DJANGO_DB_CONN_MAX_AGE` in the self-hosting env var reference — it was already supported in `common.py` but undocumented.

## How did you test this code?

Config-layer change. Verified by reading the diff against Django's docs for `CONN_HEALTH_CHECKS` and `dj_database_url`'s `conn_health_checks` keyword, which Django uses as a direct passthrough into the database options dict. No behavioural change when the var is unset (default `False` matches prior behaviour).