### PR TITLE
feat(Admin): Register LaunchDarkly import requests

### DIFF
--- a/api/integrations/launch_darkly/admin.py
+++ b/api/integrations/launch_darkly/admin.py
@@ -1,0 +1,69 @@
+from django.contrib import admin, messages
+from django.db.models import QuerySet
+from django.http import HttpRequest
+from django.utils import timezone
+
+from integrations.launch_darkly.models import LaunchDarklyImportRequest
+
+
+@admin.register(LaunchDarklyImportRequest)
+class LaunchDarklyImportRequestAdmin(admin.ModelAdmin[LaunchDarklyImportRequest]):
+    actions = ["mark_as_failure"]
+    date_hierarchy = "created_at"
+    exclude = ("ld_token",)
+    list_display = (
+        "id",
+        "project",
+        "ld_project_key",
+        "created_by",
+        "created_at",
+        "completed_at",
+        "result",
+    )
+    list_select_related = ("project", "created_by")
+    readonly_fields = (
+        "project",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "completed_at",
+        "ld_project_key",
+        "status",
+    )
+    search_fields = (
+        "project__name",
+        "ld_project_key",
+        "created_by__email",
+    )
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
+
+    @admin.display(description="Result")
+    def result(self, obj: LaunchDarklyImportRequest) -> str:
+        return obj.status.get("result") or "pending"
+
+    @admin.action(description="Mark selected imports as failed")
+    def mark_as_failure(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[LaunchDarklyImportRequest],
+    ) -> None:
+        now = timezone.now()
+        marked = 0
+        skipped = 0
+        for import_request in queryset:
+            if import_request.status.get("result"):
+                skipped += 1
+                continue
+            import_request.status = {**import_request.status, "result": "failure"}
+            if not import_request.completed_at:
+                import_request.completed_at = now
+            import_request.save()
+            marked += 1
+        self.message_user(
+            request,
+            f"Marked {marked} import(s) as failed; "
+            f"skipped {skipped} already-resolved import(s).",
+            messages.SUCCESS,
+        )

--- a/api/tests/unit/integrations/launch_darkly/test_admin.py
+++ b/api/tests/unit/integrations/launch_darkly/test_admin.py
@@ -1,0 +1,135 @@
+import datetime
+
+import pytest
+from django.contrib import messages
+from django.contrib.admin.sites import AdminSite
+from django.http import HttpRequest
+from django.test import RequestFactory
+from freezegun import freeze_time
+from pytest_mock import MockerFixture
+
+from integrations.launch_darkly.admin import LaunchDarklyImportRequestAdmin
+from integrations.launch_darkly.models import (
+    LaunchDarklyImportRequest,
+    LaunchDarklyImportStatus,
+)
+
+FROZEN_NOW = datetime.datetime(2026, 4, 23, 10, 0, 0, tzinfo=datetime.timezone.utc)
+EXISTING_COMPLETED_AT = datetime.datetime(
+    2026, 4, 1, 9, 0, 0, tzinfo=datetime.timezone.utc
+)
+PENDING_STATUS: LaunchDarklyImportStatus = {
+    "requested_environment_count": 2,
+    "requested_flag_count": 5,
+    "error_messages": [],
+}
+
+
+@pytest.fixture
+def ld_admin() -> LaunchDarklyImportRequestAdmin:
+    return LaunchDarklyImportRequestAdmin(LaunchDarklyImportRequest, AdminSite())
+
+
+@pytest.fixture
+def ld_admin_request(rf: RequestFactory) -> HttpRequest:
+    return rf.get("/admin/launch_darkly/launchdarklyimportrequest/")
+
+
+def test_launch_darkly_import_request_admin__has_add_permission__returns_false(
+    ld_admin: LaunchDarklyImportRequestAdmin,
+    ld_admin_request: HttpRequest,
+) -> None:
+    # Given / When
+    has_add = ld_admin.has_add_permission(ld_admin_request)
+
+    # Then
+    assert has_add is False
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        pytest.param(PENDING_STATUS, "pending", id="no-result-key"),
+        pytest.param({**PENDING_STATUS, "result": "success"}, "success", id="success"),
+        pytest.param({**PENDING_STATUS, "result": "failure"}, "failure", id="failure"),
+        pytest.param(
+            {**PENDING_STATUS, "result": "incomplete"}, "incomplete", id="incomplete"
+        ),
+    ],
+)
+def test_launch_darkly_import_request_admin__result__returns_expected(
+    ld_admin: LaunchDarklyImportRequestAdmin,
+    import_request: LaunchDarklyImportRequest,
+    status: LaunchDarklyImportStatus,
+    expected: str,
+) -> None:
+    # Given
+    import_request.status = status
+
+    # When
+    displayed = ld_admin.result(import_request)
+
+    # Then
+    assert displayed == expected
+
+
+@freeze_time(FROZEN_NOW)
+@pytest.mark.parametrize(
+    "initial_status, initial_completed_at, expected_status, expected_completed_at, expected_message",
+    [
+        pytest.param(
+            PENDING_STATUS,
+            None,
+            {**PENDING_STATUS, "result": "failure"},
+            FROZEN_NOW,
+            "Marked 1 import(s) as failed; skipped 0 already-resolved import(s).",
+            id="pending-no-completed-at-marked-and-completed-now",
+        ),
+        pytest.param(
+            PENDING_STATUS,
+            EXISTING_COMPLETED_AT,
+            {**PENDING_STATUS, "result": "failure"},
+            EXISTING_COMPLETED_AT,
+            "Marked 1 import(s) as failed; skipped 0 already-resolved import(s).",
+            id="pending-with-completed-at-marked-and-completed-at-preserved",
+        ),
+        pytest.param(
+            {**PENDING_STATUS, "result": "success"},
+            EXISTING_COMPLETED_AT,
+            {**PENDING_STATUS, "result": "success"},
+            EXISTING_COMPLETED_AT,
+            "Marked 0 import(s) as failed; skipped 1 already-resolved import(s).",
+            id="already-resolved-skipped",
+        ),
+    ],
+)
+def test_launch_darkly_import_request_admin__mark_as_failure__expected(
+    ld_admin: LaunchDarklyImportRequestAdmin,
+    ld_admin_request: HttpRequest,
+    import_request: LaunchDarklyImportRequest,
+    mocker: MockerFixture,
+    initial_status: LaunchDarklyImportStatus,
+    initial_completed_at: datetime.datetime | None,
+    expected_status: LaunchDarklyImportStatus,
+    expected_completed_at: datetime.datetime,
+    expected_message: str,
+) -> None:
+    # Given
+    import_request.status = initial_status
+    import_request.completed_at = initial_completed_at
+    import_request.save()
+    message_user_mock = mocker.patch.object(ld_admin, "message_user")
+    queryset = LaunchDarklyImportRequest.objects.filter(pk=import_request.pk)
+
+    # When
+    ld_admin.mark_as_failure(ld_admin_request, queryset)
+
+    # Then
+    import_request.refresh_from_db()
+    assert import_request.status == expected_status
+    assert import_request.completed_at == expected_completed_at
+    message_user_mock.assert_called_once_with(
+        ld_admin_request,
+        expected_message,
+        messages.SUCCESS,
+    )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

When a LaunchDarkly import gets wedged without a terminal `status.result`, the partial unique constraint on the import requests table blocks the customer from trying again for the same project + LD project key. Today the only fix is an engineer running a Django shell in prod. This puts the import requests in Django admin with a "mark as failed" action so customer success can unstick customers themselves.

## How did you test this code?

Unit tests in `tests/unit/integrations/launch_darkly/test_admin.py` cover the action's three branches — pending gets marked and `completed_at` filled in; pending with existing `completed_at` keeps it; already-resolved rows are skipped with a count in the admin message.