### PR TITLE
feat: add has_approvals() helper to ChangeRequest model

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -153,6 +153,9 @@ class ChangeRequest(  # type: ignore[django-manager-missing]
             return self.is_approved_via_environment()
         return self.is_approved_via_project()
 
+    def has_approvals(self) -> bool:
+        return self.approvals.filter(approved_at__isnull=False).exists()
+
     def is_approved_via_project(self) -> bool:
         return self.project.minimum_change_request_approvals is None or (
             self.approvals.filter(approved_at__isnull=False).count()

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -141,6 +141,42 @@ def test_change_request_is_approved__minimum_approvals_is_none__returns_true(  #
     assert result is True
 
 
+def test_change_request_has_approvals__approved_approval__returns_true(
+    change_request_no_required_approvals: ChangeRequest,
+) -> None:
+    # Given
+    approver = FFAdminUser.objects.create(email="approver@example.com")
+    ChangeRequestApproval.objects.create(
+        user=approver,
+        change_request=change_request_no_required_approvals,
+        approved_at=timezone.now(),
+    )
+
+    # When
+    result = change_request_no_required_approvals.has_approvals()
+
+    # Then
+    assert result is True
+
+
+def test_change_request_has_approvals__pending_approval_only__returns_false(
+    change_request_no_required_approvals: ChangeRequest,
+) -> None:
+    # Given
+    assignee = FFAdminUser.objects.create(email="assignee@example.com")
+    ChangeRequestApproval.objects.create(
+        user=assignee,
+        change_request=change_request_no_required_approvals,
+        approved_at=None,
+    )
+
+    # When
+    result = change_request_no_required_approvals.has_approvals()
+
+    # Then
+    assert result is False
+
+
 def test_change_request_commit__not_approved__raises_exception(  # type: ignore[no-untyped-def]
     change_request_1_required_approvals,
 ):


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7056

Adds a `has_approvals()` helper on the `ChangeRequest` model. Returns `True` if at least one reviewer has approved the CR (i.e. there is a `ChangeRequestApproval` row with `approved_at IS NOT NULL`).

The helper sits next to `is_approved()` and uses the same `approved_at__isnull=False` filter pattern. No behaviour change on its own — it is a prerequisite for the serializer-level guard in `flagsmith-workflows` that will block post-approval edits to a Change Request's content, plus a small frontend UI change in this repo to hide the Edit button once a CR has any approval. Both follow-ups will land in separate PRs.

## How did you test this code?

Two unit tests in `api/tests/unit/features/workflows/core/test_unit_workflows_models.py`:



