### PR TITLE
feat: Enable OpenTelemetry support for Task Processor

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -967,7 +967,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -2055,14 +2055,14 @@ resolved_reference = "b7fa1f42c333b443763548ea1fe0054f07cdf641"
 
 [[package]]
 name = "flagsmith-common"
-version = "3.6.1"
+version = "3.7.0"
 description = "Flagsmith's common library"
 optional = false
 python-versions = "<4.0,>=3.11"
 groups = ["main", "dev", "licensing", "workflows"]
 files = [
-    {file = "flagsmith_common-3.6.1-py3-none-any.whl", hash = "sha256:a51276d0ac683f967cb9e5be4e66d1a8ac6b1cf05b8b00c57097e6371d70d0e8"},
-    {file = "flagsmith_common-3.6.1.tar.gz", hash = "sha256:b9bd84dfb78d61a3579f5a0c1e964bd322772b9e192009f6e69583bc3f099634"},
+    {file = "flagsmith_common-3.7.0-py3-none-any.whl", hash = "sha256:96013812c926df779f9f960759d15607cb724656a1ccd921b923887774aa8f1b"},
+    {file = "flagsmith_common-3.7.0.tar.gz", hash = "sha256:b0a87ba4d4039970b4aedb8baa207f970cf48514386be6b3874961803980b56d"},
 ]
 
 [package.dependencies]
@@ -2077,7 +2077,7 @@ environs = {version = "<15", optional = true, markers = "extra == \"common-core\
 flagsmith-flag-engine = {version = ">6", optional = true, markers = "extra == \"flagsmith-schemas\""}
 gunicorn = {version = ">=19.1", optional = true, markers = "extra == \"common-core\""}
 inflection = {version = "*", optional = true, markers = "extra == \"common-core\""}
-opentelemetry-api = {version = ">=1.25,<2", optional = true, markers = "extra == \"common-core\""}
+opentelemetry-api = {version = ">=1.25,<2", optional = true, markers = "extra == \"common-core\" or extra == \"task-processor\""}
 opentelemetry-exporter-otlp-proto-http = {version = ">=1.25,<2", optional = true, markers = "extra == \"common-core\""}
 opentelemetry-instrumentation-django = {version = ">=0.46b0,<1", optional = true, markers = "extra == \"common-core\""}
 opentelemetry-instrumentation-psycopg2 = {version = ">=0.46b0,<1", optional = true, markers = "extra == \"common-core\""}
@@ -2097,7 +2097,7 @@ typing-extensions = {version = "*", optional = true, markers = "extra == \"commo
 [package.extras]
 common-core = ["django (>4,<6)", "django-health-check", "djangorestframework", "djangorestframework-recursive", "drf-spectacular (>=0.28.0,<1)", "drf-writable-nested", "environs (<15)", "gunicorn (>=19.1)", "inflection", "opentelemetry-api (>=1.25,<2)", "opentelemetry-exporter-otlp-proto-http (>=1.25,<2)", "opentelemetry-instrumentation-django (>=0.46b0,<1)", "opentelemetry-instrumentation-psycopg2 (>=0.46b0,<1)", "opentelemetry-instrumentation-redis (>=0.46b0,<1)", "opentelemetry-sdk (>=1.25,<2)", "prometheus-client (>=0.0.16)", "psycopg2-binary (>=2.9,<3)", "redis (>=5,<6)", "requests", "sentry-sdk (>=2.0.0,<3.0.0)", "simplejson (>=3,<4)", "structlog (>=24.4,<26)", "typing-extensions"]
 flagsmith-schemas = ["flagsmith-flag-engine (>6)", "simplejson", "typing-extensions"]
-task-processor = ["backoff (>=2.2.1,<3.0.0)", "django (>4,<6)", "django-health-check", "prometheus-client (>=0.0.16)"]
+task-processor = ["backoff (>=2.2.1,<3.0.0)", "django (>4,<6)", "django-health-check", "opentelemetry-api (>=1.25,<2)", "prometheus-client (>=0.0.16)"]
 test-tools = ["pyfakefs (>=5,<6)", "pytest-django (>=4,<5)"]
 
 [[package]]
@@ -4587,7 +4587,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -34,6 +34,10 @@
                     "value": "INFO"
                 },
                 {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
+                },
+                {
                     "name": "AWS_REGION",
                     "value": "eu-west-2"
                 },

--- a/infrastructure/aws/production/ecs-task-definition-migration.json
+++ b/infrastructure/aws/production/ecs-task-definition-migration.json
@@ -11,6 +11,14 @@
             ],
             "environment": [
                 {
+                    "name": "LOG_LEVEL",
+                    "value": "INFO"
+                },
+                {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
+                },
+                {
                     "name": "AWS_REGION",
                     "value": "eu-west-2"
                 },

--- a/infrastructure/aws/production/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-sdk-api.json
@@ -39,6 +39,10 @@
                     "value": "INFO"
                 },
                 {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
+                },
+                {
                     "name": "AWS_REGION",
                     "value": "eu-west-2"
                 },

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -184,6 +184,14 @@
                 {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
+                },
+                {
+                    "name": "LOG_LEVEL",
+                    "value": "INFO"
+                },
+                {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -167,6 +167,10 @@
                     "value": "INFO"
                 },
                 {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
+                },
+                {
                     "name": "SSE_SERVER_BASE_URL",
                     "value": "https://origin.realtime-staging.flagsmith.com"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-migration.json
+++ b/infrastructure/aws/staging/ecs-task-definition-migration.json
@@ -11,6 +11,14 @@
             ],
             "environment": [
                 {
+                    "name": "LOG_LEVEL",
+                    "value": "INFO"
+                },
+                {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
+                },
+                {
                     "name": "AWS_REGION",
                     "value": "eu-west-2"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
@@ -34,6 +34,10 @@
                     "value": "INFO"
                 },
                 {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
+                },
+                {
                     "name": "AWS_REGION",
                     "value": "eu-west-2"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith-common/issues/184.

Incorporates task processor spans added in https://github.com/Flagsmith/flagsmith-common/pull/197, and enables JSON logs for all SaaS deployments.

## How did you test this code?

Will test in staging.
