### PR TITLE
fix(frontend): stop Identity page flashing on feature search keystrokes

### DIFF
--- a/frontend/web/components/pages/IdentityPage.tsx
+++ b/frontend/web/components/pages/IdentityPage.tsx
@@ -149,7 +149,7 @@ const IdentityPage: FC = () => {
               (identity && identity.identity.identifier) || id
             const isDataLoaded =
               !!actualFlags && !!identityFlags && !!projectFlags && !!projectId
-            return isIdentityLoading || isLoadingFeatures || !isDataLoaded ? (
+            return isIdentityLoading || !isDataLoaded ? (
               <div className='text-center'>
                 <Loader />
               </div>


### PR DESCRIPTION
## Summary

On the Identity detail page (`/project/:projectId/environment/:envId/identities/:identityId/...`), typing in the Features search caused the entire `app-container` to unmount and remount on every debounced keystroke, flashing back to a centred loader. The equivalent Features list page (`FeaturesPage.tsx`) behaves correctly — only the list rows transition to a loading state.

## Issue

Closes #7272
Closes #7323 

## Changes

`frontend/web/components/pages/IdentityPage.tsx` — drop `isLoadingFeatures` from the outer render guard. It was swapping the whole page subtree for `<Loader />` on every `isFetching` flip from `useGetFeatureListQuery`.

The list-level loading state is unchanged: `isLoadingFeatures` is already passed into `PanelSearch` via `isLoading={isLoadingFeatures}`, so rows still show a loading indicator during refetches. On refetches, RTK Query keeps returning the previous `featureListData`, so `projectFlags` stays truthy and the `isDataLoaded` guard stays satisfied — the shell no longer unmounts.

This aligns `IdentityPage.tsx` with the pattern in `FeaturesPage.tsx`, where `isLoading` is scoped to `PanelSearch` rather than the page shell.

## How did you test this code?

- Ran `ENV=local npm run dev` against a local API, opened an Identity detail page, typed into the Features search — the page shell, `PageTitle`, filter bar, and pagination remained mounted; only the list rows transitioned through a loading state. Compared against `/project/:pid/environment/:eid/features` for parity.
- `npx eslint frontend/web/components/pages/IdentityPage.tsx` — only pre-existing warnings on untouched lines (non-null assertions on lines 74 and 81).
- `npm run typecheck` errors on this file all exist on untouched lines and pre-date this change (documented pattern — see discussion on #6993).
- No unit tests cover `IdentityPage.tsx` render guards; manual verification follows the repro steps in #7272.