### PR TITLE
test(Billing): Post-deploy E2E does not include plans

### DIFF
--- a/frontend/env/project_staging.js
+++ b/frontend/env/project_staging.js
@@ -16,6 +16,10 @@ const Project = {
   flagsmithClientEdgeAPI: 'https://edge.bullet-train-staging.win/api/v1/',
   // This is used for Sentry tracking
   maintenance: false,
+  plans: {
+    scaleUp: { annual: 'Scale-Up-v4-USD-Yearly', monthly: 'Scale-Up-v4-USD-Monthly' },
+    startup: { annual: 'startup-annual-v2', monthly: 'startup-v2' },
+  },
   useSecureCookies: true,
   ...(_globalThis.projectOverrides || {}),
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #7335. The post-API-deploy E2E run (triggered by `.reusable-deploy-ecs.yml` with `environment: staging`) failed on the new `@saas` billing test because `frontend/env/project_staging.js` was missing the `plans` field — `PaymentButton` is gated on `chargebeePlanId` being truthy, so the trial buttons never rendered.

The Vercel-deployed `staging.flagsmith.com` wasn't affected because the `flagsmith-frontend-staging` Vercel project bundles with `ENV=dev`, so it inherits the plan IDs from `project_dev.js`. The asymmetry was silent until the `@saas` test started exercising that path.

Copy the same plan IDs into `project_staging.js` so staging-ENV bundles render the trial buttons. `project_prod.js` already carries its own `plans` block (different `startup.annual` ID because the prod Chargebee tenant has a different catalogue) — no changes needed there.

## How did you test this code?

- Re-running the post-API-deploy E2E (or any `ENV=staging` bundle) will now render the trial buttons rather than hiding them.
- Ran the `@saas` billing test locally against `staging.flagsmith.com` on main and against the PR preview for #7335 — both passed pre-merge because those builds use `ENV=dev`. This change brings the staging-ENV bundle to parity.