### PR TITLE
fix: render all top-level segment rules in the UI instead

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -78,13 +78,11 @@ type CreateSegmentType = {
 type CreateSegmentError = {
   status: number
   data: {
-    rules: [
-      {
-        rules: Array<{
-          conditions: SegmentConditionsError[]
-        }>
-      },
-    ]
+    rules: Array<{
+      rules: Array<{
+        conditions: SegmentConditionsError[]
+      }>
+    }>
   }
 }
 
@@ -227,7 +225,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
     newValue: SegmentRule,
   ) => {
     const newRules = cloneDeep(rules)
-    newRules[0].rules[elementNumber] = newValue
+    newRules[rulesIndex].rules[elementNumber] = newValue
     setRules(newRules)
   }
 
@@ -336,10 +334,11 @@ const CreateSegment: FC<CreateSegmentType> = ({
     return () => setInterceptClose(null)
   }, [onClosing])
   const isValid = useMemo(() => {
-    if (!rules[0]?.rules?.find((v) => !v.delete)) {
+    const allSubRules = rules.flatMap((r) => r.rules)
+    if (!allSubRules.find((v) => !v.delete)) {
       return false
     }
-    const res = rules[0].rules.find((v) =>
+    const res = allSubRules.find((v) =>
       v.conditions.find((c) => !Utils.validateRule(c)),
     )
     return !res
@@ -400,38 +399,42 @@ const CreateSegment: FC<CreateSegmentType> = ({
     }
     return warnings
   }, [operators, rules])
-  //Find any non-deleted rules
-  const hasNoRules = !rules[0]?.rules?.find((v) => !v.delete)
-  const rulesToShow = rules[0].rules.filter((v) => !v.delete)
+  const allSubRules = rules.flatMap((r) => r.rules)
+  const hasNoRules = !allSubRules.find((v) => !v.delete)
+  const rulesToShow = allSubRules.filter((v) => !v.delete)
   const rulesEl = (
     <div className='overflow-visible'>
       <div>
         <div className='mb-4'>
-          {rules[0].rules.map((rule, i) => {
-            if (rule.delete || !operators) {
-              return null
-            }
-            const displayIndex = rulesToShow.indexOf(rule)
-            return (
-              <div key={i}>
-                <SegmentRuleDivider rule={rule} index={displayIndex} />
-                <Rule
-                  showDescription={showDescriptions}
-                  readOnly={readOnly}
-                  data-test={`rule-${displayIndex}`}
-                  rule={rule}
-                  index={i}
-                  operators={operators}
-                  onChange={(v: SegmentRule) => {
-                    setValueChanged(true)
-                    updateRule(0, i, v)
-                  }}
-                  errors={error?.data?.rules?.[0]?.rules?.[i]?.conditions}
-                  projectId={projectId}
-                />
-              </div>
-            )
-          })}
+          {rules.map((topRule, rulesIndex) =>
+            topRule.rules.map((rule, i) => {
+              if (rule.delete || !operators) {
+                return null
+              }
+              const displayIndex = rulesToShow.indexOf(rule)
+              return (
+                <div key={`${rulesIndex}-${i}`}>
+                  <SegmentRuleDivider rule={rule} index={displayIndex} />
+                  <Rule
+                    showDescription={showDescriptions}
+                    readOnly={readOnly}
+                    data-test={`rule-${displayIndex}`}
+                    rule={rule}
+                    index={i}
+                    operators={operators}
+                    onChange={(v: SegmentRule) => {
+                      setValueChanged(true)
+                      updateRule(rulesIndex, i, v)
+                    }}
+                    errors={
+                      error?.data?.rules?.[rulesIndex]?.rules?.[i]?.conditions
+                    }
+                    projectId={projectId}
+                  />
+                </div>
+              )
+            }),
+          )}
         </div>
         {hasNoRules && (
           <InfoMessage>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Closes #7254 

- Removed the hardcoded `*rules[0]` to properly deal with multiple top level rules

⚠️ Backend modification were overkill and might have required migrating all existing rules with multiple top level rules

## How did you test this code?
1. Create a segment with multiple top-level rules
```
  curl -s -X POST http://localhost:8000/api/v1/projects/1/segments/ \
    -H "Authorization: Token <YOUR_API_TOKEN>" \
    -H "Content-Type: application/json" \
    -d '{
    "name": "Multi-rule test segment",
    "description": "Testing multiple top-level rules render in the UI",
    "project": 1,
    "rules": [
      {
        "type": "ALL",
        "conditions": [],
        "rules": [
          {
            "type": "ANY",
            "conditions": [
              { "operator": "EQUAL", "property": "country", "value": "GB" },
              { "operator": "EQUAL", "property": "country", "value": "FR" }
            ],
            "rules": []
          }
        ]
      },
      {
        "type": "ALL",
        "conditions": [],
        "rules": [
          {
            "type": "NONE",
            "conditions": [
              { "operator": "EQUAL", "property": "is_bot", "value": "true" }
            ],
            "rules": []
          },
          {
            "type": "ANY",
            "conditions": [
              { "operator": "GREATER_THAN", "property": "age", "value": "18" }
            ],
            "rules": []
          }
        ]
      }
    ]
  }'
```
2. Verify in the UI

Open the segment in the dashboard. You should see all 3 rule cards:
- "Any of the following" — country = GB, country = FR
- "And none of the following" — is_bot = true
- "And any of the following" — age > 18

  3. Before the fix

Only the first rule card (country GB/FR) was visible. The other two were silently hidden

**Before fix**
<img width="1272" height="673" alt="image" src="https://github.com/user-attachments/assets/f878a1fc-7c8d-462b-8004-c9a53176a483" />

**After fix**
<img width="1198" height="668" alt="image" src="https://github.com/user-attachments/assets/b1654ab3-d9d0-44bc-b24b-13b59b58cc92" />
