### PR TITLE
feat: hide and show pylon on user login events

### DIFF
--- a/frontend/common/loadChat.ts
+++ b/frontend/common/loadChat.ts
@@ -62,9 +62,20 @@ function setupPylon() {
   }
 }
 
+function hidePylon() {
+  if (typeof window.Pylon !== 'undefined') {
+    window.Pylon('hideChatBubble')
+  }
+}
+
 export function identifyChatUser() {
   if (flagsmith.hasFeature('pylon_chat') && !isFreePlan()) {
     setupPylon()
+    if (typeof window.Pylon !== 'undefined') {
+      window.Pylon('showChatBubble')
+    }
+  } else {
+    hidePylon()
   }
 }
 

--- a/frontend/common/loadChat.ts
+++ b/frontend/common/loadChat.ts
@@ -62,7 +62,7 @@ function setupPylon() {
   }
 }
 
-function hidePylon() {
+export function hidePylon() {
   if (typeof window.Pylon !== 'undefined') {
     window.Pylon('hideChatBubble')
   }

--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -13,6 +13,7 @@ import { sortBy } from 'lodash'
 import Project from 'common/project'
 import { getStore } from 'common/store'
 import { setSelectedOrganisationId } from 'common/selectedOrganisationSlice'
+import { hidePylon, identifyChatUser } from 'common/loadChat'
 import { service } from 'common/service'
 import { getBuildVersion } from 'common/services/useBuildVersion'
 import { createOnboardingSupportOptIn } from 'common/services/useOnboardingSupportOptIn'
@@ -312,6 +313,7 @@ const controller = {
     store.organisation = find(store.model.organisations, { id })
     getStore().dispatch(setSelectedOrganisationId(id))
     store.changed()
+    identifyChatUser()
   },
 
   setToken: (token) => {
@@ -373,6 +375,7 @@ const controller = {
       ).finally(() => {
         API.setCookie('t', '')
         data.setToken(null)
+        hidePylon()
         API.reset().finally(() => {
           store.model = user
           store.organisation = null


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Logging in with a paid account then logging out and in with a free user would keep the bubble chat visible. As well as the opposite way.

- Make the visibility reactive by calling `identifyChatUser` when switching org and logging out

## How did you test this code?
Steps to reproduce:
- Login with a paid account
- Logout (pylon was still visible)

