### PR TITLE
fix(billing): fix chargebee on plan toggle

### DIFF
--- a/frontend/web/components/modals/payment/PricingPanel.tsx
+++ b/frontend/web/components/modals/payment/PricingPanel.tsx
@@ -114,6 +114,7 @@ export const PricingPanel = ({
             <div>
               {!isEnterprise && chargebeePlanId && (
                 <PaymentButton
+                  key={chargebeePlanId}
                   data-cb-plan-id={chargebeePlanId}
                   className='btn btn-primary btn-lg full-width mt-3'
                   isDisableAccount={isDisableAccount}


### PR DESCRIPTION
## Changes

Closes the bug reported by @emyller on #7216 — the "Start Trial" button always triggers the yearly plan regardless of the toggle state when `rtk_payment_modal_migration` is enabled.

Adds `key={chargebeePlanId}` to `PaymentButton` in `PricingPanel.tsx` so React remounts the component when switching between yearly and monthly. Without this, Chargebee caches the initial `data-cb-plan-id` from mount and ignores subsequent prop changes.

## How did you test this code?

Needs manual testing: toggle between yearly/monthly on the billing page with `rtk_payment_modal_migration` enabled, verify the Chargebee checkout opens with the correct plan for both Startup and Scale-Up tiles.