### PR TITLE
fix(gram): use-env-variables-in-ci-to-target-host

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Generate MCP schema
         env:
-          FLAGSMITH_API_URL: ${{ vars.FLAGSMITH_API_URL || 'https://api.flagsmith.com' }}
-          FLAGSMITH_FRONTEND_URL: ${{ vars.FLAGSMITH_FRONTEND_URL || 'https://app.flagsmith.com' }}
+          FLAGSMITH_API_URL: 'https://api.flagsmith.com'
+          FLAGSMITH_FRONTEND_URL: 'https://app.flagsmith.com'
         run: make generate-mcp-spec
 
       - name: Install Gram CLI

--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -48,6 +48,9 @@ jobs:
           rm -rf ${HOME}/.git-credentials
 
       - name: Generate MCP schema
+        env:
+          FLAGSMITH_API_URL: ${{ vars.FLAGSMITH_API_URL || 'https://api.flagsmith.com' }}
+          FLAGSMITH_FRONTEND_URL: ${{ vars.FLAGSMITH_FRONTEND_URL || 'https://app.flagsmith.com' }}
         run: make generate-mcp-spec
 
       - name: Install Gram CLI


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Fix MCP OpenAPI spec generation in CI using localhost URLs instead of production URLs for Gram. Bug introduced as the mcp openAPI spec dynamically sets the the `securityScheme` and `server.urls`

- Use github variables to set the target hosts

## How did you test this code?
