### PR TITLE
chore: run generate-docs pre-commit on python or toml changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         language: system
         entry: make -C api generate-docs
         pass_filenames: false
-        types: [python, toml]
+        types_or: [python, toml]
       - id: python-typecheck
         name: python-typecheck
         language: system


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The `generate-docs` pre-commit hook has been silently skipping every Python-only commit. `types: [python, toml]` is AND, not OR — the filter only matched files that are both python and toml, which no file ever is. Drift in `_events-catalogue.md`, `_metrics-catalogue.md` and `openapi.yaml` only showed up later in the "Check autogenerated documentation" CI step after push. I hit this twice this week on the GitLab webhook PRs.

One-line fix: `types_or: [python, toml]`. Pre-commit's built-in "files were modified by this hook" detection then handles blocking the commit when `make generate-docs` regenerates a tracked file that wasn't staged.

## How did you test this code?

Before the fix: staged a Python change that shifts line numbers in `_events-catalogue.md`, ran `git commit` — hook printed `generate-docs........(no files to check)Skipped` and the commit landed.

After the fix: same scenario — pre-commit stashed unstaged files, ran `make generate-docs`, detected that the catalogue changed, and failed with:

```
generate-docs............................................................Failed
- hook id: generate-docs
- files were modified by this hook
```

Commit did not land. `git status` shows the regenerated catalogue ready to stage.

Happy path (no Python/TOML changes in the commit): hook is skipped as expected.