### PR TITLE
refactor: consolidate remaining charts into LineChart + PieChart wrappers

### DIFF
--- a/frontend/documentation/components/BarChart.stories.tsx
+++ b/frontend/documentation/components/BarChart.stories.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from 'react'
 import type { Meta, StoryObj } from 'storybook'
-import BarChart, { ChartDataPoint } from 'components/charts/BarChart'
+import BarChart from 'components/charts/BarChart'
 import { MultiSelect } from 'components/base/select/multi-select'
 import { buildChartColorMap } from 'components/charts/buildChartColorMap'
+import { generateChartFakeData } from './_chartFakeData'
 
 // ============================================================================
 // Fake data
@@ -16,54 +17,23 @@ const SDKS = [
   'flagsmith-ruby-sdk',
 ]
 
-// Deterministic stand-in for Math.random — same `(label, day)` pair always
-// produces the same value, so Chromatic snapshots stay stable across runs.
-const pseudoRandom = (label: string, day: number): number => {
-  let hash = 0
-  const seed = `${label}-${day}`
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash << 5) - hash + seed.charCodeAt(i)
-    hash |= 0
-  }
-  return Math.abs(hash) / 0x7fffffff
+const BAR_BASE_MAP: Record<string, number> = {
+  Development: 1200,
+  Production: 5000,
+  Staging: 2400,
+  'flagsmith-js-sdk': 4500,
+  'flagsmith-python-sdk': 2200,
 }
 
-// Pinned reference date — using `new Date()` would shift the x-axis daily and
-// drift every Chromatic snapshot.
-const REFERENCE_DATE = new Date('2026-04-15T00:00:00Z')
-
-function generateFakeData(days: number, labels: string[]): ChartDataPoint[] {
-  const data: ChartDataPoint[] = []
-
-  const baseMap: Record<string, number> = {
-    Development: 1200,
-    Production: 5000,
-    Staging: 2400,
-    'flagsmith-js-sdk': 4500,
-    'flagsmith-python-sdk': 2200,
-  }
-
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(REFERENCE_DATE)
-    date.setUTCDate(date.getUTCDate() - i)
-    const dayStr = date.toLocaleDateString('en-GB', {
-      day: 'numeric',
-      month: 'short',
-      timeZone: 'UTC',
-    })
-
-    const point: ChartDataPoint = { day: dayStr }
-    labels.forEach((label) => {
-      const base = baseMap[label] || 800
-      const variance = Math.floor(pseudoRandom(label, i) * base * 0.4)
-      const weekday = date.getUTCDay()
-      const weekendDip = weekday === 0 || weekday === 6 ? 0.4 : 1
-      point[label] = Math.floor((base + variance) * weekendDip)
-    })
-    data.push(point)
-  }
-  return data
-}
+const generateFakeData = (days: number, labels: string[]) =>
+  generateChartFakeData({
+    baseMap: BAR_BASE_MAP,
+    days,
+    defaultBase: 800,
+    labels,
+    variance: 0.4,
+    weekendDip: 0.4,
+  })
 
 // ============================================================================
 // Stories

--- a/frontend/documentation/components/BarChart.stories.tsx
+++ b/frontend/documentation/components/BarChart.stories.tsx
@@ -72,7 +72,7 @@ function generateFakeData(days: number, labels: string[]): ChartDataPoint[] {
 const meta: Meta<typeof BarChart> = {
   component: BarChart,
   tags: ['autodocs'],
-  title: 'Components/BarChart',
+  title: 'Components/Charts/BarChart',
 }
 export default meta
 

--- a/frontend/documentation/components/LineChart.stories.tsx
+++ b/frontend/documentation/components/LineChart.stories.tsx
@@ -1,0 +1,163 @@
+import React, { useMemo } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import LineChart from 'components/charts/LineChart'
+import { ChartDataPoint } from 'components/charts/BarChart'
+import { buildChartColorMap } from 'components/charts/buildChartColorMap'
+
+// ============================================================================
+// Fake data
+// ============================================================================
+
+// Deterministic stand-in for Math.random — same `(label, day)` pair always
+// produces the same value, so Chromatic snapshots stay stable across runs.
+const pseudoRandom = (label: string, day: number): number => {
+  let hash = 0
+  const seed = `${label}-${day}`
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i)
+    hash |= 0
+  }
+  return Math.abs(hash) / 0x7fffffff
+}
+
+// Pinned reference date — using `new Date()` would shift the x-axis daily and
+// drift every Chromatic snapshot.
+const REFERENCE_DATE = new Date('2026-04-15T00:00:00Z')
+
+function generateFakeData(days: number, labels: string[]): ChartDataPoint[] {
+  const data: ChartDataPoint[] = []
+
+  const baseMap: Record<string, number> = {
+    'API Calls': 12000,
+    Clicks: 2000,
+    Conversions: 800,
+    Errors: 80,
+    'Flag Evaluations': 8000,
+    'Identity Requests': 5000,
+    'Page Views': 15000,
+  }
+
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(REFERENCE_DATE)
+    date.setUTCDate(date.getUTCDate() - i)
+    const dayStr = date.toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    })
+
+    const point: ChartDataPoint = { day: dayStr }
+    labels.forEach((label) => {
+      const base = baseMap[label] || 1000
+      const variance = Math.floor(pseudoRandom(label, i) * base * 0.35)
+      const weekday = date.getUTCDay()
+      const weekendDip = weekday === 0 || weekday === 6 ? 0.6 : 1
+      point[label] = Math.floor((base + variance) * weekendDip)
+    })
+    data.push(point)
+  }
+  return data
+}
+
+// ============================================================================
+// Stories
+// ============================================================================
+
+const meta: Meta<typeof LineChart> = {
+  component: LineChart,
+  tags: ['autodocs'],
+  title: 'Components/LineChart',
+}
+export default meta
+
+type Story = StoryObj<typeof LineChart>
+
+export const UsageTrends: Story = {
+  decorators: [
+    () => {
+      const labels = useMemo(
+        () => ['API Calls', 'Flag Evaluations', 'Identity Requests'],
+        [],
+      )
+      const data = useMemo(() => generateFakeData(30, labels), [labels])
+      const colorMap = useMemo(() => buildChartColorMap(labels), [labels])
+
+      return (
+        <div className='mx-auto' style={{ maxWidth: 900 }}>
+          <p className='text-secondary fs-small mb-3'>
+            Mirrors the API Usage Trends dashboard — three independent metrics
+            plotted over 30 days.
+          </p>
+          <LineChart
+            data={data}
+            series={labels}
+            colorMap={colorMap}
+            xAxisInterval={2}
+            showLegend
+          />
+        </div>
+      )
+    },
+  ],
+}
+
+export const SingleLine: Story = {
+  decorators: [
+    () => {
+      const labels = useMemo(() => ['API Calls'], [])
+      const data = useMemo(() => generateFakeData(30, labels), [labels])
+      const colorMap = useMemo(() => buildChartColorMap(labels), [labels])
+
+      return (
+        <div className='mx-auto' style={{ maxWidth: 900 }}>
+          <p className='text-secondary fs-small mb-3'>
+            One metric over time — legend hidden since the series is obvious
+            from the chart title.
+          </p>
+          <LineChart
+            data={data}
+            series={labels}
+            colorMap={colorMap}
+            xAxisInterval={2}
+          />
+        </div>
+      )
+    },
+  ],
+}
+
+export const ManyLines: Story = {
+  decorators: [
+    () => {
+      const labels = useMemo(
+        () => [
+          'API Calls',
+          'Flag Evaluations',
+          'Identity Requests',
+          'Page Views',
+          'Clicks',
+          'Conversions',
+          'Errors',
+        ],
+        [],
+      )
+      const data = useMemo(() => generateFakeData(30, labels), [labels])
+      const colorMap = useMemo(() => buildChartColorMap(labels), [labels])
+
+      return (
+        <div className='mx-auto' style={{ maxWidth: 900 }}>
+          <p className='text-secondary fs-small mb-3'>
+            Seven lines — stress-test of the colour palette.
+          </p>
+          <LineChart
+            data={data}
+            series={labels}
+            colorMap={colorMap}
+            xAxisInterval={2}
+            showLegend
+          />
+        </div>
+      )
+    },
+  ],
+}

--- a/frontend/documentation/components/LineChart.stories.tsx
+++ b/frontend/documentation/components/LineChart.stories.tsx
@@ -66,7 +66,7 @@ function generateFakeData(days: number, labels: string[]): ChartDataPoint[] {
 const meta: Meta<typeof LineChart> = {
   component: LineChart,
   tags: ['autodocs'],
-  title: 'Components/LineChart',
+  title: 'Components/Charts/LineChart',
 }
 export default meta
 

--- a/frontend/documentation/components/LineChart.stories.tsx
+++ b/frontend/documentation/components/LineChart.stories.tsx
@@ -1,63 +1,29 @@
 import React, { useMemo } from 'react'
 import type { Meta, StoryObj } from 'storybook'
 import LineChart from 'components/charts/LineChart'
-import { ChartDataPoint } from 'components/charts/BarChart'
 import { buildChartColorMap } from 'components/charts/buildChartColorMap'
+import { generateChartFakeData } from './_chartFakeData'
 
 // ============================================================================
 // Fake data
 // ============================================================================
 
-// Deterministic stand-in for Math.random — same `(label, day)` pair always
-// produces the same value, so Chromatic snapshots stay stable across runs.
-const pseudoRandom = (label: string, day: number): number => {
-  let hash = 0
-  const seed = `${label}-${day}`
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash << 5) - hash + seed.charCodeAt(i)
-    hash |= 0
-  }
-  return Math.abs(hash) / 0x7fffffff
+const LINE_BASE_MAP: Record<string, number> = {
+  'API Calls': 12000,
+  Clicks: 2000,
+  Conversions: 800,
+  Errors: 80,
+  'Flag Evaluations': 8000,
+  'Identity Requests': 5000,
+  'Page Views': 15000,
 }
 
-// Pinned reference date — using `new Date()` would shift the x-axis daily and
-// drift every Chromatic snapshot.
-const REFERENCE_DATE = new Date('2026-04-15T00:00:00Z')
-
-function generateFakeData(days: number, labels: string[]): ChartDataPoint[] {
-  const data: ChartDataPoint[] = []
-
-  const baseMap: Record<string, number> = {
-    'API Calls': 12000,
-    Clicks: 2000,
-    Conversions: 800,
-    Errors: 80,
-    'Flag Evaluations': 8000,
-    'Identity Requests': 5000,
-    'Page Views': 15000,
-  }
-
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(REFERENCE_DATE)
-    date.setUTCDate(date.getUTCDate() - i)
-    const dayStr = date.toLocaleDateString('en-GB', {
-      day: 'numeric',
-      month: 'short',
-      timeZone: 'UTC',
-    })
-
-    const point: ChartDataPoint = { day: dayStr }
-    labels.forEach((label) => {
-      const base = baseMap[label] || 1000
-      const variance = Math.floor(pseudoRandom(label, i) * base * 0.35)
-      const weekday = date.getUTCDay()
-      const weekendDip = weekday === 0 || weekday === 6 ? 0.6 : 1
-      point[label] = Math.floor((base + variance) * weekendDip)
-    })
-    data.push(point)
-  }
-  return data
-}
+const generateFakeData = (days: number, labels: string[]) =>
+  generateChartFakeData({
+    baseMap: LINE_BASE_MAP,
+    days,
+    labels,
+  })
 
 // ============================================================================
 // Stories

--- a/frontend/documentation/components/PieChart.stories.tsx
+++ b/frontend/documentation/components/PieChart.stories.tsx
@@ -37,7 +37,7 @@ const TWO_SLICE_DATA: PieSlice[] = [
 const meta: Meta<typeof PieChart> = {
   component: PieChart,
   tags: ['autodocs'],
-  title: 'Components/PieChart',
+  title: 'Components/Charts/PieChart',
 }
 export default meta
 

--- a/frontend/documentation/components/PieChart.stories.tsx
+++ b/frontend/documentation/components/PieChart.stories.tsx
@@ -53,15 +53,16 @@ export const Donut: Story = {
       )
       return (
         <div className='d-flex justify-content-center'>
-          <div>
+          <div style={{ width: 240 }}>
             <p className='text-secondary fs-small mb-3 text-center'>
               Donut variant — inner cutout for a secondary label or count.
             </p>
             <PieChart
               data={data}
               colorMap={colorMap}
-              size={220}
-              innerRadius={50}
+              height={240}
+              innerRadius={60}
+              outerRadius={100}
             />
           </div>
         </div>
@@ -80,11 +81,16 @@ export const SolidPie: Story = {
       )
       return (
         <div className='d-flex justify-content-center'>
-          <div>
+          <div style={{ width: 240 }}>
             <p className='text-secondary fs-small mb-3 text-center'>
               Solid pie — no inner radius.
             </p>
-            <PieChart data={data} colorMap={colorMap} size={220} />
+            <PieChart
+              data={data}
+              colorMap={colorMap}
+              height={240}
+              outerRadius={100}
+            />
           </div>
         </div>
       )
@@ -102,15 +108,16 @@ export const TwoSlices: Story = {
       )
       return (
         <div className='d-flex justify-content-center'>
-          <div>
+          <div style={{ width: 220 }}>
             <p className='text-secondary fs-small mb-3 text-center'>
               Minimal case — two slices for a released vs. in-progress split.
             </p>
             <PieChart
               data={data}
               colorMap={colorMap}
-              size={200}
-              innerRadius={50}
+              height={220}
+              innerRadius={60}
+              outerRadius={90}
             />
           </div>
         </div>
@@ -129,15 +136,16 @@ export const ManySlices: Story = {
       )
       return (
         <div className='d-flex justify-content-center'>
-          <div>
+          <div style={{ width: 300 }}>
             <p className='text-secondary fs-small mb-3 text-center'>
               Seven slices — stress-test of the colour palette.
             </p>
             <PieChart
               data={data}
               colorMap={colorMap}
-              size={260}
+              height={380}
               innerRadius={60}
+              outerRadius={100}
               showLegend
             />
           </div>
@@ -157,15 +165,16 @@ export const WithLegend: Story = {
       )
       return (
         <div className='d-flex justify-content-center'>
-          <div>
+          <div style={{ width: 300 }}>
             <p className='text-secondary fs-small mb-3 text-center'>
               Legend enabled — useful when slices are many or narrow.
             </p>
             <PieChart
               data={data}
               colorMap={colorMap}
-              size={260}
+              height={340}
               innerRadius={60}
+              outerRadius={100}
               showLegend
             />
           </div>

--- a/frontend/documentation/components/PieChart.stories.tsx
+++ b/frontend/documentation/components/PieChart.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import type { Meta, StoryObj } from 'storybook'
 import PieChart, { PieSlice } from 'components/charts/PieChart'
 import { buildChartColorMap } from 'components/charts/buildChartColorMap'
@@ -30,6 +30,12 @@ const TWO_SLICE_DATA: PieSlice[] = [
   { name: 'In progress', value: 18 },
 ]
 
+const STAGE_COLOR_MAP = buildChartColorMap(STAGE_DATA.map((s) => s.name))
+const SDK_COLOR_MAP = buildChartColorMap(SDK_DATA.map((s) => s.name))
+const TWO_SLICE_COLOR_MAP = buildChartColorMap(
+  TWO_SLICE_DATA.map((s) => s.name),
+)
+
 // ============================================================================
 // Stories
 // ============================================================================
@@ -45,141 +51,106 @@ type Story = StoryObj<typeof PieChart>
 
 export const Donut: Story = {
   decorators: [
-    () => {
-      const data = STAGE_DATA
-      const colorMap = useMemo(
-        () => buildChartColorMap(data.map((s) => s.name)),
-        [data],
-      )
-      return (
-        <div className='d-flex justify-content-center'>
-          <div style={{ width: 240 }}>
-            <p className='text-secondary fs-small mb-3 text-center'>
-              Donut variant — inner cutout for a secondary label or count.
-            </p>
-            <PieChart
-              data={data}
-              colorMap={colorMap}
-              height={240}
-              innerRadius={60}
-              outerRadius={100}
-            />
-          </div>
+    () => (
+      <div className='d-flex justify-content-center'>
+        <div style={{ width: 240 }}>
+          <p className='text-secondary fs-small mb-3 text-center'>
+            Donut variant — inner cutout for a secondary label or count.
+          </p>
+          <PieChart
+            data={STAGE_DATA}
+            colorMap={STAGE_COLOR_MAP}
+            height={240}
+            innerRadius={60}
+            outerRadius={100}
+          />
         </div>
-      )
-    },
+      </div>
+    ),
   ],
 }
 
 export const SolidPie: Story = {
   decorators: [
-    () => {
-      const data = STAGE_DATA
-      const colorMap = useMemo(
-        () => buildChartColorMap(data.map((s) => s.name)),
-        [data],
-      )
-      return (
-        <div className='d-flex justify-content-center'>
-          <div style={{ width: 240 }}>
-            <p className='text-secondary fs-small mb-3 text-center'>
-              Solid pie — no inner radius.
-            </p>
-            <PieChart
-              data={data}
-              colorMap={colorMap}
-              height={240}
-              outerRadius={100}
-            />
-          </div>
+    () => (
+      <div className='d-flex justify-content-center'>
+        <div style={{ width: 240 }}>
+          <p className='text-secondary fs-small mb-3 text-center'>
+            Solid pie — no inner radius.
+          </p>
+          <PieChart
+            data={STAGE_DATA}
+            colorMap={STAGE_COLOR_MAP}
+            height={240}
+            outerRadius={100}
+          />
         </div>
-      )
-    },
+      </div>
+    ),
   ],
 }
 
 export const TwoSlices: Story = {
   decorators: [
-    () => {
-      const data = TWO_SLICE_DATA
-      const colorMap = useMemo(
-        () => buildChartColorMap(data.map((s) => s.name)),
-        [data],
-      )
-      return (
-        <div className='d-flex justify-content-center'>
-          <div style={{ width: 220 }}>
-            <p className='text-secondary fs-small mb-3 text-center'>
-              Minimal case — two slices for a released vs. in-progress split.
-            </p>
-            <PieChart
-              data={data}
-              colorMap={colorMap}
-              height={220}
-              innerRadius={60}
-              outerRadius={90}
-            />
-          </div>
+    () => (
+      <div className='d-flex justify-content-center'>
+        <div style={{ width: 220 }}>
+          <p className='text-secondary fs-small mb-3 text-center'>
+            Minimal case — two slices for a released vs. in-progress split.
+          </p>
+          <PieChart
+            data={TWO_SLICE_DATA}
+            colorMap={TWO_SLICE_COLOR_MAP}
+            height={220}
+            innerRadius={60}
+            outerRadius={90}
+          />
         </div>
-      )
-    },
+      </div>
+    ),
   ],
 }
 
 export const ManySlices: Story = {
   decorators: [
-    () => {
-      const data = SDK_DATA
-      const colorMap = useMemo(
-        () => buildChartColorMap(data.map((s) => s.name)),
-        [data],
-      )
-      return (
-        <div className='d-flex justify-content-center'>
-          <div style={{ width: 300 }}>
-            <p className='text-secondary fs-small mb-3 text-center'>
-              Seven slices — stress-test of the colour palette.
-            </p>
-            <PieChart
-              data={data}
-              colorMap={colorMap}
-              height={380}
-              innerRadius={60}
-              outerRadius={100}
-              showLegend
-            />
-          </div>
+    () => (
+      <div className='d-flex justify-content-center'>
+        <div style={{ width: 300 }}>
+          <p className='text-secondary fs-small mb-3 text-center'>
+            Seven slices — stress-test of the colour palette.
+          </p>
+          <PieChart
+            data={SDK_DATA}
+            colorMap={SDK_COLOR_MAP}
+            height={380}
+            innerRadius={60}
+            outerRadius={100}
+            showLegend
+          />
         </div>
-      )
-    },
+      </div>
+    ),
   ],
 }
 
 export const WithLegend: Story = {
   decorators: [
-    () => {
-      const data = STAGE_DATA
-      const colorMap = useMemo(
-        () => buildChartColorMap(data.map((s) => s.name)),
-        [data],
-      )
-      return (
-        <div className='d-flex justify-content-center'>
-          <div style={{ width: 300 }}>
-            <p className='text-secondary fs-small mb-3 text-center'>
-              Legend enabled — useful when slices are many or narrow.
-            </p>
-            <PieChart
-              data={data}
-              colorMap={colorMap}
-              height={340}
-              innerRadius={60}
-              outerRadius={100}
-              showLegend
-            />
-          </div>
+    () => (
+      <div className='d-flex justify-content-center'>
+        <div style={{ width: 300 }}>
+          <p className='text-secondary fs-small mb-3 text-center'>
+            Legend enabled — useful when slices are many or narrow.
+          </p>
+          <PieChart
+            data={STAGE_DATA}
+            colorMap={STAGE_COLOR_MAP}
+            height={340}
+            innerRadius={60}
+            outerRadius={100}
+            showLegend
+          />
         </div>
-      )
-    },
+      </div>
+    ),
   ],
 }

--- a/frontend/documentation/components/PieChart.stories.tsx
+++ b/frontend/documentation/components/PieChart.stories.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+import PieChart, { PieSlice } from 'components/charts/PieChart'
+import { buildChartColorMap } from 'components/charts/buildChartColorMap'
+
+// ============================================================================
+// Fake data
+// ============================================================================
+
+const STAGE_DATA: PieSlice[] = [
+  { name: 'Development', value: 12 },
+  { name: 'Staging', value: 8 },
+  { name: 'Pre-production', value: 5 },
+  { name: 'Production', value: 15 },
+  { name: 'Released', value: 32 },
+]
+
+const SDK_DATA: PieSlice[] = [
+  { name: 'flagsmith-js-sdk', value: 4500 },
+  { name: 'flagsmith-python-sdk', value: 2200 },
+  { name: 'flagsmith-java-sdk', value: 1100 },
+  { name: 'flagsmith-go-sdk', value: 800 },
+  { name: 'flagsmith-ruby-sdk', value: 400 },
+  { name: 'flagsmith-dotnet-sdk', value: 300 },
+  { name: 'flagsmith-rust-sdk', value: 150 },
+]
+
+const TWO_SLICE_DATA: PieSlice[] = [
+  { name: 'Released', value: 32 },
+  { name: 'In progress', value: 18 },
+]
+
+// ============================================================================
+// Stories
+// ============================================================================
+
+const meta: Meta<typeof PieChart> = {
+  component: PieChart,
+  tags: ['autodocs'],
+  title: 'Components/PieChart',
+}
+export default meta
+
+type Story = StoryObj<typeof PieChart>
+
+export const Donut: Story = {
+  decorators: [
+    () => {
+      const data = STAGE_DATA
+      const colorMap = useMemo(
+        () => buildChartColorMap(data.map((s) => s.name)),
+        [data],
+      )
+      return (
+        <div className='d-flex justify-content-center'>
+          <div>
+            <p className='text-secondary fs-small mb-3 text-center'>
+              Donut variant — inner cutout for a secondary label or count.
+            </p>
+            <PieChart
+              data={data}
+              colorMap={colorMap}
+              size={220}
+              innerRadius={50}
+            />
+          </div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const SolidPie: Story = {
+  decorators: [
+    () => {
+      const data = STAGE_DATA
+      const colorMap = useMemo(
+        () => buildChartColorMap(data.map((s) => s.name)),
+        [data],
+      )
+      return (
+        <div className='d-flex justify-content-center'>
+          <div>
+            <p className='text-secondary fs-small mb-3 text-center'>
+              Solid pie — no inner radius.
+            </p>
+            <PieChart data={data} colorMap={colorMap} size={220} />
+          </div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const TwoSlices: Story = {
+  decorators: [
+    () => {
+      const data = TWO_SLICE_DATA
+      const colorMap = useMemo(
+        () => buildChartColorMap(data.map((s) => s.name)),
+        [data],
+      )
+      return (
+        <div className='d-flex justify-content-center'>
+          <div>
+            <p className='text-secondary fs-small mb-3 text-center'>
+              Minimal case — two slices for a released vs. in-progress split.
+            </p>
+            <PieChart
+              data={data}
+              colorMap={colorMap}
+              size={200}
+              innerRadius={50}
+            />
+          </div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const ManySlices: Story = {
+  decorators: [
+    () => {
+      const data = SDK_DATA
+      const colorMap = useMemo(
+        () => buildChartColorMap(data.map((s) => s.name)),
+        [data],
+      )
+      return (
+        <div className='d-flex justify-content-center'>
+          <div>
+            <p className='text-secondary fs-small mb-3 text-center'>
+              Seven slices — stress-test of the colour palette.
+            </p>
+            <PieChart
+              data={data}
+              colorMap={colorMap}
+              size={260}
+              innerRadius={60}
+              showLegend
+            />
+          </div>
+        </div>
+      )
+    },
+  ],
+}
+
+export const WithLegend: Story = {
+  decorators: [
+    () => {
+      const data = STAGE_DATA
+      const colorMap = useMemo(
+        () => buildChartColorMap(data.map((s) => s.name)),
+        [data],
+      )
+      return (
+        <div className='d-flex justify-content-center'>
+          <div>
+            <p className='text-secondary fs-small mb-3 text-center'>
+              Legend enabled — useful when slices are many or narrow.
+            </p>
+            <PieChart
+              data={data}
+              colorMap={colorMap}
+              size={260}
+              innerRadius={60}
+              showLegend
+            />
+          </div>
+        </div>
+      )
+    },
+  ],
+}

--- a/frontend/documentation/components/_chartFakeData.ts
+++ b/frontend/documentation/components/_chartFakeData.ts
@@ -1,4 +1,4 @@
-import { ChartDataPoint } from 'components/charts/BarChart'
+import { ChartDataPoint } from 'components/charts/types'
 
 // Deterministic stand-in for Math.random — same `(label, day)` pair always
 // produces the same value, so Chromatic snapshots stay stable across runs.

--- a/frontend/documentation/components/_chartFakeData.ts
+++ b/frontend/documentation/components/_chartFakeData.ts
@@ -1,0 +1,59 @@
+import { ChartDataPoint } from 'components/charts/BarChart'
+
+// Deterministic stand-in for Math.random — same `(label, day)` pair always
+// produces the same value, so Chromatic snapshots stay stable across runs.
+const pseudoRandom = (label: string, day: number): number => {
+  let hash = 0
+  const seed = `${label}-${day}`
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i)
+    hash |= 0
+  }
+  return Math.abs(hash) / 0x7fffffff
+}
+
+// Pinned reference date — using `new Date()` would shift the x-axis daily and
+// drift every Chromatic snapshot.
+const REFERENCE_DATE = new Date('2026-04-15T00:00:00Z')
+
+export type GenerateChartFakeDataOptions = {
+  days: number
+  labels: string[]
+  baseMap?: Record<string, number>
+  defaultBase?: number
+  variance?: number
+  weekendDip?: number
+}
+
+export function generateChartFakeData({
+  baseMap = {},
+  days,
+  defaultBase = 1000,
+  labels,
+  variance = 0.35,
+  weekendDip = 0.6,
+}: GenerateChartFakeDataOptions): ChartDataPoint[] {
+  const data: ChartDataPoint[] = []
+
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(REFERENCE_DATE)
+    date.setUTCDate(date.getUTCDate() - i)
+    const dayStr = date.toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    })
+
+    const point: ChartDataPoint = { day: dayStr }
+    labels.forEach((label) => {
+      const base = baseMap[label] ?? defaultBase
+      const noise = Math.floor(pseudoRandom(label, i) * base * variance)
+      const weekday = date.getUTCDay()
+      const isWeekend = weekday === 0 || weekday === 6
+      const dip = isWeekend ? weekendDip : 1
+      point[label] = Math.floor((base + noise) * dip)
+    })
+    data.push(point)
+  }
+  return data
+}

--- a/frontend/web/components/charts/BarChart.tsx
+++ b/frontend/web/components/charts/BarChart.tsx
@@ -11,11 +11,7 @@ import {
 } from 'recharts'
 import { colorTextSecondary } from 'common/theme/tokens'
 import ChartTooltip from './ChartTooltip'
-
-export type ChartDataPoint = {
-  day: string
-  [key: string]: string | number
-}
+import { ChartDataPoint } from './types'
 
 type BarChartProps = {
   data: ChartDataPoint[]

--- a/frontend/web/components/charts/BarChart.tsx
+++ b/frontend/web/components/charts/BarChart.tsx
@@ -14,7 +14,8 @@ import ChartTooltip from './ChartTooltip'
 
 export type ChartDataPoint = {
   day: string
-} & Record<string, number>
+  [key: string]: string | number
+}
 
 type BarChartProps = {
   data: ChartDataPoint[]

--- a/frontend/web/components/charts/ChartTooltip.tsx
+++ b/frontend/web/components/charts/ChartTooltip.tsx
@@ -22,10 +22,17 @@ type ChartTooltipProps = TooltipProps<ValueType, NameType> & {
    * a seriesLabels map to render human-readable names instead.
    */
   seriesLabels?: Record<string, string>
+  /**
+   * Hide the total row at the bottom. Useful for single-entry payloads
+   * (e.g. a pie-slice hover) where the total just repeats the entry value.
+   * Default: false.
+   */
+  hideTotal?: boolean
 }
 
 const ChartTooltip: FC<ChartTooltipProps> = ({
   active,
+  hideTotal = false,
   label,
   payload,
   seriesLabels,
@@ -35,13 +42,21 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
     (sum, entry) => sum + numericValue(entry.value),
     0,
   )
+  const hasLabel =
+    label !== null && label !== undefined && String(label).length > 0
 
   return (
     <div className='bg-surface-default border-default rounded-md shadow-md py-2'>
-      <div className='px-3 py-1 fs-small fw-semibold text-default'>{label}</div>
-      <hr className='border-default my-0 mb-2' />
-      {payload.map((entry: SeriesPayload) => {
-        const key = String(entry.dataKey)
+      {hasLabel && (
+        <>
+          <div className='px-3 py-1 fs-small fw-semibold text-default'>
+            {label}
+          </div>
+          <hr className='border-default my-0 mb-2' />
+        </>
+      )}
+      {payload.map((entry: SeriesPayload, i) => {
+        const key = String(entry.name ?? entry.dataKey ?? i)
         const displayName = seriesLabels?.[key] ?? key
         return (
           <div
@@ -56,9 +71,11 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
           </div>
         )
       })}
-      <div className='border-top border-default mt-2 pt-2 px-3 fs-small fw-semibold'>
-        Total: {formatNumber(total)}
-      </div>
+      {!hideTotal && (
+        <div className='border-top border-default mt-2 pt-2 px-3 fs-small fw-semibold'>
+          Total: {formatNumber(total)}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/web/components/charts/LineChart.tsx
+++ b/frontend/web/components/charts/LineChart.tsx
@@ -1,0 +1,97 @@
+import React, { FC } from 'react'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart as RawLineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { colorTextSecondary } from 'common/theme/tokens'
+import ChartTooltip from './ChartTooltip'
+import { ChartDataPoint } from './BarChart'
+
+type LineChartProps = {
+  data: ChartDataPoint[]
+  series: string[]
+  colorMap: Record<string, string>
+  xAxisInterval?: number
+  /**
+   * Render recharts' built-in `<Legend />` below the chart. Default `false` —
+   * most consumers already expose a coloured filter UI (tags / MultiSelect)
+   * that serves the same purpose, so a second legend is redundant and can
+   * display raw dataKeys (e.g. numeric env IDs) that are meaningless to users.
+   */
+  showLegend?: boolean
+  /**
+   * Optional dataKey → display name map, threaded through to the tooltip (and
+   * the legend when enabled). Use this when dataKeys are opaque identifiers
+   * (e.g. numeric env ids) that need a human-readable label on display.
+   */
+  seriesLabels?: Record<string, string>
+}
+
+const LineChart: FC<LineChartProps> = ({
+  colorMap,
+  data,
+  series,
+  seriesLabels,
+  showLegend = false,
+  xAxisInterval = 0,
+}) => {
+  return (
+    <ResponsiveContainer height={400} width='100%'>
+      <RawLineChart data={data}>
+        <CartesianGrid strokeDasharray='3 5' strokeOpacity={0.4} />
+        <XAxis
+          dataKey='day'
+          padding='gap'
+          interval={xAxisInterval}
+          height={80}
+          angle={-90}
+          textAnchor='end'
+          tick={{ dx: -4, fill: colorTextSecondary, fontSize: 11 }}
+          tickLine={false}
+          axisLine={{ stroke: colorTextSecondary }}
+        />
+        <YAxis
+          tick={{ fill: colorTextSecondary, fontSize: 11 }}
+          axisLine={{ stroke: colorTextSecondary }}
+          tickFormatter={(value) =>
+            value >= 1000 ? `${(value / 1000).toFixed(0)}k` : value
+          }
+        />
+        <Tooltip
+          cursor={{ stroke: colorTextSecondary, strokeDasharray: '3 3' }}
+          content={<ChartTooltip seriesLabels={seriesLabels} />}
+        />
+        {showLegend && (
+          <Legend
+            wrapperStyle={{ paddingTop: 16 }}
+            formatter={(value) =>
+              seriesLabels?.[String(value)] ?? String(value)
+            }
+          />
+        )}
+        {series.map((label, index) => (
+          <Line
+            key={label}
+            type='monotone'
+            dataKey={label}
+            stroke={colorMap[label]}
+            strokeWidth={2}
+            dot={false}
+            animationBegin={index * 80}
+            animationDuration={600}
+            animationEasing='ease-out'
+          />
+        ))}
+      </RawLineChart>
+    </ResponsiveContainer>
+  )
+}
+
+LineChart.displayName = 'LineChart'
+export default LineChart

--- a/frontend/web/components/charts/LineChart.tsx
+++ b/frontend/web/components/charts/LineChart.tsx
@@ -31,6 +31,8 @@ type LineChartProps = {
    * (e.g. numeric env ids) that need a human-readable label on display.
    */
   seriesLabels?: Record<string, string>
+  /** Render vertical grid lines (one per x tick). Default `true`. */
+  verticalGrid?: boolean
 }
 
 const LineChart: FC<LineChartProps> = ({
@@ -39,12 +41,17 @@ const LineChart: FC<LineChartProps> = ({
   series,
   seriesLabels,
   showLegend = false,
+  verticalGrid = true,
   xAxisInterval = 0,
 }) => {
   return (
     <ResponsiveContainer height={400} width='100%'>
       <RawLineChart data={data}>
-        <CartesianGrid strokeDasharray='3 5' strokeOpacity={0.4} />
+        <CartesianGrid
+          strokeDasharray='3 5'
+          strokeOpacity={0.4}
+          vertical={verticalGrid}
+        />
         <XAxis
           dataKey='day'
           padding='gap'

--- a/frontend/web/components/charts/LineChart.tsx
+++ b/frontend/web/components/charts/LineChart.tsx
@@ -11,7 +11,7 @@ import {
 } from 'recharts'
 import { colorTextSecondary } from 'common/theme/tokens'
 import ChartTooltip from './ChartTooltip'
-import { ChartDataPoint } from './BarChart'
+import { ChartDataPoint } from './types'
 
 type LineChartProps = {
   data: ChartDataPoint[]

--- a/frontend/web/components/charts/PieChart.tsx
+++ b/frontend/web/components/charts/PieChart.tsx
@@ -1,0 +1,80 @@
+import React, { FC } from 'react'
+import { Cell, Legend, Pie, PieChart as RawPieChart, Tooltip } from 'recharts'
+
+export type PieSlice = {
+  name: string
+  value: number
+}
+
+type PieChartProps = {
+  data: PieSlice[]
+  /** Per-slice colour, keyed by slice `name`. */
+  colorMap: Record<string, string>
+  /** Chart dimensions in pixels. Default: 200. */
+  size?: number
+  /** Inner radius in pixels. Set `> 0` for a donut. Default: 0 (solid pie). */
+  innerRadius?: number
+  /** Outer radius in pixels. Default: derived from `size` with a small margin. */
+  outerRadius?: number
+  /** Gap between slices in degrees. Default: 2. */
+  paddingAngle?: number
+  /** Render recharts' built-in `<Legend />` below the chart. Default `false`. */
+  showLegend?: boolean
+  /** Show the hover tooltip. Default: true. */
+  showTooltip?: boolean
+  /**
+   * Optional name → display name map for legend and tooltip entries. Useful
+   * when slice names are opaque identifiers.
+   */
+  seriesLabels?: Record<string, string>
+}
+
+const PieChart: FC<PieChartProps> = ({
+  colorMap,
+  data,
+  innerRadius = 0,
+  outerRadius,
+  paddingAngle = 2,
+  seriesLabels,
+  showLegend = false,
+  showTooltip = true,
+  size = 200,
+}) => {
+  const resolvedOuter = outerRadius ?? Math.floor(size / 2) - 10
+
+  return (
+    <RawPieChart width={size} height={size}>
+      <Pie
+        data={data}
+        dataKey='value'
+        nameKey='name'
+        cx='50%'
+        cy='50%'
+        innerRadius={innerRadius}
+        outerRadius={resolvedOuter}
+        paddingAngle={paddingAngle}
+      >
+        {data.map((entry) => (
+          <Cell key={entry.name} fill={colorMap[entry.name]} />
+        ))}
+      </Pie>
+      {showTooltip && (
+        <Tooltip
+          formatter={(value: number, name: string) => [
+            value.toLocaleString(),
+            seriesLabels?.[name] ?? name,
+          ]}
+        />
+      )}
+      {showLegend && (
+        <Legend
+          wrapperStyle={{ paddingTop: 16 }}
+          formatter={(value) => seriesLabels?.[String(value)] ?? String(value)}
+        />
+      )}
+    </RawPieChart>
+  )
+}
+
+PieChart.displayName = 'PieChart'
+export default PieChart

--- a/frontend/web/components/charts/PieChart.tsx
+++ b/frontend/web/components/charts/PieChart.tsx
@@ -7,6 +7,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from 'recharts'
+import ChartTooltip from './ChartTooltip'
 
 export type PieSlice = {
   name: string
@@ -70,10 +71,7 @@ const PieChart: FC<PieChartProps> = ({
         </Pie>
         {showTooltip && (
           <Tooltip
-            formatter={(value: number, name: string) => [
-              value.toLocaleString(),
-              seriesLabels?.[name] ?? name,
-            ]}
+            content={<ChartTooltip seriesLabels={seriesLabels} hideTotal />}
           />
         )}
         {showLegend && (

--- a/frontend/web/components/charts/PieChart.tsx
+++ b/frontend/web/components/charts/PieChart.tsx
@@ -7,6 +7,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from 'recharts'
+import { colorTextSecondary } from 'common/theme/tokens'
 import ChartTooltip from './ChartTooltip'
 
 export type PieSlice = {
@@ -66,7 +67,10 @@ const PieChart: FC<PieChartProps> = ({
           paddingAngle={paddingAngle}
         >
           {data.map((entry) => (
-            <Cell key={entry.name} fill={colorMap[entry.name]} />
+            <Cell
+              key={entry.name}
+              fill={colorMap[entry.name] ?? colorTextSecondary}
+            />
           ))}
         </Pie>
         {showTooltip && (

--- a/frontend/web/components/charts/PieChart.tsx
+++ b/frontend/web/components/charts/PieChart.tsx
@@ -1,5 +1,12 @@
 import React, { FC } from 'react'
-import { Cell, Legend, Pie, PieChart as RawPieChart, Tooltip } from 'recharts'
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart as RawPieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts'
 
 export type PieSlice = {
   name: string
@@ -10,11 +17,15 @@ type PieChartProps = {
   data: PieSlice[]
   /** Per-slice colour, keyed by slice `name`. */
   colorMap: Record<string, string>
-  /** Chart dimensions in pixels. Default: 200. */
-  size?: number
+  /**
+   * Chart height in pixels. Width is fluid — the chart fills its parent's
+   * width via `<ResponsiveContainer>`. Default: 240. When `showLegend` is
+   * true, remember to reserve vertical space for the legend too.
+   */
+  height?: number
   /** Inner radius in pixels. Set `> 0` for a donut. Default: 0 (solid pie). */
   innerRadius?: number
-  /** Outer radius in pixels. Default: derived from `size` with a small margin. */
+  /** Outer radius in pixels. Default: 80. */
   outerRadius?: number
   /** Gap between slices in degrees. Default: 2. */
   paddingAngle?: number
@@ -32,47 +43,49 @@ type PieChartProps = {
 const PieChart: FC<PieChartProps> = ({
   colorMap,
   data,
+  height = 240,
   innerRadius = 0,
-  outerRadius,
+  outerRadius = 80,
   paddingAngle = 2,
   seriesLabels,
   showLegend = false,
   showTooltip = true,
-  size = 200,
 }) => {
-  const resolvedOuter = outerRadius ?? Math.floor(size / 2) - 10
-
   return (
-    <RawPieChart width={size} height={size}>
-      <Pie
-        data={data}
-        dataKey='value'
-        nameKey='name'
-        cx='50%'
-        cy='50%'
-        innerRadius={innerRadius}
-        outerRadius={resolvedOuter}
-        paddingAngle={paddingAngle}
-      >
-        {data.map((entry) => (
-          <Cell key={entry.name} fill={colorMap[entry.name]} />
-        ))}
-      </Pie>
-      {showTooltip && (
-        <Tooltip
-          formatter={(value: number, name: string) => [
-            value.toLocaleString(),
-            seriesLabels?.[name] ?? name,
-          ]}
-        />
-      )}
-      {showLegend && (
-        <Legend
-          wrapperStyle={{ paddingTop: 16 }}
-          formatter={(value) => seriesLabels?.[String(value)] ?? String(value)}
-        />
-      )}
-    </RawPieChart>
+    <ResponsiveContainer width='100%' height={height}>
+      <RawPieChart>
+        <Pie
+          data={data}
+          dataKey='value'
+          nameKey='name'
+          cx='50%'
+          cy='50%'
+          innerRadius={innerRadius}
+          outerRadius={outerRadius}
+          paddingAngle={paddingAngle}
+        >
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={colorMap[entry.name]} />
+          ))}
+        </Pie>
+        {showTooltip && (
+          <Tooltip
+            formatter={(value: number, name: string) => [
+              value.toLocaleString(),
+              seriesLabels?.[name] ?? name,
+            ]}
+          />
+        )}
+        {showLegend && (
+          <Legend
+            wrapperStyle={{ paddingTop: 16 }}
+            formatter={(value) =>
+              seriesLabels?.[String(value)] ?? String(value)
+            }
+          />
+        )}
+      </RawPieChart>
+    </ResponsiveContainer>
   )
 }
 

--- a/frontend/web/components/charts/index.ts
+++ b/frontend/web/components/charts/index.ts
@@ -1,0 +1,7 @@
+export { default as BarChart } from './BarChart'
+export type { ChartDataPoint } from './BarChart'
+export { default as LineChart } from './LineChart'
+export { default as PieChart } from './PieChart'
+export type { PieSlice } from './PieChart'
+export { default as ChartTooltip } from './ChartTooltip'
+export { buildChartColorMap } from './buildChartColorMap'

--- a/frontend/web/components/charts/index.ts
+++ b/frontend/web/components/charts/index.ts
@@ -1,7 +1,7 @@
 export { default as BarChart } from './BarChart'
-export type { ChartDataPoint } from './BarChart'
 export { default as LineChart } from './LineChart'
 export { default as PieChart } from './PieChart'
 export type { PieSlice } from './PieChart'
 export { default as ChartTooltip } from './ChartTooltip'
 export { buildChartColorMap } from './buildChartColorMap'
+export type { ChartDataPoint } from './types'

--- a/frontend/web/components/charts/types.ts
+++ b/frontend/web/components/charts/types.ts
@@ -1,0 +1,4 @@
+export type ChartDataPoint = {
+  day: string
+  [key: string]: string | number
+}

--- a/frontend/web/components/feature-page/FeatureNavTab/utils.ts
+++ b/frontend/web/components/feature-page/FeatureNavTab/utils.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { ChartDataPoint } from 'components/charts/BarChart'
+import { ChartDataPoint } from 'components/charts/types'
 import { Res } from 'common/types/responses'
 import { buildChartColorMap } from 'components/charts/buildChartColorMap'
 

--- a/frontend/web/components/modals/create-experiment/ExperimentResultsTab.tsx
+++ b/frontend/web/components/modals/create-experiment/ExperimentResultsTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
 import {
   Bar,
   BarChart,
@@ -31,6 +31,17 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
     featureName,
   })
 
+  const variantColorMap = useMemo<Record<string, string>>(() => {
+    if (!data?.variants?.length) return {}
+    const winner = data.statistics?.winner
+    return {
+      ...buildChartColorMap(
+        data.variants.map((v: { variant: string }) => v.variant),
+      ),
+      ...(winner ? { [winner]: colorTextSuccess } : {}),
+    }
+  }, [data])
+
   if (isLoading) {
     return (
       <div className='text-center'>
@@ -46,14 +57,6 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
         users use it.
       </div>
     )
-  }
-
-  const winner = data.statistics?.winner
-  const variantColorMap: Record<string, string> = {
-    ...buildChartColorMap(
-      data.variants.map((v: { variant: string }) => v.variant),
-    ),
-    ...(winner ? { [winner]: colorTextSuccess } : {}),
   }
   const chanceToWinData = data.statistics?.chance_to_win
     ? Object.entries(data.statistics.chance_to_win).map(([variant, value]) => ({

--- a/frontend/web/components/modals/create-experiment/ExperimentResultsTab.tsx
+++ b/frontend/web/components/modals/create-experiment/ExperimentResultsTab.tsx
@@ -13,6 +13,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
+import { colorTextSecondary } from 'common/theme/tokens'
 import { useGetExperimentResultsQuery } from 'common/services/useExperimentResults'
 
 const WINNER_COLOUR = 'rgba(22, 163, 74, 0.8)'
@@ -78,24 +79,28 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
         <h5 className='mb-2'>Conversion Rate (%)</h5>
         <ResponsiveContainer height={300} width='100%'>
           <BarChart data={data.variants}>
-            <CartesianGrid stroke='#EFF1F4' vertical={false} />
+            <CartesianGrid
+              strokeDasharray='3 5'
+              strokeOpacity={0.4}
+              vertical={false}
+            />
             <XAxis
               dataKey='variant'
-              tick={{ fill: '#656D7B' }}
+              tick={{ fill: colorTextSecondary }}
               tickLine={false}
-              axisLine={{ stroke: '#EFF1F4' }}
+              axisLine={{ stroke: colorTextSecondary }}
             />
             <YAxis
-              tick={{ fill: '#656D7B' }}
+              tick={{ fill: colorTextSecondary }}
               tickLine={false}
-              axisLine={{ stroke: '#EFF1F4' }}
+              axisLine={{ stroke: colorTextSecondary }}
             />
             <Tooltip cursor={{ fill: 'transparent' }} />
             <Bar dataKey='conversion_rate' barSize={40}>
               <LabelList
                 dataKey='conversion_rate'
                 position='top'
-                fill='#656D7B'
+                fill={colorTextSecondary}
                 formatter={(v: number) => `${v.toFixed(1)}%`}
               />
               {data.variants.map(
@@ -116,17 +121,21 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
         <h5 className='mb-2'>Evaluations & Conversions</h5>
         <ResponsiveContainer height={300} width='100%'>
           <BarChart data={data.variants}>
-            <CartesianGrid stroke='#EFF1F4' vertical={false} />
+            <CartesianGrid
+              strokeDasharray='3 5'
+              strokeOpacity={0.4}
+              vertical={false}
+            />
             <XAxis
               dataKey='variant'
-              tick={{ fill: '#656D7B' }}
+              tick={{ fill: colorTextSecondary }}
               tickLine={false}
-              axisLine={{ stroke: '#EFF1F4' }}
+              axisLine={{ stroke: colorTextSecondary }}
             />
             <YAxis
-              tick={{ fill: '#656D7B' }}
+              tick={{ fill: colorTextSecondary }}
               tickLine={false}
-              axisLine={{ stroke: '#EFF1F4' }}
+              axisLine={{ stroke: colorTextSecondary }}
             />
             <Tooltip cursor={{ fill: 'transparent' }} />
             <Legend />

--- a/frontend/web/components/modals/create-experiment/ExperimentResultsTab.tsx
+++ b/frontend/web/components/modals/create-experiment/ExperimentResultsTab.tsx
@@ -13,25 +13,9 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { colorTextSecondary } from 'common/theme/tokens'
+import { colorTextSecondary, colorTextSuccess } from 'common/theme/tokens'
 import { useGetExperimentResultsQuery } from 'common/services/useExperimentResults'
-
-const WINNER_COLOUR = 'rgba(22, 163, 74, 0.8)'
-const VARIANT_COLOURS = [
-  'rgba(37, 99, 235, 0.8)',
-  'rgba(234, 88, 12, 0.8)',
-  'rgba(124, 58, 237, 0.8)',
-  'rgba(8, 145, 178, 0.8)',
-  'rgba(219, 39, 119, 0.8)',
-  'rgba(220, 38, 38, 0.8)',
-  'rgba(132, 204, 22, 0.8)',
-  'rgba(245, 158, 11, 0.8)',
-]
-
-const getVariantColour = (variant: string, index: number, winner?: string) =>
-  variant === winner
-    ? WINNER_COLOUR
-    : VARIANT_COLOURS[index % VARIANT_COLOURS.length]
+import { buildChartColorMap } from 'components/charts'
 
 type ExperimentResultsTabProps = {
   environmentId: string
@@ -65,6 +49,12 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
   }
 
   const winner = data.statistics?.winner
+  const variantColorMap: Record<string, string> = {
+    ...buildChartColorMap(
+      data.variants.map((v: { variant: string }) => v.variant),
+    ),
+    ...(winner ? { [winner]: colorTextSuccess } : {}),
+  }
   const chanceToWinData = data.statistics?.chance_to_win
     ? Object.entries(data.statistics.chance_to_win).map(([variant, value]) => ({
         chance: (value as number) * 100,
@@ -103,14 +93,12 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
                 fill={colorTextSecondary}
                 formatter={(v: number) => `${v.toFixed(1)}%`}
               />
-              {data.variants.map(
-                (entry: { variant: string }, index: number) => (
-                  <Cell
-                    key={index}
-                    fill={getVariantColour(entry.variant, index, winner)}
-                  />
-                ),
-              )}
+              {data.variants.map((entry: { variant: string }) => (
+                <Cell
+                  key={entry.variant}
+                  fill={variantColorMap[entry.variant]}
+                />
+              ))}
             </Bar>
           </BarChart>
         </ResponsiveContainer>
@@ -139,8 +127,14 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
             />
             <Tooltip cursor={{ fill: 'transparent' }} />
             <Legend />
-            <Bar dataKey='evaluations' fill={VARIANT_COLOURS[0]} barSize={40} />
-            <Bar dataKey='conversions' fill={WINNER_COLOUR} barSize={40} />
+            <Bar
+              dataKey='evaluations'
+              fill={
+                variantColorMap[data.variants[0]?.variant] ?? colorTextSecondary
+              }
+              barSize={40}
+            />
+            <Bar dataKey='conversions' fill={colorTextSuccess} barSize={40} />
           </BarChart>
         </ResponsiveContainer>
       </div>
@@ -162,10 +156,10 @@ const ExperimentResultsTab: FC<ExperimentResultsTabProps> = ({
                   `${variant}: ${chance.toFixed(1)}%`
                 }
               >
-                {chanceToWinData.map((entry, index) => (
+                {chanceToWinData.map((entry) => (
                   <Cell
-                    key={index}
-                    fill={getVariantColour(entry.variant, index, winner)}
+                    key={entry.variant}
+                    fill={variantColorMap[entry.variant] ?? colorTextSecondary}
                   />
                 ))}
               </Pie>

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -4,7 +4,7 @@ import {
   ReleasePipelineStageStats,
 } from 'common/types/responses'
 import { SortOrder } from 'common/types/requests'
-import { colorTextSuccess } from 'common/theme/tokens'
+import { colorBorderDefault, colorTextSuccess } from 'common/theme/tokens'
 import PanelSearch from 'components/PanelSearch'
 import ColorSwatch from 'components/ColorSwatch'
 import Icon from 'components/icons/Icon'
@@ -177,7 +177,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
           <div
             className='d-flex flex-row align-items-center gap-2'
             style={{
-              borderTop: '1px solid #e0e0e0',
+              borderTop: `1px solid ${colorBorderDefault}`,
               marginTop: 4,
               paddingRight: 20,
               paddingTop: 8,

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -132,13 +132,15 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
           }}
         >
           {pieSlices.length > 0 ? (
-            <PieChart
-              data={pieSlices}
-              colorMap={pieColorMap}
-              size={180}
-              innerRadius={40}
-              outerRadius={75}
-            />
+            <div style={{ width: 180 }}>
+              <PieChart
+                data={pieSlices}
+                colorMap={pieColorMap}
+                height={180}
+                innerRadius={40}
+                outerRadius={75}
+              />
+            </div>
           ) : (
             <div className='text-muted fs-captionSmall'>No features yet</div>
           )}

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -6,6 +6,7 @@ import {
 import { SortOrder } from 'common/types/requests'
 import { colorTextSuccess } from 'common/theme/tokens'
 import PanelSearch from 'components/PanelSearch'
+import ColorSwatch from 'components/ColorSwatch'
 import Icon from 'components/icons/Icon'
 import { buildChartColorMap, PieChart, PieSlice } from 'components/charts'
 
@@ -150,19 +151,10 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
           {stages.map((stage) => (
             <div
               key={stage.order}
-              className='d-flex flex-row align-items-center'
+              className='d-flex flex-row align-items-center gap-2'
               style={{ paddingBottom: 6, paddingRight: 20, paddingTop: 6 }}
             >
-              <div
-                style={{
-                  background: stageColorMap[stage.stage_name],
-                  borderRadius: 3,
-                  height: 10,
-                  marginRight: 8,
-                  minWidth: 10,
-                  width: 10,
-                }}
-              />
+              <ColorSwatch color={stageColorMap[stage.stage_name]} size='md' />
               <div style={{ flex: 1 }}>
                 <span className='font-weight-medium' style={{ fontSize: 13 }}>
                   {stage.stage_name}
@@ -183,7 +175,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
             </div>
           ))}
           <div
-            className='d-flex flex-row align-items-center'
+            className='d-flex flex-row align-items-center gap-2'
             style={{
               borderTop: '1px solid #e0e0e0',
               marginTop: 4,
@@ -191,20 +183,11 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
               paddingTop: 8,
             }}
           >
-            <div
-              style={{
-                background: RELEASED_COLOUR,
-                borderRadius: 3,
-                height: 10,
-                marginRight: 8,
-                minWidth: 10,
-                width: 10,
-              }}
-            />
+            <ColorSwatch color={RELEASED_COLOUR} size='md' />
             <div style={{ flex: 1 }}>
               <span
-                className='font-weight-medium'
-                style={{ color: RELEASED_COLOUR, fontSize: 13 }}
+                className='font-weight-medium text-success'
+                style={{ fontSize: 13 }}
               >
                 Released
               </span>

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -1,5 +1,4 @@
 import { FC, useMemo, useState } from 'react'
-import { Cell, Pie, PieChart, Tooltip } from 'recharts'
 import {
   ReleasePipelineOverview,
   ReleasePipelineStageStats,
@@ -7,6 +6,7 @@ import {
 import { SortOrder } from 'common/types/requests'
 import PanelSearch from 'components/PanelSearch'
 import Icon from 'components/icons/Icon'
+import { PieChart, PieSlice } from 'components/charts'
 
 interface ReleasePipelineStatsTableProps {
   stats: ReleasePipelineOverview[]
@@ -102,15 +102,24 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
     _totalFeatures: number,
     completedFeatures: number,
   ) => {
-    // Build pie chart data for this pipeline
-    const pieData = [
-      ...stages.map((stage, idx) => ({
-        colour: stageColours[idx % stageColours.length],
+    // Build pie chart data and colour map for this pipeline
+    const pieSlices: PieSlice[] = [
+      ...stages.map((stage) => ({
         name: stage.stage_name,
         value: stage.features_in_stage,
       })),
-      { colour: releasedColour, name: 'Released', value: completedFeatures },
-    ].filter((d) => d.value > 0)
+      { name: 'Released', value: completedFeatures },
+    ].filter((s) => s.value > 0)
+
+    const pieColorMap: Record<string, string> = {
+      ...Object.fromEntries(
+        stages.map((stage, idx) => [
+          stage.stage_name,
+          stageColours[idx % stageColours.length],
+        ]),
+      ),
+      Released: releasedColour,
+    }
 
     return (
       <div
@@ -132,24 +141,14 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
             paddingLeft: 72,
           }}
         >
-          {pieData.length > 0 ? (
-            <PieChart width={180} height={180}>
-              <Pie
-                data={pieData}
-                dataKey='value'
-                nameKey='name'
-                cx='50%'
-                cy='50%'
-                innerRadius={40}
-                outerRadius={75}
-                paddingAngle={2}
-              >
-                {pieData.map((entry, idx) => (
-                  <Cell key={idx} fill={entry.colour} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
+          {pieSlices.length > 0 ? (
+            <PieChart
+              data={pieSlices}
+              colorMap={pieColorMap}
+              size={180}
+              innerRadius={40}
+              outerRadius={75}
+            />
           ) : (
             <div className='text-muted' style={{ fontSize: 12 }}>
               No features yet

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -140,9 +140,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
               outerRadius={75}
             />
           ) : (
-            <div className='text-muted' style={{ fontSize: 12 }}>
-              No features yet
-            </div>
+            <div className='text-muted fs-captionSmall'>No features yet</div>
           )}
         </div>
 
@@ -156,19 +154,19 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
             >
               <ColorSwatch color={stageColorMap[stage.stage_name]} size='md' />
               <div style={{ flex: 1 }}>
-                <span className='font-weight-medium' style={{ fontSize: 13 }}>
+                <span className='font-weight-medium fs-caption'>
                   {stage.stage_name}
                 </span>
                 <div
-                  className='text-muted'
-                  style={{ fontSize: 11, marginTop: 1 }}
+                  className='text-muted fs-captionXSmall'
+                  style={{ marginTop: 1 }}
                 >
                   {stage.trigger_description} · {stage.action_description}
                 </div>
               </div>
               <span
-                className='font-weight-medium'
-                style={{ fontSize: 13, minWidth: 90, textAlign: 'right' }}
+                className='font-weight-medium fs-caption'
+                style={{ minWidth: 90, textAlign: 'right' }}
               >
                 Features ({stage.features_in_stage})
               </span>
@@ -185,22 +183,19 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
           >
             <ColorSwatch color={RELEASED_COLOUR} size='md' />
             <div style={{ flex: 1 }}>
-              <span
-                className='font-weight-medium text-success'
-                style={{ fontSize: 13 }}
-              >
+              <span className='font-weight-medium text-success fs-caption'>
                 Released
               </span>
               <div
-                className='text-muted'
-                style={{ fontSize: 11, marginTop: 1 }}
+                className='text-muted fs-captionXSmall'
+                style={{ marginTop: 1 }}
               >
                 Features that completed this pipeline
               </div>
             </div>
             <span
-              className='font-weight-medium'
-              style={{ fontSize: 13, minWidth: 90, textAlign: 'right' }}
+              className='font-weight-medium fs-caption'
+              style={{ minWidth: 90, textAlign: 'right' }}
             >
               Features ({completedFeatures})
             </span>
@@ -240,7 +235,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   name={isExpanded ? 'chevron-down' : 'chevron-right'}
                   width={14}
                 />
-                <span className='font-weight-medium' style={{ fontSize: 13 }}>
+                <span className='font-weight-medium fs-caption'>
                   {pipeline.pipeline_name}
                 </span>
                 <span
@@ -260,18 +255,18 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                 </span>
               </div>
               <div
-                className='table-column text-muted'
-                style={{ fontSize: 13, width: 100 }}
+                className='table-column text-muted fs-caption'
+                style={{ width: 100 }}
               >
                 {pipeline.stages.length} stages
               </div>
               <div
-                className='table-column text-muted'
-                style={{ fontSize: 13, width: 100 }}
+                className='table-column text-muted fs-caption'
+                style={{ width: 100 }}
               >
                 {pipeline.total_features} features
                 {inFlightTotal > 0 && (
-                  <span style={{ fontSize: 11 }}>
+                  <span className='fs-captionXSmall'>
                     {' '}
                     ({inFlightTotal} in progress)
                   </span>
@@ -307,8 +302,8 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   />
                 </div>
                 <span
-                  className='font-weight-medium'
-                  style={{ fontSize: 12, minWidth: 52, whiteSpace: 'nowrap' }}
+                  className='font-weight-medium fs-captionSmall'
+                  style={{ minWidth: 52, whiteSpace: 'nowrap' }}
                 >
                   {pipeline.completed_features}/{pipeline.total_features}{' '}
                   released
@@ -356,23 +351,23 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   name={isExpanded ? 'chevron-down' : 'chevron-right'}
                   width={14}
                 />
-                <span className='font-weight-medium' style={{ fontSize: 13 }}>
+                <span className='font-weight-medium fs-caption'>
                   {project.project_name}
                 </span>
-                <span className='text-muted' style={{ fontSize: 12 }}>
+                <span className='text-muted fs-captionSmall'>
                   ({projectPipelineCount}{' '}
                   {projectPipelineCount === 1 ? 'pipeline' : 'pipelines'})
                 </span>
               </div>
               <div
-                className='table-column text-muted'
-                style={{ fontSize: 13, width: 120 }}
+                className='table-column text-muted fs-caption'
+                style={{ width: 120 }}
               >
                 {projectFeatures} features
               </div>
               <div
-                className='table-column font-weight-medium'
-                style={{ color: '#27AB95', fontSize: 13, width: 120 }}
+                className='table-column font-weight-medium text-success fs-caption'
+                style={{ width: 120 }}
               >
                 {projectReleased} released
               </div>
@@ -386,7 +381,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
 
   return (
     <div>
-      <div className='text-muted mb-3' style={{ fontSize: 13, paddingLeft: 4 }}>
+      <div className='text-muted mb-3 fs-caption' style={{ paddingLeft: 4 }}>
         {projectsWithPipelines} of {totalProjects} projects use release
         pipelines ({adoptionPct}%)
       </div>
@@ -452,14 +447,14 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   </span>
                 </div>
                 <div
-                  className='table-column font-weight-medium'
-                  style={{ fontSize: 13, width: 120 }}
+                  className='table-column font-weight-medium fs-caption'
+                  style={{ width: 120 }}
                 >
                   {org.pipeline_count}
                 </div>
                 <div
-                  className='table-column font-weight-medium'
-                  style={{ fontSize: 13, width: 120 }}
+                  className='table-column font-weight-medium fs-caption'
+                  style={{ width: 120 }}
                 >
                   {org.total_features}
                 </div>
@@ -467,13 +462,10 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   className='table-column d-flex align-items-center'
                   style={{ gap: 8, width: 120 }}
                 >
-                  <span
-                    className='font-weight-medium'
-                    style={{ color: '#27AB95', fontSize: 13 }}
-                  >
+                  <span className='font-weight-medium text-success fs-caption'>
                     {org.total_released}
                   </span>
-                  <span className='text-muted' style={{ fontSize: 12 }}>
+                  <span className='text-muted fs-captionSmall'>
                     ({releasedPct}%)
                   </span>
                 </div>

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -4,24 +4,17 @@ import {
   ReleasePipelineStageStats,
 } from 'common/types/responses'
 import { SortOrder } from 'common/types/requests'
+import { colorTextSuccess } from 'common/theme/tokens'
 import PanelSearch from 'components/PanelSearch'
 import Icon from 'components/icons/Icon'
-import { PieChart, PieSlice } from 'components/charts'
+import { buildChartColorMap, PieChart, PieSlice } from 'components/charts'
 
 interface ReleasePipelineStatsTableProps {
   stats: ReleasePipelineOverview[]
   totalProjects: number
 }
 
-const stageColours = [
-  '#6C63FF',
-  '#0AADDF',
-  '#FF9F43',
-  '#E74C3C',
-  '#9B59B6',
-  '#3498DB',
-]
-const releasedColour = '#27AB95'
+const RELEASED_COLOUR = colorTextSuccess
 
 type OrgRow = {
   organisation_id: number
@@ -111,14 +104,10 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
       { name: 'Released', value: completedFeatures },
     ].filter((s) => s.value > 0)
 
+    const stageColorMap = buildChartColorMap(stages.map((s) => s.stage_name))
     const pieColorMap: Record<string, string> = {
-      ...Object.fromEntries(
-        stages.map((stage, idx) => [
-          stage.stage_name,
-          stageColours[idx % stageColours.length],
-        ]),
-      ),
-      Released: releasedColour,
+      ...stageColorMap,
+      Released: RELEASED_COLOUR,
     }
 
     return (
@@ -158,7 +147,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
 
         {/* Stage list */}
         <div style={{ flex: 1 }}>
-          {stages.map((stage, idx) => (
+          {stages.map((stage) => (
             <div
               key={stage.order}
               className='d-flex flex-row align-items-center'
@@ -166,7 +155,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
             >
               <div
                 style={{
-                  background: stageColours[idx % stageColours.length],
+                  background: stageColorMap[stage.stage_name],
                   borderRadius: 3,
                   height: 10,
                   marginRight: 8,
@@ -204,7 +193,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
           >
             <div
               style={{
-                background: releasedColour,
+                background: RELEASED_COLOUR,
                 borderRadius: 3,
                 height: 10,
                 marginRight: 8,
@@ -215,7 +204,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
             <div style={{ flex: 1 }}>
               <span
                 className='font-weight-medium'
-                style={{ color: releasedColour, fontSize: 13 }}
+                style={{ color: RELEASED_COLOUR, fontSize: 13 }}
               >
                 Released
               </span>

--- a/frontend/web/components/pages/admin-dashboard/components/UsageTrendsChart.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/UsageTrendsChart.tsx
@@ -1,80 +1,54 @@
-import { FC } from 'react'
-import {
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
+import { FC, useMemo } from 'react'
 import moment from 'moment'
 import { UsageTrend } from 'common/types/responses'
-import Utils from 'common/utils/utils'
 import Card from 'components/Card'
+import {
+  buildChartColorMap,
+  ChartDataPoint,
+  LineChart,
+} from 'components/charts'
 
 interface UsageTrendsChartProps {
   trends: UsageTrend[]
   days?: number
 }
 
+const SERIES = ['api_calls', 'flag_evaluations', 'identity_requests'] as const
+
+const SERIES_LABELS: Record<string, string> = {
+  api_calls: 'API Calls',
+  flag_evaluations: 'Flag Evaluations',
+  identity_requests: 'Identity Requests',
+}
+
 const UsageTrendsChart: FC<UsageTrendsChartProps> = ({ days = 30, trends }) => {
-  const chartData = trends.map((trend) => ({
-    ...trend,
-    date: moment(trend.date).format('MMM DD'),
-  }))
+  const data = useMemo<ChartDataPoint[]>(
+    () =>
+      trends.map(
+        (trend) =>
+          ({
+            api_calls: trend.api_calls,
+            day: moment(trend.date).format('MMM DD'),
+            flag_evaluations: trend.flag_evaluations,
+            identity_requests: trend.identity_requests,
+          } as unknown as ChartDataPoint),
+      ),
+    [trends],
+  )
+
+  const colorMap = useMemo(() => buildChartColorMap([...SERIES]), [])
 
   return (
     <Card className='shadow p-4'>
       <h5 className='mb-4 mt-2'>API Usage Trends (Last {days} Days)</h5>
-      <div style={{ height: 340, marginTop: 16 }}>
-        <ResponsiveContainer width='100%' height='100%'>
-          <LineChart
-            data={chartData}
-            margin={{ bottom: 10, left: 10, right: 10, top: 10 }}
-          >
-            <CartesianGrid strokeDasharray='3 3' />
-            <XAxis
-              dataKey='date'
-              tick={{ fontSize: 12 }}
-              interval='preserveStartEnd'
-            />
-            <YAxis
-              tickFormatter={(value: number) => Utils.numberWithCommas(value)}
-              tick={{ fontSize: 12 }}
-            />
-            <Tooltip
-              formatter={(value: number) => Utils.numberWithCommas(value)}
-            />
-            <Legend />
-            <Line
-              type='monotone'
-              dataKey='api_calls'
-              name='API Calls'
-              stroke='#0AADDF'
-              strokeWidth={2}
-              dot={false}
-            />
-            <Line
-              type='monotone'
-              dataKey='flag_evaluations'
-              name='Flag Evaluations'
-              stroke='#27AB95'
-              strokeWidth={2}
-              dot={false}
-            />
-            <Line
-              type='monotone'
-              dataKey='identity_requests'
-              name='Identity Requests'
-              stroke='#FF9F43'
-              strokeWidth={2}
-              dot={false}
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+      <LineChart
+        data={data}
+        series={[...SERIES]}
+        colorMap={colorMap}
+        seriesLabels={SERIES_LABELS}
+        xAxisInterval={2}
+        showLegend
+      />
     </Card>
   )
 }

--- a/frontend/web/components/pages/admin-dashboard/components/UsageTrendsChart.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/UsageTrendsChart.tsx
@@ -24,15 +24,12 @@ const SERIES_LABELS: Record<string, string> = {
 const UsageTrendsChart: FC<UsageTrendsChartProps> = ({ days = 30, trends }) => {
   const data = useMemo<ChartDataPoint[]>(
     () =>
-      trends.map(
-        (trend) =>
-          ({
-            api_calls: trend.api_calls,
-            day: moment(trend.date).format('MMM DD'),
-            flag_evaluations: trend.flag_evaluations,
-            identity_requests: trend.identity_requests,
-          } as unknown as ChartDataPoint),
-      ),
+      trends.map((trend) => ({
+        api_calls: trend.api_calls,
+        day: moment(trend.date).format('MMM DD'),
+        flag_evaluations: trend.flag_evaluations,
+        identity_requests: trend.identity_requests,
+      })),
     [trends],
   )
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6889. Adds `<LineChart>` and `<PieChart>` alongside the existing `<BarChart>`, migrates the last three raw-recharts consumers, and makes their dark-mode bugs go away in the process.

### New shared components

| Component | API shape |
|---|---|
| `<LineChart>` | Mirrors `<BarChart>`: `data`, `series`, `colorMap`, `xAxisInterval`, `showLegend`, `seriesLabels`, `verticalGrid`. Monotone lines, no dots. Token-based axis / grid colours via `colorTextSecondary`. |
| `<PieChart>` | Pie/donut wrapper: `data` (`{name, value}[]`), `colorMap` keyed by slice name, `height`, `innerRadius` (set `> 0` for donut), `outerRadius`, `paddingAngle`, `showLegend`, `showTooltip`. Width flows from the parent (uses `<ResponsiveContainer>` — same pattern as `<BarChart>` / `<LineChart>`). |
| `components/charts/index.ts` | Barrel export. Consumers can now do `import { BarChart, LineChart, PieChart } from 'components/charts'`. |

### ChartDataPoint type fix

Replaced the broken `{ day: string } & Record<string, number>` intersection (which forced consumers to use `as unknown as ChartDataPoint` double-casts) with a proper index signature: `{ day: string; [key: string]: string | number }`. Drops the cast in `UsageTrendsChart.tsx` and makes the type honest for future consumers.

### Shared tooltip

All three chart components now render the same `<ChartTooltip>`. `<PieChart>` passes `hideTotal` because a single-slice hover makes "Total: X" equal to the slice's own value — redundant. Bar / line charts keep the Total row.

Dropped `<PieChart>`'s original default-recharts tooltip path (white box, dark text, not theme-aware) — with `_recharts.scss` going away via #7223, the default tooltip is no longer themed.

### Storybook stories

Added `LineChart.stories.tsx` and `PieChart.stories.tsx` following the pattern from `BarChart.stories.tsx` — deterministic pseudo-random fake data, pinned reference date (Chromatic-safe), `buildChartColorMap` for colour assignment.

All three chart stories now live under a **Components/Charts/** umbrella in the Storybook sidebar (previously scattered under `Components/`).

- **LineChart stories:** `UsageTrends` (3 metrics), `SingleLine`, `ManyLines` (7-line palette stress test).
- **PieChart stories:** `Donut`, `SolidPie`, `TwoSlices`, `ManySlices`, `WithLegend`.

### Consumer migrations

| File | How |
|---|---|
| `UsageTrendsChart.tsx` (admin dashboard) | Full migration to `<LineChart>`. Drops 3 hardcoded stroke colours (`#0AADDF` / `#27AB95` / `#FF9F43`) in favour of the shared chart palette. |
| `ReleasePipelineStatsTable.tsx` (admin dashboard) | Full migration to `<PieChart>` plus a design-system pass: stage palette now uses `buildChartColorMap`, `Released` uses `colorTextSuccess`, legend swatches are `<ColorSwatch>` components, inline `fontSize` replaced with `.fs-caption` / `.fs-captionSmall` / `.fs-captionXSmall`, `color: '#27AB95'` replaced with `.text-success` utility. |
| `ExperimentResultsTab.tsx` (legacy v1 experiments) | **Token replacement only** — not migrated to shared components. This file uses `variant` as x-axis and per-cell bar colouring, which doesn't match the shared `<BarChart>` API. Rather than expand the shared API for one legacy caller, replaces the hardcoded `#EFF1F4` / `#656D7B` with `colorTextSecondary`. Still fixes the dark-mode concern. |

### Related PRs

- **#7215** — earlier migration (`FeatureAnalytics.tsx`) that introduced `<BarChart>`, `ChartTooltip`, `buildChartColorMap`, and the token foundation.
- **#7223** — in-flight migration of `OrganisationUsage` + `SingleSDKLabelsChart` to `<BarChart>`. This PR is net-additive to #7223; no overlap in files. Either PR can merge first.

After #7223 and this PR merge, `recharts` has **zero raw consumers** outside of the `components/charts/` wrappers and the legacy `ExperimentResultsTab.tsx` (retained until Experiments v2 replaces it).

### Out of scope

- **Chart palette dark-mode a11y.** Chromatic's axe-core flagged contrast issues on the dark-mode `--color-chart-N` overrides (`400/300/200` shades in `_tokens.scss`). Not a per-chart bug — fixing is a single token-level edit that cascades to every chart consumer. Parked; low-severity (graphical, dark-mode only, admin surfaces).
- **Non-chart inline styles in `ReleasePipelineStatsTable.tsx`** — Published/Draft pill, progress-bar semantic colours, row backgrounds, layout widths/padding. Real design-system cleanup but not chart-related.
- **Extracting shared primitives (`<ChartContainer>`, `<ChartAxes>`).** Internal duplication across the three wrappers is small; revisit if it becomes painful.
- **`<AreaChart>` / `<ScatterChart>` / `<RadialBarChart>`** — no consumers today.
- **Full migration of `ExperimentResultsTab.tsx`** — legacy v1 code, will be deleted when Experiments v2 ships.

## How did you test this code?

- **App, light + dark mode:**
  - Admin dashboard → API Usage Trends → confirmed 3 lines render correctly, legend reads as "API Calls / Flag Evaluations / Identity Requests"
  - Admin dashboard → Release Pipelines → expanded a pipeline, confirmed the donut renders with the same stage colours as the accompanying stage list, legend uses `<ColorSwatch>`
  - Experiment results modal → confirmed axis labels visible in dark mode (previously invisible against dark background)
- **Storybook:** `npm run storybook` → browsed all LineChart and PieChart variants under `Components/Charts/`. Chromatic-safe (deterministic data + pinned date).
- **Types:** `npm run typecheck` — no new errors in any of the touched files.
- **Lint:** `npx eslint --fix` on all modified / added files — clean.

