### PR TITLE
fix: prevent infinite API loop on invalid environment URLs

### DIFF
--- a/frontend/web/components/EnvironmentReadyChecker.tsx
+++ b/frontend/web/components/EnvironmentReadyChecker.tsx
@@ -1,8 +1,5 @@
-import { PropsWithChildren, useEffect, useState } from 'react'
-import {
-  useGetEnvironmentQuery,
-  useGetEnvironmentsQuery,
-} from 'common/services/useEnvironment'
+import { PropsWithChildren } from 'react'
+import { useGetEnvironmentQuery } from 'common/services/useEnvironment'
 import { useRouteMatch } from 'react-router-dom'
 
 interface RouteParams {
@@ -48,51 +45,26 @@ const EnvironmentReadyChecker = ({
   const match = useRouteMatch<RouteParams>()
   const environmentId = match?.params?.environmentId
   const projectId = match?.params?.projectId
-  // `/environment/create` is the new-env form — the slot is a sentinel, not an ID.
+  // 'create' is the new-env form route sentinel, not an env ID.
   const hasEnvironmentId = !!environmentId && environmentId !== 'create'
-  const [pollingDone, setPollingDone] = useState(false)
-  const [trackedEnvId, setTrackedEnvId] = useState(environmentId)
 
-  // Reset during render when the URL env changes — keeps `skip` in sync with the
-  // new env on the very first render, avoiding a flash of stale children.
-  if (trackedEnvId !== environmentId) {
-    setTrackedEnvId(environmentId)
-    setPollingDone(false)
-  }
-
-  // Source of truth for "does this env belong to this project" — the backend
-  // returns a single env by api_key regardless of project scope, so we can't
-  // rely on a 4xx from the env endpoint alone.
-  const { data: environments, isSuccess: environmentsLoaded } =
-    useGetEnvironmentsQuery(
-      { projectId: Number(projectId) },
-      { skip: !projectId },
-    )
-  const envBelongsToProject = !!environments?.results?.some(
-    (env) => env.api_key === environmentId,
-  )
-  const environmentNotFound =
-    hasEnvironmentId && environmentsLoaded && !envBelongsToProject
-
-  const { data, isLoading } = useGetEnvironmentQuery(
+  const { data, isError } = useGetEnvironmentQuery(
     { id: environmentId || '' },
     {
-      pollingInterval: POLL_INTERVAL_MS,
-      skip: !hasEnvironmentId || pollingDone || environmentNotFound,
+      pollingInterval: data?.is_creating ? POLL_INTERVAL_MS : 0,
+      skip: !hasEnvironmentId,
     },
   )
 
-  // Stop polling once the env resolves (not creating).
-  useEffect(() => {
-    if (data && !data.is_creating) {
-      setPollingDone(true)
-    }
-  }, [data])
+  // Env-by-api_key endpoint isn't project-scoped — verify the match client-side.
+  const wrongProject =
+    !!data && !!projectId && data.project !== Number(projectId)
+  const environmentNotFound = hasEnvironmentId && (wrongProject || isError)
 
   if (!hasEnvironmentId) return children
   if (environmentNotFound) return <NotFoundState />
-  if (isLoading || !environmentsLoaded) return <LoadingState />
-  if (data?.is_creating) return <CreatingState />
+  if (!data) return <LoadingState />
+  if (data.is_creating) return <CreatingState />
   return children
 }
 

--- a/frontend/web/components/EnvironmentReadyChecker.tsx
+++ b/frontend/web/components/EnvironmentReadyChecker.tsx
@@ -1,8 +1,12 @@
 import { PropsWithChildren, useEffect, useState } from 'react'
-import { useGetEnvironmentQuery } from 'common/services/useEnvironment'
+import {
+  useGetEnvironmentQuery,
+  useGetEnvironmentsQuery,
+} from 'common/services/useEnvironment'
 import { useRouteMatch } from 'react-router-dom'
 
 interface RouteParams {
+  projectId?: string
   environmentId?: string
 }
 
@@ -10,44 +14,86 @@ type EnvironmentReadyCheckerType = {
   children: React.ReactNode
 }
 
+const POLL_INTERVAL_MS = 1000
+
+const LoadingState = () => (
+  <div className='text-center'>
+    <Loader />
+  </div>
+)
+
+const CreatingState = () => (
+  <div className='container'>
+    <div className='d-flex flex-column h-100 flex-1 justify-content-center align-items-center'>
+      <Loader />
+      <h3>Preparing your environment</h3>
+      <p>We are setting up your new environment...</p>
+    </div>
+  </div>
+)
+
+const NotFoundState = () => (
+  <div className='app-container container'>
+    <h3 className='pt-5'>Environment not found</h3>
+    <p>
+      This environment may have been deleted, or you may not have permission to
+      access it. Check the URL and try again.
+    </p>
+  </div>
+)
+
 const EnvironmentReadyChecker = ({
   children,
 }: PropsWithChildren<EnvironmentReadyCheckerType>) => {
   const match = useRouteMatch<RouteParams>()
-  const [environmentCreated, setEnvironmentCreated] = useState(false)
+  const environmentId = match?.params?.environmentId
+  const projectId = match?.params?.projectId
+  // `/environment/create` is the new-env form — the slot is a sentinel, not an ID.
+  const hasEnvironmentId = !!environmentId && environmentId !== 'create'
+  const [pollingDone, setPollingDone] = useState(false)
+  const [trackedEnvId, setTrackedEnvId] = useState(environmentId)
+
+  // Reset during render when the URL env changes — keeps `skip` in sync with the
+  // new env on the very first render, avoiding a flash of stale children.
+  if (trackedEnvId !== environmentId) {
+    setTrackedEnvId(environmentId)
+    setPollingDone(false)
+  }
+
+  // Source of truth for "does this env belong to this project" — the backend
+  // returns a single env by api_key regardless of project scope, so we can't
+  // rely on a 4xx from the env endpoint alone.
+  const { data: environments, isSuccess: environmentsLoaded } =
+    useGetEnvironmentsQuery(
+      { projectId: Number(projectId) },
+      { skip: !projectId },
+    )
+  const envBelongsToProject = !!environments?.results?.some(
+    (env) => env.api_key === environmentId,
+  )
+  const environmentNotFound =
+    hasEnvironmentId && environmentsLoaded && !envBelongsToProject
 
   const { data, isLoading } = useGetEnvironmentQuery(
+    { id: environmentId || '' },
     {
-      id: match?.params?.environmentId || '',
-    },
-    {
-      pollingInterval: 1000,
-      skip: !match?.params?.environmentId || environmentCreated,
+      pollingInterval: POLL_INTERVAL_MS,
+      skip: !hasEnvironmentId || pollingDone || environmentNotFound,
     },
   )
+
+  // Stop polling once the env resolves (not creating).
   useEffect(() => {
-    if (!!data && !data?.is_creating) {
-      setEnvironmentCreated(true)
+    if (data && !data.is_creating) {
+      setPollingDone(true)
     }
   }, [data])
-  if (!match?.params?.environmentId) {
-    return children
-  }
-  return isLoading ? (
-    <div className='text-center'>
-      <Loader />
-    </div>
-  ) : data?.is_creating ? (
-    <div className='container'>
-      <div className='d-flex flex-column h-100 flex-1 justify-content-center align-items-center'>
-        <Loader />
-        <h3>Preparing your environment</h3>
-        <p>We are setting up your new environment...</p>
-      </div>
-    </div>
-  ) : (
-    children
-  )
+
+  if (!hasEnvironmentId) return children
+  if (environmentNotFound) return <NotFoundState />
+  if (isLoading || !environmentsLoaded) return <LoadingState />
+  if (data?.is_creating) return <CreatingState />
+  return children
 }
 
 export default EnvironmentReadyChecker

--- a/frontend/web/components/navigation/EnvironmentAside.tsx
+++ b/frontend/web/components/navigation/EnvironmentAside.tsx
@@ -16,11 +16,12 @@ import AppActions from 'common/dispatcher/app-actions'
 import EnvironmentSelect from 'components/EnvironmentSelect'
 import { components } from 'react-select'
 import BuildVersion from 'components/BuildVersion'
+import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import { useGetHealthEventsQuery } from 'common/services/useHealthEvents'
 import Constants from 'common/constants'
 import EnvironmentNavbar from './navbars/EnvironmentNavbar'
 import OverflowNav from './OverflowNav'
-import { ProjectPermission } from 'common/types/permissions.types';
+import { ProjectPermission } from 'common/types/permissions.types'
 
 type HomeAsideType = {
   environmentId: string
@@ -102,6 +103,8 @@ const CustomSingleValue = ({ hasWarning, ...rest }: CustomSingleValueProps) => {
 
 const EnvironmentAside: FC<HomeAsideType> = ({ environmentId, projectId }) => {
   const history = useHistory()
+  const { data: environments, isSuccess: environmentsLoaded } =
+    useGetEnvironmentsQuery({ projectId }, { skip: !projectId })
   const { data: healthEvents } = useGetHealthEventsQuery(
     { projectId: projectId },
     { skip: !projectId },
@@ -126,8 +129,17 @@ const EnvironmentAside: FC<HomeAsideType> = ({ environmentId, projectId }) => {
       ? null
       : (ProjectStore.getEnvironment(environmentId) as any)
 
+  const environmentNotFound =
+    environmentId !== 'create' &&
+    environmentsLoaded &&
+    !environments?.results?.some((env) => env.api_key === environmentId)
+
   const onProjectSave = () => {
     AppActions.refreshOrganisation()
+  }
+
+  if (environmentNotFound) {
+    return null
   }
   return (
     <>

--- a/frontend/web/components/navigation/navbars/EnvironmentNavbar.tsx
+++ b/frontend/web/components/navigation/navbars/EnvironmentNavbar.tsx
@@ -21,29 +21,35 @@ const EnvironmentNavbar: FC<EnvironmentNavType> = ({
 }) => {
   const date = useRef(moment().toISOString())
 
-  const { data: environments } = useGetEnvironmentsQuery(
-    {
-      projectId: `${projectId}`,
-    },
-    { skip: !projectId },
-  )
-
-  const { data: scheduledData } = useGetChangeRequestsQuery({
-    committed: true,
-    environmentId,
-    live_from_after: date.current,
-    page_size: 1,
-  })
-
-  const { data: changeRequestsData } = useGetChangeRequestsQuery({
-    committed: false,
-    environmentId,
-    page_size: 1,
-  })
+  const { data: environments, isSuccess: environmentsLoaded } =
+    useGetEnvironmentsQuery({ projectId }, { skip: !projectId })
 
   const environment = environments?.results?.find(
     (v) => v.api_key === environmentId,
   )
+
+  const { data: scheduledData } = useGetChangeRequestsQuery(
+    {
+      committed: true,
+      environmentId,
+      live_from_after: date.current,
+      page_size: 1,
+    },
+    { skip: !environment },
+  )
+
+  const { data: changeRequestsData } = useGetChangeRequestsQuery(
+    {
+      committed: false,
+      environmentId,
+      page_size: 1,
+    },
+    { skip: !environment },
+  )
+
+  if (environmentsLoaded && !environment) {
+    return null
+  }
 
   const changeRequests =
     (Utils.changeRequestsEnabled(


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7283

When the URL contained an environment key that didn't belong to the current project (deleted env, typo, env from another project, stale bookmark, or permission revoked mid-session), the app entered an infinite API request loop and showed a sidebar loader that never resolved. Further requests appeared with the literal string `undefined` in the path.

### Root cause

Two bugs compounded:

1. **`EnvironmentReadyChecker` polled every 1s with no error off-ramp.** It only stopped polling on a successful response with `is_creating: false` — on a 4xx it kept polling forever.
2. **Project scoping wasn't checked.** The backend returns a single environment by `api_key` regardless of project scope, so a valid env key belonging to a different project returns `200 OK` and the checker falls through to render the page. Downstream components then fire queries with missing or stale env context — some using `env?.api_key` in URL templates without a fallback, producing `/api/v1/environments/undefined/...` URLs.

Sibling sidebar components (`EnvironmentAside`, `EnvironmentNavbar`) conflated "env list loading" with "env missing from list" and showed loaders forever.

### Fix

- **`EnvironmentReadyChecker`**: source of truth is now the project's env list (`useGetEnvironmentsQuery`). If the URL env isn't in the list, render an "Environment not found" state. The single-env poll is kept for the `is_creating` happy path but now skips once polling is complete or the env is known missing.
- State reset during render (not via `useEffect`) when the env ID changes, so recovering via URL change is instant and doesn't flash stale children.
- Extracted the three view states into `LoadingState`, `CreatingState`, `NotFoundState` components; render flow is now guard clauses instead of nested ternaries.
- Handled the `/environment/create` sentinel so the new-env form isn't caught.
- **`EnvironmentAside`**: hides the whole sidebar when the env isn't in the project list.
- **`EnvironmentNavbar`**: `skip: !environment` on the change-request queries (no more `undefined` URL fetches); returns `null` when env isn't in the list.
- Small cleanup: dropped redundant `` `${projectId}` `` template coerces in the two files touched (fixes pre-existing `string not assignable to number` TS errors).

## How did you test this code?

Manual verification on local dev server (`ENV=local npm run dev`):

- [x] `/project/<id>/environment/<invalid-key>/features` → shows "Environment not found" in the main area, sidebar hidden, no repeat requests in Network tab.
- [x] `/project/<id>/environment/<valid-key>/features` → loads features normally.
- [x] `/project/<id>/environment/create` → create form renders (sentinel preserved).
- [x] From an invalid env → click top tabs / env selector → navigate into a valid env → app recovers without reload.
- [x] Confirmed no `/environments/undefined/...` URLs fire in any of the above flows.