### PR TITLE
feat(OTel): Add first structlog events for OTel event pipeline

### DIFF
--- a/api/core/workflows_services.py
+++ b/api/core/workflows_services.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from features.workflows.core.models import ChangeRequest
     from users.models import FFAdminUser
 
-logger = structlog.get_logger()
+logger = structlog.get_logger("workflows")
 
 
 class ChangeRequestCommitService:
@@ -34,6 +34,15 @@ class ChangeRequestCommitService:
 
         self.change_request.committed_at = timezone.now()
         self.change_request.committed_by = committed_by
+
+        if environment := self.change_request.environment:
+            logger.info(
+                "change_request.committed",
+                organisation__id=environment.project.organisation_id,
+                environment__id=environment.id,
+                feature_states__count=self.change_request.feature_states.count(),
+            )
+
         self.change_request.save()
 
     def _publish_feature_states(self) -> None:

--- a/api/integrations/github/views.py
+++ b/api/integrations/github/views.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from urllib.parse import urlparse
 
 import requests
+import structlog
 from django.conf import settings
 from django.db.utils import IntegrityError
 from rest_framework import status, viewsets
@@ -54,6 +55,7 @@ from organisations.permissions.permissions import GithubIsAdminOrganisation
 from projects.code_references.services import get_code_references_for_feature_flag
 
 logger = logging.getLogger(__name__)
+code_references_logger = structlog.get_logger("code_references")
 
 
 def github_auth_required(func):  # type: ignore[no-untyped-def]
@@ -382,6 +384,12 @@ def create_cleanup_issue(request, organisation_pk: int) -> Response:  # type: ig
             )
         except IntegrityError:
             pass
+
+    code_references_logger.info(
+        "cleanup_issues.created",
+        organisation__id=organisation_pk,
+        issues_created__count=len(summaries),
+    )
 
     return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/api/projects/code_references/views.py
+++ b/api/projects/code_references/views.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import structlog
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, response
@@ -19,6 +20,8 @@ from projects.code_references.types import (
     FeatureFlagCodeReferencesRepositorySummary,
 )
 
+logger = structlog.get_logger("code_references")
+
 
 class FeatureFlagCodeReferencesScanCreateAPIView(
     generics.CreateAPIView[FeatureFlagCodeReferencesScan]
@@ -33,7 +36,14 @@ class FeatureFlagCodeReferencesScanCreateAPIView(
     def perform_create(  # type: ignore[override]
         self, serializer: FeatureFlagCodeReferencesScanSerializer
     ) -> None:
-        serializer.save(project_id=self.kwargs["project_pk"])
+        instance = serializer.save(project_id=self.kwargs["project_pk"])
+        feature_names = {ref["feature_name"] for ref in instance.code_references}
+        logger.info(
+            "scan.created",
+            organisation__id=instance.project.organisation_id,
+            code_references__count=len(instance.code_references),
+            feature__count=len(feature_names),
+        )
 
 
 @extend_schema(

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from flag_engine.segments.constants import EQUAL, PERCENTAGE_SPLIT
 from freezegun.api import FrozenDateTimeFactory
 from pytest_mock import MockerFixture
+from pytest_structlog import StructuredLogCapture
 
 from audit.constants import (
     CHANGE_REQUEST_APPROVED_MESSAGE,
@@ -170,6 +171,28 @@ def test_change_request_commit__not_scheduled__sets_committed_at_and_version(  #
 
     assert change_request_no_required_approvals.feature_states.first().version == 2
     assert change_request_no_required_approvals.feature_states.first().live_from == now
+
+
+def test_change_request_commit__valid_request__emits_structlog_event(
+    change_request_no_required_approvals: ChangeRequest,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    user = FFAdminUser.objects.create(email="committer@example.com")
+
+    # When
+    change_request_no_required_approvals.commit(committed_by=user)
+
+    # Then
+    environment = change_request_no_required_approvals.environment
+    assert environment is not None
+    assert {
+        "event": "change_request.committed",
+        "level": "info",
+        "organisation__id": environment.project.organisation_id,
+        "environment__id": environment.id,
+        "feature_states__count": change_request_no_required_approvals.feature_states.count(),
+    } in log.events
 
 
 def test_change_request_create__valid_environment__creates_audit_log(  # type: ignore[no-untyped-def]

--- a/api/tests/unit/integrations/github/test_unit_github_cleanup_issue.py
+++ b/api/tests/unit/integrations/github/test_unit_github_cleanup_issue.py
@@ -6,6 +6,7 @@ import pytest
 import responses
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
+from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -78,6 +79,7 @@ def test_create_cleanup_issue__valid_request__returns_204(
     admin_client_new: APIClient,
     organisation: Organisation,
     feature: Feature,
+    log: StructuredLogCapture,
 ) -> None:
     # Given
     github_issue_response_1: dict[str, Any] = {
@@ -134,6 +136,15 @@ def test_create_cleanup_issue__valid_request__returns_204(
     assert "src/app.py#L42" in request_body_1["body"]
     request_body_2 = json.loads(responses.calls[1].request.body)
     assert "lib/flags.py#L7" in request_body_2["body"]
+
+    assert log.events == [
+        {
+            "event": "cleanup_issues.created",
+            "level": "info",
+            "organisation__id": organisation.id,
+            "issues_created__count": 2,
+        },
+    ]
 
 
 @responses.activate

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
@@ -1,4 +1,5 @@
 import freezegun
+from pytest_structlog import StructuredLogCapture
 from rest_framework.test import APIClient
 
 from features.models import Feature
@@ -10,6 +11,7 @@ from projects.models import Project
 def test_create_code_reference__valid_payload__returns_201_with_accepted_references(
     admin_client_new: APIClient,
     project: Project,
+    log: StructuredLogCapture,
 ) -> None:
     # Given / When
     response = admin_client_new.post(
@@ -60,6 +62,16 @@ def test_create_code_reference__valid_payload__returns_201_with_accepted_referen
             "feature_name": "feature-2",
             "file_path": "path/to/file3.py",
             "line_number": 30,
+        },
+    ]
+
+    assert log.events == [
+        {
+            "event": "scan.created",
+            "level": "info",
+            "organisation__id": project.organisation_id,
+            "code_references__count": 3,
+            "feature__count": 2,
         },
     ]
 

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -171,6 +171,10 @@
                 {
                     "name": "LOG_LEVEL",
                     "value": "INFO"
+                },
+                {
+                    "name": "LOG_FORMAT",
+                    "value": "json"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith/issues/7012

Adds the first product-meaningful structured log events for the OTel event pipeline ([RFC](https://www.notion.so/flagsmith/Open-Structured-Event-Pipeline-329a2b634bf98061b448fda6c15903d6)). These events flow through `StructlogOTelProcessor` in flagsmith-common 3.7.0 and reach the OTel Collector when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.

Events added:

| Event | Signal | Attributes |
|-------|--------|------------|
| `code_references.scan.created` | Adoption: org has set up CI scanning | `organisation.id`, `code_references.count`, `feature.count` |
| `code_references.cleanup_issues.created` | Retention: org acting on stale flag insights | `organisation.id`, `issues_created.count` |
| `workflows.change_request.committed` | Adoption: org using governance workflows | `organisation.id`, `environment.id`, `feature_states.count` |

Code references events are backend-only (CI pushes scans, GitHub issues created server-side). Change request committed is a multi-actor flow (requester ≠ approver) that the frontend Amplitude SDK can't reliably attribute.

Adding an event is a one-liner:

```python
logger = structlog.get_logger("code_references")
logger.info("scan.created", organisation__id=org_id, code_references__count=3)
```

The `StructlogOTelProcessor` normalises this to an OTel LogRecord with `EventName=code_references.scan.created` and dotted attributes (`organisation.id`, `code_references.count`).

Infra changes (collector config, SG rules, service discovery, env vars) tracked in Flagsmith/pulumi#170.

## How did you test this code?

Unit tests using `pytest-structlog` `log` fixture assert the exact event shape for all 3 events. `make lint` and `make typecheck` clean.