### PR TITLE
infra(OTel): Rename OTEL_EXPORTER_ENDPOINT to OTEL_EXPORTER_OTLP_ENDPOINT

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -206,7 +206,7 @@
                     "value": "True"
                 },
                 {
-                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://adot-collector.metrics.local:4318"
                 },
                 {

--- a/infrastructure/aws/production/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-sdk-api.json
@@ -219,7 +219,7 @@
                     "value": "True"
                 },
                 {
-                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://adot-collector.metrics.local:4318"
                 },
                 {

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -166,7 +166,7 @@
                     "value": "True"
                 },
                 {
-                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://adot-collector.metrics.local:4318"
                 },
                 {

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -207,7 +207,7 @@
                     "value": "True"
                 },
                 {
-                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://adot-collector.metrics.local:4318"
                 },
                 {

--- a/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
@@ -222,7 +222,7 @@
                     "value": "True"
                 },
                 {
-                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://adot-collector.metrics.local:4318"
                 },
                 {

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -161,7 +161,7 @@
                     "value": "True"
                 },
                 {
-                    "name": "OTEL_EXPORTER_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://adot-collector.metrics.local:4318"
                 },
                 {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to Flagsmith/pulumi#170

In this PR, we rename the OTel endpoint env var on admin-api, sdk-api, and task-processor task defs for both staging and production to the standard OpenTelemetry name `OTEL_EXPORTER_OTLP_ENDPOINT`. flagsmith-common's `common.core.main` reads this exact env var and gates the whole OTel setup on it being present — with the old name the API and Task Processor never initialised OTel, so nothing reached the ADOT collector.

Companion rename on the Pulumi side lands as Flagsmith/pulumi#186.

## How did you test this code?

In staging with a manually amended task definition.