### PR TITLE
feat: Only enforce project limits when edge is enabled

### DIFF
--- a/api/edge_api/utils.py
+++ b/api/edge_api/utils.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def is_edge_enabled() -> bool:
+    return bool(settings.EDGE_ENABLED)

--- a/api/features/feature_segments/limits.py
+++ b/api/features/feature_segments/limits.py
@@ -1,5 +1,6 @@
 from django.db.models import Q
 
+from edge_api.utils import is_edge_enabled
 from environments.models import Environment
 from features.versioning.models import EnvironmentFeatureVersion
 
@@ -14,6 +15,9 @@ def exceeds_segment_override_limit(
     segment_ids_to_delete_overrides: list[int] | None = None,
     exclusive: bool = False,
 ) -> bool:
+    if not is_edge_enabled():
+        return False
+
     q = Q()
 
     segment_ids_to_create_overrides = segment_ids_to_create_overrides or []

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -20,6 +20,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
 from app_analytics.serializers import LabelsQuerySerializerMixin, LabelsSerializer
+from edge_api.utils import is_edge_enabled
 from environments.identities.models import Identity
 from environments.sdk.serializers_mixins import (
     HideSensitiveFieldsSerializerMixin,
@@ -278,6 +279,8 @@ class CreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerializer):
         return instance  # type: ignore[no-any-return]
 
     def validate_project_features_limit(self, project: Project) -> None:
+        if not is_edge_enabled():
+            return
         if project.features.count() >= project.max_features_allowed:
             raise serializers.ValidationError(
                 {

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -7,6 +7,7 @@ from drf_writable_nested.serializers import WritableNestedModelSerializer
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from edge_api.utils import is_edge_enabled
 from metadata.serializers import MetadataSerializer, MetadataSerializerMixin
 from projects.models import Project
 from segments.models import Condition, Segment, SegmentRule
@@ -177,6 +178,8 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
         ]
 
     def _validate_project_segment_limit(self, project: Project) -> None:
+        if not is_edge_enabled():
+            return
         segment_count = Segment.live_objects.filter(project=project).count()
         if segment_count >= project.max_segments_allowed:
             raise ValidationError(

--- a/api/tests/unit/edge_api/test_unit_edge_api_utils.py
+++ b/api/tests/unit/edge_api/test_unit_edge_api_utils.py
@@ -1,0 +1,29 @@
+from pytest_django.fixtures import SettingsWrapper
+
+from edge_api.utils import is_edge_enabled
+
+
+def test_is_edge_enabled__setting_true__returns_true(
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EDGE_ENABLED = True
+
+    # When
+    result = is_edge_enabled()
+
+    # Then
+    assert result is True
+
+
+def test_is_edge_enabled__setting_false__returns_false(
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EDGE_ENABLED = False
+
+    # When
+    result = is_edge_enabled()
+
+    # Then
+    assert result is False

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_limits.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_limits.py
@@ -1,3 +1,5 @@
+from pytest_django.fixtures import SettingsWrapper
+
 from environments.models import Environment
 from features.feature_segments.limits import exceeds_segment_override_limit
 from features.models import Feature, FeatureSegment
@@ -9,8 +11,10 @@ from segments.models import Segment
 def test_exceeds_segment_override_limit__shared_segment_across_features__returns_true(
     project: Project,
     environment: Environment,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.EDGE_ENABLED = True
     project.max_segment_overrides_allowed = 3
     project.save()
 
@@ -34,8 +38,10 @@ def test_exceeds_segment_override_limit__shared_segment_across_features__returns
 def test_exceeds_segment_override_limit__distinct_segments_per_feature__returns_true(
     project: Project,
     environment: Environment,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.EDGE_ENABLED = True
     project.max_segment_overrides_allowed = 3
     project.save()
 
@@ -61,8 +67,10 @@ def test_exceeds_segment_override_limit__distinct_segments_per_feature__returns_
 def test_exceeds_segment_override_limit__v2_delete_uses_unique_segment_ids__returns_true(
     project: Project,
     environment_v2_versioning: Environment,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.EDGE_ENABLED = True
     project.max_segment_overrides_allowed = 5
     project.save()
 
@@ -101,8 +109,10 @@ def test_exceeds_segment_override_limit__deleting_override_with_zero_limit__retu
     another_segment: Segment,
     environment_v2_versioning: Environment,
     project: Project,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.EDGE_ENABLED = True
     project.max_segment_overrides_allowed = 0
     project.save()
 
@@ -115,3 +125,29 @@ def test_exceeds_segment_override_limit__deleting_override_with_zero_limit__retu
 
     # Then
     assert result is True
+
+
+def test_exceeds_segment_override_limit__edge_disabled__returns_false(
+    project: Project,
+    environment: Environment,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EDGE_ENABLED = False
+    project.max_segment_overrides_allowed = 1
+    project.save()
+
+    features = [
+        Feature.objects.create(name=f"feature_{i}", project=project) for i in range(3)
+    ]
+    segment = Segment.objects.create(name="segment", project=project)
+    for feature in features:
+        FeatureSegment.objects.create(
+            feature=feature, segment=segment, environment=environment
+        )
+
+    # When
+    result = exceeds_segment_override_limit(environment=environment)
+
+    # Then
+    assert result is False

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -572,9 +572,10 @@ def test_create_segment_override__correct_feature_for_feature_based_segment__ret
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
 )
 def test_create_segment_override__max_limit_reached__returns_400(  # type: ignore[no-untyped-def]
-    client, segment, environment, project, feature, feature_based_segment
+    client, segment, environment, project, feature, feature_based_segment, settings
 ):
     # Given
+    settings.EDGE_ENABLED = True
     project.max_segment_overrides_allowed = 1
     project.save()
 

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -2490,6 +2490,7 @@ def test_create_segment_override__max_limit_reached__returns_400(
     settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.EDGE_ENABLED = True
     project.max_segment_overrides_allowed = 1
     project.save()
 
@@ -2530,6 +2531,7 @@ def test_create_feature__max_limit_reached__returns_400(
     settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.EDGE_ENABLED = True
     project.max_features_allowed = 1
     project.save()
 
@@ -2552,6 +2554,83 @@ def test_create_feature__max_limit_reached__returns_400(
         response.json()["project"]
         == "The Project has reached the maximum allowed features limit."
     )
+
+
+def test_create_feature__edge_disabled_max_limit_reached__returns_201(
+    admin_client_new: APIClient,
+    project: Project,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EDGE_ENABLED = False
+    project.max_features_allowed = 1
+    project.save()
+
+    url = reverse("api-v1:projects:project-features-list", args=[project.id])
+
+    # Now, create the first feature
+    response = admin_client_new.post(
+        url, data={"name": "test_feature", "project": project.id}
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+    # When
+    response = admin_client_new.post(
+        url, data={"name": "second_feature", "project": project.id}
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_create_segment_override__edge_disabled_max_limit_reached__returns_201(
+    admin_client_new: APIClient,
+    feature: Feature,
+    segment: Segment,
+    another_segment: Segment,
+    project: Project,
+    environment: Environment,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EDGE_ENABLED = False
+    project.max_segment_overrides_allowed = 1
+    project.save()
+
+    url = reverse(
+        "api-v1:environments:create-segment-override",
+        args=[environment.api_key, feature.id],
+    )
+
+    # First override
+    response = admin_client_new.post(
+        url,
+        data=json.dumps(
+            {
+                "feature_state_value": {"string_value": "value"},
+                "enabled": True,
+                "feature_segment": {"segment": segment.id},
+            }
+        ),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+    # When - second override exceeds the limit but edge is off
+    response = admin_client_new.post(
+        url,
+        data=json.dumps(
+            {
+                "feature_state_value": {"string_value": "value"},
+                "enabled": True,
+                "feature_segment": {"segment": another_segment.id},
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
 
 
 def test_create_segment_override__environment_viewset__returns_201(

--- a/api/tests/unit/features/versioning/test_unit_versioning_views.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_views.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
+from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -1235,11 +1236,13 @@ def test_create_version__exceeds_segment_override_limit__returns_bad_request(
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     with_project_permissions: WithProjectPermissionsCallable,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
     with_environment_permissions([VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE])  # type: ignore[call-arg]
     with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
 
+    settings.EDGE_ENABLED = True
     # We update the limit of segment overrides on the project
     project.max_segment_overrides_allowed = 1
     project.save()
@@ -1306,11 +1309,13 @@ def test_create_version__no_new_overrides_with_existing_at_limit__returns_create
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     with_project_permissions: WithProjectPermissionsCallable,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
     with_environment_permissions([VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE])  # type: ignore[call-arg]
     with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
 
+    settings.EDGE_ENABLED = True
     # We update the limit of segment overrides on the project
     project.max_segment_overrides_allowed = 1
     project.save()
@@ -1364,11 +1369,13 @@ def test_create_version__new_override_within_limit__returns_created(
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     with_project_permissions: WithProjectPermissionsCallable,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
     with_environment_permissions([VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE])  # type: ignore[call-arg]
     with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
 
+    settings.EDGE_ENABLED = True
     # We update the limit of segment overrides on the project
     project.max_segment_overrides_allowed = 2
     project.save()
@@ -1439,11 +1446,13 @@ def test_create_version__delete_and_create_override_at_limit__returns_created(
     staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     with_project_permissions: WithProjectPermissionsCallable,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
     with_environment_permissions([VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE])  # type: ignore[call-arg]
     with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
 
+    settings.EDGE_ENABLED = True
     # We update the limit of segment overrides on the project
     project.max_segment_overrides_allowed = 1
     project.save()

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -171,6 +171,7 @@ def test_create_segment__max_segments_limit_reached__returns_400(  # type: ignor
     project, client, settings
 ):
     # Given
+    settings.EDGE_ENABLED = True
     # let's reduce the max segments allowed to 1
     project.max_segments_allowed = 1
     project.save()
@@ -204,15 +205,56 @@ def test_create_segment__max_segments_limit_reached__returns_400(  # type: ignor
     assert project.segments.count() == 1
 
 
+def test_create_segment__edge_disabled_max_limit_reached__returns_201(
+    project: Project,
+    admin_client: APIClient,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EDGE_ENABLED = False
+    project.max_segments_allowed = 1
+    project.save()
+
+    url = reverse("api-v1:projects:project-segments-list", args=[project.id])
+    data = {
+        "name": "Second segment",
+        "project": project.id,
+        "rules": [
+            {
+                "type": "ALL",
+                "rules": [],
+                "conditions": [{"operator": EQUAL, "property": "test-property"}],
+            }
+        ],
+    }
+
+    # Create the first segment (at the limit)
+    res = admin_client.post(
+        url,
+        data=json.dumps({**data, "name": "First segment"}),
+        content_type="application/json",
+    )
+    assert res.status_code == status.HTTP_201_CREATED
+
+    # When - second segment exceeds the limit but edge is off
+    res = admin_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert res.status_code == status.HTTP_201_CREATED
+    assert project.segments.count() == 2
+
+
 def test_create_segment__old_segment_versions_exist__ignores_old_versions_in_limit(
     project: Project,
     segment: Segment,
     staff_client: APIClient,
     with_project_permissions: WithProjectPermissionsCallable,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
     with_project_permissions([MANAGE_SEGMENTS, VIEW_PROJECT])  # type: ignore[call-arg]
 
+    settings.EDGE_ENABLED = True
     # let's reduce the max segments allowed to 2
     project.max_segments_allowed = 2
     project.save()

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -190,7 +190,7 @@ Attributes:
 ### `segments.serializers.segment_revision_created`
 
 Logged at `info` from:
- - `api/segments/serializers.py:141`
+ - `api/segments/serializers.py:142`
 
 Attributes:
  - `revision_id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to internal hardening of project limits.

The three `Project` limits — `max_features_allowed`, `max_segments_allowed` and `max_segment_overrides_allowed` — were enforced unconditionally on every write, even on installs where the edge/dynamo backend is not configured. These limits exist to protect dynamo storage, so on non-edge installs they just rejected valid writes for no reason.

This PR:

- Adds `is_edge_enabled()` in `api/edge_api/utils.py`, wrapping `settings.EDGE_ENABLED`.
- Gates the three limit validators on it:
  - `CreateFeatureSerializer.validate_project_features_limit` (`features/serializers.py`)
  - `SegmentSerializer._validate_project_segment_limit` (`segments/serializers.py`)
  - `exceeds_segment_override_limit` (`features/feature_segments/limits.py`) — gating here covers all three callers (features, feature_segments, and versioning serializers)

Behaviour on edge-enabled installs is unchanged. Behaviour on non-edge installs: limits are skipped.

`Project.is_too_large` (used only by the `migrate_to_edge` pre-flight check) is intentionally left as-is — it already lives behind an edge-only code path.

## How did you test this code?

Full TDD: tests were written first and observed failing before the helper was implemented.

- New unit tests for `is_edge_enabled()` in `tests/unit/edge_api/test_unit_edge_api_utils.py`.
- New "edge disabled → limit skipped" tests for each of the three validators.
- Existing "limit enforced" tests were updated to explicitly set `settings.EDGE_ENABLED = True` so they continue to exercise the enforcement path.
- All 25 touched tests pass; `make typecheck` is clean on the touched files.