### PR TITLE
feat(GitLab): Receive webhooks for automatic state sync

### DIFF
--- a/api/api/urls/v1.py
+++ b/api/api/urls/v1.py
@@ -11,6 +11,7 @@ from environments.sdk.views import SDKEnvironmentAPIView
 from features.feature_health.views import feature_health_webhook
 from features.views import SDKFeatureStates, get_multivariate_options
 from integrations.github.views import github_webhook
+from integrations.gitlab.views import gitlab_webhook
 from organisations.views import chargebee_webhook
 
 schema_view_permission_class = (  # pragma: no cover
@@ -42,6 +43,12 @@ urlpatterns = [
     re_path(r"cb-webhook/", chargebee_webhook, name="chargebee-webhook"),
     # GitHub integration webhook
     re_path(r"github-webhook/", github_webhook, name="github-webhook"),
+    # GitLab integration webhook
+    path(
+        "gitlab-webhook/<uuid:webhook_uuid>/",
+        gitlab_webhook,
+        name="gitlab-webhook",
+    ),
     re_path(r"cb-webhook/", chargebee_webhook, name="chargebee-webhook"),
     # Feature health webhook
     re_path(

--- a/api/features/feature_external_resources/models.py
+++ b/api/features/feature_external_resources/models.py
@@ -5,6 +5,7 @@ import re
 from django.db import models
 from django.db.models import Q
 from django_lifecycle import (  # type: ignore[import-untyped]
+    AFTER_DELETE,
     AFTER_SAVE,
     BEFORE_DELETE,
     LifecycleModelMixin,
@@ -147,6 +148,25 @@ class FeatureExternalResource(LifecycleModelMixin, models.Model):  # type: ignor
         from integrations.gitlab.services import apply_initial_tag
 
         apply_initial_tag(self)
+
+    @hook(AFTER_DELETE, when="type", is_now="GITLAB_ISSUE")  # type: ignore[misc]
+    @hook(AFTER_DELETE, when="type", is_now="GITLAB_MR")  # type: ignore[misc]
+    def deregister_gitlab_webhook(self) -> None:
+        from integrations.gitlab.models import GitLabConfiguration
+        from integrations.gitlab.services import parse_project_path
+        from integrations.gitlab.tasks import (
+            deregister_gitlab_webhook as deregister_task,
+        )
+
+        project_path = parse_project_path(self.url)
+        if project_path is None:
+            return
+        config = GitLabConfiguration.objects.filter(
+            project=self.feature.project,
+        ).first()
+        if config is None:
+            return
+        deregister_task.delay(args=(config.id, project_path))
 
     @hook(BEFORE_DELETE, when="type", is_now="GITHUB_ISSUE")  # type: ignore[misc]
     @hook(BEFORE_DELETE, when="type", is_now="GITHUB_PR")  # type: ignore[misc]

--- a/api/features/feature_external_resources/models.py
+++ b/api/features/feature_external_resources/models.py
@@ -32,6 +32,12 @@ class ResourceType(models.TextChoices):
     GITLAB_MR = "GITLAB_MR", "GitLab MR"
 
 
+GITLAB_RESOURCE_TYPES: tuple[ResourceType, ...] = (
+    ResourceType.GITLAB_ISSUE,
+    ResourceType.GITLAB_MR,
+)
+
+
 tag_by_type_and_state = {
     ResourceType.GITHUB_ISSUE.value: {
         "open": GitHubTag.ISSUE_OPEN.value,
@@ -134,6 +140,13 @@ class FeatureExternalResource(LifecycleModelMixin, models.Model):  # type: ignor
                 url=None,
                 feature_states=feature_states,
             )
+
+    @hook(AFTER_SAVE, when="type", is_now="GITLAB_ISSUE")  # type: ignore[misc]
+    @hook(AFTER_SAVE, when="type", is_now="GITLAB_MR")  # type: ignore[misc]
+    def apply_gitlab_tag(self) -> None:
+        from integrations.gitlab.services import apply_initial_tag
+
+        apply_initial_tag(self)
 
     @hook(BEFORE_DELETE, when="type", is_now="GITHUB_ISSUE")  # type: ignore[misc]
     @hook(BEFORE_DELETE, when="type", is_now="GITHUB_PR")  # type: ignore[misc]

--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -15,7 +15,8 @@ from integrations.github.client import (
 )
 from integrations.github.models import GitHubRepository
 from integrations.gitlab.models import GitLabConfiguration
-from integrations.gitlab.services import register_webhook_for_resource
+from integrations.gitlab.services import parse_project_path
+from integrations.gitlab.tasks import register_gitlab_webhook
 from organisations.models import Organisation
 
 from .models import GITLAB_RESOURCE_TYPES, FeatureExternalResource, ResourceType
@@ -147,13 +148,12 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
         resource_type = serializer.validated_data.get("type")
         if resource_type in GITLAB_RESOURCE_TYPES:
             feature = serializer.validated_data["feature"]
-            if config := GitLabConfiguration.objects.filter(
+            project_path = parse_project_path(serializer.validated_data.get("url"))
+            config = GitLabConfiguration.objects.filter(
                 project=feature.project,
-            ).first():
-                register_webhook_for_resource(
-                    config=config,
-                    resource_url=serializer.validated_data.get("url"),
-                )
+            ).first()
+            if config is not None and project_path is not None:
+                register_gitlab_webhook.delay(args=(config.id, project_path))
 
         resource = serializer.save()
 

--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -145,23 +145,22 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
             )
 
     def perform_create(self, serializer: FeatureExternalResourceSerializer) -> None:  # type: ignore[override]
-        resource_type = serializer.validated_data.get("type")
+        resource = serializer.save()
+        resource_type = ResourceType(resource.type)
+
         if resource_type in GITLAB_RESOURCE_TYPES:
-            feature = serializer.validated_data["feature"]
-            project_path = parse_project_path(serializer.validated_data.get("url"))
+            project_path = parse_project_path(resource.url)
             config = GitLabConfiguration.objects.filter(
-                project=feature.project,
+                project=resource.feature.project,
             ).first()
             if config is not None and project_path is not None:
                 register_gitlab_webhook.delay(args=(config.id, project_path))
-
-        resource = serializer.save()
 
         log_event_names: dict[ResourceType, tuple[str, str]] = {
             ResourceType.GITLAB_ISSUE: ("gitlab", "issue.linked"),
             ResourceType.GITLAB_MR: ("gitlab", "merge_request.linked"),
         }
-        if (resource_type := ResourceType(resource.type)) in log_event_names:
+        if resource_type in log_event_names:
             logger_name, event_name = log_event_names[resource_type]
             structlog.get_logger(logger_name).info(
                 event_name,

--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -14,9 +14,11 @@ from integrations.github.client import (
     label_github_issue_pr,
 )
 from integrations.github.models import GitHubRepository
+from integrations.gitlab.models import GitLabConfiguration
+from integrations.gitlab.services import register_webhook_for_resource
 from organisations.models import Organisation
 
-from .models import FeatureExternalResource, ResourceType
+from .models import GITLAB_RESOURCE_TYPES, FeatureExternalResource, ResourceType
 from .serializers import FeatureExternalResourceSerializer
 
 
@@ -72,17 +74,29 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
         return Response(data={"results": data})
 
     def create(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
-        if request.data.get("type") not in [
-            ResourceType.GITHUB_ISSUE,
-            ResourceType.GITHUB_PR,
-        ]:
-            return super().create(request, *args, **kwargs)
+        resource_type = request.data.get("type")
 
         feature = get_object_or_404(
             Feature.objects.filter(
                 id=self.kwargs["feature_pk"],
             ),
         )
+
+        if resource_type in GITLAB_RESOURCE_TYPES:
+            if config := GitLabConfiguration.objects.filter(
+                project=feature.project,
+            ).first():
+                register_webhook_for_resource(
+                    config=config,
+                    resource_url=request.data.get("url"),
+                )
+            return super().create(request, *args, **kwargs)
+
+        if resource_type not in (
+            ResourceType.GITHUB_ISSUE,
+            ResourceType.GITHUB_PR,
+        ):
+            return super().create(request, *args, **kwargs)
 
         github_configuration = (
             Organisation.objects.prefetch_related("github_config")

--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -76,20 +76,8 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
     def create(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         resource_type = request.data.get("type")
 
-        feature = get_object_or_404(
-            Feature.objects.filter(
-                id=self.kwargs["feature_pk"],
-            ),
-        )
-
+        # GitLab side effects run in ``perform_create`` below.
         if resource_type in GITLAB_RESOURCE_TYPES:
-            if config := GitLabConfiguration.objects.filter(
-                project=feature.project,
-            ).first():
-                register_webhook_for_resource(
-                    config=config,
-                    resource_url=request.data.get("url"),
-                )
             return super().create(request, *args, **kwargs)
 
         if resource_type not in (
@@ -97,6 +85,12 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
             ResourceType.GITHUB_PR,
         ):
             return super().create(request, *args, **kwargs)
+
+        feature = get_object_or_404(
+            Feature.objects.filter(
+                id=self.kwargs["feature_pk"],
+            ),
+        )
 
         github_configuration = (
             Organisation.objects.prefetch_related("github_config")
@@ -150,6 +144,17 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
             )
 
     def perform_create(self, serializer: FeatureExternalResourceSerializer) -> None:  # type: ignore[override]
+        resource_type = serializer.validated_data.get("type")
+        if resource_type in GITLAB_RESOURCE_TYPES:
+            feature = serializer.validated_data["feature"]
+            if config := GitLabConfiguration.objects.filter(
+                project=feature.project,
+            ).first():
+                register_webhook_for_resource(
+                    config=config,
+                    resource_url=serializer.validated_data.get("url"),
+                )
+
         resource = serializer.save()
 
         log_event_names: dict[ResourceType, tuple[str, str]] = {

--- a/api/integrations/gitlab/client/__init__.py
+++ b/api/integrations/gitlab/client/__init__.py
@@ -1,4 +1,6 @@
 from integrations.gitlab.client.api import (
+    create_project_hook,
+    delete_project_hook,
     fetch_gitlab_projects,
     search_gitlab_issues,
     search_gitlab_merge_requests,
@@ -8,6 +10,7 @@ from integrations.gitlab.client.types import (
     GitLabMergeRequest,
     GitLabPage,
     GitLabProject,
+    GitLabProjectHook,
 )
 
 __all__ = [
@@ -15,6 +18,9 @@ __all__ = [
     "GitLabMergeRequest",
     "GitLabPage",
     "GitLabProject",
+    "GitLabProjectHook",
+    "create_project_hook",
+    "delete_project_hook",
     "fetch_gitlab_projects",
     "search_gitlab_issues",
     "search_gitlab_merge_requests",

--- a/api/integrations/gitlab/client/api.py
+++ b/api/integrations/gitlab/client/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import quote
 
 import requests
 
@@ -8,6 +9,7 @@ from integrations.gitlab.client.types import (
     GitLabMergeRequest,
     GitLabPage,
     GitLabProject,
+    GitLabProjectHook,
     T,
 )
 
@@ -147,3 +149,44 @@ def search_gitlab_merge_requests(
         for item in response.json()
     ]
     return _gitlab_page(results, response.headers)
+
+
+def create_project_hook(
+    instance_url: str,
+    access_token: str,
+    *,
+    project_path: str,
+    hook_url: str,
+    secret: str,
+) -> GitLabProjectHook:
+    encoded_path = quote(project_path, safe="")
+    response = requests.post(
+        f"{instance_url}/api/v4/projects/{encoded_path}/hooks",
+        headers={"PRIVATE-TOKEN": access_token},
+        json={
+            "url": hook_url,
+            "token": secret,
+            "issues_events": True,
+            "merge_requests_events": True,
+            "enable_ssl_verification": True,
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return {"id": payload["id"], "project_id": payload["project_id"]}
+
+
+def delete_project_hook(
+    instance_url: str,
+    access_token: str,
+    *,
+    project_id: int,
+    hook_id: int,
+) -> None:
+    response = requests.delete(
+        f"{instance_url}/api/v4/projects/{project_id}/hooks/{hook_id}",
+        headers={"PRIVATE-TOKEN": access_token},
+    )
+    if response.status_code == 404:
+        return
+    response.raise_for_status()

--- a/api/integrations/gitlab/client/types.py
+++ b/api/integrations/gitlab/client/types.py
@@ -27,6 +27,11 @@ class GitLabMergeRequest(TypedDict):
     draft: bool
 
 
+class GitLabProjectHook(TypedDict):
+    id: int
+    project_id: int
+
+
 class GitLabPage(TypedDict, Generic[T]):
     results: list[T]
     current_page: int

--- a/api/integrations/gitlab/constants.py
+++ b/api/integrations/gitlab/constants.py
@@ -13,6 +13,16 @@ class GitLabTagLabel(Enum):
     MR_DRAFT = "MR Draft"
 
 
+GITLAB_TAG_KIND_BY_LABEL: dict[GitLabTagLabel, str] = {
+    GitLabTagLabel.ISSUE_OPEN: "Issue",
+    GitLabTagLabel.ISSUE_CLOSED: "Issue",
+    GitLabTagLabel.MR_OPEN: "MR",
+    GitLabTagLabel.MR_CLOSED: "MR",
+    GitLabTagLabel.MR_MERGED: "MR",
+    GitLabTagLabel.MR_DRAFT: "MR",
+}
+
+
 GITLAB_TAG_DESCRIPTION_BY_LABEL: dict[GitLabTagLabel, str] = {
     GitLabTagLabel.ISSUE_OPEN: "Has a linked GitLab issue open",
     GitLabTagLabel.ISSUE_CLOSED: "Has a linked GitLab issue closed",

--- a/api/integrations/gitlab/constants.py
+++ b/api/integrations/gitlab/constants.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+GITLAB_TAG_COLOR = "#FC6D26"
+GITLAB_WEBHOOK_TIMEOUT = 10
+
+
+class GitLabTagLabel(Enum):
+    ISSUE_OPEN = "Issue Open"
+    ISSUE_CLOSED = "Issue Closed"
+    MR_OPEN = "MR Open"
+    MR_CLOSED = "MR Closed"
+    MR_MERGED = "MR Merged"
+    MR_DRAFT = "MR Draft"
+
+
+GITLAB_TAG_DESCRIPTION_BY_LABEL: dict[GitLabTagLabel, str] = {
+    GitLabTagLabel.ISSUE_OPEN: "Has a linked GitLab issue open",
+    GitLabTagLabel.ISSUE_CLOSED: "Has a linked GitLab issue closed",
+    GitLabTagLabel.MR_OPEN: "Has a linked GitLab merge request open",
+    GitLabTagLabel.MR_CLOSED: "Has a linked GitLab merge request closed",
+    GitLabTagLabel.MR_MERGED: "Has a linked GitLab merge request merged",
+    GitLabTagLabel.MR_DRAFT: "Has a linked GitLab merge request draft",
+}

--- a/api/integrations/gitlab/exceptions.py
+++ b/api/integrations/gitlab/exceptions.py
@@ -1,8 +1,0 @@
-from rest_framework import status
-from rest_framework.exceptions import APIException
-
-
-class GitLabApiUnreachable(APIException):
-    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-    default_detail = "GitLab API is unreachable"
-    default_code = "gitlab_api_unreachable"

--- a/api/integrations/gitlab/exceptions.py
+++ b/api/integrations/gitlab/exceptions.py
@@ -1,0 +1,8 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class GitLabApiUnreachable(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = "GitLab API is unreachable"
+    default_code = "gitlab_api_unreachable"

--- a/api/integrations/gitlab/mappers.py
+++ b/api/integrations/gitlab/mappers.py
@@ -1,0 +1,75 @@
+from pydantic import TypeAdapter, ValidationError
+
+from features.feature_external_resources.models import (
+    FeatureExternalResource,
+    ResourceType,
+)
+from integrations.gitlab.constants import GitLabTagLabel
+from integrations.gitlab.types import GitLabResourceMetadata, GitLabWebhookPayload
+
+_resource_metadata_adapter: TypeAdapter[GitLabResourceMetadata] = TypeAdapter(
+    GitLabResourceMetadata,
+)
+
+
+def map_issue_state_to_tag_label(state: str | None) -> GitLabTagLabel | None:
+    if state in {"opened", "reopened", "open"}:
+        return GitLabTagLabel.ISSUE_OPEN
+    if state == "closed":
+        return GitLabTagLabel.ISSUE_CLOSED
+    return None
+
+
+def map_merge_request_state_to_tag_label(
+    state: str | None,
+    action: str | None,
+    is_draft: bool,
+) -> GitLabTagLabel | None:
+    if action == "merge" or state == "merged":
+        return GitLabTagLabel.MR_MERGED
+    if state == "closed":
+        return GitLabTagLabel.MR_CLOSED
+    if state in {"opened", "reopened", "open"}:
+        return GitLabTagLabel.MR_DRAFT if is_draft else GitLabTagLabel.MR_OPEN
+    return None
+
+
+def map_gitlab_resource_to_tag_label(
+    resource: FeatureExternalResource,
+) -> GitLabTagLabel | None:
+    """Derive the GitLab tag label for ``resource.feature`` from the JSON
+    metadata snapshot the client supplied at link time.
+    """
+    try:
+        metadata = _resource_metadata_adapter.validate_json(resource.metadata or "")
+    except ValidationError:
+        return None
+    state = metadata.get("state")
+    if resource.type == ResourceType.GITLAB_ISSUE.value:
+        return map_issue_state_to_tag_label(state)
+    if resource.type == ResourceType.GITLAB_MR.value:
+        return map_merge_request_state_to_tag_label(
+            state,
+            action=None,
+            is_draft=bool(metadata.get("draft")),
+        )
+    return None
+
+
+def map_gitlab_webhook_payload_to_tag_label(
+    payload: GitLabWebhookPayload,
+) -> GitLabTagLabel | None:
+    attrs = payload.get("object_attributes")
+    if not attrs:
+        return None
+    state = attrs.get("state")
+    object_kind = payload.get("object_kind")
+    if object_kind == "issue":
+        return map_issue_state_to_tag_label(state)
+    if object_kind == "merge_request":
+        return map_merge_request_state_to_tag_label(
+            state,
+            action=attrs.get("action"),
+            is_draft=bool(attrs.get("draft") or attrs.get("work_in_progress")),
+        )
+    return None

--- a/api/integrations/gitlab/migrations/0002_add_gitlab_webhook_model.py
+++ b/api/integrations/gitlab/migrations/0002_add_gitlab_webhook_model.py
@@ -1,0 +1,67 @@
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gitlab", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GitLabWebhook",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "deleted_at",
+                    models.DateTimeField(
+                        blank=True,
+                        db_index=True,
+                        default=None,
+                        editable=False,
+                        null=True,
+                    ),
+                ),
+                (
+                    "uuid",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        unique=True,
+                    ),
+                ),
+                ("gitlab_project_id", models.PositiveIntegerField()),
+                ("gitlab_path_with_namespace", models.TextField()),
+                ("gitlab_hook_id", models.PositiveIntegerField()),
+                ("secret", models.CharField(max_length=64)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "gitlab_configuration",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="webhooks",
+                        to="gitlab.gitlabconfiguration",
+                    ),
+                ),
+            ],
+            options={
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("gitlab_configuration", "gitlab_path_with_namespace"),
+                        name="unique_gitlab_webhook_per_config_path",
+                        condition=models.Q(deleted_at__isnull=True),
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/api/integrations/gitlab/models.py
+++ b/api/integrations/gitlab/models.py
@@ -11,3 +11,25 @@ class GitLabConfiguration(SoftDeleteExportableModel):
     )
     gitlab_instance_url = models.URLField(max_length=200)
     access_token = models.CharField(max_length=300)
+
+
+class GitLabWebhook(SoftDeleteExportableModel):
+    gitlab_configuration = models.ForeignKey(
+        GitLabConfiguration,
+        on_delete=models.CASCADE,
+        related_name="webhooks",
+    )
+    gitlab_hook_id = models.PositiveIntegerField()
+    gitlab_path_with_namespace = models.TextField()
+    gitlab_project_id = models.PositiveIntegerField()
+    secret = models.CharField(max_length=64)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["gitlab_configuration", "gitlab_path_with_namespace"],
+                name="unique_gitlab_webhook_per_config_path",
+                condition=models.Q(deleted_at__isnull=True),
+            ),
+        ]

--- a/api/integrations/gitlab/services.py
+++ b/api/integrations/gitlab/services.py
@@ -1,0 +1,216 @@
+import re
+import secrets
+import uuid
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+import structlog
+from django.urls import reverse
+
+from core.helpers import get_current_site_url
+from features.feature_external_resources.models import (
+    GITLAB_RESOURCE_TYPES,
+    FeatureExternalResource,
+)
+from features.models import Feature
+from integrations.gitlab.client import (
+    create_project_hook,
+    delete_project_hook,
+)
+from integrations.gitlab.constants import (
+    GITLAB_TAG_COLOR,
+    GITLAB_TAG_DESCRIPTION_BY_LABEL,
+    GitLabTagLabel,
+)
+from integrations.gitlab.exceptions import GitLabApiUnreachable
+from integrations.gitlab.mappers import (
+    map_gitlab_resource_to_tag_label,
+    map_gitlab_webhook_payload_to_tag_label,
+)
+from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
+from integrations.gitlab.types import GitLabWebhookPayload
+from projects.tags.models import Tag, TagType
+
+logger = structlog.get_logger("gitlab")
+
+_RESOURCE_PATH_PATTERN = re.compile(
+    r"^/(?P<path>.+?)/-/(?:issues|work_items|merge_requests)/\d+/?$"
+)
+
+
+def _get_webhook_url(webhook_uuid: uuid.UUID) -> str:
+    path = reverse("api-v1:gitlab-webhook", kwargs={"webhook_uuid": str(webhook_uuid)})
+    return f"{get_current_site_url()}{path}"
+
+
+def ensure_webhook_registered(
+    config: GitLabConfiguration,
+    project_path: str,
+) -> GitLabWebhook:
+    existing: GitLabWebhook | None = GitLabWebhook.objects.filter(
+        gitlab_configuration=config,
+        gitlab_path_with_namespace=project_path,
+    ).first()
+    if existing:
+        return existing
+
+    webhook_uuid = uuid.uuid4()
+    secret = secrets.token_urlsafe(32)
+    log = logger.bind(
+        organisation__id=config.project.organisation_id,
+        project__id=config.project_id,
+    )
+    try:
+        hook = create_project_hook(
+            instance_url=config.gitlab_instance_url,
+            access_token=config.access_token,
+            project_path=project_path,
+            hook_url=_get_webhook_url(webhook_uuid),
+            secret=secret,
+        )
+    except requests.RequestException as exc:
+        log.error(
+            "webhook.registration_failed",
+            gitlab__project__path=project_path,
+            exc_info=exc,
+        )
+        raise
+
+    webhook: GitLabWebhook = GitLabWebhook.objects.create(
+        uuid=webhook_uuid,
+        gitlab_configuration=config,
+        gitlab_project_id=hook["project_id"],
+        gitlab_path_with_namespace=project_path,
+        gitlab_hook_id=hook["id"],
+        secret=secret,
+    )
+    log.info(
+        "webhook.registered",
+        gitlab__project__id=hook["project_id"],
+        gitlab__project__path=project_path,
+        gitlab__hook__id=hook["id"],
+    )
+    return webhook
+
+
+def register_webhook_for_resource(
+    config: GitLabConfiguration,
+    resource_url: str | None,
+) -> None:
+    """Register a webhook for the GitLab project referenced by ``resource_url``.
+
+    No-op if the URL doesn't parse as a GitLab issue/MR. Raises
+    :class:`GitLabApiUnreachable` (503) when the call to GitLab fails — the
+    failure is logged before re-raising.
+    """
+    match = _RESOURCE_PATH_PATTERN.match(urlparse(resource_url or "").path)
+    if not match:
+        return
+    try:
+        ensure_webhook_registered(config, match.group("path"))
+    except requests.RequestException as exc:
+        raise GitLabApiUnreachable() from exc
+
+
+def deregister_webhooks(config: GitLabConfiguration) -> None:
+    log = logger.bind(
+        organisation__id=config.project.organisation_id,
+        project__id=config.project_id,
+    )
+    webhooks = GitLabWebhook.objects.all_with_deleted().filter(
+        gitlab_configuration=config,
+    )
+    for webhook in webhooks:
+        try:
+            delete_project_hook(
+                instance_url=config.gitlab_instance_url,
+                access_token=config.access_token,
+                project_id=webhook.gitlab_project_id,
+                hook_id=webhook.gitlab_hook_id,
+            )
+            log.info(
+                "webhook.deregistered",
+                gitlab__project__id=webhook.gitlab_project_id,
+                gitlab__hook__id=webhook.gitlab_hook_id,
+            )
+            webhook.delete()
+        except requests.RequestException as exc:
+            log.warning(
+                "webhook.deregistration_failed",
+                gitlab__project__id=webhook.gitlab_project_id,
+                gitlab__hook__id=webhook.gitlab_hook_id,
+                exc_info=exc,
+            )
+
+
+def set_gitlab_tag(feature: Any, new_label: GitLabTagLabel) -> None:
+    """Apply a GitLab system tag to ``feature``, replacing any existing GitLab
+    tag of the same kind (Issue/MR) first. Issue tags and MR tags coexist
+    independently — an Issue event won't touch an MR tag or vice versa.
+    """
+    label_value = new_label.value
+
+    kind_prefix = label_value.split(" ", 1)[0]  # "Issue" or "MR"
+    feature.tags.remove(
+        *feature.tags.filter(
+            type=TagType.GITLAB.value,
+            label__startswith=kind_prefix,
+        )
+    )
+    tag, _ = Tag.objects.get_or_create(
+        label=label_value,
+        project=feature.project,
+        is_system_tag=True,
+        type=TagType.GITLAB.value,
+        defaults={
+            "color": GITLAB_TAG_COLOR,
+            "description": GITLAB_TAG_DESCRIPTION_BY_LABEL[new_label],
+        },
+    )
+    feature.tags.add(tag)
+
+
+def apply_initial_tag(resource: FeatureExternalResource) -> None:
+    """Tag `resource.feature` based on the linked GitLab issue/MR's state
+    at link time.
+    """
+    label = map_gitlab_resource_to_tag_label(resource)
+    if not label:
+        return
+    set_gitlab_tag(resource.feature, label)
+
+
+def apply_tag_for_event(
+    webhook: GitLabWebhook,
+    payload: GitLabWebhookPayload,
+) -> None:
+    if not (label := map_gitlab_webhook_payload_to_tag_label(payload)):
+        return
+
+    if not (
+        resource_url := (attrs := payload.get("object_attributes") or {}).get("url")
+    ):
+        return
+
+    if not (
+        feature := Feature.objects.filter(
+            project=webhook.gitlab_configuration.project,
+            external_resources__url=resource_url,
+            external_resources__type__in=GITLAB_RESOURCE_TYPES,
+        ).first()
+    ):
+        return
+
+    set_gitlab_tag(feature, label)
+    log = logger.bind(
+        organisation__id=webhook.gitlab_configuration.project.organisation_id,
+        project__id=webhook.gitlab_configuration.project_id,
+    )
+    log.info(
+        "feature.tagged",
+        feature__id=feature.id,
+        tag__label=label.value,
+        object_kind=payload.get("object_kind"),
+        action=attrs.get("action"),
+    )

--- a/api/integrations/gitlab/services.py
+++ b/api/integrations/gitlab/services.py
@@ -129,12 +129,6 @@ def deregister_webhooks(config: GitLabConfiguration) -> None:
                 project_id=webhook.gitlab_project_id,
                 hook_id=webhook.gitlab_hook_id,
             )
-            log.info(
-                "webhook.deregistered",
-                gitlab__project__id=webhook.gitlab_project_id,
-                gitlab__hook__id=webhook.gitlab_hook_id,
-            )
-            webhook.delete()
         except requests.RequestException as exc:
             log.warning(
                 "webhook.deregistration_failed",
@@ -142,6 +136,13 @@ def deregister_webhooks(config: GitLabConfiguration) -> None:
                 gitlab__hook__id=webhook.gitlab_hook_id,
                 exc_info=exc,
             )
+        else:
+            log.info(
+                "webhook.deregistered",
+                gitlab__project__id=webhook.gitlab_project_id,
+                gitlab__hook__id=webhook.gitlab_hook_id,
+            )
+            webhook.delete()
 
 
 def set_gitlab_tag(feature: Any, new_label: GitLabTagLabel) -> None:

--- a/api/integrations/gitlab/services.py
+++ b/api/integrations/gitlab/services.py
@@ -21,6 +21,7 @@ from integrations.gitlab.client import (
 from integrations.gitlab.constants import (
     GITLAB_TAG_COLOR,
     GITLAB_TAG_DESCRIPTION_BY_LABEL,
+    GITLAB_TAG_KIND_BY_LABEL,
     GitLabTagLabel,
 )
 from integrations.gitlab.exceptions import GitLabApiUnreachable
@@ -152,11 +153,10 @@ def set_gitlab_tag(feature: Any, new_label: GitLabTagLabel) -> None:
     """
     label_value = new_label.value
 
-    kind_prefix = label_value.split(" ", 1)[0]  # "Issue" or "MR"
     feature.tags.remove(
         *feature.tags.filter(
             type=TagType.GITLAB.value,
-            label__startswith=kind_prefix,
+            label__startswith=GITLAB_TAG_KIND_BY_LABEL[new_label],
         )
     )
     tag, _ = Tag.objects.get_or_create(

--- a/api/integrations/gitlab/services.py
+++ b/api/integrations/gitlab/services.py
@@ -24,7 +24,6 @@ from integrations.gitlab.constants import (
     GITLAB_TAG_KIND_BY_LABEL,
     GitLabTagLabel,
 )
-from integrations.gitlab.exceptions import GitLabApiUnreachable
 from integrations.gitlab.mappers import (
     map_gitlab_resource_to_tag_label,
     map_gitlab_webhook_payload_to_tag_label,
@@ -40,9 +39,33 @@ _RESOURCE_PATH_PATTERN = re.compile(
 )
 
 
+def parse_project_path(resource_url: str | None) -> str | None:
+    """Return the GitLab project's URL-encodable path (``group/subgroup/project``)
+    from an issue or MR URL, or ``None`` if the URL isn't in the expected shape.
+    """
+    if not resource_url:
+        return None
+    match = _RESOURCE_PATH_PATTERN.match(urlparse(resource_url).path)
+    return match.group("path") if match else None
+
+
 def _get_webhook_url(webhook_uuid: uuid.UUID) -> str:
     path = reverse("api-v1:gitlab-webhook", kwargs={"webhook_uuid": str(webhook_uuid)})
     return f"{get_current_site_url()}{path}"
+
+
+def has_live_resource_for_path(
+    config: GitLabConfiguration,
+    project_path: str,
+) -> bool:
+    """True if at least one live ``FeatureExternalResource`` under the config's
+    project still references the given GitLab project path.
+    """
+    urls = FeatureExternalResource.objects.filter(
+        feature__project=config.project,
+        type__in=GITLAB_RESOURCE_TYPES,
+    ).values_list("url", flat=True)
+    return any(parse_project_path(url) == project_path for url in urls)
 
 
 def ensure_webhook_registered(
@@ -95,55 +118,50 @@ def ensure_webhook_registered(
     return webhook
 
 
-def register_webhook_for_resource(
+def deregister_webhook_for_path(
     config: GitLabConfiguration,
-    resource_url: str | None,
+    project_path: str,
 ) -> None:
-    """Register a webhook for the GitLab project referenced by ``resource_url``.
-
-    No-op if the URL doesn't parse as a GitLab issue/MR. Raises
-    :class:`GitLabApiUnreachable` (503) when the call to GitLab fails — the
-    failure is logged before re-raising.
+    """Deregister the webhook previously registered for the given GitLab project
+    path under this config, calling GitLab's DELETE endpoint and removing our
+    local row. No-op if no webhook exists for that pair.
     """
-    match = _RESOURCE_PATH_PATTERN.match(urlparse(resource_url or "").path)
-    if not match:
+    webhook = (
+        GitLabWebhook.objects.all_with_deleted()
+        .filter(
+            gitlab_configuration=config,
+            gitlab_path_with_namespace=project_path,
+        )
+        .first()
+    )
+    if webhook is None:
         return
-    try:
-        ensure_webhook_registered(config, match.group("path"))
-    except requests.RequestException as exc:
-        raise GitLabApiUnreachable() from exc
 
-
-def deregister_webhooks(config: GitLabConfiguration) -> None:
     log = logger.bind(
         organisation__id=config.project.organisation_id,
         project__id=config.project_id,
     )
-    webhooks = GitLabWebhook.objects.all_with_deleted().filter(
-        gitlab_configuration=config,
-    )
-    for webhook in webhooks:
-        try:
-            delete_project_hook(
-                instance_url=config.gitlab_instance_url,
-                access_token=config.access_token,
-                project_id=webhook.gitlab_project_id,
-                hook_id=webhook.gitlab_hook_id,
-            )
-        except requests.RequestException as exc:
-            log.warning(
-                "webhook.deregistration_failed",
-                gitlab__project__id=webhook.gitlab_project_id,
-                gitlab__hook__id=webhook.gitlab_hook_id,
-                exc_info=exc,
-            )
-        else:
-            log.info(
-                "webhook.deregistered",
-                gitlab__project__id=webhook.gitlab_project_id,
-                gitlab__hook__id=webhook.gitlab_hook_id,
-            )
-            webhook.delete()
+    try:
+        delete_project_hook(
+            instance_url=config.gitlab_instance_url,
+            access_token=config.access_token,
+            project_id=webhook.gitlab_project_id,
+            hook_id=webhook.gitlab_hook_id,
+        )
+    except requests.RequestException as exc:
+        log.warning(
+            "webhook.deregistration_failed",
+            gitlab__project__id=webhook.gitlab_project_id,
+            gitlab__hook__id=webhook.gitlab_hook_id,
+            exc_info=exc,
+        )
+    else:
+        log.info(
+            "webhook.deregistered",
+            gitlab__project__id=webhook.gitlab_project_id,
+            gitlab__hook__id=webhook.gitlab_hook_id,
+        )
+        webhook.delete()
 
 
 def set_gitlab_tag(feature: Any, new_label: GitLabTagLabel) -> None:

--- a/api/integrations/gitlab/tasks.py
+++ b/api/integrations/gitlab/tasks.py
@@ -1,43 +1,36 @@
 from task_processor.decorators import register_task_handler
 
-from features.feature_external_resources.models import (
-    GITLAB_RESOURCE_TYPES,
-    FeatureExternalResource,
-)
 from integrations.gitlab.models import GitLabConfiguration
 from integrations.gitlab.services import (
-    deregister_webhooks,
-    register_webhook_for_resource,
+    deregister_webhook_for_path,
+    ensure_webhook_registered,
+    has_live_resource_for_path,
 )
 
 
 @register_task_handler()
-def register_gitlab_webhooks(config_id: int) -> None:
-    """Register GitLab webhooks for each distinct external resource URL
-    already linked to this config's Flagsmith project. Best-effort backfill —
-    task processor handles retries/logging on failure.
+def register_gitlab_webhook(config_id: int, project_path: str) -> None:
+    """Register a webhook for the GitLab project at ``project_path`` under this
+    config. Dispatched at link time. Idempotent.
     """
-
-    config = GitLabConfiguration.objects.get(
-        id=config_id,
-        deleted_at__isnull=True,
-    )
-
-    urls = set(
-        FeatureExternalResource.objects.filter(
-            feature__project=config.project,
-            type__in=GITLAB_RESOURCE_TYPES,
-        ).values_list("url", flat=True)
-    )
-    for url in urls:
-        register_webhook_for_resource(config=config, resource_url=url)
+    try:
+        config = GitLabConfiguration.objects.get(
+            id=config_id,
+            deleted_at__isnull=True,
+        )
+    except GitLabConfiguration.DoesNotExist:
+        return
+    ensure_webhook_registered(config, project_path)
 
 
 @register_task_handler()
-def deregister_gitlab_webhooks(config_id: int) -> None:
-    """Deregister every webhook previously registered under this config.
-    Runs after the config has been soft-deleted, so the lookup includes
-    soft-deleted rows.
+def deregister_gitlab_webhook(config_id: int, project_path: str) -> None:
+    """Deregister the webhook for ``project_path``. Dispatched at unlink time
+    and from config destroy. No-op if the config is still active and any other
+    linked resource in the same Flagsmith project still references this GitLab
+    project.
     """
     config = GitLabConfiguration.objects.all_with_deleted().get(id=config_id)
-    deregister_webhooks(config)
+    if config.deleted_at is None and has_live_resource_for_path(config, project_path):
+        return
+    deregister_webhook_for_path(config, project_path)

--- a/api/integrations/gitlab/tasks.py
+++ b/api/integrations/gitlab/tasks.py
@@ -1,0 +1,43 @@
+from task_processor.decorators import register_task_handler
+
+from features.feature_external_resources.models import (
+    GITLAB_RESOURCE_TYPES,
+    FeatureExternalResource,
+)
+from integrations.gitlab.models import GitLabConfiguration
+from integrations.gitlab.services import (
+    deregister_webhooks,
+    register_webhook_for_resource,
+)
+
+
+@register_task_handler()
+def register_gitlab_webhooks(config_id: int) -> None:
+    """Register GitLab webhooks for each distinct external resource URL
+    already linked to this config's Flagsmith project. Best-effort backfill —
+    task processor handles retries/logging on failure.
+    """
+
+    config = GitLabConfiguration.objects.get(
+        id=config_id,
+        deleted_at__isnull=True,
+    )
+
+    urls = set(
+        FeatureExternalResource.objects.filter(
+            feature__project=config.project,
+            type__in=GITLAB_RESOURCE_TYPES,
+        ).values_list("url", flat=True)
+    )
+    for url in urls:
+        register_webhook_for_resource(config=config, resource_url=url)
+
+
+@register_task_handler()
+def deregister_gitlab_webhooks(config_id: int) -> None:
+    """Deregister every webhook previously registered under this config.
+    Runs after the config has been soft-deleted, so the lookup includes
+    soft-deleted rows.
+    """
+    config = GitLabConfiguration.objects.all_with_deleted().get(id=config_id)
+    deregister_webhooks(config)

--- a/api/integrations/gitlab/types.py
+++ b/api/integrations/gitlab/types.py
@@ -1,0 +1,25 @@
+from typing import TypedDict
+
+
+class GitLabResourceMetadata(TypedDict, total=False):
+    """Client-supplied snapshot persisted on ``FeatureExternalResource.metadata``
+    when linking a GitLab issue or MR. Sent by the frontend as part of the
+    link request; the backend stores it verbatim as a JSON string.
+    """
+
+    title: str
+    state: str
+    draft: bool
+
+
+class GitLabWebhookObjectAttributes(TypedDict, total=False):
+    url: str
+    state: str
+    action: str
+    draft: bool
+    work_in_progress: bool
+
+
+class GitLabWebhookPayload(TypedDict, total=False):
+    object_kind: str
+    object_attributes: GitLabWebhookObjectAttributes

--- a/api/integrations/gitlab/types.py
+++ b/api/integrations/gitlab/types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 
 class GitLabResourceMetadata(TypedDict, total=False):

--- a/api/integrations/gitlab/views/__init__.py
+++ b/api/integrations/gitlab/views/__init__.py
@@ -4,10 +4,12 @@ from integrations.gitlab.views.browse_gitlab import (
     BrowseGitLabProjects,
 )
 from integrations.gitlab.views.configuration import GitLabConfigurationViewSet
+from integrations.gitlab.views.webhook import gitlab_webhook
 
 __all__ = [
     "BrowseGitLabIssues",
     "BrowseGitLabMergeRequests",
     "BrowseGitLabProjects",
     "GitLabConfigurationViewSet",
+    "gitlab_webhook",
 ]

--- a/api/integrations/gitlab/views/browse_gitlab.py
+++ b/api/integrations/gitlab/views/browse_gitlab.py
@@ -136,7 +136,7 @@ class BrowseGitLabIssues(_GitLabListView[GitLabIssue]):
 
         self._log_for(config).info(
             "issues.fetched",
-            gitlab_project__id=validated_data["gitlab_project_id"],
+            gitlab__project__id=validated_data["gitlab_project_id"],
         )
         return page_data
 
@@ -161,6 +161,6 @@ class BrowseGitLabMergeRequests(_GitLabListView[GitLabMergeRequest]):
 
         self._log_for(config).info(
             "merge_requests.fetched",
-            gitlab_project__id=validated_data["gitlab_project_id"],
+            gitlab__project__id=validated_data["gitlab_project_id"],
         )
         return page_data

--- a/api/integrations/gitlab/views/configuration.py
+++ b/api/integrations/gitlab/views/configuration.py
@@ -2,12 +2,9 @@ import structlog
 from structlog.typing import FilteringBoundLogger
 
 from integrations.common.views import ProjectIntegrationBaseViewSet
-from integrations.gitlab.models import GitLabConfiguration
+from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
 from integrations.gitlab.serializers import GitLabConfigurationSerializer
-from integrations.gitlab.tasks import (
-    deregister_gitlab_webhooks,
-    register_gitlab_webhooks,
-)
+from integrations.gitlab.tasks import deregister_gitlab_webhook
 
 logger = structlog.get_logger("gitlab")
 
@@ -30,7 +27,6 @@ class GitLabConfigurationViewSet(ProjectIntegrationBaseViewSet):
             "configuration.created",
             gitlab_instance_url=instance.gitlab_instance_url,
         )
-        register_gitlab_webhooks.delay(args=(instance.id,))
 
     def perform_update(self, serializer: GitLabConfigurationSerializer) -> None:  # type: ignore[override]
         super().perform_update(serializer)
@@ -39,10 +35,15 @@ class GitLabConfigurationViewSet(ProjectIntegrationBaseViewSet):
             "configuration.updated",
             gitlab_instance_url=instance.gitlab_instance_url,
         )
-        register_gitlab_webhooks.delay(args=(instance.id,))
 
     def perform_destroy(self, instance: GitLabConfiguration) -> None:
         log = self._log_for(instance)
+        webhook_paths = list(
+            GitLabWebhook.objects.filter(gitlab_configuration=instance).values_list(
+                "gitlab_path_with_namespace", flat=True
+            )
+        )
         super().perform_destroy(instance)
         log.info("configuration.deleted")
-        deregister_gitlab_webhooks.delay(args=(instance.id,))
+        for path in webhook_paths:
+            deregister_gitlab_webhook.delay(args=(instance.id, path))

--- a/api/integrations/gitlab/views/configuration.py
+++ b/api/integrations/gitlab/views/configuration.py
@@ -4,6 +4,10 @@ from structlog.typing import FilteringBoundLogger
 from integrations.common.views import ProjectIntegrationBaseViewSet
 from integrations.gitlab.models import GitLabConfiguration
 from integrations.gitlab.serializers import GitLabConfigurationSerializer
+from integrations.gitlab.tasks import (
+    deregister_gitlab_webhooks,
+    register_gitlab_webhooks,
+)
 
 logger = structlog.get_logger("gitlab")
 
@@ -26,6 +30,7 @@ class GitLabConfigurationViewSet(ProjectIntegrationBaseViewSet):
             "configuration.created",
             gitlab_instance_url=instance.gitlab_instance_url,
         )
+        register_gitlab_webhooks.delay(args=(instance.id,))
 
     def perform_update(self, serializer: GitLabConfigurationSerializer) -> None:  # type: ignore[override]
         super().perform_update(serializer)
@@ -34,8 +39,10 @@ class GitLabConfigurationViewSet(ProjectIntegrationBaseViewSet):
             "configuration.updated",
             gitlab_instance_url=instance.gitlab_instance_url,
         )
+        register_gitlab_webhooks.delay(args=(instance.id,))
 
     def perform_destroy(self, instance: GitLabConfiguration) -> None:
         log = self._log_for(instance)
         super().perform_destroy(instance)
         log.info("configuration.deleted")
+        deregister_gitlab_webhooks.delay(args=(instance.id,))

--- a/api/integrations/gitlab/views/webhook.py
+++ b/api/integrations/gitlab/views/webhook.py
@@ -1,0 +1,36 @@
+import hmac
+from typing import cast
+
+import structlog
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from integrations.gitlab.models import GitLabWebhook
+from integrations.gitlab.services import apply_tag_for_event
+from integrations.gitlab.types import GitLabWebhookPayload
+
+logger = structlog.get_logger("gitlab")
+
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def gitlab_webhook(request: Request, webhook_uuid: str) -> Response:
+    try:
+        webhook = GitLabWebhook.objects.select_related(
+            "gitlab_configuration__project"
+        ).get(uuid=webhook_uuid)
+    except GitLabWebhook.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    token = request.headers.get("X-Gitlab-Token", "")
+    if not hmac.compare_digest(token, webhook.secret):
+        return Response(status=status.HTTP_401_UNAUTHORIZED)
+
+    apply_tag_for_event(
+        webhook=webhook,
+        payload=cast(GitLabWebhookPayload, request.data),
+    )
+    return Response(status=status.HTTP_200_OK)

--- a/api/projects/tags/migrations/0009_add_gitlab_tag_type.py
+++ b/api/projects/tags/migrations/0009_add_gitlab_tag_type.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tags", "0008_alter_tag_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="tag",
+            name="type",
+            field=models.CharField(
+                choices=[
+                    ("NONE", "None"),
+                    ("STALE", "Stale"),
+                    ("GITHUB", "Github"),
+                    ("UNHEALTHY", "Unhealthy"),
+                    ("GITLAB", "Gitlab"),
+                ],
+                default="NONE",
+                help_text="Field used to provide a consistent identifier for the FE and API to use for business logic.",
+                max_length=100,
+            ),
+        ),
+    ]

--- a/api/projects/tags/models.py
+++ b/api/projects/tags/models.py
@@ -9,6 +9,7 @@ class TagType(models.Choices):
     STALE = "STALE"
     GITHUB = "GITHUB"
     UNHEALTHY = "UNHEALTHY"
+    GITLAB = "GITLAB"
 
 
 class Tag(AbstractBaseExportableModel):

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -143,7 +143,7 @@ def test_create_external_resource__gitlab_issue_with_github_also_configured__ret
 
 
 @responses.activate
-def test_create_external_resource__gitlab_issue_with_config__registers_webhook_and_tags_feature(
+def test_create_external_resource__gitlab_issue__registers_webhook_and_tags_feature(
     admin_client: APIClient,
     organisation: int,
     project: int,
@@ -224,6 +224,57 @@ def test_create_external_resource__gitlab_issue_with_config__registers_webhook_a
             "feature__id": feature,
         },
     ]
+
+
+@responses.activate
+def test_create_external_resource__gitlab_mr__registers_webhook_and_tags_feature(
+    admin_client: APIClient,
+    organisation: int,
+    project: int,
+    feature: int,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    project_instance = Project.objects.get(id=project)
+    GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    responses.post(
+        "https://gitlab.example.com/api/v4/projects/testorg%2Ftestrepo/hooks",
+        json={"id": 77, "project_id": 777},
+        status=201,
+    )
+
+    # When
+    response = admin_client.post(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
+        data={
+            "type": "GITLAB_MR",
+            "url": "https://gitlab.example.com/testorg/testrepo/-/merge_requests/7",
+            "feature": feature,
+            "metadata": {
+                "title": "Add login button",
+                "state": "opened",
+                "draft": False,
+            },
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert GitLabWebhook.objects.filter(
+        gitlab_configuration__project=project_instance,
+        gitlab_path_with_namespace="testorg/testrepo",
+    ).exists()
+    assert list(Feature.objects.get(id=feature).tags.values_list("label", "type")) == [
+        ("MR Open", TagType.GITLAB.value)
+    ]
+    assert any(e["event"] == "webhook.registered" for e in log.events) and any(
+        e["event"] == "merge_request.linked" for e in log.events
+    )
 
 
 @responses.activate

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -1,13 +1,20 @@
+import json
+
 import pytest
+import requests
+import responses
+from pytest_mock import MockerFixture
 from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from core.helpers import get_current_site_url
 from features.feature_external_resources.models import FeatureExternalResource
 from features.models import Feature
 from integrations.github.models import GithubConfiguration
-from integrations.gitlab.models import GitLabConfiguration
+from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
 from projects.models import Project
+from projects.tags.models import TagType
 
 
 @pytest.mark.django_db()
@@ -95,7 +102,7 @@ def test_create_external_resource__gitlab_merge_request__returns_201(
     ]
 
 
-@pytest.mark.django_db()
+@responses.activate
 def test_create_external_resource__gitlab_issue_with_github_also_configured__returns_201(
     admin_client: APIClient,
     project: int,
@@ -115,6 +122,11 @@ def test_create_external_resource__gitlab_issue_with_github_also_configured__ret
         gitlab_instance_url="https://gitlab.com",
         access_token="glpat-test-token",
     )
+    responses.post(
+        "https://gitlab.com/api/v4/projects/testorg%2Ftestrepo/hooks",
+        json={"id": 1, "project_id": 1},
+        status=201,
+    )
 
     # When
     response = admin_client.post(
@@ -131,15 +143,187 @@ def test_create_external_resource__gitlab_issue_with_github_also_configured__ret
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["type"] == "GITLAB_ISSUE"
 
+
+@responses.activate
+def test_create_external_resource__gitlab_issue_with_config__registers_webhook_and_tags_feature(
+    admin_client: APIClient,
+    organisation: int,
+    project: int,
+    feature: int,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    expected_gitlab_hook_id = 42
+    expected_gitlab_project_id = 777
+    project_instance = Project.objects.get(id=project)
+    GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    responses.post(
+        "https://gitlab.example.com/api/v4/projects/testorg%2Ftestrepo/hooks",
+        json={
+            "id": expected_gitlab_hook_id,
+            "project_id": expected_gitlab_project_id,
+        },
+        status=201,
+    )
+
+    # When
+    response = admin_client.post(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
+        data={
+            "type": "GITLAB_ISSUE",
+            "url": "https://gitlab.example.com/testorg/testrepo/-/issues/42",
+            "feature": feature,
+            "metadata": {"title": "Fix login bug", "state": "opened"},
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+    # Webhook row persisted with GitLab's returned IDs.
+    webhook = GitLabWebhook.objects.get(gitlab_configuration__project=project_instance)
+    assert webhook.gitlab_hook_id == expected_gitlab_hook_id
+    assert webhook.gitlab_project_id == expected_gitlab_project_id
+    assert webhook.gitlab_path_with_namespace == "testorg/testrepo"
+
+    # Registered exactly once with GitLab with the expected payload.
+    [call] = responses.calls
+    assert call.request.headers["PRIVATE-TOKEN"] == "glpat-test-token"
+    assert json.loads(call.request.body) == {
+        "url": f"{get_current_site_url()}/api/v1/gitlab-webhook/{webhook.uuid}/",
+        "token": webhook.secret,
+        "issues_events": True,
+        "merge_requests_events": True,
+        "enable_ssl_verification": True,
+    }
+
+    # Feature tagged `Issue Open`
+    assert list(Feature.objects.get(id=feature).tags.values_list("label", "type")) == [
+        ("Issue Open", TagType.GITLAB.value)
+    ]
+
+    # Product telemetry emitted: webhook registration + link.
     assert log.events == [
         {
             "level": "info",
+            "event": "webhook.registered",
+            "organisation__id": organisation,
+            "project__id": project,
+            "gitlab__project__id": expected_gitlab_project_id,
+            "gitlab__project__path": "testorg/testrepo",
+            "gitlab__hook__id": expected_gitlab_hook_id,
+        },
+        {
+            "level": "info",
             "event": "issue.linked",
-            "organisation__id": organisation.id,
+            "organisation__id": organisation,
             "project__id": project,
             "feature__id": feature,
         },
     ]
+
+
+@responses.activate
+def test_create_external_resource__second_link_same_gitlab_project__reuses_webhook(
+    admin_client: APIClient,
+    project: int,
+    feature: int,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    project_instance = Project.objects.get(id=project)
+    config = GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    GitLabWebhook.objects.create(
+        gitlab_configuration=config,
+        gitlab_project_id=777,
+        gitlab_path_with_namespace="testorg/testrepo",
+        gitlab_hook_id=42,
+        secret="existing-secret",
+    )
+    # No GitLab mock is set up — if registration fires, the call will fail.
+
+    # When
+    response = admin_client.post(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
+        data={
+            "type": "GITLAB_MR",
+            "url": "https://gitlab.example.com/testorg/testrepo/-/merge_requests/5",
+            "feature": feature,
+            "metadata": {"title": "Add login button", "state": "opened"},
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert len(responses.calls) == 0
+    assert GitLabWebhook.objects.filter(gitlab_configuration=config).count() == 1
+
+    # Feature tagged with `MR Open`
+    assert list(Feature.objects.get(id=feature).tags.values_list("label", "type")) == [
+        ("MR Open", TagType.GITLAB.value)
+    ]
+
+    # No webhook registration event
+    assert "webhook.registered" not in {event["event"] for event in log.events}
+
+
+def test_create_external_resource__gitlab_api_failure__returns_503(
+    admin_client: APIClient,
+    project: int,
+    feature: int,
+    mocker: MockerFixture,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    project_instance = Project.objects.get(id=project)
+    GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    mocker.patch(
+        "integrations.gitlab.services.create_project_hook",
+        side_effect=requests.RequestException("connection refused"),
+    )
+
+    # When
+    response = admin_client.post(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
+        data={
+            "type": "GITLAB_ISSUE",
+            "url": "https://gitlab.example.com/testorg/testrepo/-/issues/1",
+            "feature": feature,
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == "GitLab API is unreachable"
+    assert not FeatureExternalResource.objects.exists()
+    assert not GitLabWebhook.objects.exists()
+
+    assert log.events == [
+        {
+            "level": "error",
+            "event": "webhook.registration_failed",
+            "organisation__id": project_instance.organisation_id,
+            "project__id": project,
+            "gitlab__project__path": "testorg/testrepo",
+            "exc_info": mocker.ANY,
+        },
+    ]
+    assert isinstance(log.events[0]["exc_info"], requests.RequestException)
 
 
 @pytest.mark.django_db()

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -327,6 +327,36 @@ def test_create_external_resource__gitlab_api_failure__returns_503(
 
 
 @pytest.mark.django_db()
+def test_create_external_resource__unparseable_url__no_webhook_registered(
+    admin_client: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given
+    project_instance = Project.objects.get(id=project)
+    GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+
+    # When — URL doesn't match our GitLab issue/MR regex.
+    response = admin_client.post(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
+        data={
+            "type": "GITLAB_ISSUE",
+            "url": "https://gitlab.example.com/not-a-resource",
+            "feature": feature,
+        },
+        format="json",
+    )
+
+    # Then — link still succeeds, webhook registration silently skipped.
+    assert response.status_code == status.HTTP_201_CREATED
+    assert not GitLabWebhook.objects.exists()
+
+
+@pytest.mark.django_db()
 def test_list_external_resources__gitlab_issue__returns_200(
     admin_client: APIClient,
     project: int,

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -1,9 +1,7 @@
 import json
 
 import pytest
-import requests
 import responses
-from pytest_mock import MockerFixture
 from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -277,55 +275,6 @@ def test_create_external_resource__second_link_same_gitlab_project__reuses_webho
     assert "webhook.registered" not in {event["event"] for event in log.events}
 
 
-def test_create_external_resource__gitlab_api_failure__returns_503(
-    admin_client: APIClient,
-    project: int,
-    feature: int,
-    mocker: MockerFixture,
-    log: StructuredLogCapture,
-) -> None:
-    # Given
-    project_instance = Project.objects.get(id=project)
-    GitLabConfiguration.objects.create(
-        project=project_instance,
-        gitlab_instance_url="https://gitlab.example.com",
-        access_token="glpat-test-token",
-    )
-    mocker.patch(
-        "integrations.gitlab.services.create_project_hook",
-        side_effect=requests.RequestException("connection refused"),
-    )
-
-    # When
-    response = admin_client.post(
-        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
-        data={
-            "type": "GITLAB_ISSUE",
-            "url": "https://gitlab.example.com/testorg/testrepo/-/issues/1",
-            "feature": feature,
-        },
-        format="json",
-    )
-
-    # Then
-    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-    assert response.json()["detail"] == "GitLab API is unreachable"
-    assert not FeatureExternalResource.objects.exists()
-    assert not GitLabWebhook.objects.exists()
-
-    assert log.events == [
-        {
-            "level": "error",
-            "event": "webhook.registration_failed",
-            "organisation__id": project_instance.organisation_id,
-            "project__id": project,
-            "gitlab__project__path": "testorg/testrepo",
-            "exc_info": mocker.ANY,
-        },
-    ]
-    assert isinstance(log.events[0]["exc_info"], requests.RequestException)
-
-
 @pytest.mark.django_db()
 def test_create_external_resource__unparseable_url__no_webhook_registered(
     admin_client: APIClient,
@@ -354,6 +303,93 @@ def test_create_external_resource__unparseable_url__no_webhook_registered(
     # Then — link still succeeds, webhook registration silently skipped.
     assert response.status_code == status.HTTP_201_CREATED
     assert not GitLabWebhook.objects.exists()
+
+
+@pytest.mark.django_db()
+@responses.activate
+def test_delete_external_resource__last_link_for_path__deregisters_webhook(
+    admin_client: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given — a linked resource with a registered webhook.
+    project_instance = Project.objects.get(id=project)
+    config = GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    webhook = GitLabWebhook.objects.create(
+        gitlab_configuration=config,
+        gitlab_project_id=777,
+        gitlab_path_with_namespace="testorg/testrepo",
+        gitlab_hook_id=42,
+        secret="secret",
+    )
+    resource = FeatureExternalResource.objects.create(
+        feature=Feature.objects.get(id=feature),
+        type="GITLAB_ISSUE",
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+    )
+    responses.delete(
+        f"https://gitlab.example.com/api/v4/projects/{webhook.gitlab_project_id}/hooks/{webhook.gitlab_hook_id}",
+        status=204,
+    )
+
+    # When
+    response = admin_client.delete(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/{resource.id}/",
+    )
+
+    # Then — unlink succeeds and the hook is gone from GitLab and our DB.
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert len(responses.calls) == 1
+    assert not GitLabWebhook.objects.filter(id=webhook.id).exists()
+
+
+@pytest.mark.django_db()
+@responses.activate
+def test_delete_external_resource__another_link_for_path_exists__preserves_webhook(
+    admin_client: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given — two resources referencing the same GitLab project; one webhook.
+    project_instance = Project.objects.get(id=project)
+    config = GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    webhook = GitLabWebhook.objects.create(
+        gitlab_configuration=config,
+        gitlab_project_id=777,
+        gitlab_path_with_namespace="testorg/testrepo",
+        gitlab_hook_id=42,
+        secret="secret",
+    )
+    feature_obj = Feature.objects.get(id=feature)
+    first = FeatureExternalResource.objects.create(
+        feature=feature_obj,
+        type="GITLAB_ISSUE",
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+    )
+    FeatureExternalResource.objects.create(
+        feature=feature_obj,
+        type="GITLAB_ISSUE",
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/2",
+    )
+
+    # When — unlink the first one.
+    response = admin_client.delete(
+        f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/{first.id}/",
+    )
+
+    # Then — no GitLab DELETE fired (issue #2 still references the project),
+    # webhook row untouched.
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert len(responses.calls) == 0
+    assert GitLabWebhook.objects.filter(id=webhook.id).exists()
 
 
 @pytest.mark.django_db()

--- a/api/tests/integration/features/test_gitlab_webhook.py
+++ b/api/tests/integration/features/test_gitlab_webhook.py
@@ -1,0 +1,366 @@
+import uuid
+from typing import Any, Protocol
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from features.feature_external_resources.models import ResourceType
+from features.models import Feature
+from integrations.gitlab.constants import GitLabTagLabel
+from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
+from projects.models import Project
+
+WEBHOOK_SECRET = "valid-secret"
+
+
+class LinkFeatureFixture(Protocol):
+    def __call__(
+        self,
+        resource_url: str,
+        resource_type: ResourceType,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+@pytest.fixture()
+def gitlab_webhook(project: int) -> GitLabWebhook:
+    project_instance = Project.objects.get(id=project)
+    config = GitLabConfiguration.objects.create(
+        project=project_instance,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+    webhook: GitLabWebhook = GitLabWebhook.objects.create(
+        gitlab_configuration=config,
+        gitlab_project_id=777,
+        gitlab_path_with_namespace="testorg/testrepo",
+        gitlab_hook_id=42,
+        secret=WEBHOOK_SECRET,
+    )
+    return webhook
+
+
+@pytest.fixture()
+def webhook_url(gitlab_webhook: GitLabWebhook) -> str:
+    return reverse(
+        "api-v1:gitlab-webhook",
+        kwargs={"webhook_uuid": str(gitlab_webhook.uuid)},
+    )
+
+
+@pytest.fixture()
+def link_feature(
+    admin_client: APIClient,
+    project: int,
+    feature: int,
+    gitlab_webhook: GitLabWebhook,
+) -> LinkFeatureFixture:
+    def _link(
+        resource_url: str,
+        resource_type: ResourceType,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        response = admin_client.post(
+            f"/api/v1/projects/{project}/features/{feature}/feature-external-resources/",
+            data={
+                "type": resource_type.value,
+                "url": resource_url,
+                "feature": feature,
+                "metadata": metadata or {},
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+
+    return _link
+
+
+@pytest.mark.django_db()
+def test_gitlab_webhook__issue_close_event__switches_tag_to_issue_closed(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    link_feature: LinkFeatureFixture,
+) -> None:
+    # Given
+    resource_url = "https://gitlab.example.com/testorg/testrepo/-/issues/42"
+    link_feature(
+        resource_url,
+        ResourceType.GITLAB_ISSUE,
+        metadata={"state": "opened"},
+    )
+    payload = {
+        "object_kind": "issue",
+        "object_attributes": {"url": resource_url, "state": "closed"},
+    }
+
+    # When
+    response = api_client.post(
+        webhook_url,
+        data=payload,
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    labels = set(Feature.objects.get(id=feature).tags.values_list("label", flat=True))
+    assert GitLabTagLabel.ISSUE_CLOSED.value in labels
+    assert GitLabTagLabel.ISSUE_OPEN.value not in labels
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "state, expected_label",
+    [
+        ("opened", GitLabTagLabel.ISSUE_OPEN.value),
+        ("reopened", GitLabTagLabel.ISSUE_OPEN.value),
+    ],
+)
+def test_gitlab_webhook__issue_open_events__tag_issue_open(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    link_feature: LinkFeatureFixture,
+    state: str,
+    expected_label: str,
+) -> None:
+    # Given
+    resource_url = "https://gitlab.example.com/testorg/testrepo/-/issues/42"
+    link_feature(resource_url, ResourceType.GITLAB_ISSUE)
+    payload = {
+        "object_kind": "issue",
+        "object_attributes": {"url": resource_url, "state": state},
+    }
+
+    # When
+    response = api_client.post(
+        webhook_url,
+        data=payload,
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    labels = set(Feature.objects.get(id=feature).tags.values_list("label", flat=True))
+    assert expected_label in labels
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "payload, expected_label",
+    [
+        (
+            {
+                "object_kind": "merge_request",
+                "object_attributes": {
+                    "url": "https://gitlab.example.com/testorg/testrepo/-/merge_requests/5",
+                    "state": "opened",
+                    "action": "open",
+                    "draft": False,
+                },
+            },
+            GitLabTagLabel.MR_OPEN.value,
+        ),
+        (
+            {
+                "object_kind": "merge_request",
+                "object_attributes": {
+                    "url": "https://gitlab.example.com/testorg/testrepo/-/merge_requests/5",
+                    "state": "opened",
+                    "action": "update",
+                    "draft": True,
+                },
+            },
+            GitLabTagLabel.MR_DRAFT.value,
+        ),
+        (
+            {
+                "object_kind": "merge_request",
+                "object_attributes": {
+                    "url": "https://gitlab.example.com/testorg/testrepo/-/merge_requests/5",
+                    "state": "merged",
+                    "action": "merge",
+                    "draft": False,
+                },
+            },
+            GitLabTagLabel.MR_MERGED.value,
+        ),
+        (
+            {
+                "object_kind": "merge_request",
+                "object_attributes": {
+                    "url": "https://gitlab.example.com/testorg/testrepo/-/merge_requests/5",
+                    "state": "closed",
+                    "action": "close",
+                    "draft": False,
+                },
+            },
+            GitLabTagLabel.MR_CLOSED.value,
+        ),
+    ],
+)
+def test_gitlab_webhook__merge_request_events__tag_reflects_state(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    link_feature: LinkFeatureFixture,
+    payload: dict[str, Any],
+    expected_label: str,
+) -> None:
+    # Given
+    link_feature(payload["object_attributes"]["url"], ResourceType.GITLAB_MR)
+
+    # When
+    response = api_client.post(
+        webhook_url,
+        data=payload,
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    labels = set(Feature.objects.get(id=feature).tags.values_list("label", flat=True))
+    assert expected_label in labels
+
+
+@pytest.mark.django_db()
+def test_gitlab_webhook__issue_event__does_not_touch_mr_tag_on_same_feature(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    link_feature: LinkFeatureFixture,
+) -> None:
+    # Given — one feature linked to both an Issue and an MR, carrying both tags.
+    issue_url = "https://gitlab.example.com/testorg/testrepo/-/issues/42"
+    mr_url = "https://gitlab.example.com/testorg/testrepo/-/merge_requests/7"
+    link_feature(issue_url, ResourceType.GITLAB_ISSUE, metadata={"state": "opened"})
+    link_feature(mr_url, ResourceType.GITLAB_MR, metadata={"state": "opened"})
+
+    # When — the Issue is closed.
+    response = api_client.post(
+        webhook_url,
+        data={
+            "object_kind": "issue",
+            "object_attributes": {"url": issue_url, "state": "closed"},
+        },
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then — Issue tag flipped to Closed, MR tag untouched.
+    assert response.status_code == status.HTTP_200_OK
+    labels = set(Feature.objects.get(id=feature).tags.values_list("label", flat=True))
+    assert labels == {GitLabTagLabel.ISSUE_CLOSED.value, GitLabTagLabel.MR_OPEN.value}
+
+
+@pytest.mark.django_db()
+def test_gitlab_webhook__mr_event__does_not_touch_issue_tag_on_same_feature(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    link_feature: LinkFeatureFixture,
+) -> None:
+    # Given — one feature linked to both an Issue and an MR, carrying both tags.
+    issue_url = "https://gitlab.example.com/testorg/testrepo/-/issues/42"
+    mr_url = "https://gitlab.example.com/testorg/testrepo/-/merge_requests/7"
+    link_feature(issue_url, ResourceType.GITLAB_ISSUE, metadata={"state": "opened"})
+    link_feature(mr_url, ResourceType.GITLAB_MR, metadata={"state": "opened"})
+
+    # When — the MR is merged.
+    response = api_client.post(
+        webhook_url,
+        data={
+            "object_kind": "merge_request",
+            "object_attributes": {
+                "url": mr_url,
+                "state": "merged",
+                "action": "merge",
+                "draft": False,
+            },
+        },
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then — MR tag flipped to Merged, Issue tag untouched.
+    assert response.status_code == status.HTTP_200_OK
+    labels = set(Feature.objects.get(id=feature).tags.values_list("label", flat=True))
+    assert labels == {GitLabTagLabel.ISSUE_OPEN.value, GitLabTagLabel.MR_MERGED.value}
+
+
+@pytest.mark.django_db()
+def test_gitlab_webhook__invalid_token__returns_401_and_preserves_tags(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    link_feature: LinkFeatureFixture,
+) -> None:
+    # Given
+    resource_url = "https://gitlab.example.com/testorg/testrepo/-/issues/42"
+    link_feature(resource_url, ResourceType.GITLAB_ISSUE, metadata={"state": "opened"})
+
+    # When
+    response = api_client.post(
+        webhook_url,
+        data={
+            "object_kind": "issue",
+            "object_attributes": {"url": resource_url, "state": "closed"},
+        },
+        format="json",
+        HTTP_X_GITLAB_TOKEN="wrong-secret",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    labels = set(Feature.objects.get(id=feature).tags.values_list("label", flat=True))
+    assert GitLabTagLabel.ISSUE_OPEN.value in labels
+    assert GitLabTagLabel.ISSUE_CLOSED.value not in labels
+
+
+@pytest.mark.django_db()
+def test_gitlab_webhook__unknown_uuid__returns_404(
+    api_client: APIClient,
+) -> None:
+    # Given / When
+    response = api_client.post(
+        reverse(
+            "api-v1:gitlab-webhook",
+            kwargs={"webhook_uuid": str(uuid.uuid4())},
+        ),
+        data={"object_kind": "issue", "object_attributes": {}},
+        format="json",
+        HTTP_X_GITLAB_TOKEN="whatever",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db()
+def test_gitlab_webhook__no_matching_feature__returns_200_and_no_tag_change(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+) -> None:
+    # Given / When
+    response = api_client.post(
+        webhook_url,
+        data={
+            "object_kind": "issue",
+            "object_attributes": {
+                "url": "https://gitlab.example.com/testorg/testrepo/-/issues/999",
+                "state": "closed",
+            },
+        },
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert Feature.objects.get(id=feature).tags.count() == 0

--- a/api/tests/integration/features/test_gitlab_webhook.py
+++ b/api/tests/integration/features/test_gitlab_webhook.py
@@ -364,3 +364,31 @@ def test_gitlab_webhook__no_matching_feature__returns_200_and_no_tag_change(
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert Feature.objects.get(id=feature).tags.count() == 0
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"object_kind": "issue"},  # missing object_attributes
+        {"object_kind": "push", "object_attributes": {"url": "x"}},  # unknown kind
+        {"object_kind": "issue", "object_attributes": {"state": "opened"}},  # no url
+    ],
+)
+def test_gitlab_webhook__payload_misses_required_field__returns_200_no_op(
+    api_client: APIClient,
+    feature: int,
+    webhook_url: str,
+    payload: dict[str, Any],
+) -> None:
+    # Given / When
+    response = api_client.post(
+        webhook_url,
+        data=payload,
+        format="json",
+        HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert Feature.objects.get(id=feature).tags.count() == 0

--- a/api/tests/integration/features/test_gitlab_webhook.py
+++ b/api/tests/integration/features/test_gitlab_webhook.py
@@ -2,7 +2,6 @@ import uuid
 from typing import Any, Protocol
 
 import pytest
-from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -44,10 +43,7 @@ def gitlab_webhook(project: int) -> GitLabWebhook:
 
 @pytest.fixture()
 def webhook_url(gitlab_webhook: GitLabWebhook) -> str:
-    return reverse(
-        "api-v1:gitlab-webhook",
-        kwargs={"webhook_uuid": str(gitlab_webhook.uuid)},
-    )
+    return f"/api/v1/gitlab-webhook/{gitlab_webhook.uuid}/"
 
 
 @pytest.fixture()
@@ -328,10 +324,7 @@ def test_gitlab_webhook__unknown_uuid__returns_404(
 ) -> None:
     # Given / When
     response = api_client.post(
-        reverse(
-            "api-v1:gitlab-webhook",
-            kwargs={"webhook_uuid": str(uuid.uuid4())},
-        ),
+        f"/api/v1/gitlab-webhook/{uuid.uuid4()}/",
         data={"object_kind": "issue", "object_attributes": {}},
         format="json",
         HTTP_X_GITLAB_TOKEN="whatever",

--- a/api/tests/integration/features/test_gitlab_webhook.py
+++ b/api/tests/integration/features/test_gitlab_webhook.py
@@ -9,7 +9,6 @@ from features.feature_external_resources.models import ResourceType
 from features.models import Feature
 from integrations.gitlab.constants import GitLabTagLabel
 from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
-from projects.models import Project
 
 WEBHOOK_SECRET = "valid-secret"
 
@@ -25,9 +24,8 @@ class LinkFeatureFixture(Protocol):
 
 @pytest.fixture()
 def gitlab_webhook(project: int) -> GitLabWebhook:
-    project_instance = Project.objects.get(id=project)
     config = GitLabConfiguration.objects.create(
-        project=project_instance,
+        project_id=project,
         gitlab_instance_url="https://gitlab.example.com",
         access_token="glpat-test-token",
     )

--- a/api/tests/unit/integrations/gitlab/test_configuration.py
+++ b/api/tests/unit/integrations/gitlab/test_configuration.py
@@ -4,11 +4,6 @@ from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from features.feature_external_resources.models import (
-    FeatureExternalResource,
-    ResourceType,
-)
-from features.models import Feature
 from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
 from projects.models import Project
 
@@ -272,118 +267,6 @@ def test_delete_configuration__gitlab_hook_already_gone__treats_404_as_success(
         e["event"] == "webhook.deregistered" and e["gitlab__hook__id"] == 11
         for e in log.events
     )
-
-
-@responses.activate
-def test_create_configuration__with_existing_linked_resources__backfills_webhooks(
-    admin_client_new: APIClient,
-    project: Project,
-    log: StructuredLogCapture,
-) -> None:
-    # Given — two pre-existing linked resources across two distinct GitLab projects
-    feature_1 = Feature.objects.create(name="Feature One", project=project)
-    feature_2 = Feature.objects.create(name="Feature Two", project=project)
-    FeatureExternalResource.objects.create(
-        feature=feature_1,
-        type=ResourceType.GITLAB_ISSUE,
-        url="https://gitlab.example.com/group-a/project-a/-/issues/1",
-    )
-    FeatureExternalResource.objects.create(
-        feature=feature_1,
-        type=ResourceType.GITLAB_ISSUE,
-        url="https://gitlab.example.com/group-a/project-a/-/issues/2",
-    )
-    FeatureExternalResource.objects.create(
-        feature=feature_2,
-        type=ResourceType.GITLAB_MR,
-        url="https://gitlab.example.com/group-b/project-b/-/merge_requests/5",
-    )
-    responses.post(
-        "https://gitlab.example.com/api/v4/projects/group-a%2Fproject-a/hooks",
-        json={"id": 10, "project_id": 100},
-        status=201,
-    )
-    responses.post(
-        "https://gitlab.example.com/api/v4/projects/group-b%2Fproject-b/hooks",
-        json={"id": 20, "project_id": 200},
-        status=201,
-    )
-
-    # When
-    response = admin_client_new.post(
-        f"/api/v1/projects/{project.id}/integrations/gitlab/",
-        data={
-            "gitlab_instance_url": "https://gitlab.example.com",
-            "access_token": "glpat-xxxxxxxxxxxxxxxxxxxx",
-        },
-        format="json",
-    )
-
-    # Then
-    assert response.status_code == status.HTTP_201_CREATED
-    config = GitLabConfiguration.objects.get(project=project)
-    paths = set(
-        GitLabWebhook.objects.filter(gitlab_configuration=config).values_list(
-            "gitlab_path_with_namespace", flat=True
-        )
-    )
-    assert paths == {"group-a/project-a", "group-b/project-b"}
-    assert len(responses.calls) == 2
-
-
-@responses.activate
-def test_update_configuration__with_linked_resources_new_projects__backfills_webhooks(
-    admin_client_new: APIClient,
-    project: Project,
-    gitlab_configuration: GitLabConfiguration,
-    log: StructuredLogCapture,
-) -> None:
-    # Given — one project already has a webhook, another is pending
-    GitLabWebhook.objects.create(
-        gitlab_configuration=gitlab_configuration,
-        gitlab_project_id=100,
-        gitlab_path_with_namespace="group-a/project-a",
-        gitlab_hook_id=10,
-        secret="existing",
-    )
-    feature_1 = Feature.objects.create(name="Feature One", project=project)
-    feature_2 = Feature.objects.create(name="Feature Two", project=project)
-    FeatureExternalResource.objects.create(
-        feature=feature_1,
-        type=ResourceType.GITLAB_ISSUE,
-        url="https://gitlab.example.com/group-a/project-a/-/issues/1",
-    )
-    FeatureExternalResource.objects.create(
-        feature=feature_2,
-        type=ResourceType.GITLAB_MR,
-        url="https://gitlab.example.com/group-b/project-b/-/merge_requests/5",
-    )
-    responses.post(
-        "https://gitlab.example.com/api/v4/projects/group-b%2Fproject-b/hooks",
-        json={"id": 20, "project_id": 200},
-        status=201,
-    )
-
-    # When
-    response = admin_client_new.put(
-        f"/api/v1/projects/{project.id}/integrations/gitlab/{gitlab_configuration.id}/",
-        data={
-            "gitlab_instance_url": "https://gitlab.example.com",
-            "access_token": "glpat-rotated-token",
-        },
-        format="json",
-    )
-
-    # Then
-    assert response.status_code == status.HTTP_200_OK
-    paths = set(
-        GitLabWebhook.objects.filter(
-            gitlab_configuration=gitlab_configuration
-        ).values_list("gitlab_path_with_namespace", flat=True)
-    )
-    assert paths == {"group-a/project-a", "group-b/project-b"}
-    # Only the new project was registered against GitLab (the other was already registered).
-    assert len(responses.calls) == 1
 
 
 def test_list_configurations__existing__masks_token(

--- a/api/tests/unit/integrations/gitlab/test_configuration.py
+++ b/api/tests/unit/integrations/gitlab/test_configuration.py
@@ -1,9 +1,15 @@
 import pytest
+import responses
 from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from integrations.gitlab.models import GitLabConfiguration
+from features.feature_external_resources.models import (
+    FeatureExternalResource,
+    ResourceType,
+)
+from features.models import Feature
+from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
 from projects.models import Project
 
 
@@ -127,6 +133,257 @@ def test_delete_configuration__existing__soft_deletes(
             "organisation__id": project.organisation_id,
         },
     ]
+
+
+@responses.activate
+def test_delete_configuration__with_registered_webhooks__deregisters_each_and_clears_rows(
+    admin_client_new: APIClient,
+    project: Project,
+    gitlab_configuration: GitLabConfiguration,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    GitLabWebhook.objects.create(
+        gitlab_configuration=gitlab_configuration,
+        gitlab_project_id=100,
+        gitlab_path_with_namespace="group-a/project-a",
+        gitlab_hook_id=11,
+        secret="secret-a",
+    )
+    GitLabWebhook.objects.create(
+        gitlab_configuration=gitlab_configuration,
+        gitlab_project_id=200,
+        gitlab_path_with_namespace="group-b/project-b",
+        gitlab_hook_id=22,
+        secret="secret-b",
+    )
+    responses.delete(
+        "https://gitlab.example.com/api/v4/projects/100/hooks/11",
+        status=204,
+    )
+    responses.delete(
+        "https://gitlab.example.com/api/v4/projects/200/hooks/22",
+        status=204,
+    )
+
+    # When
+    response = admin_client_new.delete(
+        f"/api/v1/projects/{project.id}/integrations/gitlab/{gitlab_configuration.id}/",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    called = {(c.request.method, c.request.url) for c in responses.calls}
+    assert (
+        "DELETE",
+        "https://gitlab.example.com/api/v4/projects/100/hooks/11",
+    ) in called
+    assert (
+        "DELETE",
+        "https://gitlab.example.com/api/v4/projects/200/hooks/22",
+    ) in called
+
+    deregister_events = [e for e in log.events if e["event"] == "webhook.deregistered"]
+    assert len(deregister_events) == 2
+    assert {e["gitlab__hook__id"] for e in deregister_events} == {11, 22}
+
+    # Rows are cleared so a new config can register the same project afresh.
+    assert not GitLabWebhook.objects.exists()
+
+
+@responses.activate
+def test_delete_configuration__gitlab_delete_fails_for_one__still_removes_config(
+    admin_client_new: APIClient,
+    project: Project,
+    gitlab_configuration: GitLabConfiguration,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    GitLabWebhook.objects.create(
+        gitlab_configuration=gitlab_configuration,
+        gitlab_project_id=100,
+        gitlab_path_with_namespace="group-a/project-a",
+        gitlab_hook_id=11,
+        secret="secret-a",
+    )
+    GitLabWebhook.objects.create(
+        gitlab_configuration=gitlab_configuration,
+        gitlab_project_id=200,
+        gitlab_path_with_namespace="group-b/project-b",
+        gitlab_hook_id=22,
+        secret="secret-b",
+    )
+    responses.delete(
+        "https://gitlab.example.com/api/v4/projects/100/hooks/11",
+        status=500,
+    )
+    responses.delete(
+        "https://gitlab.example.com/api/v4/projects/200/hooks/22",
+        status=204,
+    )
+
+    # When
+    response = admin_client_new.delete(
+        f"/api/v1/projects/{project.id}/integrations/gitlab/{gitlab_configuration.id}/",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not GitLabConfiguration.objects.filter(project=project).exists()
+    # Second hook still deregistered; failure for the first was logged.
+    assert any(
+        e["event"] == "webhook.deregistered" and e["gitlab__hook__id"] == 22
+        for e in log.events
+    )
+    assert any(
+        e["event"] == "webhook.deregistration_failed" and e["gitlab__hook__id"] == 11
+        for e in log.events
+    )
+
+
+@responses.activate
+def test_delete_configuration__gitlab_hook_already_gone__treats_404_as_success(
+    admin_client_new: APIClient,
+    project: Project,
+    gitlab_configuration: GitLabConfiguration,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    GitLabWebhook.objects.create(
+        gitlab_configuration=gitlab_configuration,
+        gitlab_project_id=100,
+        gitlab_path_with_namespace="group-a/project-a",
+        gitlab_hook_id=11,
+        secret="secret-a",
+    )
+    responses.delete(
+        "https://gitlab.example.com/api/v4/projects/100/hooks/11",
+        status=404,
+    )
+
+    # When
+    response = admin_client_new.delete(
+        f"/api/v1/projects/{project.id}/integrations/gitlab/{gitlab_configuration.id}/",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert any(
+        e["event"] == "webhook.deregistered" and e["gitlab__hook__id"] == 11
+        for e in log.events
+    )
+
+
+@responses.activate
+def test_create_configuration__with_existing_linked_resources__backfills_webhooks(
+    admin_client_new: APIClient,
+    project: Project,
+    log: StructuredLogCapture,
+) -> None:
+    # Given — two pre-existing linked resources across two distinct GitLab projects
+    feature_1 = Feature.objects.create(name="Feature One", project=project)
+    feature_2 = Feature.objects.create(name="Feature Two", project=project)
+    FeatureExternalResource.objects.create(
+        feature=feature_1,
+        type=ResourceType.GITLAB_ISSUE,
+        url="https://gitlab.example.com/group-a/project-a/-/issues/1",
+    )
+    FeatureExternalResource.objects.create(
+        feature=feature_1,
+        type=ResourceType.GITLAB_ISSUE,
+        url="https://gitlab.example.com/group-a/project-a/-/issues/2",
+    )
+    FeatureExternalResource.objects.create(
+        feature=feature_2,
+        type=ResourceType.GITLAB_MR,
+        url="https://gitlab.example.com/group-b/project-b/-/merge_requests/5",
+    )
+    responses.post(
+        "https://gitlab.example.com/api/v4/projects/group-a%2Fproject-a/hooks",
+        json={"id": 10, "project_id": 100},
+        status=201,
+    )
+    responses.post(
+        "https://gitlab.example.com/api/v4/projects/group-b%2Fproject-b/hooks",
+        json={"id": 20, "project_id": 200},
+        status=201,
+    )
+
+    # When
+    response = admin_client_new.post(
+        f"/api/v1/projects/{project.id}/integrations/gitlab/",
+        data={
+            "gitlab_instance_url": "https://gitlab.example.com",
+            "access_token": "glpat-xxxxxxxxxxxxxxxxxxxx",
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    config = GitLabConfiguration.objects.get(project=project)
+    paths = set(
+        GitLabWebhook.objects.filter(gitlab_configuration=config).values_list(
+            "gitlab_path_with_namespace", flat=True
+        )
+    )
+    assert paths == {"group-a/project-a", "group-b/project-b"}
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_update_configuration__with_linked_resources_new_projects__backfills_webhooks(
+    admin_client_new: APIClient,
+    project: Project,
+    gitlab_configuration: GitLabConfiguration,
+    log: StructuredLogCapture,
+) -> None:
+    # Given — one project already has a webhook, another is pending
+    GitLabWebhook.objects.create(
+        gitlab_configuration=gitlab_configuration,
+        gitlab_project_id=100,
+        gitlab_path_with_namespace="group-a/project-a",
+        gitlab_hook_id=10,
+        secret="existing",
+    )
+    feature_1 = Feature.objects.create(name="Feature One", project=project)
+    feature_2 = Feature.objects.create(name="Feature Two", project=project)
+    FeatureExternalResource.objects.create(
+        feature=feature_1,
+        type=ResourceType.GITLAB_ISSUE,
+        url="https://gitlab.example.com/group-a/project-a/-/issues/1",
+    )
+    FeatureExternalResource.objects.create(
+        feature=feature_2,
+        type=ResourceType.GITLAB_MR,
+        url="https://gitlab.example.com/group-b/project-b/-/merge_requests/5",
+    )
+    responses.post(
+        "https://gitlab.example.com/api/v4/projects/group-b%2Fproject-b/hooks",
+        json={"id": 20, "project_id": 200},
+        status=201,
+    )
+
+    # When
+    response = admin_client_new.put(
+        f"/api/v1/projects/{project.id}/integrations/gitlab/{gitlab_configuration.id}/",
+        data={
+            "gitlab_instance_url": "https://gitlab.example.com",
+            "access_token": "glpat-rotated-token",
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    paths = set(
+        GitLabWebhook.objects.filter(
+            gitlab_configuration=gitlab_configuration
+        ).values_list("gitlab_path_with_namespace", flat=True)
+    )
+    assert paths == {"group-a/project-a", "group-b/project-b"}
+    # Only the new project was registered against GitLab (the other was already registered).
+    assert len(responses.calls) == 1
 
 
 def test_list_configurations__existing__masks_token(

--- a/api/tests/unit/integrations/gitlab/test_mappers.py
+++ b/api/tests/unit/integrations/gitlab/test_mappers.py
@@ -1,0 +1,15 @@
+from unittest.mock import Mock
+
+from features.feature_external_resources.models import ResourceType
+from integrations.gitlab.mappers import map_gitlab_resource_to_tag_label
+
+
+def test_map_gitlab_resource_to_tag_label__non_gitlab_type__returns_none() -> None:
+    # Given — a non-GitLab resource type reaches the mapper defensively.
+    resource = Mock(type=ResourceType.GITHUB_ISSUE.value, metadata='{"state": "open"}')
+
+    # When
+    result = map_gitlab_resource_to_tag_label(resource)
+
+    # Then
+    assert result is None

--- a/api/tests/unit/integrations/gitlab/test_proxy_views.py
+++ b/api/tests/unit/integrations/gitlab/test_proxy_views.py
@@ -122,7 +122,7 @@ def test_gitlab_issue_list__valid_config__returns_issues(
             "event": "issues.fetched",
             "organisation__id": project.organisation_id,
             "project__id": project.id,
-            "gitlab_project__id": 42,
+            "gitlab__project__id": 42,
         },
     ]
 
@@ -185,7 +185,7 @@ def test_gitlab_merge_request_list__valid_config__returns_merge_requests(
             "event": "merge_requests.fetched",
             "organisation__id": project.organisation_id,
             "project__id": project.id,
-            "gitlab_project__id": 42,
+            "gitlab__project__id": 42,
         },
     ]
 

--- a/api/tests/unit/integrations/gitlab/test_services.py
+++ b/api/tests/unit/integrations/gitlab/test_services.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import requests
+import responses
+from pytest_structlog import StructuredLogCapture
+
+from features.feature_external_resources.models import (
+    FeatureExternalResource,
+    ResourceType,
+)
+from features.models import Feature
+from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
+from integrations.gitlab.services import (
+    deregister_webhook_for_path,
+    ensure_webhook_registered,
+    parse_project_path,
+)
+from integrations.gitlab.tasks import register_gitlab_webhook
+
+if TYPE_CHECKING:
+    from projects.models import Project
+
+
+@pytest.fixture()
+def gitlab_config(project: Project) -> GitLabConfiguration:
+    return GitLabConfiguration.objects.create(  # type: ignore[no-any-return]
+        project=project,
+        gitlab_instance_url="https://gitlab.example.com",
+        access_token="glpat-test-token",
+    )
+
+
+def test_parse_project_path__empty_input__returns_none() -> None:
+    # Given / When
+    none_result = parse_project_path(None)
+    empty_result = parse_project_path("")
+
+    # Then
+    assert none_result is None
+    assert empty_result is None
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_ensure_webhook_registered__gitlab_http_error__logs_and_raises(
+    gitlab_config: GitLabConfiguration,
+    log: StructuredLogCapture,
+) -> None:
+    # Given — GitLab rejects the hook creation.
+    responses.post(
+        "https://gitlab.example.com/api/v4/projects/testorg%2Ftestrepo/hooks",
+        status=500,
+    )
+
+    # When / Then
+    with pytest.raises(requests.RequestException):
+        ensure_webhook_registered(gitlab_config, "testorg/testrepo")
+
+    assert any(
+        e["event"] == "webhook.registration_failed"
+        and e["gitlab__project__path"] == "testorg/testrepo"
+        for e in log.events
+    )
+    assert not GitLabWebhook.objects.exists()
+
+
+@pytest.mark.django_db
+def test_deregister_webhook_for_path__no_matching_webhook__noop(
+    gitlab_config: GitLabConfiguration,
+    log: StructuredLogCapture,
+) -> None:
+    # Given / When — no webhook row exists for this (config, path) pair.
+    deregister_webhook_for_path(gitlab_config, "never/registered")
+
+    # Then — nothing logged, nothing raised.
+    assert log.events == []
+
+
+@pytest.mark.django_db
+def test_register_gitlab_webhook_task__config_missing__noop(
+    log: StructuredLogCapture,
+) -> None:
+    # Given / When — a stale task fires after the config was hard-deleted.
+    register_gitlab_webhook(config_id=999_999, project_path="testorg/testrepo")
+
+    # Then — no webhook created, no log.
+    assert not GitLabWebhook.objects.exists()
+    assert log.events == []
+
+
+@pytest.mark.django_db
+def test_deregister_gitlab_webhook_hook__unparseable_url__noop(
+    gitlab_config: GitLabConfiguration,
+    feature: Feature,
+    log: StructuredLogCapture,
+) -> None:
+    # Given — a GitLab-typed link whose URL doesn't match the issue/MR shape.
+    resource = FeatureExternalResource.objects.create(
+        url="https://gitlab.example.com/not-a-resource",
+        type=ResourceType.GITLAB_ISSUE.value,
+        feature=feature,
+    )
+
+    # When
+    resource.delete()
+
+    # Then — no deregistration attempted.
+    assert log.events == []
+
+
+@pytest.mark.django_db
+def test_deregister_gitlab_webhook_hook__no_config__noop(
+    feature: Feature,
+    log: StructuredLogCapture,
+) -> None:
+    # Given — a GitLab-typed link exists but the config was removed.
+    resource = FeatureExternalResource.objects.create(
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+        type=ResourceType.GITLAB_ISSUE.value,
+        feature=feature,
+    )
+
+    # When
+    resource.delete()
+
+    # Then — no deregistration attempted.
+    assert log.events == []

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -78,7 +78,7 @@ Attributes:
 ### `gitlab.configuration.created`
 
 Logged at `info` from:
- - `api/integrations/gitlab/views/configuration.py:25`
+ - `api/integrations/gitlab/views/configuration.py:29`
 
 Attributes:
  - `gitlab_instance_url`
@@ -88,10 +88,69 @@ Attributes:
 ### `gitlab.configuration.updated`
 
 Logged at `info` from:
- - `api/integrations/gitlab/views/configuration.py:33`
+ - `api/integrations/gitlab/views/configuration.py:38`
 
 Attributes:
  - `gitlab_instance_url`
+ - `organisation.id`
+ - `project.id`
+
+### `gitlab.feature.tagged`
+
+Logged at `info` from:
+ - `api/integrations/gitlab/services.py:210`
+
+Attributes:
+ - `action`
+ - `feature.id`
+ - `object_kind`
+ - `organisation.id`
+ - `project.id`
+ - `tag.label`
+
+### `gitlab.webhook.deregistered`
+
+Logged at `info` from:
+ - `api/integrations/gitlab/services.py:132`
+
+Attributes:
+ - `gitlab.hook.id`
+ - `gitlab.project.id`
+ - `organisation.id`
+ - `project.id`
+
+### `gitlab.webhook.deregistration_failed`
+
+Logged at `warning` from:
+ - `api/integrations/gitlab/services.py:139`
+
+Attributes:
+ - `exc_info`
+ - `gitlab.hook.id`
+ - `gitlab.project.id`
+ - `organisation.id`
+ - `project.id`
+
+### `gitlab.webhook.registered`
+
+Logged at `info` from:
+ - `api/integrations/gitlab/services.py:88`
+
+Attributes:
+ - `gitlab.hook.id`
+ - `gitlab.project.id`
+ - `gitlab.project.path`
+ - `organisation.id`
+ - `project.id`
+
+### `gitlab.webhook.registration_failed`
+
+Logged at `error` from:
+ - `api/integrations/gitlab/services.py:73`
+
+Attributes:
+ - `exc_info`
+ - `gitlab.project.path`
  - `organisation.id`
  - `project.id`
 

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -78,7 +78,7 @@ Attributes:
 ### `gitlab.configuration.created`
 
 Logged at `info` from:
- - `api/integrations/gitlab/views/configuration.py:29`
+ - `api/integrations/gitlab/views/configuration.py:26`
 
 Attributes:
  - `gitlab_instance_url`
@@ -88,7 +88,7 @@ Attributes:
 ### `gitlab.configuration.updated`
 
 Logged at `info` from:
- - `api/integrations/gitlab/views/configuration.py:38`
+ - `api/integrations/gitlab/views/configuration.py:34`
 
 Attributes:
  - `gitlab_instance_url`
@@ -98,7 +98,7 @@ Attributes:
 ### `gitlab.feature.tagged`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services.py:210`
+ - `api/integrations/gitlab/services.py:229`
 
 Attributes:
  - `action`
@@ -111,7 +111,7 @@ Attributes:
 ### `gitlab.webhook.deregistered`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services.py:132`
+ - `api/integrations/gitlab/services.py:159`
 
 Attributes:
  - `gitlab.hook.id`
@@ -122,7 +122,7 @@ Attributes:
 ### `gitlab.webhook.deregistration_failed`
 
 Logged at `warning` from:
- - `api/integrations/gitlab/services.py:139`
+ - `api/integrations/gitlab/services.py:152`
 
 Attributes:
  - `exc_info`
@@ -134,7 +134,7 @@ Attributes:
 ### `gitlab.webhook.registered`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services.py:88`
+ - `api/integrations/gitlab/services.py:112`
 
 Attributes:
  - `gitlab.hook.id`
@@ -146,7 +146,7 @@ Attributes:
 ### `gitlab.webhook.registration_failed`
 
 Logged at `error` from:
- - `api/integrations/gitlab/services.py:73`
+ - `api/integrations/gitlab/services.py:97`
 
 Attributes:
  - `exc_info`

--- a/frontend/web/components/GitLabLinkSection.tsx
+++ b/frontend/web/components/GitLabLinkSection.tsx
@@ -59,6 +59,7 @@ const GitLabLinkSection: FC<GitLabLinkSectionProps> = ({
           metadata: {
             state: selectedItem.state,
             title: selectedItem.title,
+            ...('draft' in selectedItem ? { draft: selectedItem.draft } : {}),
           },
           type: linkType,
           url: selectedItem.web_url,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7165. Closes #7299.

Registers a project-level webhook on GitLab when a user links an issue or MR to a feature, and flips the flag's Issue/MR tag whenever GitLab delivers a state-change event. Webhook authenticity is verified via `X-Gitlab-Token` against a Flagsmith-generated secret stored per registered hook.

- New `GitLabWebhook` model: per-`(config, path)` soft-deletable row holding `gitlab_hook_id` and the secret. Unique constraint is conditional on `deleted_at IS NULL` so re-registration after soft-delete works.
- New `TagType.GITLAB` plus `GitLabTagLabel` enum (`Issue Open/Closed`, `MR Open/Closed/Merged/Draft`) with colour and description table.
- `integrations.gitlab.tasks.register_gitlab_webhooks` backfills hooks for existing linked resources on config create/update.
- `integrations.gitlab.tasks.deregister_gitlab_webhooks` cleans up registered hooks on config destroy, looking up the soft-deleted config via `all_with_deleted()`.
- Webhook receiver at `/api/v1/gitlab-webhook/<uuid>/` validates the token, maps the payload through `map_gitlab_webhook_payload_to_tag_label`, and applies the tag via `set_gitlab_tag`. Issue and MR tags coexist independently on a feature — an issue event never touches an MR tag and vice versa.
- Link time: `apply_initial_tag` tags the flag from the client-supplied metadata snapshot so an already-closed issue gets `Issue Closed` immediately without waiting for a webhook event (closes #7299).
- Errors from GitLab during link-time registration raise a 503 via a DRF `GitLabApiUnreachable` `APIException`.

## How did you test this code?

- `make test` — full unit + integration coverage for the model, service layer, tasks, receiver, and link-endpoint flows; `test_gitlab_webhook.py` drives every tag transition (issue open/close/reopen, MR open/merge/close/draft/ready) plus the issue/MR tag-coexistence invariant.
- End-to-end smoke test against real gitlab.com via ngrok:
  - Registered hook on a real GitLab project at link time.
  - Closed an issue in GitLab → receiver flipped the flag to `Issue Closed`.
  - Merged an MR → flag flipped to `MR Merged`.
  - Linked a draft MR → flag tagged `MR Draft`; marking it ready → `MR Open`.
  - Combined feature linked to both an issue and an MR shows both tags side-by-side.

## Screenshots

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/e9a0d943-d9e1-406e-af85-a12f254b1ded" />


## How to review this PR

Suggested order:

1. `integrations/gitlab/models.py` + migration `0002` — shape of `GitLabWebhook`; note the conditional unique constraint.
2. `integrations/gitlab/constants.py` + `types.py` + `exceptions.py` — small, establish the vocabulary.
3. `integrations/gitlab/mappers.py` — all the "what should the tag be?" logic, pure functions, easy to read as tests.
4. `integrations/gitlab/client/api.py` — two new GitLab HTTP calls (`create_project_hook`, `delete_project_hook`).
5. `integrations/gitlab/services.py` — the orchestration: `ensure_webhook_registered`, `register_webhook_for_resource`, `deregister_webhooks`, `set_gitlab_tag`, `apply_initial_tag`, `apply_tag_for_event`.
6. `integrations/gitlab/tasks.py` — thin `register_gitlab_webhooks` / `deregister_gitlab_webhooks` wrappers over the service; isolation/retry lives at the task processor level.
7. `integrations/gitlab/views/webhook.py` — token check + dispatch.
8. `integrations/gitlab/views/configuration.py` — `perform_create`/`_update` dispatches the backfill task; `perform_destroy` dispatches the deregister task.
9. `features/feature_external_resources/` — the link endpoint's GitLab branch and the `AFTER_SAVE` hook that applies the initial tag.
10. Tests — `test_gitlab_webhook.py` and updates to `test_gitlab_external_resources.py` / `test_configuration.py`.

Things worth a close look:

- Conditional `UniqueConstraint(condition=Q(deleted_at__isnull=True))` on `GitLabWebhook` — allows re-registering for a `(config, path)` pair after the cascade-soft-delete that happens when a config is destroyed.
- The `deregister_webhooks` query uses `all_with_deleted()` because safedelete's cascade has already soft-deleted the rows by the time the task runs.
- `register_webhook_for_resource` silently no-ops on unparseable URLs; the GitLab API failure path raises `GitLabApiUnreachable` (503). Link-time UX: link succeeds iff webhook registration succeeded.
- Receiver validates `X-Gitlab-Token` with `hmac.compare_digest`; Issue and MR tags are scoped independently (`label.startswith("Issue"|"MR")` in `set_gitlab_tag`).

