### PR TITLE
fix(Logging): Expand APPLICATION_LOGGERS and fix unnamed loggers

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import site
 import typing
@@ -1251,23 +1250,6 @@ def superuser():  # type: ignore[no-untyped-def]
 def superuser_client(superuser: FFAdminUser, client: APIClient):  # type: ignore[no-untyped-def]
     client.force_login(superuser, backend="django.contrib.auth.backends.ModelBackend")
     return client
-
-
-@pytest.fixture
-def inspecting_handler() -> logging.Handler:
-    """
-    Fixture used to test the output of logger related output.
-    """
-
-    class InspectingHandler(logging.Handler):
-        def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
-            super().__init__(*args, **kwargs)
-            self.messages = []  # type: ignore[var-annotated]
-
-        def handle(self, record: logging.LogRecord) -> None:  # type: ignore[override]
-            self.messages.append(self.format(record))
-
-    return InspectingHandler()
 
 
 @pytest.fixture

--- a/api/edge_api/identities/export.py
+++ b/api/edge_api/identities/export.py
@@ -13,7 +13,7 @@ from util.engine_models.identities.traits.types import map_any_value_to_trait_va
 
 EXPORT_EDGE_IDENTITY_PAGINATION_LIMIT = 20000
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def export_edge_identity_and_overrides(  # noqa: C901

--- a/api/edge_api/management/commands/ensure_identity_traits_blanks.py
+++ b/api/edge_api/management/commands/ensure_identity_traits_blanks.py
@@ -9,7 +9,7 @@ from environments.dynamodb import DynamoIdentityWrapper
 
 identity_wrapper = DynamoIdentityWrapper()
 
-logger: structlog.BoundLogger = structlog.get_logger()
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 LOG_COUNT_EVERY = 100_000
 

--- a/api/environments/dynamodb/wrappers/identity_wrapper.py
+++ b/api/environments/dynamodb/wrappers/identity_wrapper.py
@@ -31,7 +31,7 @@ if typing.TYPE_CHECKING:
 
     from environments.identities.models import Identity
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class DynamoIdentityWrapper(BaseDynamoWrapper):

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -110,8 +110,7 @@ from .versioning.versioning_service import (
     get_environment_flags_queryset,
 )
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 flags_cache = caches[settings.FLAGS_CACHE_LOCATION]
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -76,6 +76,7 @@ addopts = [
   '--dist=worksteal',
 ]
 console_output_style = 'count'
+log_level = 'INFO'
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -3,7 +3,7 @@ set -e
 
 # common environment variables
 ACCESS_LOG_FORMAT=${ACCESS_LOG_FORMAT:-'%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({origin}i)s %({access-control-allow-origin}o)s'}
-APPLICATION_LOGGERS=${APPLICATION_LOGGERS:-"common,features,task_processor,app_analytics,webhooks"}
+APPLICATION_LOGGERS=${APPLICATION_LOGGERS:-"app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,oauth2_metadata,organisations,projects,segments,task_processor,users,webhooks,workflows"}
 
 waitfordb() {
   if [ -z "${SKIP_WAIT_FOR_DB}" ]; then

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -11,7 +11,7 @@ from metadata.serializers import MetadataSerializer, MetadataSerializerMixin
 from projects.models import Project
 from segments.models import Condition, Segment, SegmentRule
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(__name__)
 
 DictList = list[dict[str, Any]]
 

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -35,7 +35,7 @@ from .services import delete_segment
 if TYPE_CHECKING:
     from users.models import FFAdminUser
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 @method_decorator(

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import typing
 
 import pytest
@@ -120,13 +119,9 @@ def test_create_lead_form__valid_user_data__submits_form_successfully(
 def test_create_lead_form__api_returns_error__logs_error(
     staff_user: FFAdminUser,
     hubspot_client: HubspotClient,
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Given
-    from integrations.lead_tracking.hubspot.client import logger
-
-    logger.addHandler(inspecting_handler)
-
     hubspot_cookie = "test_hubspot_cookie"
     url = f"{HUBSPOT_ROOT_FORM_URL}/{HUBSPOT_PORTAL_ID}/{HUBSPOT_FORM_ID_SAAS}"
     responses.add(
@@ -141,7 +136,7 @@ def test_create_lead_form__api_returns_error__logs_error(
 
     # Then
     assert response == {"error": "Problem processing."}
-    assert inspecting_handler.messages == [  # type: ignore[attr-defined]
+    assert caplog.messages == [
         "Creating Hubspot lead form for user staff@example.com with hubspot cookie test_hubspot_cookie",
         "Problem posting data to Hubspot's form API due to 400 status code and following response: "
         + '{"error": "Problem processing."}',

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from datetime import timedelta
 from unittest.mock import MagicMock, call
@@ -291,7 +290,7 @@ def test_send_org_subscription_cancelled_alert__valid_organisation__sends_cancel
 
 def test_handle_api_usage_notification_for_organisation__billing_starts_at_is_none__logs_warning(
     organisation: Organisation,
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -308,23 +307,20 @@ def test_handle_api_usage_notification_for_organisation__billing_starts_at_is_no
         current_billing_term_starts_at=None,
         current_billing_term_ends_at=None,
     )
-    from organisations.task_helpers import logger
-
-    logger.addHandler(inspecting_handler)
 
     # When
     handle_api_usage_notification_for_organisation(organisation)
 
     # Then
     api_usage_mock.assert_not_called()
-    assert inspecting_handler.messages == [  # type: ignore[attr-defined]
+    assert caplog.messages == [
         f"Paid organisation {organisation.id} is missing billing_starts_at datetime"
     ]
 
 
 def test_handle_api_usage_notification_for_organisation__cancellation_date_is_set__skips_notification(
     organisation: Organisation,
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -344,10 +340,6 @@ def test_handle_api_usage_notification_for_organisation__cancellation_date_is_se
         api_calls_30d=usage,
     )
 
-    from organisations.task_helpers import logger
-
-    logger.addHandler(inspecting_handler)
-
     # When
     handle_api_usage_notification_for_organisation(organisation)
 
@@ -355,7 +347,7 @@ def test_handle_api_usage_notification_for_organisation__cancellation_date_is_se
     assert OrganisationAPIUsageNotification.objects.count() == 0
 
     # Check to ensure that error messages haven't been set.
-    assert inspecting_handler.messages == []  # type: ignore[attr-defined]
+    assert caplog.messages == []
 
 
 def test_handle_api_usage_notification_for_organisation__billing_starts_at_over_12_months_ago__uses_12_month_offset(
@@ -678,13 +670,9 @@ def test_handle_api_usage_notifications__usage_above_100_percent__sends_limit_no
 def test_handle_api_usage_notifications__processing_error__logs_error_message(
     mocker: MockerFixture,
     organisation: Organisation,
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Given
-    from organisations.tasks import logger
-
-    logger.addHandler(inspecting_handler)
-
     now = timezone.now()
     organisation.subscription.plan = SCALE_UP
     organisation.subscription.subscription_id = "fancy_id"
@@ -719,8 +707,8 @@ def test_handle_api_usage_notifications__processing_error__logs_error_message(
         ).count()
         == 0
     )
-    assert len(inspecting_handler.messages) == 1  # type: ignore[attr-defined]
-    error_message = inspecting_handler.messages[0].split("\n")[0]  # type: ignore[attr-defined]
+    assert len(caplog.messages) == 1
+    error_message = caplog.messages[0].split("\n")[0]
 
     assert (
         error_message
@@ -828,7 +816,6 @@ def test_handle_api_usage_notifications__missing_info_cache__skips_processing(
     mocker: MockerFixture,
     organisation: Organisation,
     mailoutbox: list[EmailMultiAlternatives],
-    inspecting_handler: logging.Handler,
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
@@ -1328,15 +1315,11 @@ def test_charge_for_api_call_count_overages__startup_plan__charges_correct_addon
 def test_charge_for_api_call_count_overages__non_standard_plan__logs_unknown_plan_warning(
     organisation: Organisation,
     mocker: MockerFixture,
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
     now = timezone.now()
-
-    from organisations.tasks import logger
-
-    logger.addHandler(inspecting_handler)
 
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
@@ -1376,7 +1359,7 @@ def test_charge_for_api_call_count_overages__non_standard_plan__logs_unknown_pla
 
     # Then
     mock_chargebee_update.assert_not_called()
-    assert inspecting_handler.messages == [  # type: ignore[attr-defined]
+    assert caplog.messages == [
         "Unknown subscription plan when trying to bill for overages "
         f"organisation.id={organisation.id} "
         "organisation.subscription.plan='nonstandard-v2'"
@@ -1389,15 +1372,12 @@ def test_charge_for_api_call_count_overages__non_standard_plan__logs_unknown_pla
 def test_charge_for_api_call_count_overages__billing_exception__logs_error_and_does_not_charge(
     organisation: Organisation,
     mocker: MockerFixture,
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
     now = timezone.now()
 
-    from organisations.tasks import logger
-
-    logger.addHandler(inspecting_handler)
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
         allowed_seats=10,
@@ -1439,7 +1419,7 @@ def test_charge_for_api_call_count_overages__billing_exception__logs_error_and_d
     charge_for_api_call_count_overages()  # type: ignore[no-untyped-call]
 
     # Then
-    assert inspecting_handler.messages[0].startswith(  # type: ignore[attr-defined]
+    assert caplog.messages[0].startswith(
         f"Unable to charge organisation {organisation.id} due to billing error"
     )
     mock_chargebee_update.assert_not_called()
@@ -1935,15 +1915,12 @@ def test_restrict_use_due_to_api_limit_grace_period_over__reduced_api_usage__doe
     organisation: Organisation,
     freezer: FrozenDateTimeFactory,
     mailoutbox: list[EmailMultiAlternatives],
-    inspecting_handler: logging.Handler,
+    caplog: pytest.LogCaptureFixture,
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
     assert not organisation.has_subscription_information_cache()
 
-    from organisations.tasks import logger
-
-    logger.addHandler(inspecting_handler)
     enable_features(
         "api_limiting_stop_serving_flags",
         "api_limiting_block_access_to_admin",
@@ -1987,7 +1964,7 @@ def test_restrict_use_due_to_api_limit_grace_period_over__reduced_api_usage__doe
     assert organisation.block_access_to_admin is False
     assert not hasattr(organisation, "api_limit_access_block")
     assert len(mailoutbox) == 0
-    assert inspecting_handler.messages == [  # type: ignore[attr-defined]
+    assert caplog.messages == [
         f"API use for organisation {organisation.id} has fallen to below limit, so not restricting use."
     ]
 

--- a/api/users/migrations/0044_remove_users_from_groups_in_orgs_they_do_not_belong_to.py
+++ b/api/users/migrations/0044_remove_users_from_groups_in_orgs_they_do_not_belong_to.py
@@ -6,7 +6,7 @@ from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models import F
 
 
-logger = structlog.get_logger()
+logger = structlog.get_logger(__name__)
 
 
 def remove_users_from_groups(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`APPLICATION_LOGGERS` only listed 5 packages, so INFO-level logs from most of the codebase were silently filtered at the root WARNING level. This expands the list to cover all packages and explicit structlog logger names that actually emit info logs.

Fixes 7 loggers that called `logging.getLogger()` or `structlog.get_logger()` without a name, routing them through the root logger and bypassing `APPLICATION_LOGGERS` entirely. These now use `__name__`. The manual `logger.setLevel(logging.INFO)` in `features/views.py` is removed since `features` is already covered centrally.

That `setLevel` call was on the root logger, so it was accidentally making INFO logs visible process-wide. Tests that asserted on INFO messages via a custom `inspecting_handler` fixture relied on this side effect. Added `log_level = 'INFO'` to `[tool.pytest.ini_options]` so `caplog` captures INFO in tests, then replaced `inspecting_handler` with `caplog` and removed the fixture.

One old migration (`features/migrations/0018`) still has an unnamed logger but shouldn't be modified.

## How did you test this code?

Audited every `logging.getLogger` and `structlog.get_logger` call in the codebase against the list. Ran all affected tests locally. Pre-commit hooks pass.