### PR TITLE
fix(integrations): Adds Delete button with each integration row

### DIFF
--- a/frontend/web/components/IntegrationList.tsx
+++ b/frontend/web/components/IntegrationList.tsx
@@ -150,24 +150,6 @@ const Integration: FC<IntegrationProps> = (props) => {
               )}
             </div>
             <Row style={{ flexWrap: 'noWrap' }}>
-              {activeIntegrations &&
-                activeIntegrations.map((integration) => (
-                  <Button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      remove(integration)
-                      return false
-                    }}
-                    className='ml-3'
-                    theme='secondary'
-                    type='submit'
-                    size='xSmall'
-                    key={integration.id}
-                  >
-                    Delete Integration
-                  </Button>
-                ))}
               {showAdd && (
                 <>
                   {external && !isExternalInstallation ? (
@@ -241,6 +223,20 @@ const Integration: FC<IntegrationProps> = (props) => {
                   integration={props.integration}
                 />
               </Flex>
+              <Button
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  remove(integration)
+                  return false
+                }}
+                className='ml-3'
+                theme='secondary'
+                type='submit'
+                size='xSmall'
+              >
+                Delete Integration
+              </Button>
             </Row>
           </div>
         ))}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

<img width="1234" height="363" alt="Screenshot 2026-04-22 at 16 49 32" src="https://github.com/user-attachments/assets/a56b77d4-322f-4560-9a7a-2807f802a99c" />


Closes #7302

When a project had multiple integrations of the same type (e.g. one Slack integration per environment), all "Delete Integration" buttons rendered together in the panel header with identical labels and no association to the integration they referred to, making it easy to delete the wrong one.

This PR moves the Delete button out of the panel header and into each integration row, next to the integration details, so each button is unambiguously tied to the integration it deletes.

## How did you test this code?

Manually, on the project Integrations page:

1. Go to a project's Integrations page.
2. Configure two Slack integrations for different environments.
3. Confirm each integration row now renders its own "Delete Integration" button on the right-hand side.
4. Confirm the existing delete confirmation modal still names the correct environment for the selected row.