### PR TITLE
fix(GitLab): Webhook registration fails with NoReverseMatch in task processor

### DIFF
--- a/api/integrations/gitlab/services/webhooks.py
+++ b/api/integrations/gitlab/services/webhooks.py
@@ -3,7 +3,6 @@ import uuid
 
 import requests
 import structlog
-from django.urls import reverse
 
 from core.helpers import get_current_site_url
 from features.feature_external_resources.models import (
@@ -18,11 +17,6 @@ from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
 from integrations.gitlab.services.url_parsing import parse_project_path
 
 logger = structlog.get_logger("gitlab")
-
-
-def _get_webhook_url(webhook_uuid: uuid.UUID) -> str:
-    path = reverse("api-v1:gitlab-webhook", kwargs={"webhook_uuid": str(webhook_uuid)})
-    return f"{get_current_site_url()}{path}"
 
 
 def has_live_resource_for_path(
@@ -83,7 +77,7 @@ def ensure_webhook_registered(
             instance_url=config.gitlab_instance_url,
             access_token=config.access_token,
             project_path=project_path,
-            hook_url=_get_webhook_url(webhook_uuid),
+            hook_url=f"{get_current_site_url()}/api/v1/gitlab-webhook/{webhook_uuid}/",
             secret=secret,
         )
     except requests.RequestException as exc:

--- a/api/tests/unit/integrations/gitlab/test_webhooks.py
+++ b/api/tests/unit/integrations/gitlab/test_webhooks.py
@@ -1,6 +1,9 @@
+import uuid
+
 import pytest
 import requests
 import responses
+from django.urls import resolve
 from pytest_mock import MockerFixture
 from pytest_structlog import StructuredLogCapture
 
@@ -15,6 +18,19 @@ from integrations.gitlab.services.webhooks import (
     ensure_webhook_registered,
 )
 from integrations.gitlab.tasks import register_gitlab_webhook
+from integrations.gitlab.views import gitlab_webhook
+
+
+def test_gitlab_webhook_url__expected_path__resolves_to_webhook_view() -> None:
+    # Given
+    webhook_uuid = uuid.uuid4()
+
+    # When
+    match = resolve(f"/api/v1/gitlab-webhook/{webhook_uuid}/")
+
+    # Then
+    assert match.func is gitlab_webhook
+    assert match.kwargs == {"webhook_uuid": webhook_uuid}
 
 
 @pytest.mark.django_db

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -239,7 +239,7 @@ Attributes:
 ### `gitlab.webhook.deregistered`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services/webhooks.py:152`
+ - `api/integrations/gitlab/services/webhooks.py:146`
 
 Attributes:
  - `gitlab.hook.id`
@@ -250,7 +250,7 @@ Attributes:
 ### `gitlab.webhook.deregistration_failed`
 
 Logged at `warning` from:
- - `api/integrations/gitlab/services/webhooks.py:145`
+ - `api/integrations/gitlab/services/webhooks.py:139`
 
 Attributes:
  - `exc_info`
@@ -262,7 +262,7 @@ Attributes:
 ### `gitlab.webhook.registered`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services/webhooks.py:105`
+ - `api/integrations/gitlab/services/webhooks.py:99`
 
 Attributes:
  - `gitlab.hook.id`
@@ -274,7 +274,7 @@ Attributes:
 ### `gitlab.webhook.registration_failed`
 
 Logged at `error` from:
- - `api/integrations/gitlab/services/webhooks.py:90`
+ - `api/integrations/gitlab/services/webhooks.py:84`
 
 Attributes:
  - `exc_info`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7345

The `api-v1` URL namespace is only registered when `TASK_PROCESSOR_MODE` is false (see `api/app/urls.py`), so `reverse("api-v1:gitlab-webhook", ...)` raised `NoReverseMatch` from `ensure_webhook_registered` when called inside the `register_gitlab_webhook` task — causing webhook registration to fail in production.

Webhook URL is now built directly at the single call site where it's needed, removing the dependency on the namespaced URL resolver. Added a unit test that resolves `/api/v1/gitlab-webhook/<uuid>/` back to the `gitlab_webhook` view to guard against route drift.

## How did you test this code?

- `make test opts='tests/unit/integrations/gitlab/test_webhooks.py'` — all 6 tests pass, including the new route-resolution test.
- `make lint` and `make typecheck` pass.