### PR TITLE
Make segment deletion task idempotent

### DIFF
--- a/api/segments/tasks.py
+++ b/api/segments/tasks.py
@@ -11,7 +11,10 @@ from segments.models import Segment
 
 @register_task_handler()
 def delete_segment(segment_id: int) -> None:
-    Segment.objects.get(pk=segment_id).delete()
+    try:
+        Segment.objects.get(pk=segment_id).delete()
+    except Segment.DoesNotExist:
+        pass
 
 
 @register_task_handler()

--- a/api/tests/unit/segments/test_unit_segments_tasks.py
+++ b/api/tests/unit/segments/test_unit_segments_tasks.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from segments.models import Segment
+from segments.tasks import delete_segment
+
+
+def test_delete_segment__existing_segment__deletes_segment(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    segment_id = 1
+    segment = Mock()
+    get_segment_mock = mocker.patch.object(Segment.objects, "get", return_value=segment)
+
+    # When
+    delete_segment(segment_id)
+
+    # Then
+    get_segment_mock.assert_called_once_with(pk=segment_id)
+    segment.delete.assert_called_once_with()
+
+
+@pytest.mark.django_db
+def test_delete_segment__missing_segment__does_not_raise(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    segment_id = 1
+    get_segment_mock = mocker.patch.object(
+        Segment.objects, "get", side_effect=Segment.DoesNotExist
+    )
+
+    # When
+    delete_segment(segment_id)
+
+    # Then
+    get_segment_mock.assert_called_once_with(pk=segment_id)


### PR DESCRIPTION
### Summary

- Make `segments.tasks.delete_segment` ignore already-deleted/missing segments by catching `Segment.DoesNotExist`
- Add focused unit tests for existing segment deletion and missing segment no-op behavior

Fixes #7354.

### Testing

- `git diff --check origin/main..HEAD`
- `poetry run pytest tests/unit/segments/test_unit_segments_tasks.py -q`
- `poetry run ruff format segments/tasks.py tests/unit/segments/test_unit_segments_tasks.py --check`
- `poetry run ruff check segments/tasks.py tests/unit/segments/test_unit_segments_tasks.py`