### PR TITLE
fix: env columns hard to distinguish in compare view

### DIFF
--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -313,6 +313,7 @@ class CompareEnvironments extends Component {
                         <FeatureRow
                           condensed
                           isCompareEnv
+                          className='border-left-1 ps-2'
                           fadeEnabled={fadeEnabled}
                           fadeValue={fadeValue}
                           history={this.props.history}
@@ -390,7 +391,7 @@ class CompareEnvironments extends Component {
                                 </div>
                                 <Flex className='table-column'></Flex>
                               </Flex>
-                              <Flex className='flex-row'>
+                              <Flex className='flex-row border-left-1 ps-2'>
                                 <div
                                   className='table-column'
                                   style={{ width: '80px' }}

--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -14,6 +14,7 @@ import Tag from './tags/Tag'
 import Icon from './icons/Icon'
 import Constants from 'common/constants'
 import Button from './base/forms/Button'
+import EmptyState from './EmptyState'
 import Tooltip from './Tooltip'
 import { withRouter } from 'react-router-dom'
 import { getDarkMode } from 'project/darkMode'
@@ -345,9 +346,11 @@ class CompareEnvironments extends Component {
                   )}
                   {!this.state.isLoading &&
                     (!this.state.changes || !this.state.changes.length) && (
-                      <div className='text-center mt-2'>
-                        These environments have no flag differences
-                      </div>
+                      <EmptyState
+                        title='No flag differences'
+                        description='These environments have identical flag configurations.'
+                        icon='checkmark-circle'
+                      />
                     )}
                   {!this.state.isLoading &&
                     this.state.changes &&

--- a/frontend/web/components/CondensedFeatureRow.tsx
+++ b/frontend/web/components/CondensedFeatureRow.tsx
@@ -74,17 +74,6 @@ const CondensedFeatureRow: React.FC<CondensedFeatureRowProps> = ({
       </div>
       <Flex className='table-column clickable'>
         <Row>
-          <div
-            onClick={() => permission && !readOnly && editFeature()}
-            style={{ flex: 1 }}
-            className={`overflow-hidden ${fadeValue ? 'faded' : ''}`}
-          >
-            <FeatureValue
-              value={environmentFlags?.[id]?.feature_state_value ?? null}
-              data-test={`feature-value-${index}`}
-            />
-          </div>
-
           <SegmentOverridesIcon
             onClick={(e) => {
               e.stopPropagation()
@@ -100,6 +89,16 @@ const CondensedFeatureRow: React.FC<CondensedFeatureRowProps> = ({
             count={projectFlag.num_identity_overrides}
             showPlusIndicator={showPlusIndicator}
           />
+          <div
+            onClick={() => permission && !readOnly && editFeature()}
+            style={{ flex: 1 }}
+            className={`overflow-hidden ${fadeValue ? 'faded' : ''}`}
+          >
+            <FeatureValue
+              value={environmentFlags?.[id]?.feature_state_value ?? null}
+              data-test={`feature-value-${index}`}
+            />
+          </div>
         </Row>
       </Flex>
     </Flex>


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to \`docs/\` if required so people know about the feature.
- [x] I have filled in the \"Changes\" section below.
- [x] I have filled in the \"How did you test this code\" section below.

## Changes

Closes #7249

In the environment comparison view, the segment override icon (pie icon) sat flush against the next environment's column, making it hard to visually separate where one environment ends and the next begins.

This PR adds a left border and small padding to the right environment column (both header and rows) so the boundary between environments is clear.

<img width="1015" height="524" alt="image" src="https://github.com/user-attachments/assets/bace49d6-3cfd-4d27-ae41-d3c4bd2a9efc" />

## How did you test this code?

1. Open a project with multiple environments and segment overrides on at least one feature
2. Navigate to \`/project/{id}/compare\`
3. Select two environments
4. Confirm there is now a visible vertical divider between the left and right environment columns
5. Confirm the segment override icon no longer sits flush against the next column