### PR TITLE
fix: ussage limit misleading when viewing non-monthly periods (#7084)

### DIFF
--- a/frontend/documentation/components/StatItem.stories.tsx
+++ b/frontend/documentation/components/StatItem.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from 'storybook'
+import StatItem from 'components/StatItem'
+
+const meta: Meta<typeof StatItem> = {
+  component: StatItem,
+  tags: ['autodocs'],
+  title: 'Components/StatItem',
+}
+export default meta
+
+type Story = StoryObj<typeof StatItem>
+
+export const Default: Story = {
+  args: {
+    icon: 'features',
+    label: 'Flags',
+    value: 437008,
+  },
+}
+
+export const WithLimit: Story = {
+  args: {
+    icon: 'bar-chart',
+    label: 'Total API Calls',
+    limit: 50000000,
+    value: 4569636,
+  },
+}
+
+export const WithTooltip: Story = {
+  args: {
+    icon: 'bar-chart',
+    label: 'Total API Calls',
+    tooltip: 'Your plan limit is 50,000,000 / month',
+    value: 4569636,
+  },
+}
+
+export const WithVisibilityToggle: Story = {
+  args: {
+    icon: 'person',
+    label: 'Identities',
+    value: 2162461,
+    visibilityToggle: {
+      colour: '#27AB95',
+      isVisible: true,
+      onToggle: () => {},
+    },
+  },
+}
+
+export const StringValue: Story = {
+  args: {
+    icon: 'layers',
+    label: 'Plan',
+    value: 'Scale-Up',
+  },
+}

--- a/frontend/web/components/StatItem.tsx
+++ b/frontend/web/components/StatItem.tsx
@@ -1,8 +1,7 @@
 import React, { FC, KeyboardEvent } from 'react'
-import { IonIcon } from '@ionic/react'
-import { checkmarkSharp } from 'ionicons/icons'
+import { colorIconDefault } from 'common/theme/tokens'
 import Icon, { IconName } from './icons/Icon'
-import Utils from 'common/utils/utils'
+import Tooltip from './Tooltip'
 
 type VisibilityToggleProps = {
   colour: string
@@ -16,6 +15,8 @@ export type StatItemProps = {
   value: string | number
   // Optional: for displaying limits (e.g., "1,000 / 10,000")
   limit?: number | null
+  // Optional: hover tooltip on the label
+  tooltip?: string
   // Optional: for visibility toggle in charts
   visibilityToggle?: VisibilityToggleProps
 }
@@ -24,11 +25,12 @@ const StatItem: FC<StatItemProps> = ({
   icon,
   label,
   limit,
+  tooltip,
   value,
   visibilityToggle,
 }) => {
-  const formattedValue =
-    typeof value === 'number' ? Utils.numberWithCommas(value) : value
+  const formatNumber = (n: number) => n.toLocaleString()
+  const formattedValue = typeof value === 'number' ? formatNumber(value) : value
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -40,16 +42,18 @@ const StatItem: FC<StatItemProps> = ({
   return (
     <div className='d-flex flex-row align-items-start gap-2'>
       <div className='plan-icon flex-shrink-0'>
-        <Icon name={icon} width={32} fill='#1A2634' />
+        <Icon name={icon} width={32} fill={colorIconDefault} />
       </div>
       <div>
-        <p className='fs-small lh-sm mb-0'>{label}</p>
+        <p className='fs-small lh-sm mb-0'>
+          {tooltip ? <Tooltip title={label}>{tooltip}</Tooltip> : label}
+        </p>
         <h4 className='mb-0'>
           {formattedValue}
           {limit !== null && limit !== undefined && (
             <span className='text-muted fs-small fw-normal'>
               {' '}
-              / {Utils.numberWithCommas(limit)}
+              / {formatNumber(limit)}
             </span>
           )}
         </h4>
@@ -68,7 +72,7 @@ const StatItem: FC<StatItemProps> = ({
               style={{ backgroundColor: visibilityToggle.colour }}
             >
               {visibilityToggle.isVisible && (
-                <IonIcon size={'8px'} color='white' icon={checkmarkSharp} />
+                <Icon name='checkmark' width={10} fill='white' />
               )}
             </div>
             <span className='text-muted fs-small'>Visible</span>

--- a/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
+++ b/frontend/web/components/organisation-settings/usage/components/UsageChartTotals.tsx
@@ -8,6 +8,7 @@ type TotalItem = {
   icon: IconName
   limit: number | null | undefined
   title: string
+  tooltip?: string
   value: number
 }
 
@@ -64,8 +65,11 @@ const UsageChartTotals: FC<UsageChartTotalsProps> = ({
     {
       colour: undefined,
       icon: 'bar-chart',
-      limit: maxApiCalls,
+      limit: undefined,
       title: 'Total API Calls',
+      tooltip: maxApiCalls
+        ? `Your plan limit is ${maxApiCalls.toLocaleString()} / month`
+        : undefined,
       value: data.totals.total,
     },
   ]
@@ -81,6 +85,7 @@ const UsageChartTotals: FC<UsageChartTotalsProps> = ({
             label={item.title}
             value={item.value}
             limit={item.limit}
+            tooltip={item.tooltip}
             visibilityToggle={
               withColor && item.colour
                 ? {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7084

The Total API Calls section displayed the monthly plan limit inline (e.g. `150,000 / 500,000`). When viewing 90 days, the 90-day total was compared against a monthly limit — looked like a massive overage when usage was actually within limits.

- Remove the inline `/ X` limit display from the Total API Calls stat
- Show the limit as a native tooltip on hover: "Your plan limit is X / month"
- Add `tooltip` prop to `StatItem` component for reuse

### Visual comparison

**Before:** `150,000 / 500,000` (misleading — 90-day total vs monthly limit)
**After:** `150,000` with tooltip "Your plan limit is 500,000 / month"

<img width="1202" height="594" alt="image" src="https://github.com/user-attachments/assets/ecc9346f-29af-4b4f-b2ae-a3abfd5933a3" />
<img width="1182" height="607" alt="image" src="https://github.com/user-attachments/assets/7e141dbe-6ff8-45e1-a813-3a342d5dcb0d" />


## How did you test this code?

- **App**: Organisation → Usage → hover over "Total API Calls" label, tooltip shows monthly limit
- **Period toggle**: switch between 30 days / 90 days / billing period — total changes but no misleading `/ X` comparison
- **Automated**: lint clean
