### PR TITLE
fix: properly display error message with html

### DIFF
--- a/frontend/web/components/pages/IntegrationsPage.tsx
+++ b/frontend/web/components/pages/IntegrationsPage.tsx
@@ -79,7 +79,11 @@ const IntegrationsPage: FC = () => {
                 )}
               </div>
             ) : (
-              <div>{Constants.projectPermissions(ProjectPermission.ADMIN)}</div>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: Constants.projectPermissions(ProjectPermission.ADMIN),
+                }}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- use `dangerouslySetInnerHtml` to render (internal) error message with html

## How did you test this code?
**Before**
<img width="2464" height="134" alt="image" src="https://github.com/user-attachments/assets/f76e4928-944e-4438-a723-cd44632c10b3" />

**After**
<img width="2560" height="300" alt="image" src="https://github.com/user-attachments/assets/b0d0be52-bbed-458c-84e2-6dfc605a021a" />
