### PR TITLE
fix(GitLab): Orphaned feature tag after unlinking an issue or merge request

### DIFF
--- a/api/integrations/gitlab/constants.py
+++ b/api/integrations/gitlab/constants.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from features.feature_external_resources.models import ResourceType
+
 GITLAB_TAG_COLOR = "#FC6D26"
 GITLAB_CLIENT_TIMEOUT_SECONDS = 10
 
@@ -20,6 +22,12 @@ GITLAB_TAG_KIND_BY_LABEL: dict[GitLabTagLabel, str] = {
     GitLabTagLabel.MR_CLOSED: "MR",
     GitLabTagLabel.MR_MERGED: "MR",
     GitLabTagLabel.MR_DRAFT: "MR",
+}
+
+
+GITLAB_TAG_KIND_BY_RESOURCE_TYPE: dict[str, str] = {
+    ResourceType.GITLAB_ISSUE.value: "Issue",
+    ResourceType.GITLAB_MR.value: "MR",
 }
 
 

--- a/api/integrations/gitlab/services/__init__.py
+++ b/api/integrations/gitlab/services/__init__.py
@@ -8,6 +8,7 @@ from integrations.gitlab.services.comments import (
 from integrations.gitlab.services.tagging import (
     apply_initial_tag,
     apply_tag_for_event,
+    clear_tag_for_resource,
     set_gitlab_tag,
 )
 from integrations.gitlab.services.url_parsing import (
@@ -25,6 +26,7 @@ from integrations.gitlab.services.webhooks import (
 __all__ = [
     "apply_initial_tag",
     "apply_tag_for_event",
+    "clear_tag_for_resource",
     "deregister_gitlab_webhook_for_resource",
     "deregister_webhook_for_path",
     "ensure_webhook_registered",

--- a/api/integrations/gitlab/services/tagging.py
+++ b/api/integrations/gitlab/services/tagging.py
@@ -9,6 +9,7 @@ from integrations.gitlab.constants import (
     GITLAB_TAG_COLOR,
     GITLAB_TAG_DESCRIPTION_BY_LABEL,
     GITLAB_TAG_KIND_BY_LABEL,
+    GITLAB_TAG_KIND_BY_RESOURCE_TYPE,
     GitLabTagLabel,
 )
 from integrations.gitlab.mappers import (
@@ -91,4 +92,30 @@ def apply_tag_for_event(
         tag__label=label.value,
         object_kind=payload.get("object_kind"),
         action=attrs.get("action"),
+    )
+
+
+def clear_tag_for_resource(resource: FeatureExternalResource) -> None:
+    """Remove the GitLab tag for `resource`'s kind (Issue/MR) from its
+    feature when no other linked `FeatureExternalResource` of the same
+    kind remains. Safe to call whether `resource` is still in the DB or
+    has already been deleted.
+    """
+    kind = GITLAB_TAG_KIND_BY_RESOURCE_TYPE.get(resource.type)
+    if kind is None:
+        return
+    if (
+        FeatureExternalResource.objects.filter(
+            feature=resource.feature,
+            type=resource.type,
+        )
+        .exclude(pk=resource.pk)
+        .exists()
+    ):
+        return
+    resource.feature.tags.remove(
+        *resource.feature.tags.filter(
+            type=TagType.GITLAB.value,
+            label__startswith=kind,
+        )
     )

--- a/api/integrations/vcs/services.py
+++ b/api/integrations/vcs/services.py
@@ -10,15 +10,8 @@ from features.feature_external_resources.models import (
     GITLAB_RESOURCE_TYPES,
     FeatureExternalResource,
 )
-from integrations.gitlab.services import (
-    apply_initial_tag,
-    deregister_gitlab_webhook_for_resource,
-    register_gitlab_webhook_for_resource,
-)
-from integrations.gitlab.tasks import (
-    post_gitlab_linked_comment,
-    post_gitlab_unlinked_comment,
-)
+from integrations.gitlab import services as gitlab
+from integrations.gitlab import tasks as gitlab_tasks
 
 gitlab_logger = structlog.get_logger("gitlab")
 
@@ -28,6 +21,9 @@ def dispatch_vcs_on_resource_create(resource: FeatureExternalResource) -> None:
     is created.
     """
     if resource.type in GITLAB_RESOURCE_TYPES:
+        gitlab.register_gitlab_webhook_for_resource(resource)
+        gitlab.apply_initial_tag(resource)
+        gitlab_tasks.post_gitlab_linked_comment.delay(args=(resource.id,))
         gitlab_logger.info(
             "resource.linked",
             organisation__id=resource.feature.project.organisation_id,
@@ -35,9 +31,6 @@ def dispatch_vcs_on_resource_create(resource: FeatureExternalResource) -> None:
             feature__id=resource.feature.id,
             resource__type=resource.type.lower(),
         )
-        register_gitlab_webhook_for_resource(resource)
-        apply_initial_tag(resource)
-        post_gitlab_linked_comment.delay(args=(resource.id,))
 
 
 def dispatch_vcs_on_resource_destroy(resource: FeatureExternalResource) -> None:
@@ -45,7 +38,7 @@ def dispatch_vcs_on_resource_destroy(resource: FeatureExternalResource) -> None:
     has been destroyed. `resource` is a memory-only object at this point.
     """
     if resource.type in GITLAB_RESOURCE_TYPES:
-        post_gitlab_unlinked_comment.delay(
+        gitlab_tasks.post_gitlab_unlinked_comment.delay(
             args=(
                 resource.feature.name,
                 resource.feature.id,
@@ -54,7 +47,9 @@ def dispatch_vcs_on_resource_destroy(resource: FeatureExternalResource) -> None:
                 resource.feature.project_id,
             ),
         )
-        deregister_gitlab_webhook_for_resource(resource)
+        gitlab.deregister_gitlab_webhook_for_resource(resource)
+
+        gitlab.clear_tag_for_resource(resource)
         gitlab_logger.info(
             "resource.unlinked",
             organisation__id=resource.feature.project.organisation_id,

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -217,14 +217,6 @@ def test_create_external_resource__gitlab_issue__registers_webhook_and_tags_feat
     assert log.events == [
         {
             "level": "info",
-            "event": "resource.linked",
-            "organisation__id": organisation,
-            "project__id": project,
-            "feature__id": feature,
-            "resource__type": "gitlab_issue",
-        },
-        {
-            "level": "info",
             "event": "webhook.registered",
             "organisation__id": organisation,
             "project__id": project,
@@ -240,6 +232,14 @@ def test_create_external_resource__gitlab_issue__registers_webhook_and_tags_feat
             "feature__id": feature,
             "gitlab__project__path": "testorg/testrepo",
             "gitlab__resource__iid": 42,
+        },
+        {
+            "level": "info",
+            "event": "resource.linked",
+            "organisation__id": organisation,
+            "project__id": project,
+            "feature__id": feature,
+            "resource__type": "gitlab_issue",
         },
     ]
 
@@ -298,14 +298,6 @@ def test_create_external_resource__gitlab_mr__registers_webhook_and_tags_feature
     assert log.events == [
         {
             "level": "info",
-            "event": "resource.linked",
-            "organisation__id": organisation,
-            "project__id": project,
-            "feature__id": feature,
-            "resource__type": "gitlab_mr",
-        },
-        {
-            "level": "info",
             "event": "webhook.registered",
             "organisation__id": organisation,
             "project__id": project,
@@ -321,6 +313,14 @@ def test_create_external_resource__gitlab_mr__registers_webhook_and_tags_feature
             "feature__id": feature,
             "gitlab__project__path": "testorg/testrepo",
             "gitlab__resource__iid": 7,
+        },
+        {
+            "level": "info",
+            "event": "resource.linked",
+            "organisation__id": organisation,
+            "project__id": project,
+            "feature__id": feature,
+            "resource__type": "gitlab_mr",
         },
     ]
 
@@ -377,20 +377,20 @@ def test_create_external_resource__second_link_same_gitlab_project__reuses_webho
     assert log.events == [
         {
             "level": "info",
-            "event": "resource.linked",
-            "organisation__id": organisation,
-            "project__id": project,
-            "feature__id": feature,
-            "resource__type": "gitlab_mr",
-        },
-        {
-            "level": "info",
             "event": "comment.posted",
             "organisation__id": organisation,
             "project__id": project,
             "feature__id": feature,
             "gitlab__project__path": "testorg/testrepo",
             "gitlab__resource__iid": 5,
+        },
+        {
+            "level": "info",
+            "event": "resource.linked",
+            "organisation__id": organisation,
+            "project__id": project,
+            "feature__id": feature,
+            "resource__type": "gitlab_mr",
         },
     ]
 

--- a/api/tests/unit/integrations/gitlab/test_tagging.py
+++ b/api/tests/unit/integrations/gitlab/test_tagging.py
@@ -1,0 +1,145 @@
+import pytest
+
+from features.feature_external_resources.models import (
+    FeatureExternalResource,
+    ResourceType,
+)
+from features.models import Feature
+from integrations.gitlab.services.tagging import (
+    apply_initial_tag,
+    clear_tag_for_resource,
+)
+from projects.models import Project
+from projects.tags.models import Tag, TagType
+
+
+@pytest.mark.django_db
+def test_clear_tag_for_resource__only_resource_of_kind__removes_tag(
+    feature: Feature,
+) -> None:
+    # Given
+    resource = FeatureExternalResource.objects.create(
+        feature=feature,
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+        type=ResourceType.GITLAB_ISSUE.value,
+        metadata='{"state": "opened"}',
+    )
+    apply_initial_tag(resource)
+    assert sorted(
+        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+    ) == ["Issue Open"]
+
+    # When
+    clear_tag_for_resource(resource)
+
+    # Then
+    assert (
+        sorted(
+            feature.tags.filter(type=TagType.GITLAB.value).values_list(
+                "label", flat=True
+            )
+        )
+        == []
+    )
+
+
+@pytest.mark.django_db
+def test_clear_tag_for_resource__other_resource_of_same_kind_remains__keeps_tag(
+    feature: Feature,
+) -> None:
+    # Given
+    first = FeatureExternalResource.objects.create(
+        feature=feature,
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+        type=ResourceType.GITLAB_ISSUE.value,
+        metadata='{"state": "opened"}',
+    )
+    FeatureExternalResource.objects.create(
+        feature=feature,
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/2",
+        type=ResourceType.GITLAB_ISSUE.value,
+        metadata='{"state": "opened"}',
+    )
+    apply_initial_tag(first)
+    assert sorted(
+        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+    ) == ["Issue Open"]
+
+    # When
+    clear_tag_for_resource(first)
+
+    # Then
+    assert sorted(
+        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+    ) == ["Issue Open"]
+
+
+@pytest.mark.django_db
+def test_clear_tag_for_resource__different_kind_remains__keeps_other_kind_tag(
+    feature: Feature,
+) -> None:
+    # Given
+    issue = FeatureExternalResource.objects.create(
+        feature=feature,
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+        type=ResourceType.GITLAB_ISSUE.value,
+        metadata='{"state": "opened"}',
+    )
+    mr = FeatureExternalResource.objects.create(
+        feature=feature,
+        url="https://gitlab.example.com/testorg/testrepo/-/merge_requests/7",
+        type=ResourceType.GITLAB_MR.value,
+        metadata='{"state": "opened"}',
+    )
+    apply_initial_tag(issue)
+    apply_initial_tag(mr)
+    assert sorted(
+        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+    ) == ["Issue Open", "MR Open"]
+
+    # When
+    clear_tag_for_resource(issue)
+
+    # Then
+    assert sorted(
+        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+    ) == ["MR Open"]
+
+
+@pytest.mark.django_db
+def test_clear_tag_for_resource__non_gitlab_type__leaves_tags_intact(
+    feature: Feature,
+    project: Project,
+) -> None:
+    # Given — feature has both a GitHub tag and a GitLab tag already.
+    expected_tags = [
+        ("Issue Open", TagType.GITHUB.value),
+        ("Issue Open", TagType.GITLAB.value),
+    ]
+
+    github_tag = Tag.objects.create(
+        label="Issue Open",
+        project=project,
+        type=TagType.GITHUB.value,
+        is_system_tag=True,
+    )
+    gitlab_issue = FeatureExternalResource.objects.create(
+        feature=feature,
+        url="https://gitlab.example.com/testorg/testrepo/-/issues/1",
+        type=ResourceType.GITLAB_ISSUE.value,
+        metadata='{"state": "opened"}',
+    )
+    apply_initial_tag(gitlab_issue)
+    feature.tags.add(github_tag)
+    assert sorted(feature.tags.values_list("label", "type")) == expected_tags
+
+    # When — clearing for a GitHub FER
+    github_resource = FeatureExternalResource(
+        feature=feature,
+        url="https://github.com/testorg/testrepo/issues/1",
+        type=ResourceType.GITHUB_ISSUE.value,
+    )
+    clear_tag_for_resource(github_resource)
+
+    # Then — must not touch either tag
+    assert sorted(feature.tags.values_list("label", "type")) == expected_tags

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -123,7 +123,7 @@ Attributes:
 ### `gitlab.feature.tagged`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services/tagging.py:88`
+ - `api/integrations/gitlab/services/tagging.py:89`
 
 Attributes:
  - `action`
@@ -136,7 +136,7 @@ Attributes:
 ### `gitlab.resource.linked`
 
 Logged at `info` from:
- - `api/integrations/vcs/services.py:31`
+ - `api/integrations/vcs/services.py:27`
 
 Attributes:
  - `feature.id`
@@ -147,7 +147,7 @@ Attributes:
 ### `gitlab.resource.unlinked`
 
 Logged at `info` from:
- - `api/integrations/vcs/services.py:58`
+ - `api/integrations/vcs/services.py:53`
 
 Attributes:
  - `feature.id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #7306.

Linking a feature to a GitLab issue or merge request applies a GitLab tag (e.g. `Issue Open`, `MR Draft`). Unlinking left that tag on the feature with no corresponding `FeatureExternalResource`.

Introduce `clear_tag_for_resource` in the GitLab tagging service and wire it into `dispatch_vcs_on_resource_destroy`. It removes the Issue/MR-kind tag from the feature only when no other linked FER of the same kind remains — features linked to several issues, or to both an issue and an MR, keep the still-valid tag. The helper excludes `resource.pk` from its survivor query so it's safe to call regardless of whether the caller has already destroyed the row.

Review effort: 1/5

## How did you test this code?

Unit tests for the new helper cover:
- single FER of a kind → tag cleared
- multiple FERs of the same kind → tag retained
- mixed Issue + MR → only the unlinked kind's tag cleared
- non-GitLab type → no-op