### PR TITLE
infra(OTel): Wire OTEL_EXPORTER_ENDPOINT in ECS task defs

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -206,6 +206,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "value": "http://adot-collector.metrics.local:4318"
+                },
+                {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_API_URL",
                     "value": "https://edge.api.flagsmith.com/api/v1/"
                 },

--- a/infrastructure/aws/production/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-sdk-api.json
@@ -219,6 +219,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "value": "http://adot-collector.metrics.local:4318"
+                },
+                {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_API_URL",
                     "value": "https://edge.api.flagsmith.com/api/v1/"
                 },

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -166,6 +166,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "value": "http://adot-collector.metrics.local:4318"
+                },
+                {
                     "name": "ENABLE_API_USAGE_ALERTING",
                     "value": "True"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -207,6 +207,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "value": "http://adot-collector.metrics.local:4318"
+                },
+                {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
@@ -222,6 +222,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "value": "http://adot-collector.metrics.local:4318"
+                },
+                {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -161,6 +161,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "value": "http://adot-collector.metrics.local:4318"
+                },
+                {
                     "name": "TASK_PROCESSOR_SLEEP_INTERVAL_MS",
                     "value": "1000"
                 },


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to Flagsmith/pulumi#170

In this PR, we add `OTEL_EXPORTER_ENDPOINT` pointing at the ADOT collector's CloudMap hostname to the admin-api, sdk-api, and task-processor task definitions for both staging and production, so the services can emit OTLP logs and traces to the shared collector once Flagsmith/pulumi#182 is deployed. The migration task def is intentionally left alone — it's a one-shot and doesn't emit events.

The endpoint is identical for staging and production because CloudMap is per-VPC and the `metrics.local` namespace resolves `adot-collector` inside each environment's VPC.

Depends on Flagsmith/pulumi#182.

## How did you test this code?

- [ ] Merge the pulumi plumbing PR first and verify the CloudMap hostname resolves from an API task in staging
- [ ] Deploy this to staging and verify the env var lands in running containers
- [ ] Verify the API emits OTLP traffic to the collector by checking the collector's debug log output in CloudWatch
- [ ] Roll out to production