### PR TITLE
fix: Organisation breadcrumb shows wrong name for non-admin users

### DIFF
--- a/frontend/common/hooks/useSelectedOrganisation.ts
+++ b/frontend/common/hooks/useSelectedOrganisation.ts
@@ -1,0 +1,17 @@
+import { useSelector } from 'react-redux'
+import { useGetOrganisationsQuery } from 'common/services/useOrganisation'
+import { StoreStateType } from 'common/store'
+
+const useSelectedOrganisation = () => {
+  const selectedId = useSelector(
+    (state: StoreStateType) => state.selectedOrganisation?.id,
+  )
+  const { data: organisationsData } = useGetOrganisationsQuery({})
+  const organisation = organisationsData?.results?.find(
+    (org) => org.id === selectedId,
+  )
+
+  return organisation
+}
+
+export default useSelectedOrganisation

--- a/frontend/common/selectedOrganisationSlice.ts
+++ b/frontend/common/selectedOrganisationSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import API from 'project/api'
 
 type SelectedOrganisationState = {
   id: number | undefined
@@ -15,7 +14,6 @@ const selectedOrganisationSlice = createSlice({
   reducers: {
     setSelectedOrganisationId(state, action: PayloadAction<number>) {
       state.id = action.payload
-      API.setCookie('organisation', `${action.payload}`)
     },
   },
 })

--- a/frontend/common/selectedOrganisationSlice.ts
+++ b/frontend/common/selectedOrganisationSlice.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import API from 'project/api'
+
+type SelectedOrganisationState = {
+  id: number | undefined
+}
+
+const initialState: SelectedOrganisationState = {
+  id: undefined,
+}
+
+const selectedOrganisationSlice = createSlice({
+  initialState,
+  name: 'selectedOrganisation',
+  reducers: {
+    setSelectedOrganisationId(state, action: PayloadAction<number>) {
+      state.id = action.payload
+      API.setCookie('organisation', `${action.payload}`)
+    },
+  },
+})
+
+export const { setSelectedOrganisationId } = selectedOrganisationSlice.actions
+export default selectedOrganisationSlice.reducer

--- a/frontend/common/store.ts
+++ b/frontend/common/store.ts
@@ -13,10 +13,12 @@ import {
 import storage from 'redux-persist/lib/storage'
 import { Persistor } from 'redux-persist/es/types'
 import { service } from './service'
+import selectedOrganisationReducer from './selectedOrganisationSlice'
 // END OF IMPORTS
 const createStore = () => {
   const reducer = combineReducers({
     [service.reducerPath]: service.reducer,
+    selectedOrganisation: selectedOrganisationReducer,
     // END OF REDUCERS
   })
 

--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -12,6 +12,7 @@ import dataRelay from 'data-relay'
 import { sortBy } from 'lodash'
 import Project from 'common/project'
 import { getStore } from 'common/store'
+import { setSelectedOrganisationId } from 'common/selectedOrganisationSlice'
 import { service } from 'common/service'
 import { getBuildVersion } from 'common/services/useBuildVersion'
 import { createOnboardingSupportOptIn } from 'common/services/useOnboardingSupportOptIn'
@@ -309,6 +310,7 @@ const controller = {
   selectOrganisation: (id) => {
     API.setCookie('organisation', `${id}`)
     store.organisation = find(store.model.organisations, { id })
+    getStore().dispatch(setSelectedOrganisationId(id))
     store.changed()
   },
 
@@ -343,6 +345,9 @@ const controller = {
             store.organisation = foundOrganisation
             AppActions.getOrganisation(orgId)
           }
+        }
+        if (store.organisation?.id) {
+          getStore().dispatch(setSelectedOrganisationId(store.organisation.id))
         }
       }
 

--- a/frontend/web/components/BreadcrumbSeparator.tsx
+++ b/frontend/web/components/BreadcrumbSeparator.tsx
@@ -13,7 +13,6 @@ import AccountStore from 'common/stores/account-store'
 import { useGetProjectsQuery } from 'common/services/useProject'
 import { useGetOrganisationsQuery } from 'common/services/useOrganisation'
 import { useHistory } from 'react-router-dom'
-import OrganisationStore from 'common/stores/organisation-store'
 import AppActions from 'common/dispatcher/app-actions'
 import Utils from 'common/utils/utils'
 import { getStore } from 'common/store'
@@ -177,7 +176,7 @@ const BreadcrumbSeparator: FC<BreadcrumbSeparatorType> = ({
     }
     AccountStore.on('change', onChangeAccountStore)
     return () => {
-      OrganisationStore.off('change', onChangeAccountStore)
+      AccountStore.off('change', onChangeAccountStore)
     }
     //eslint-disable-next-line
   }, [])

--- a/frontend/web/components/navigation/SelectOrgAndProject.tsx
+++ b/frontend/web/components/navigation/SelectOrgAndProject.tsx
@@ -1,11 +1,10 @@
 import React, { FC } from 'react'
-import AccountStore from 'common/stores/account-store'
 import { Link, NavLink } from 'react-router-dom'
 import BreadcrumbSeparator from 'components/BreadcrumbSeparator'
 import classNames from 'classnames'
 import Utils from 'common/utils/utils'
 import { Project } from 'common/types/responses'
-import { useGetOrganisationQuery } from 'common/services/useOrganisation'
+import useSelectedOrganisation from 'common/hooks/useSelectedOrganisation'
 import { appLevelPaths } from './constants'
 
 type SelectOrgAndProjectType = {
@@ -18,12 +17,7 @@ const SelectOrgAndProject: FC<SelectOrgAndProjectType> = ({
   projectId,
 }) => {
   const isAppLevelPage = appLevelPaths.includes(document.location.pathname)
-
-  const organisationId = AccountStore.getOrganisation()?.id
-  const { data: organisation } = useGetOrganisationQuery(
-    { id: organisationId as number },
-    { skip: !organisationId },
-  )
+  const organisation = useSelectedOrganisation()
 
   return (
     <Row className='gap-2'>
@@ -57,9 +51,7 @@ const SelectOrgAndProject: FC<SelectOrgAndProjectType> = ({
                 })}
                 to={Utils.getOrganisationHomePage()}
               >
-                <div>
-                  {organisation?.name || AccountStore.getOrganisation()?.name}
-                </div>
+                <div>{organisation?.name}</div>
               </NavLink>
             </BreadcrumbSeparator>
           </div>


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7233

Non-admin users switching organisations via the breadcrumb dropdown see a stale org name. The page content updates correctly but the breadcrumb stays on the previous organisation.

**Root cause**: `SelectOrgAndProject` used `useGetOrganisationQuery` which calls `GET /api/v1/organisations/{id}/` — a detail endpoint that returns 403 for non-admin users. The query fails silently and the component shows stale data.

**Fix**:
- Introduced a `selectedOrganisationSlice` in Redux to hold the selected org ID
- Created a `useSelectedOrganisation` hook that combines the Redux slice with `useGetOrganisationsQuery` (list endpoint, accessible to all members)
- Bridged `AccountStore.selectOrganisation` to dispatch into Redux during the Flux→RTK migration
- Fixed a listener cleanup bug in `BreadcrumbSeparator` (was unsubscribing from `OrganisationStore` instead of `AccountStore`)

## How did you test this code?

1. Log in as a non-admin user with access to multiple organisations
2. Open the breadcrumb dropdown and switch organisations
3. Verify the breadcrumb name updates to the selected organisation
4. Verify page content (projects, tabs) also updates correctly

Reported by @kyle-ssg