### PR TITLE
fix(Mappers): Env document includes feature-specific segments with no FeatureSegment in env

### DIFF
--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -425,6 +425,65 @@ def test_map_environment_to_engine__multiple_segments_and_versions__returns_expe
     assert segment_featurestate.uuid not in segment_feature_state_uuids
 
 
+def test_map_environment_to_engine__feature_specific_segment_not_in_env__excludes_segment(
+    environment: Environment,
+    feature: "Feature",
+    feature_specific_segment: Segment,
+) -> None:
+    # Given
+    # `feature_specific_segment` has no `FeatureSegment` pointing at it
+    # in this environment, so it has no evaluation path here.
+
+    # When
+    result = engine.map_environment_to_engine(environment)
+
+    # Then
+    segment_ids = [s.id for s in result.project.segments]
+    assert feature_specific_segment.id not in segment_ids
+
+
+def test_map_environment_to_engine__feature_specific_segment_in_env__includes_segment(
+    environment: Environment,
+    feature: "Feature",
+    feature_specific_segment: Segment,
+) -> None:
+    # Given
+    feature_segment = FeatureSegment.objects.create(
+        feature=feature,
+        segment=feature_specific_segment,
+        environment=environment,
+    )
+    FeatureState.objects.create(
+        feature_segment=feature_segment,
+        feature=feature,
+        environment=environment,
+    )
+
+    # When
+    result = engine.map_environment_to_engine(environment)
+
+    # Then
+    segment_ids = [s.id for s in result.project.segments]
+    assert feature_specific_segment.id in segment_ids
+
+
+def test_map_environment_to_engine__project_wide_segment_not_in_env__includes_segment(
+    environment: Environment,
+    segment: Segment,
+) -> None:
+    # Given
+    # `segment` is a project-wide segment (Segment.feature_id IS NULL)
+    # with no `FeatureSegment` in this environment. Project-wide segments
+    # must remain in the environment document regardless.
+
+    # When
+    result = engine.map_environment_to_engine(environment)
+
+    # Then
+    segment_ids = [s.id for s in result.project.segments]
+    assert segment.id in segment_ids
+
+
 def test_map_environment_api_key_to_engine__valid_key__returns_expected_model(
     environment: Environment,
     environment_api_key: "EnvironmentAPIKey",

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -211,10 +211,6 @@ def map_environment_to_engine(
         ps for ps in project.segments.all() if ps.id == ps.version_of_id
     ]
 
-    project_segment_rules_by_segment_id: Dict[
-        int,
-        Iterable["SegmentRule"],
-    ] = {segment.pk: segment.rules.all() for segment in project_segments}
     project_segment_feature_states_by_segment_id = _get_segment_feature_states(
         project_segments,
         environment.pk,
@@ -229,6 +225,19 @@ def map_environment_to_engine(
             else []
         ),
     )
+    # Drop feature-specific segments that have no FeatureSegment in this
+    # environment — without one, they have no evaluation path here, and
+    # their rules only inflate the environment document.
+    project_segments = [
+        ps
+        for ps in project_segments
+        if ps.feature_id is None
+        or project_segment_feature_states_by_segment_id.get(ps.pk)
+    ]
+    project_segment_rules_by_segment_id: Dict[
+        int,
+        Iterable["SegmentRule"],
+    ] = {segment.pk: segment.rules.all() for segment in project_segments}
     environment_feature_states: List["FeatureState"] = _get_prioritised_feature_states(
         [
             feature_state


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7333

`map_environment_to_engine` loaded every canonical project segment into every environment document, including feature-specific segments (`Segment.feature_id IS NOT NULL`) that had no `FeatureSegment` pointing at them in that environment. `_get_segment_feature_states` already env-scopes each segment's feature-states list, so those segments ended up as `{id, name, rules, feature_states: []}` — but their `rules` payload stayed, and that's what drove per-env document size.

After computing the per-env feature-states dict, drop feature-specific segments with no entry in it. Project-wide segments (`feature_id IS NULL`) remain unfiltered.

Feature-specific segments are schema-scoped to one feature and reach evaluation only via `FeatureSegment(feature=F, segment=S, environment=E)`. If no such row exists for env E, S has no evaluation path in E.

On one project we measured (178 envs, substantial feature-level targeting), this drops per-env feature-specific-segment count from ~8,270 to ~46 — large enough to fit a project that currently overflows DynamoDB's 400 KB `BatchWriteItem` limit.

## How did you test this code?

Red-green TDD:

- `test_map_environment_to_engine__feature_specific_segment_not_in_env__excludes_segment` — feature-specific segment with no `FeatureSegment` in the env is dropped from the document.
- `test_map_environment_to_engine__feature_specific_segment_in_env__includes_segment` — feature-specific segment with a `FeatureSegment` in the env is retained.
- `test_map_environment_to_engine__project_wide_segment_not_in_env__includes_segment` — project-wide segments remain in the document regardless.

Full mapper test suite passes (25/25); `make typecheck` clean.