### PR TITLE
fix(GitLab): GitLab webhooks not reaching our API

### DIFF
--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -145,7 +145,10 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[typ
 
     def perform_create(self, serializer: FeatureExternalResourceSerializer) -> None:  # type: ignore[override]
         resource = serializer.save()
-        dispatch_vcs_on_resource_create(resource)
+        dispatch_vcs_on_resource_create(
+            resource,
+            api_base_url=self.request.build_absolute_uri("/"),
+        )
 
     def perform_destroy(self, instance: FeatureExternalResource) -> None:
         super().perform_destroy(instance)

--- a/api/integrations/gitlab/services/webhooks.py
+++ b/api/integrations/gitlab/services/webhooks.py
@@ -1,10 +1,10 @@
 import secrets
 import uuid
+from urllib.parse import urljoin
 
 import requests
 import structlog
 
-from core.helpers import get_current_site_url
 from features.feature_external_resources.models import (
     GITLAB_RESOURCE_TYPES,
     FeatureExternalResource,
@@ -33,7 +33,11 @@ def has_live_resource_for_path(
     return any(parse_project_path(url) == project_path for url in urls)
 
 
-def register_gitlab_webhook_for_resource(resource: FeatureExternalResource) -> None:
+def register_gitlab_webhook_for_resource(
+    resource: FeatureExternalResource,
+    *,
+    api_base_url: str,
+) -> None:
     from integrations.gitlab.tasks import register_gitlab_webhook
 
     project_path = parse_project_path(resource.url)
@@ -41,7 +45,9 @@ def register_gitlab_webhook_for_resource(resource: FeatureExternalResource) -> N
         project=resource.feature.project,
     ).first()
     if config is not None and project_path is not None:
-        register_gitlab_webhook.delay(args=(config.id, project_path))
+        register_gitlab_webhook.delay(
+            args=(config.id, project_path, api_base_url),
+        )
 
 
 def deregister_gitlab_webhook_for_resource(resource: FeatureExternalResource) -> None:
@@ -58,6 +64,8 @@ def deregister_gitlab_webhook_for_resource(resource: FeatureExternalResource) ->
 def ensure_webhook_registered(
     config: GitLabConfiguration,
     project_path: str,
+    *,
+    api_base_url: str,
 ) -> GitLabWebhook:
     existing: GitLabWebhook | None = GitLabWebhook.objects.filter(
         gitlab_configuration=config,
@@ -77,7 +85,10 @@ def ensure_webhook_registered(
             instance_url=config.gitlab_instance_url,
             access_token=config.access_token,
             project_path=project_path,
-            hook_url=f"{get_current_site_url()}/api/v1/gitlab-webhook/{webhook_uuid}/",
+            hook_url=urljoin(
+                api_base_url,
+                f"/api/v1/gitlab-webhook/{webhook_uuid}/",
+            ),
             secret=secret,
         )
     except requests.RequestException as exc:

--- a/api/integrations/gitlab/tasks.py
+++ b/api/integrations/gitlab/tasks.py
@@ -28,7 +28,11 @@ logger = structlog.get_logger("gitlab")
 
 
 @register_task_handler()
-def register_gitlab_webhook(config_id: int, project_path: str) -> None:
+def register_gitlab_webhook(
+    config_id: int,
+    project_path: str,
+    api_base_url: str,
+) -> None:
     """Register a webhook for the GitLab project at ``project_path`` under this
     config. Dispatched at link time. Idempotent.
     """
@@ -39,7 +43,7 @@ def register_gitlab_webhook(config_id: int, project_path: str) -> None:
         )
     except GitLabConfiguration.DoesNotExist:
         return
-    ensure_webhook_registered(config, project_path)
+    ensure_webhook_registered(config, project_path, api_base_url=api_base_url)
 
 
 @register_task_handler()

--- a/api/integrations/vcs/services.py
+++ b/api/integrations/vcs/services.py
@@ -16,12 +16,19 @@ from integrations.gitlab import tasks as gitlab_tasks
 gitlab_logger = structlog.get_logger("gitlab")
 
 
-def dispatch_vcs_on_resource_create(resource: FeatureExternalResource) -> None:
+def dispatch_vcs_on_resource_create(
+    resource: FeatureExternalResource,
+    *,
+    api_base_url: str,
+) -> None:
     """Dispatch integration side-effects after a `FeatureExternalResource`
     is created.
     """
     if resource.type in GITLAB_RESOURCE_TYPES:
-        gitlab.register_gitlab_webhook_for_resource(resource)
+        gitlab.register_gitlab_webhook_for_resource(
+            resource,
+            api_base_url=api_base_url,
+        )
         gitlab.apply_initial_tag(resource)
         gitlab_tasks.apply_gitlab_label.delay(args=(resource.id,))
         gitlab_tasks.post_gitlab_linked_comment.delay(args=(resource.id,))

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -5,7 +5,6 @@ from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from core.helpers import get_current_site_url
 from features.feature_external_resources.models import FeatureExternalResource
 from features.models import Feature
 from integrations.github.models import GithubConfiguration
@@ -202,7 +201,7 @@ def test_create_external_resource__gitlab_issue__registers_webhook_and_tags_feat
     hook_call, *_ = responses.calls
     assert hook_call.request.headers["PRIVATE-TOKEN"] == "glpat-test-token"
     assert json.loads(hook_call.request.body) == {
-        "url": f"{get_current_site_url()}/api/v1/gitlab-webhook/{webhook.uuid}/",
+        "url": f"http://testserver/api/v1/gitlab-webhook/{webhook.uuid}/",
         "token": webhook.secret,
         "issues_events": True,
         "merge_requests_events": True,

--- a/api/tests/unit/integrations/gitlab/test_webhooks.py
+++ b/api/tests/unit/integrations/gitlab/test_webhooks.py
@@ -48,7 +48,11 @@ def test_ensure_webhook_registered__gitlab_http_error__logs_and_raises(
 
     # When / Then
     with pytest.raises(requests.RequestException):
-        ensure_webhook_registered(gitlab_config, "testorg/testrepo")
+        ensure_webhook_registered(
+            gitlab_config,
+            "testorg/testrepo",
+            api_base_url="https://api.flagsmith.example.com/",
+        )
 
     assert log.events == [
         {
@@ -80,7 +84,11 @@ def test_register_gitlab_webhook_task__config_missing__noop(
     log: StructuredLogCapture,
 ) -> None:
     # Given / When
-    register_gitlab_webhook(config_id=999_999, project_path="testorg/testrepo")
+    register_gitlab_webhook(
+        config_id=999_999,
+        project_path="testorg/testrepo",
+        api_base_url="https://api.flagsmith.example.com/",
+    )
 
     # Then
     assert not GitLabWebhook.objects.exists()

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -193,7 +193,7 @@ Attributes:
 ### `gitlab.label.removal_failed`
 
 Logged at `exception` from:
- - `api/integrations/gitlab/tasks.py:185`
+ - `api/integrations/gitlab/tasks.py:189`
 
 Attributes:
  - `feature.id`
@@ -205,7 +205,7 @@ Attributes:
 ### `gitlab.label.removed`
 
 Logged at `info` from:
- - `api/integrations/gitlab/tasks.py:183`
+ - `api/integrations/gitlab/tasks.py:187`
 
 Attributes:
  - `feature.id`
@@ -217,7 +217,7 @@ Attributes:
 ### `gitlab.resource.linked`
 
 Logged at `info` from:
- - `api/integrations/vcs/services.py:28`
+ - `api/integrations/vcs/services.py:35`
 
 Attributes:
  - `feature.id`
@@ -228,7 +228,7 @@ Attributes:
 ### `gitlab.resource.unlinked`
 
 Logged at `info` from:
- - `api/integrations/vcs/services.py:63`
+ - `api/integrations/vcs/services.py:70`
 
 Attributes:
  - `feature.id`
@@ -239,7 +239,7 @@ Attributes:
 ### `gitlab.webhook.deregistered`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services/webhooks.py:146`
+ - `api/integrations/gitlab/services/webhooks.py:157`
 
 Attributes:
  - `gitlab.hook.id`
@@ -250,7 +250,7 @@ Attributes:
 ### `gitlab.webhook.deregistration_failed`
 
 Logged at `warning` from:
- - `api/integrations/gitlab/services/webhooks.py:139`
+ - `api/integrations/gitlab/services/webhooks.py:150`
 
 Attributes:
  - `exc_info`
@@ -262,7 +262,7 @@ Attributes:
 ### `gitlab.webhook.registered`
 
 Logged at `info` from:
- - `api/integrations/gitlab/services/webhooks.py:99`
+ - `api/integrations/gitlab/services/webhooks.py:110`
 
 Attributes:
  - `gitlab.hook.id`
@@ -274,7 +274,7 @@ Attributes:
 ### `gitlab.webhook.registration_failed`
 
 Logged at `error` from:
- - `api/integrations/gitlab/services/webhooks.py:84`
+ - `api/integrations/gitlab/services/webhooks.py:95`
 
 Attributes:
  - `exc_info`


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/7355

Fix our API URL in GitLab webhooks so they actually point to the API.

## How did you test this code?

I will once in production.