### PR TITLE
fix(Billing): Free trial buttons stop working after toggling yearly/monthly

### DIFF
--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -68,6 +68,7 @@ jobs:
           e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           environment: prod
+          tests: --grep "@oss|@enterprise|@saas"
 
   deploy-production:
     name: Deploy to Vercel Production

--- a/.github/workflows/frontend-test-staging.yml
+++ b/.github/workflows/frontend-test-staging.yml
@@ -21,3 +21,4 @@ jobs:
           e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           environment: staging
+          tests: --grep "@oss|@enterprise|@saas"

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -601,6 +601,9 @@ E2E_NON_ADMIN_USER_WITH_A_ROLE = (
     f"e2e_non_admin_user_with_a_role@{E2E_TEST_EMAIL_DOMAIN}"
 )
 E2E_SEPARATE_TEST_USER = f"e2e_separate_test_user@{E2E_TEST_EMAIL_DOMAIN}"
+# User on a Free-plan organisation, used by the Billing tab E2E tests
+# that need to exercise the "no active subscription" payment flow.
+E2E_BILLING_USER = f"e2e_billing_user@{E2E_TEST_EMAIL_DOMAIN}"
 #  Identity for E2E segment tests
 E2E_IDENTITY = "test-identity"
 

--- a/api/e2etests/e2e_seed_data.py
+++ b/api/e2etests/e2e_seed_data.py
@@ -59,6 +59,7 @@ def teardown() -> None:
         user_email=settings.E2E_NON_ADMIN_USER_WITH_A_ROLE
     )
     delete_user_and_its_organisations(user_email=settings.E2E_SEPARATE_TEST_USER)
+    delete_user_and_its_organisations(user_email=settings.E2E_BILLING_USER)
 
 
 def seed_data() -> None:
@@ -107,6 +108,17 @@ def seed_data() -> None:
         password=PASSWORD,
     )
     separate_test_user.add_organisation(separate_org, OrganisationRole.ADMIN)
+
+    # Billing-tab tests need an organisation on a Free plan (no
+    # `subscription_id`) so PaymentButton renders the Chargebee DOM-scan
+    # branch. The default Subscription created by Organisation's AFTER_CREATE
+    # hook already matches — leave it untouched.
+    billing_org: Organisation = Organisation.objects.create(name="E2E Billing Org")
+    billing_user: FFAdminUser = FFAdminUser.objects.create_user(  # type: ignore[no-untyped-call]
+        email=settings.E2E_BILLING_USER,
+        password=PASSWORD,
+    )
+    billing_user.add_organisation(billing_org, OrganisationRole.ADMIN)
 
     # We add different projects and environments to give each e2e test its own isolated context.
     project_test_data = [

--- a/frontend/e2e/config.ts
+++ b/frontend/e2e/config.ts
@@ -10,6 +10,7 @@ export const E2E_NON_ADMIN_USER_WITH_ENV_PERMISSIONS = `e2e_non_admin_user_with_
 export const E2E_NON_ADMIN_USER_WITH_A_ROLE = `e2e_non_admin_user_with_a_role@${E2E_EMAIL_DOMAIN}`
 export const E2E_CHANGE_MAIL = `e2e_change_email@${E2E_EMAIL_DOMAIN}`
 export const E2E_SEPARATE_TEST_USER = `e2e_separate_test_user@${E2E_EMAIL_DOMAIN}`
+export const E2E_BILLING_USER = `e2e_billing_user@${E2E_EMAIL_DOMAIN}`
 export const PASSWORD = 'Str0ngp4ssw0rd!'
 export const E2E_TEST_IDENTITY = 'test-identity'
 

--- a/frontend/e2e/tests/billing-test.pw.ts
+++ b/frontend/e2e/tests/billing-test.pw.ts
@@ -69,7 +69,7 @@ test.describe('Billing', () => {
     await click(byId('org-settings-link'))
     await click(byId('billing'))
 
-    const trialButton = () =>
+    const getTrialButton = () =>
       page
         .locator('button[data-cb-type="checkout"]')
         .filter({ hasText: '14 Day Free Trial' })
@@ -77,7 +77,7 @@ test.describe('Billing', () => {
     const toggle = page.getByRole('switch').first()
 
     log('Confirm free-trial button is wired in yearly mode')
-    const yearlyButton = trialButton()
+    const yearlyButton = getTrialButton()
     await yearlyButton.waitFor({ state: 'visible' })
     const yearlyPlanId = await yearlyButton.getAttribute('data-cb-plan-id')
     expect(yearlyPlanId).toBeTruthy()
@@ -88,7 +88,7 @@ test.describe('Billing', () => {
 
     log('Toggle to Monthly and click the free-trial button')
     await toggle.click()
-    const monthlyButton = trialButton()
+    const monthlyButton = getTrialButton()
     await monthlyButton.waitFor({ state: 'visible' })
     const monthlyPlanId = await monthlyButton.getAttribute('data-cb-plan-id')
     expect(monthlyPlanId).toBeTruthy()
@@ -102,7 +102,7 @@ test.describe('Billing', () => {
 
     log('Toggle back to Yearly and click the free-trial button')
     await toggle.click()
-    const yearlyButtonAgain = trialButton()
+    const yearlyButtonAgain = getTrialButton()
     await yearlyButtonAgain.waitFor({ state: 'visible' })
     expect(await yearlyButtonAgain.getAttribute('data-cb-plan-id')).toBe(
       yearlyPlanId,

--- a/frontend/e2e/tests/billing-test.pw.ts
+++ b/frontend/e2e/tests/billing-test.pw.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../test-setup'
-import { byId, log, createHelpers, getFlagsmith } from '../helpers'
+import { byId, log, createHelpers } from '../helpers'
 import { E2E_USER, PASSWORD } from '../config'
 
 declare global {
@@ -9,21 +9,10 @@ declare global {
 }
 
 test.describe('Billing', () => {
-  test('Free trial buttons stay wired after toggling between yearly and monthly @enterprise', async ({
+  test('Free trial buttons stay wired after toggling between yearly and monthly @saas', async ({
     page,
   }) => {
     const { click, login, waitForElementVisible } = createHelpers(page)
-
-    const flagsmith = await getFlagsmith()
-    if (
-      !flagsmith.hasFeature('payments_enabled') ||
-      !flagsmith.hasFeature('rtk_payment_modal_migration')
-    ) {
-      log(
-        'Skipping: requires payments_enabled and rtk_payment_modal_migration flags',
-      )
-      return
-    }
 
     // Serve an empty Chargebee bundle so useScript resolves without pulling
     // the real library from Chargebee's CDN.

--- a/frontend/e2e/tests/billing-test.pw.ts
+++ b/frontend/e2e/tests/billing-test.pw.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../test-setup'
 import { byId, log, createHelpers } from '../helpers'
-import { E2E_USER, PASSWORD } from '../config'
+import { E2E_BILLING_USER, PASSWORD } from '../config'
 
 declare global {
   interface Window {
@@ -60,7 +60,7 @@ test.describe('Billing', () => {
     })
 
     log('Login')
-    await login(E2E_USER, PASSWORD)
+    await login(E2E_BILLING_USER, PASSWORD)
 
     log('Navigate to Billing tab')
     await waitForElementVisible(byId('organisation-link'))

--- a/frontend/e2e/tests/billing-test.pw.ts
+++ b/frontend/e2e/tests/billing-test.pw.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '../test-setup'
+import { byId, log, createHelpers, getFlagsmith } from '../helpers'
+import { E2E_USER, PASSWORD } from '../config'
+
+declare global {
+  interface Window {
+    __cbCheckoutClicks: Array<string | null>
+  }
+}
+
+test.describe('Billing', () => {
+  test('Free trial buttons stay wired after toggling between yearly and monthly @enterprise', async ({
+    page,
+  }) => {
+    const { click, login, waitForElementVisible } = createHelpers(page)
+
+    const flagsmith = await getFlagsmith()
+    if (
+      !flagsmith.hasFeature('payments_enabled') ||
+      !flagsmith.hasFeature('rtk_payment_modal_migration')
+    ) {
+      log(
+        'Skipping: requires payments_enabled and rtk_payment_modal_migration flags',
+      )
+      return
+    }
+
+    // Serve an empty Chargebee bundle so useScript resolves without pulling
+    // the real library from Chargebee's CDN.
+    await page.route('**/js.chargebee.com/**/chargebee.js*', (route) =>
+      route.fulfill({
+        body: '',
+        contentType: 'application/javascript',
+        status: 200,
+      }),
+    )
+
+    // Stub window.Chargebee with a minimal implementation of the DOM-scan
+    // contract: registerAgain() binds a click handler to every
+    // [data-cb-type="checkout"] element that records the plan id.
+    // This is what the real library does — we record instead of opening a
+    // hosted checkout so the test can observe whether the button is wired.
+    await page.addInitScript(() => {
+      window.__cbCheckoutClicks = []
+      const registerAgain = () => {
+        document
+          .querySelectorAll<HTMLElement>('[data-cb-type="checkout"]')
+          .forEach((element) => {
+            const marker = '__cbBound'
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if ((element as any)[marker]) return
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(element as any)[marker] = true
+            element.addEventListener('click', (event) => {
+              event.preventDefault()
+              window.__cbCheckoutClicks.push(
+                element.getAttribute('data-cb-plan-id'),
+              )
+            })
+          })
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).Chargebee = {
+        getInstance: () => ({
+          openCheckout: () => {},
+          setCheckoutCallbacks: () => {},
+        }),
+        init: () => {},
+        registerAgain,
+      }
+    })
+
+    log('Login')
+    await login(E2E_USER, PASSWORD)
+
+    log('Navigate to Billing tab')
+    await waitForElementVisible(byId('organisation-link'))
+    await click(byId('organisation-link'))
+    await waitForElementVisible(byId('org-settings-link'))
+    await click(byId('org-settings-link'))
+    await click(byId('billing'))
+
+    const trialButton = () =>
+      page
+        .locator('button[data-cb-type="checkout"]')
+        .filter({ hasText: '14 Day Free Trial' })
+        .first()
+    const toggle = page.getByRole('switch').first()
+
+    log('Confirm free-trial button is wired in yearly mode')
+    const yearlyButton = trialButton()
+    await yearlyButton.waitFor({ state: 'visible' })
+    const yearlyPlanId = await yearlyButton.getAttribute('data-cb-plan-id')
+    expect(yearlyPlanId).toBeTruthy()
+    await yearlyButton.click()
+    await expect
+      .poll(() => page.evaluate(() => window.__cbCheckoutClicks))
+      .toEqual([yearlyPlanId])
+
+    log('Toggle to Monthly and click the free-trial button')
+    await toggle.click()
+    const monthlyButton = trialButton()
+    await monthlyButton.waitFor({ state: 'visible' })
+    const monthlyPlanId = await monthlyButton.getAttribute('data-cb-plan-id')
+    expect(monthlyPlanId).toBeTruthy()
+    expect(monthlyPlanId).not.toBe(yearlyPlanId)
+    await monthlyButton.click()
+    // Before the fix, registerAgain is not called after the toggle, so the
+    // remounted button has no click handler and nothing is recorded.
+    await expect
+      .poll(() => page.evaluate(() => window.__cbCheckoutClicks))
+      .toEqual([yearlyPlanId, monthlyPlanId])
+
+    log('Toggle back to Yearly and click the free-trial button')
+    await toggle.click()
+    const yearlyButtonAgain = trialButton()
+    await yearlyButtonAgain.waitFor({ state: 'visible' })
+    expect(await yearlyButtonAgain.getAttribute('data-cb-plan-id')).toBe(
+      yearlyPlanId,
+    )
+    await yearlyButtonAgain.click()
+    await expect
+      .poll(() => page.evaluate(() => window.__cbCheckoutClicks))
+      .toEqual([yearlyPlanId, monthlyPlanId, yearlyPlanId])
+  })
+})

--- a/frontend/web/components/modals/payment/Payment.tsx
+++ b/frontend/web/components/modals/payment/Payment.tsx
@@ -19,7 +19,7 @@ import {
 } from './constants'
 import { useScript } from 'common/hooks/useScript'
 import { usePaymentState } from './hooks'
-import { initChargebee } from './chargebee'
+import { bindChargebeeButtons } from './chargebee'
 
 export type PaymentProps = {
   isDisableAccountText?: string
@@ -42,7 +42,7 @@ export const Payment: FC<PaymentProps> = ({
 
   useEffect(() => {
     if (ready && !error) {
-      initChargebee({ isPaymentsEnabled })
+      bindChargebeeButtons({ isPaymentsEnabled })
     }
   }, [ready, error, isPaymentsEnabled, yearly])
 

--- a/frontend/web/components/modals/payment/Payment.tsx
+++ b/frontend/web/components/modals/payment/Payment.tsx
@@ -44,7 +44,7 @@ export const Payment: FC<PaymentProps> = ({
     if (ready && !error) {
       initChargebee({ isPaymentsEnabled })
     }
-  }, [ready, error, isPaymentsEnabled])
+  }, [ready, error, isPaymentsEnabled, yearly])
 
   if (isAWS) {
     return (

--- a/frontend/web/components/modals/payment/chargebee.ts
+++ b/frontend/web/components/modals/payment/chargebee.ts
@@ -8,30 +8,34 @@ type InitChargebeeParams = {
 }
 
 export const initChargebee = ({ isPaymentsEnabled }: InitChargebeeParams) => {
-  if (initialised || !Project.chargebee?.site) return
+  if (!Project.chargebee?.site) return
 
-  Chargebee.init({ site: Project.chargebee.site })
-  Chargebee.registerAgain()
-  firstpromoter()
-  Chargebee.getInstance().setCheckoutCallbacks?.(() => ({
-    success: (hostedPageId: string) => {
-      AppActions.updateSubscription(hostedPageId)
-    },
-  }))
+  if (!initialised) {
+    Chargebee.init({ site: Project.chargebee.site })
+    firstpromoter()
+    Chargebee.getInstance().setCheckoutCallbacks?.(() => ({
+      success: (hostedPageId: string) => {
+        AppActions.updateSubscription(hostedPageId)
+      },
+    }))
 
-  // Handle plan cookie from signup flow
-  const planId = API.getCookie('plan')
-  if (planId && isPaymentsEnabled) {
-    const link = document.createElement('a')
-    link.setAttribute('data-cb-type', 'checkout')
-    link.setAttribute('data-cb-plan-id', planId)
-    link.setAttribute('href', '#')
-    document.body.appendChild(link)
-    Chargebee.registerAgain()
-    link.click()
-    document.body.removeChild(link)
-    API.setCookie('plan', null)
+    const planId = API.getCookie('plan')
+    if (planId && isPaymentsEnabled) {
+      const link = document.createElement('a')
+      link.setAttribute('data-cb-type', 'checkout')
+      link.setAttribute('data-cb-plan-id', planId)
+      link.setAttribute('href', '#')
+      document.body.appendChild(link)
+      Chargebee.registerAgain()
+      link.click()
+      document.body.removeChild(link)
+      API.setCookie('plan', null)
+    }
+
+    initialised = true
   }
 
-  initialised = true
+  // Re-scan the DOM so buttons rendered after the initial mount
+  // (e.g. after toggling the yearly/monthly switch) get wired up.
+  Chargebee.registerAgain()
 }

--- a/frontend/web/components/modals/payment/chargebee.ts
+++ b/frontend/web/components/modals/payment/chargebee.ts
@@ -3,35 +3,42 @@ import firstpromoter from 'project/firstPromoter'
 
 let initialised = false
 
-type InitChargebeeParams = {
+type BindChargebeeButtonsParams = {
   isPaymentsEnabled: boolean
 }
 
-export const initChargebee = ({ isPaymentsEnabled }: InitChargebeeParams) => {
+const initChargebee = ({
+  isPaymentsEnabled,
+}: BindChargebeeButtonsParams) => {
+  Chargebee.init({ site: Project.chargebee.site })
+  firstpromoter()
+  Chargebee.getInstance().setCheckoutCallbacks?.(() => ({
+    success: (hostedPageId: string) => {
+      AppActions.updateSubscription(hostedPageId)
+    },
+  }))
+
+  const planId = API.getCookie('plan')
+  if (planId && isPaymentsEnabled) {
+    const link = document.createElement('a')
+    link.setAttribute('data-cb-type', 'checkout')
+    link.setAttribute('data-cb-plan-id', planId)
+    link.setAttribute('href', '#')
+    document.body.appendChild(link)
+    Chargebee.registerAgain()
+    link.click()
+    document.body.removeChild(link)
+    API.setCookie('plan', null)
+  }
+}
+
+export const bindChargebeeButtons = ({
+  isPaymentsEnabled,
+}: BindChargebeeButtonsParams) => {
   if (!Project.chargebee?.site) return
 
   if (!initialised) {
-    Chargebee.init({ site: Project.chargebee.site })
-    firstpromoter()
-    Chargebee.getInstance().setCheckoutCallbacks?.(() => ({
-      success: (hostedPageId: string) => {
-        AppActions.updateSubscription(hostedPageId)
-      },
-    }))
-
-    const planId = API.getCookie('plan')
-    if (planId && isPaymentsEnabled) {
-      const link = document.createElement('a')
-      link.setAttribute('data-cb-type', 'checkout')
-      link.setAttribute('data-cb-plan-id', planId)
-      link.setAttribute('href', '#')
-      document.body.appendChild(link)
-      Chargebee.registerAgain()
-      link.click()
-      document.body.removeChild(link)
-      API.setCookie('plan', null)
-    }
-
+    initChargebee({ isPaymentsEnabled })
     initialised = true
   }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith-private/issues/122

On the organisation Billing tab, the "14 Day Free Trial" buttons only work on first page load in Yearly mode. Toggling to Monthly — or back to Yearly — leaves the buttons inert.

Chargebee binds click handlers to `[data-cb-type="checkout"]` elements when `Chargebee.registerAgain()` scans the DOM. `initChargebee` was guarded by a one-shot `initialised` flag, so `registerAgain()` only ran once. The toggle in `Payment.tsx` remounts `PaymentButton` (its `key` is the `data-cb-plan-id`), and the freshly rendered buttons never get wired up.

Fix: keep the one-time work (`Chargebee.init`, first-promoter, checkout callbacks, plan-cookie flow) behind the `initialised` guard, split it out as `initChargebee`, and have the new exported `bindChargebeeButtons` call `Chargebee.registerAgain()` on every entry. Add `yearly` to the effect's dependency array so the scan re-runs after the toggle.

Also adds a new `@saas` E2E marker for SaaS-only tests (billing, trials, payments), wired into the staging and production E2E runs, and a dedicated `e2e_billing_user` seeded on a Free-plan organisation so the trial-button path under test is actually reachable.

## How did you test this code?

Added `frontend/e2e/tests/billing-test.pw.ts` (tagged `@saas`). It logs in as `e2e_billing_user`, stubs `window.Chargebee` via `addInitScript` so `registerAgain()` records which `data-cb-plan-id` is clicked, and asserts the trial button fires a checkout in yearly → monthly → yearly order. Without the fix the second click records nothing; with the fix all three are recorded.

Ran the test manually against real Vercel deployments:

- **`staging.flagsmith.com` (main, unfixed)** — test fails at the expected assertion. Yearly click records `startup-annual-v2`, toggle to monthly, click records nothing: `["startup-annual-v2"]` vs expected `["startup-annual-v2", "startup-v2"]`. Bug reproduced.
- **PR's Vercel staging preview (this branch, fixed)** — test passes end to end: login, billing tab, toggle yearly → monthly → yearly, all three clicks recorded. 6.6s.

Manual smoke in-browser: billing tab, click "14 Day Free Trial" in yearly (opens checkout), toggle to monthly and click (opens checkout), toggle back to yearly and click (opens checkout).

## Follow-up

Hooking `@saas` tests up to run against Vercel PR previews on every PR (not just staging/prod deploys) will come in a separate PR — it needs a workflow that waits for the Vercel preview to finish and passes its URL to the composite E2E action, which is out of scope for this bug fix.