### PR TITLE
fix(Billing): Polish the new Scale-Up pricing tile

### DIFF
--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -350,7 +350,7 @@ const Payment = class extends Component {
                                 <Icon name='checkmark-circle' fill='#27AB95' />
                               </span>
                               <div className='ml-2'>
-                                Up to <strong>20</strong> Team members
+                                Additional seats at $60/seat (up to 20)
                               </div>
                             </Row>
                           </li>

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -340,6 +340,16 @@ const Payment = class extends Component {
                                 <Icon name='checkmark-circle' fill='#27AB95' />
                               </span>
                               <div className='ml-2'>
+                                <strong>5</strong> Team members
+                              </div>
+                            </Row>
+                          </li>
+                          <li>
+                            <Row className='mb-3 pricing-features-item'>
+                              <span>
+                                <Icon name='checkmark-circle' fill='#27AB95' />
+                              </span>
+                              <div className='ml-2'>
                                 Up to <strong>20</strong> Team members
                               </div>
                             </Row>

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -291,9 +291,6 @@ const Payment = class extends Component {
                             <h5 className='fs-lg mb-0'>/mo</h5>
                           </h1>
                         </Row>
-                        <div className='pricing-type pt-1 text-muted'>
-                          + ${this.state.yearly ? '50' : '60'}/seat
-                        </div>
                         {!viewOnly ? (
                           <>
                             <PaymentButton

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -277,9 +277,6 @@ const Payment = class extends Component {
                           minHeight: '250px',
                         }}
                       >
-                        <span className='fw-bold text-primary fs-small'>
-                          Most Popular
-                        </span>
                         <Row className='pt-4 justify-content-center'>
                           <Icon name='flash' width={32} />
                           <h4 className='mb-0 ml-2'>Scale-Up</h4>

--- a/frontend/web/components/modals/payment/Payment.tsx
+++ b/frontend/web/components/modals/payment/Payment.tsx
@@ -113,8 +113,6 @@ export const Payment: FC<PaymentProps> = ({
             title='Scale-Up'
             priceYearly='270'
             priceMonthly='300'
-            seatPriceYearly='50'
-            seatPriceMonthly='60'
             isYearly={yearly}
             isFeatured
             chargebeePlanId={

--- a/frontend/web/components/modals/payment/Payment.tsx
+++ b/frontend/web/components/modals/payment/Payment.tsx
@@ -114,7 +114,6 @@ export const Payment: FC<PaymentProps> = ({
             priceYearly='270'
             priceMonthly='300'
             isYearly={yearly}
-            isFeatured
             chargebeePlanId={
               yearly
                 ? Project.plans?.scaleUp?.annual

--- a/frontend/web/components/modals/payment/PricingPanel.tsx
+++ b/frontend/web/components/modals/payment/PricingPanel.tsx
@@ -12,7 +12,6 @@ export type PricingPanelProps = {
   priceMonthly?: string
   priceYearly?: string
   includesFrom: string
-  isFeatured?: boolean
   isYearly: boolean
   chargebeePlanId?: string
   isPurchased?: boolean
@@ -32,7 +31,6 @@ export const PricingPanel = ({
   includesFrom,
   isDisableAccount,
   isEnterprise,
-  isFeatured,
   isPurchased,
   isYearly,
   organisationId,
@@ -50,11 +48,6 @@ export const PricingPanel = ({
         <div className='p-3 pt-4 pricing-panel-content'>
           <div className='pricing-panel-layout'>
             <div>
-              {isFeatured && (
-                <span className='fw-bold text-primary fs-small'>
-                  Most Popular
-                </span>
-              )}
               {headerContent && (
                 <span
                   className={classNames('featured', {

--- a/frontend/web/components/modals/payment/PricingPanel.tsx
+++ b/frontend/web/components/modals/payment/PricingPanel.tsx
@@ -11,8 +11,6 @@ export type PricingPanelProps = {
   title: string
   priceMonthly?: string
   priceYearly?: string
-  seatPriceMonthly?: string
-  seatPriceYearly?: string
   includesFrom: string
   isFeatured?: boolean
   isYearly: boolean
@@ -40,8 +38,6 @@ export const PricingPanel = ({
   organisationId,
   priceMonthly,
   priceYearly,
-  seatPriceMonthly,
-  seatPriceYearly,
   title,
 }: PricingPanelProps) => {
   return (
@@ -92,12 +88,6 @@ export const PricingPanel = ({
                     <span className='fs-lg mb-0'>/mo</span>
                   </h1>
                 </Row>
-              )}
-
-              {(seatPriceMonthly || seatPriceYearly) && (
-                <div className='pricing-type pt-1 text-muted'>
-                  + ${isYearly ? seatPriceYearly : seatPriceMonthly}/seat
-                </div>
               )}
 
               {isEnterprise && (

--- a/frontend/web/components/modals/payment/pricingFeatures.tsx
+++ b/frontend/web/components/modals/payment/pricingFeatures.tsx
@@ -42,6 +42,13 @@ export const SCALE_UP_FEATURES: PricingFeature[] = [
   {
     text: (
       <>
+        <strong>5</strong> Team members
+      </>
+    ),
+  },
+  {
+    text: (
+      <>
         Up to <strong>20</strong> Team members
       </>
     ),

--- a/frontend/web/components/modals/payment/pricingFeatures.tsx
+++ b/frontend/web/components/modals/payment/pricingFeatures.tsx
@@ -47,11 +47,7 @@ export const SCALE_UP_FEATURES: PricingFeature[] = [
     ),
   },
   {
-    text: (
-      <>
-        Up to <strong>20</strong> Team members
-      </>
-    ),
+    text: 'Additional seats at $60/seat (up to 20)',
   },
   {
     text: 'User roles and permissions',


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith-private/issues/107

Tweaks to the Scale-Up pricing tile.

## How did you test this code?

Before: 
<img width="1462" height="1147" alt="image" src="https://github.com/user-attachments/assets/d219efa2-2a2f-4aeb-9f6e-9fceab589a52" />

After:
<img width="1455" height="1080" alt="image" src="https://github.com/user-attachments/assets/0cc10585-d232-4c30-909a-8862d56edf3d" />
