### PR TITLE
feat(OTel): Push Amplitude IDs to Baggage

### DIFF
--- a/frontend/common/service.ts
+++ b/frontend/common/service.ts
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/dist/query/react'
 
 import { FetchBaseQueryArgs } from '@reduxjs/toolkit/dist/query/fetchBaseQuery'
@@ -34,6 +35,17 @@ const baseApiOptions = (queryArgs?: Partial<FetchBaseQueryArgs>) => {
               headers.set('Authorization', `Token ${token}`)
             }
           } catch (e) {}
+        }
+
+        const deviceId = amplitude.getDeviceId()
+        const sessionId = amplitude.getSessionId()
+        const userId = amplitude.getUserId()
+        if (deviceId || sessionId || userId) {
+          const entries: string[] = []
+          if (deviceId) entries.push(`amplitude.device_id=${deviceId}`)
+          if (sessionId) entries.push(`amplitude.session_id=${sessionId}`)
+          if (userId) entries.push(`amplitude.user_id=${userId}`)
+          headers.set('baggage', entries.join(','))
         }
 
         return headers

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -694,6 +694,7 @@ export type Account = {
   pylon_email_signature: string
   sign_up_type: SignupType
   id: number
+  uuid: string
   email: string
   auth_type: AuthType
   is_superuser: boolean

--- a/frontend/web/project/api.ts
+++ b/frontend/web/project/api.ts
@@ -112,7 +112,8 @@ const API = {
     }
 
     if (Project.amplitude) {
-      amplitude.setUserId(id)
+      const amplitudeUserId = user.uuid || id
+      amplitude.setUserId(amplitudeUserId)
       API.trackTraits({ email: id })
       if (window.engagement) {
         window.engagement.boot({
@@ -122,7 +123,7 @@ const API = {
                 amplitude.track(event.event_type, event.event_properties),
             },
           ],
-          user: { user_id: id, user_properties: {} },
+          user: { user_id: amplitudeUserId, user_properties: {} },
         })
       }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/7029

Two changes to support session stitching between frontend and backend events in Amplitude:

1. Inject Amplitude's `device_id`, `session_id`, and `user_id` into the W3C `Baggage` header on every RTK Query API request (`common/service.ts`). The backend's `W3CBaggagePropagator` parses these and the `StructlogOTelProcessor` copies them into OTel log attributes, which the Amplitude exporter maps to Amplitude's identity fields.

2. Migrate Amplitude user identity from email to UUID (`web/project/api.ts`). This removes PII from Amplitude's identity model and aligns frontend/backend identity — the backend sends the same UUID as `amplitude.user_id` via baggage. Also adds the missing `uuid` field to the `Account` type (`common/types/responses.ts`).

## How did you test this code?

`npm run typecheck` — no new errors (only pre-existing ones). Changes are straightforward header injection and a `setUserId` call swap.