### PR TITLE
chore: Track flagsmith-swift-ios-sdk 3.10.0

### DIFF
--- a/api/app_analytics/constants.py
+++ b/api/app_analytics/constants.py
@@ -82,7 +82,8 @@ SDK_USER_AGENT_KNOWN_VERSIONS: dict[KnownSDK, list[str]] = {
         "unknown",
         "2.1.0",
     ],
-    "flagsmith-swift-ios-sdk": ["unknown",
+    "flagsmith-swift-ios-sdk": [
+        "unknown",
         "3.10.0",
     ],
 }

--- a/api/app_analytics/constants.py
+++ b/api/app_analytics/constants.py
@@ -82,7 +82,9 @@ SDK_USER_AGENT_KNOWN_VERSIONS: dict[KnownSDK, list[str]] = {
         "unknown",
         "2.1.0",
     ],
-    "flagsmith-swift-ios-sdk": ["unknown"],
+    "flagsmith-swift-ios-sdk": ["unknown",
+        "3.10.0",
+    ],
 }
 
 SDK_USER_AGENT_INFLUX_IDS: list[tuple[KnownSDK, int]] = [


### PR DESCRIPTION
Results of `make add-known-sdk-version opts="--sdk flagsmith-swift-ios-sdk --version 3.10.0"` ran manually to compensate for a missed webhook dispatch.

Triggered by https://github.com/Flagsmith/flagsmith-ios-client/releases/tag/v3.10.0.

The webhook handler had a wrong repo name in its `SDK_NAMES_BY_REPO` mapping (`Flagsmith/flagsmith-swift-client` instead of `Flagsmith/flagsmith-ios-client`), so the release event was silently ignored. The root cause fix is in https://github.com/Flagsmith/github-webhook-handler/pull/79.