### PR TITLE
feat: limit number of environments per project (#3875)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-Read @AGENTS.md

--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -42,15 +42,31 @@ class EnvironmentPermissions(IsAuthenticated):
 
             try:
                 project = Project.objects.get(id=project_id)
-                return request.user.has_project_permission(CREATE_ENVIRONMENT, project)
             except Project.DoesNotExist:
                 return False
+
+            if (
+                project.environments.count() >= project.max_environments_allowed
+                and getattr(request, "is_e2e", False) is not True
+            ):
+                raise exceptions.ValidationError(
+                    "The project has reached the maximum number of allowed environments."
+                )
+
+            return request.user.has_project_permission(CREATE_ENVIRONMENT, project)
 
         # return true as all users can list and obj permissions will be handled later
         return True
 
     def has_object_permission(self, request, view, obj):  # type: ignore[no-untyped-def]
         if view.action == "clone":
+            if (
+                obj.project.environments.count() >= obj.project.max_environments_allowed
+                and getattr(request, "is_e2e", False) is not True
+            ):
+                raise exceptions.ValidationError(
+                    "The project has reached the maximum number of allowed environments."
+                )
             return request.user.has_project_permission(CREATE_ENVIRONMENT, obj.project)
         elif view.action in ("get_document", "retrieve", "trait_keys"):
             return request.user.has_environment_permission(VIEW_ENVIRONMENT, obj)

--- a/api/projects/admin.py
+++ b/api/projects/admin.py
@@ -71,6 +71,7 @@ class ProjectAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         "max_segment_overrides_allowed",
         "edge_v2_migration_status",
         "edge_v2_migration_read_capacity_budget",
+        "max_environments_allowed",
     )
 
     @admin.action(

--- a/api/projects/migrations/0029_add_max_environments_allowed.py
+++ b/api/projects/migrations/0029_add_max_environments_allowed.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0028_add_enforce_feature_owners_to_project"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="project",
+            name="max_environments_allowed",
+            field=models.IntegerField(
+                default=100,
+                help_text="Max environments allowed for this project",
+            ),
+        ),
+    ]

--- a/api/projects/models.py
+++ b/api/projects/models.py
@@ -87,6 +87,10 @@ class Project(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ignore[d
         default=100,
         help_text="Max segments overrides allowed for any (one) environment within this project",
     )
+    max_environments_allowed = models.IntegerField(
+        default=100,
+        help_text="Max environments allowed for this project",
+    )
     edge_v2_migration_status = models.CharField(
         max_length=50,
         choices=EdgeV2MigrationStatus.choices,
@@ -125,6 +129,7 @@ class Project(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ignore[d
         return (
             self.features.count() > self.max_features_allowed
             or self.live_segment_count() > self.max_segments_allowed
+            or self.environments.count() > self.max_environments_allowed
             or self.environments.annotate(
                 segment_override_count=Count("feature_segments")
             )

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -120,6 +120,7 @@ class ProjectRetrieveSerializer(ProjectListSerializer):
             "max_segments_allowed",
             "max_features_allowed",
             "max_segment_overrides_allowed",
+            "max_environments_allowed",
             "total_features",
             "total_segments",
         )
@@ -128,6 +129,7 @@ class ProjectRetrieveSerializer(ProjectListSerializer):
             "max_segments_allowed",
             "max_features_allowed",
             "max_segment_overrides_allowed",
+            "max_environments_allowed",
             "total_features",
             "total_segments",
         )

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -121,7 +121,6 @@ class ProjectRetrieveSerializer(ProjectListSerializer):
             "max_segments_allowed",
             "max_features_allowed",
             "max_segment_overrides_allowed",
-            "max_environments_allowed",
             "total_features",
             "total_segments",
         )

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -45,6 +45,7 @@ class ProjectListSerializer(serializers.ModelSerializer):  # type: ignore[type-a
             "edge_v2_migration_status",
             "minimum_change_request_approvals",
             "enforce_feature_owners",
+            "max_environments_allowed",
         )
         read_only_fields = (
             "enable_dynamo_db",

--- a/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
+++ b/api/tests/unit/environments/permissions/test_unit_environments_permissions.py
@@ -5,6 +5,7 @@ from common.projects.permissions import (
     CREATE_ENVIRONMENT,
 )
 from pytest_mock import MockerFixture
+from rest_framework.exceptions import ValidationError
 
 from environments.identities.models import Identity
 from environments.models import Environment
@@ -399,3 +400,109 @@ def test_nested_environment_permissions__regular_user_destroys__returns_false(
 
     # Then
     assert result is False
+
+
+def test_environment_permissions__create_at_limit__raises_validation_error(
+    admin_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+) -> None:
+    # Given
+    project.max_environments_allowed = 1
+    project.save()
+
+    mock_view.action = "create"
+    mock_view.detail = False
+    mock_request.user = admin_user
+    mock_request.data = {"project": project.id, "name": "Another environment"}
+    mock_request.is_e2e = False
+
+    # When / Then
+    with pytest.raises(ValidationError, match="maximum number of allowed environments"):
+        environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+
+
+def test_environment_permissions__create_below_limit__returns_true(
+    admin_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+) -> None:
+    # Given
+    project.max_environments_allowed = 100
+    project.save()
+
+    mock_view.action = "create"
+    mock_view.detail = False
+    mock_request.user = admin_user
+    mock_request.data = {"project": project.id, "name": "Another environment"}
+
+    # When
+    result = environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+
+    # Then
+    assert result is True
+
+
+def test_environment_permissions__clone_at_limit__raises_validation_error(
+    admin_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+) -> None:
+    # Given
+    project.max_environments_allowed = 1
+    project.save()
+
+    mock_view.action = "clone"
+    mock_view.detail = True
+    mock_request.user = admin_user
+    mock_request.is_e2e = False
+
+    # When / Then
+    with pytest.raises(ValidationError, match="maximum number of allowed environments"):
+        environment_permissions.has_object_permission(  # type: ignore[no-untyped-call]
+            mock_request, mock_view, environment
+        )
+
+
+def test_environment_permissions__clone_below_limit__returns_true(
+    admin_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+) -> None:
+    # Given
+    project.max_environments_allowed = 100
+    project.save()
+
+    mock_view.action = "clone"
+    mock_view.detail = True
+    mock_request.user = admin_user
+
+    # When
+    result = environment_permissions.has_object_permission(  # type: ignore[no-untyped-call]
+        mock_request, mock_view, environment
+    )
+
+    # Then
+    assert result is True
+
+
+def test_environment_permissions__create_at_limit_with_increased_limit__returns_true(
+    admin_user: FFAdminUser,
+    project: Project,
+    environment: Environment,
+) -> None:
+    """Grandfathering: projects with a higher limit can still create environments."""
+    # Given
+    project.max_environments_allowed = 200
+    project.save()
+
+    mock_view.action = "create"
+    mock_view.detail = False
+    mock_request.user = admin_user
+    mock_request.data = {"project": project.id, "name": "Another environment"}
+
+    # When
+    result = environment_permissions.has_permission(mock_request, mock_view)  # type: ignore[no-untyped-call]
+
+    # Then
+    assert result is True

--- a/api/tests/unit/projects/test_unit_projects_models.py
+++ b/api/tests/unit/projects/test_unit_projects_models.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
 
+from environments.models import Environment
 from organisations.models import Organisation
 from projects.models import EdgeV2MigrationStatus, Project
 from segments.models import Segment
@@ -215,7 +216,6 @@ def test_is_too_large__environments_exceed_limit__returns_true(
     project: Project,
 ) -> None:
     # Given
-    from environments.models import Environment
 
     project.max_environments_allowed = 1
     project.save()
@@ -234,7 +234,6 @@ def test_is_too_large__environments_within_limit__returns_false(
     project: Project,
 ) -> None:
     # Given
-    from environments.models import Environment
 
     project.max_environments_allowed = 100
     project.save()

--- a/api/tests/unit/projects/test_unit_projects_models.py
+++ b/api/tests/unit/projects/test_unit_projects_models.py
@@ -209,3 +209,40 @@ def test_create_project__edge_enabled__sets_edge_v2_migration_complete(
 
     # Then
     assert project.edge_v2_migration_status == EdgeV2MigrationStatus.COMPLETE
+
+
+def test_is_too_large__environments_exceed_limit__returns_true(
+    project: Project,
+) -> None:
+    # Given
+    from environments.models import Environment
+
+    project.max_environments_allowed = 1
+    project.save()
+
+    Environment.objects.create(name="Env 1", project=project)
+    Environment.objects.create(name="Env 2", project=project)
+
+    # When
+    result = project.is_too_large
+
+    # Then
+    assert result is True
+
+
+def test_is_too_large__environments_within_limit__returns_false(
+    project: Project,
+) -> None:
+    # Given
+    from environments.models import Environment
+
+    project.max_environments_allowed = 100
+    project.save()
+
+    Environment.objects.create(name="Env 1", project=project)
+
+    # When
+    result = project.is_too_large
+
+    # Then
+    assert result is False


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✅]  I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [✅]  I have added information to `docs/` if required so people know about the feature.
- [✅]  I have filled in the "Changes" section below.
- [✅]  I have filled in the "How did you test this code" section below.

- Adds a `max_environments_allowed` field (default: 100) to the `Project` model to soft-limit the number of environments per  project, mitigating N+1 query impact from the permission system                                                                   
  - Enforces the limit on environment creation and cloning in `EnvironmentPermissions`, raising a clear `ValidationError` when  exceeded                                                                                                                          
  - Exposes the field in `ProjectRetrieveSerializer` (read-only) and includes environments in the `Project.is_too_large` check      
                                                                                                                              
  ### Grandfathering existing clients                                                                                               
                                                        
  Existing organisations already operating above the limit are not affected — admins can set `max_environments_allowed` to a higher value per project via the Django admin panel or API to accommodate them.                                                          
                                                                         

## Changes

-  Adds a soft limit of 100 environments per project to mitigate N+1 query impact from the permission system.                                                                               - Added `max_environments_allowed` field (default: 100) to the `Project` model, following the existing pattern of                 
  `max_segments_allowed` and `max_features_allowed`     
 - Enforced the limit in `EnvironmentPermissions` for both `create` and `clone` actions, raising a `ValidationError` with a clear message when exceeded                                                                                                             
  - Added environments count to the `Project.is_too_large` property
  - Exposed the field as read-only in `ProjectRetrieveSerializer`                                                                   
  - Existing clients operating above the limit can be grandfathered by setting `max_environments_allowed` to a higher value per project via the Django admin panel 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->



## How did you test this code?

- Added 5 unit tests for environment permissions:                                                                                 
    - `test_environment_permissions__create_at_limit__raises_validation_error`
    - `test_environment_permissions__create_below_limit__returns_true`                                                              
    - `test_environment_permissions__clone_at_limit__raises_validation_error`                                                       
    - `test_environment_permissions__clone_below_limit__returns_true`
    - `test_environment_permissions__create_at_limit_with_increased_limit__returns_true` (grandfathering)                           
  - Added 2 unit tests for the project model:                                                                                       
    - `test_is_too_large__environments_exceed_limit__returns_true`                                                                  
    - `test_is_too_large__environments_within_limit__returns_false`                                                                 
  - All files pass `mypy --strict` and `ruff` linting   



