### PR TITLE
fix: improve GitHub installation completion page

### DIFF
--- a/frontend/web/components/pages/GitHubSetupPage.tsx
+++ b/frontend/web/components/pages/GitHubSetupPage.tsx
@@ -283,7 +283,10 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
           </Button>
         </>
       ) : (
-        <h1>Installation Completed</h1>
+        <div className='text-center py-5'>
+          <h1 className='mb-3'>GitHub installation completed!</h1>
+          <p className='text-muted'>You can close this window.</p>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Simplify the GitHub App installation completion view for popup usage
- Show the emphasised message "GitHub installation completed!" with a smaller close-window hint

## Testing
- git diff --check

Closes #7143