### PR TITLE
fix(Billing): Update yearly price for Scale-Up

### DIFF
--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -133,7 +133,7 @@ const Payment = class extends Component {
                       'text-muted': !this.state.yearly,
                     })}
                   >
-                    Pay Yearly (Save 10%)
+                    Pay Yearly & Save
                   </h5>
                   <Switch
                     checked={!this.state.yearly}
@@ -284,7 +284,7 @@ const Payment = class extends Component {
                         <Row className='pt-3 justify-content-center'>
                           <h5 className='mb-0 align-self-start'>$</h5>
                           <h1 className='mb-0 d-flex align-items-end'>
-                            {this.state.yearly ? '270' : '300'}{' '}
+                            {this.state.yearly ? '250' : '300'}{' '}
                             <h5 className='fs-lg mb-0'>/mo</h5>
                           </h1>
                         </Row>

--- a/frontend/web/components/modals/payment/Payment.tsx
+++ b/frontend/web/components/modals/payment/Payment.tsx
@@ -111,7 +111,7 @@ export const Payment: FC<PaymentProps> = ({
 
           <PricingPanel
             title='Scale-Up'
-            priceYearly='270'
+            priceYearly='250'
             priceMonthly='300'
             isYearly={yearly}
             chargebeePlanId={

--- a/frontend/web/components/modals/payment/PricingToggle.tsx
+++ b/frontend/web/components/modals/payment/PricingToggle.tsx
@@ -14,7 +14,7 @@ export const PricingToggle = ({ isYearly, onChange }: PricingToggleProps) => {
           'text-muted': !isYearly,
         })}
       >
-        Pay Yearly (Save 10%)
+        Pay Yearly & Save
       </h5>
       <Switch
         checked={!isYearly}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith-private/issues/107

- [x] Update yearly Scale-Up price to 250 USD / mo.
- [x] Fix outdated 10% discount text

## How did you test this code?

<img width="1397" height="1058" alt="image" src="https://github.com/user-attachments/assets/0c7c5d3c-419f-41b4-9cf0-02a747817329" />
