### PR TITLE
fix(tabs): consolidate isDirty marker and decouple URL sync from Tabs

### DIFF
--- a/frontend/common/hooks/useTabUrlSync.ts
+++ b/frontend/common/hooks/useTabUrlSync.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react'
+import { useHistory } from 'react-router-dom'
+
+const slugify = (label: string): string =>
+  label.toLowerCase().replace(/ /g, '-')
+
+// Keeps a tab index in sync with a URL search param. Returns
+// `[index, setIndex]` for use as the `value`/`onChange` of `<Tabs>`.
+//
+// Pass the labels in the same order the TabItems are rendered. The hook
+// slugifies them (lowercase, spaces → hyphens) so URLs stay readable.
+//
+// Falls back to `window.history.replaceState` when called outside a Router
+// — modals open via `openModal` mount in a separate `createRoot` and lose
+// Router context, so `useHistory()` returns undefined there.
+export function useTabUrlSync(
+  paramName: string,
+  labels: string[],
+): [number, (next: number) => void] {
+  const history = useHistory()
+
+  const param = new URLSearchParams(window.location.search).get(paramName)
+  let index = 0
+  if (param) {
+    const matched = labels.findIndex((label) => slugify(label) === param)
+    if (matched !== -1) index = matched
+  }
+
+  const setIndex = useCallback(
+    (next: number) => {
+      const search = new URLSearchParams(window.location.search)
+      search.set(paramName, slugify(labels[next]))
+      const target = {
+        pathname: window.location.pathname,
+        search: search.toString(),
+      }
+      if (history) {
+        history.replace(target)
+      } else {
+        window.history.replaceState(
+          null,
+          '',
+          `${target.pathname}?${target.search}`,
+        )
+      }
+    },
+    // labels is intentionally stringified — consumers pass new array refs
+    // each render, but we only care if the slug list actually changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [history, paramName, labels.join('|')],
+  )
+
+  return [index, setIndex]
+}

--- a/frontend/documentation/components/Tabs.stories.tsx
+++ b/frontend/documentation/components/Tabs.stories.tsx
@@ -50,3 +50,27 @@ export const PillTheme: Story = {
     </Tabs>
   ),
 }
+
+export const WithDirtyMarker: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Set `isDirty` on a `TabItem` to show an unsaved-changes badge next to its label. The badge sits inside an inline-flex wrapper so it never breaks onto a second line and stays vertically aligned with the label.',
+      },
+    },
+  },
+  render: () => (
+    <Tabs uncontrolled>
+      <TabItem tabLabel='Value' isDirty>
+        <p className='mt-3'>This tab has unsaved changes.</p>
+      </TabItem>
+      <TabItem tabLabel='Segment Overrides' isDirty>
+        <p className='mt-3'>This tab also has unsaved changes.</p>
+      </TabItem>
+      <TabItem tabLabel='Settings'>
+        <p className='mt-3'>No unsaved changes here.</p>
+      </TabItem>
+    </Tabs>
+  ),
+}

--- a/frontend/documentation/components/Tabs.stories.tsx
+++ b/frontend/documentation/components/Tabs.stories.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import type { Meta, StoryObj } from 'storybook'
 
 import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
 import { withRouter } from './_decorators'
 
 const meta: Meta = {
@@ -49,6 +50,79 @@ export const PillTheme: Story = {
       </TabItem>
     </Tabs>
   ),
+}
+
+export const HideNavOnSingleTab: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass `hideNavOnSingleTab` so the tab bar collapses to nothing when only one TabItem is rendered (e.g. after permission or plan filtering removes the others). Avoids showing a single, useless tab button.',
+      },
+    },
+  },
+  render: () => (
+    <Tabs hideNavOnSingleTab uncontrolled>
+      <TabItem tabLabel='Permissions'>
+        <p className='mt-3'>
+          Tab nav is hidden because there is only one TabItem.
+        </p>
+      </TabItem>
+    </Tabs>
+  ),
+}
+
+const URL_SYNC_LABELS = ['Overview', 'Activity', 'Settings']
+
+const WithUrlSyncRenderer = () => {
+  const [tab, setTab] = useTabUrlSync('demo', URL_SYNC_LABELS)
+  return (
+    <Tabs value={tab} onChange={setTab}>
+      {URL_SYNC_LABELS.map((label) => (
+        <TabItem key={label} tabLabel={label}>
+          <p className='mt-3'>Active label: {label}.</p>
+        </TabItem>
+      ))}
+    </Tabs>
+  )
+}
+
+export const WithUrlSync: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Compose `useTabUrlSync(paramName, labels)` with a controlled `<Tabs value onChange>` to persist the active tab in a URL query param. Labels are slugified (lowercase, spaces → hyphens). The hook also handles modal-portal contexts where `useHistory()` is unavailable by falling back to `history.replaceState`.',
+      },
+    },
+  },
+  render: () => <WithUrlSyncRenderer />,
+}
+
+const ControlledRenderer = () => {
+  const [tab, setTab] = useState(0)
+  return (
+    <Tabs value={tab} onChange={setTab}>
+      <TabItem tabLabel='Overview'>
+        <p className='mt-3'>Active index: {tab}</p>
+      </TabItem>
+      <TabItem tabLabel='Activity'>
+        <p className='mt-3'>Active index: {tab}</p>
+      </TabItem>
+    </Tabs>
+  )
+}
+
+export const Controlled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tabs is controlled — pass `value` (active index) and `onChange`. For local state use `useState`, for URL state use `useTabUrlSync`. Avoid the legacy `uncontrolled` and `urlParam` props on new code.',
+      },
+    },
+  },
+  render: () => <ControlledRenderer />,
 }
 
 export const WithDirtyMarker: Story = {

--- a/frontend/documentation/components/Tabs.stories.tsx
+++ b/frontend/documentation/components/Tabs.stories.tsx
@@ -23,9 +23,10 @@ export default meta
 
 type Story = StoryObj
 
-export const Default: Story = {
-  render: () => (
-    <Tabs uncontrolled>
+const DefaultRenderer = () => {
+  const [tab, setTab] = useState(0)
+  return (
+    <Tabs value={tab} onChange={setTab}>
       <TabItem tabLabel='Features'>
         <p className='mt-3'>Features tab content</p>
       </TabItem>
@@ -36,12 +37,17 @@ export const Default: Story = {
         <p className='mt-3'>Settings tab content</p>
       </TabItem>
     </Tabs>
-  ),
+  )
 }
 
-export const PillTheme: Story = {
-  render: () => (
-    <Tabs theme='pill' uncontrolled>
+export const Default: Story = {
+  render: () => <DefaultRenderer />,
+}
+
+const PillThemeRenderer = () => {
+  const [tab, setTab] = useState(0)
+  return (
+    <Tabs theme='pill' value={tab} onChange={setTab}>
       <TabItem tabLabel='Overview'>
         <p className='mt-3'>Overview content</p>
       </TabItem>
@@ -49,7 +55,24 @@ export const PillTheme: Story = {
         <p className='mt-3'>Activity content</p>
       </TabItem>
     </Tabs>
-  ),
+  )
+}
+
+export const PillTheme: Story = {
+  render: () => <PillThemeRenderer />,
+}
+
+const HideNavOnSingleTabRenderer = () => {
+  const [tab, setTab] = useState(0)
+  return (
+    <Tabs hideNavOnSingleTab value={tab} onChange={setTab}>
+      <TabItem tabLabel='Permissions'>
+        <p className='mt-3'>
+          Tab nav is hidden because there is only one TabItem.
+        </p>
+      </TabItem>
+    </Tabs>
+  )
 }
 
 export const HideNavOnSingleTab: Story = {
@@ -61,15 +84,7 @@ export const HideNavOnSingleTab: Story = {
       },
     },
   },
-  render: () => (
-    <Tabs hideNavOnSingleTab uncontrolled>
-      <TabItem tabLabel='Permissions'>
-        <p className='mt-3'>
-          Tab nav is hidden because there is only one TabItem.
-        </p>
-      </TabItem>
-    </Tabs>
-  ),
+  render: () => <HideNavOnSingleTabRenderer />,
 }
 
 const URL_SYNC_LABELS = ['Overview', 'Activity', 'Settings']
@@ -125,17 +140,10 @@ export const Controlled: Story = {
   render: () => <ControlledRenderer />,
 }
 
-export const WithDirtyMarker: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Set `isDirty` on a `TabItem` to show an unsaved-changes badge next to its label. The badge sits inside an inline-flex wrapper so it never breaks onto a second line and stays vertically aligned with the label.',
-      },
-    },
-  },
-  render: () => (
-    <Tabs uncontrolled>
+const WithDirtyMarkerRenderer = () => {
+  const [tab, setTab] = useState(0)
+  return (
+    <Tabs value={tab} onChange={setTab}>
       <TabItem tabLabel='Value' isDirty>
         <p className='mt-3'>This tab has unsaved changes.</p>
       </TabItem>
@@ -146,5 +154,17 @@ export const WithDirtyMarker: Story = {
         <p className='mt-3'>No unsaved changes here.</p>
       </TabItem>
     </Tabs>
-  ),
+  )
+}
+
+export const WithDirtyMarker: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Set `isDirty` on a `TabItem` to show an unsaved-changes badge next to its label. The badge sits inside an inline-flex wrapper so it never breaks onto a second line and stays vertically aligned with the label.',
+      },
+    },
+  },
+  render: () => <WithDirtyMarkerRenderer />,
 }

--- a/frontend/web/components/EnvironmentDocumentCodeHelp.tsx
+++ b/frontend/web/components/EnvironmentDocumentCodeHelp.tsx
@@ -20,6 +20,7 @@ const EnvironmentDocumentCodeHelp: FC<EnvironmentDocumentCodeHelpType> = ({
   title,
 }) => {
   const [visible, setVisible] = useState(false)
+  const [tab, setTab] = useState(0)
   const { data } = useGetServersideEnvironmentKeysQuery({ environmentId })
   const envAdmin = useHasPermission({
     id: environmentId,
@@ -66,7 +67,7 @@ const EnvironmentDocumentCodeHelp: FC<EnvironmentDocumentCodeHelpType> = ({
             </a>{' '}
             and allowing offline capabilities.
           </div>
-          <Tabs uncontrolled theme='pill' history={history}>
+          <Tabs value={tab} onChange={setTab} theme='pill'>
             <TabItem tabLabel={'Client-side'}>
               <div className='mt-3'>
                 <InfoMessage

--- a/frontend/web/components/PermissionsTabs.tsx
+++ b/frontend/web/components/PermissionsTabs.tsx
@@ -22,9 +22,8 @@ type PermissionsTabsType = {
   group?: UserGroupSummary
   user?: User
   role?: Role | undefined
-  value?: number
-  onChange?: (v: number) => void
-  uncontrolled?: boolean
+  value: number
+  onChange: (v: number) => void
   tabRef?: Ref<any>
 }
 
@@ -34,7 +33,6 @@ const PermissionsTabs: FC<PermissionsTabsType> = ({
   orgId,
   role,
   tabRef,
-  uncontrolled,
   user,
   value,
 }) => {
@@ -79,7 +77,6 @@ const PermissionsTabs: FC<PermissionsTabsType> = ({
     <PlanBasedAccess feature={'RBAC'} theme={'page'}>
       {!!group && <WarningMessage warningMessage={deprecationMessage} />}
       <Tabs
-        uncontrolled={uncontrolled}
         value={value}
         onChange={onChange}
         theme='pill'

--- a/frontend/web/components/diff/DiffSegmentOverrides.tsx
+++ b/frontend/web/components/diff/DiffSegmentOverrides.tsx
@@ -1,5 +1,5 @@
 import { TDiffSegmentOverride } from './diff-utils'
-import React, { FC, useMemo } from 'react'
+import React, { FC, useMemo, useState } from 'react'
 import DiffString from './DiffString'
 import DiffEnabled from './DiffEnabled'
 import { sortBy } from 'lodash'
@@ -7,7 +7,7 @@ import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import Icon from 'components/icons/Icon'
 import Tooltip from 'components/Tooltip'
-import { Link, useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import DiffVariations from './DiffVariations'
 import { ProjectFlag } from 'common/types/responses'
 
@@ -96,7 +96,7 @@ const DiffSegmentOverrides: FC<DiffSegmentOverridesType> = ({
   projectFlag,
   projectId,
 }) => {
-  const history = useHistory()
+  const [tab, setTab] = useState(0)
   const { created, deleted, modified, unChanged } = useMemo(() => {
     const created: TDiffSegmentOverride[] = []
     const deleted: TDiffSegmentOverride[] = []
@@ -133,7 +133,7 @@ const DiffSegmentOverrides: FC<DiffSegmentOverridesType> = ({
   )
 
   return diffs ? (
-    <Tabs className='mt-4' uncontrolled theme='pill' history={history}>
+    <Tabs className='mt-4' value={tab} onChange={setTab} theme='pill'>
       {!!created.length && (
         <TabItem
           className='p-0'

--- a/frontend/web/components/import-export/ImportPage.tsx
+++ b/frontend/web/components/import-export/ImportPage.tsx
@@ -17,6 +17,9 @@ import AccountStore from 'common/stores/account-store'
 import Constants from 'common/constants'
 import { useHistory } from 'react-router-dom'
 import { OrganisationPermission } from 'common/types/permissions.types'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
+
+const IMPORT_PAGE_TABS = ['Flagsmith', 'LaunchDarkly']
 
 type ImportPageType = {
   projectId: string
@@ -25,6 +28,7 @@ type ImportPageType = {
 
 const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
   const history = useHistory()
+  const [tab, setTab] = useTabUrlSync('import', IMPORT_PAGE_TABS)
   const [LDKey, setLDKey] = useState<string>('')
   const [importId, setImportId] = useState<number>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -227,7 +231,7 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
         </div>
       )}
       <div className='mt-4'>
-        <Tabs urlParam={'import'} theme='pill' history={history}>
+        <Tabs value={tab} onChange={setTab} theme='pill'>
           <TabItem tabLabel={'Flagsmith'}>
             <div className='mt-4'>
               <FeatureImport projectId={projectId} />

--- a/frontend/web/components/inspect-permissions/InspectPermissions.tsx
+++ b/frontend/web/components/inspect-permissions/InspectPermissions.tsx
@@ -16,16 +16,14 @@ type InspectPermissionsType = {
   group?: UserGroupSummary
   user?: User
   role?: Role | undefined
-  value?: number
-  onChange?: (v: number) => void
-  uncontrolled?: boolean
+  value: number
+  onChange: (v: number) => void
   tabRef?: Ref<any>
 }
 
 const InspectPermissions: FC<InspectPermissionsType> = ({
   onChange,
   orgId,
-  uncontrolled,
   user,
   value,
 }) => {
@@ -46,13 +44,7 @@ const InspectPermissions: FC<InspectPermissionsType> = ({
 
   return (
     <PlanBasedAccess feature={'RBAC'} theme={'page'}>
-      <Tabs
-        uncontrolled={uncontrolled}
-        value={value}
-        onChange={onChange}
-        theme='pill'
-        isRoles={true}
-      >
+      <Tabs value={value} onChange={onChange} theme='pill' isRoles={true}>
         <TabItem
           tabLabel='Organisation'
           data-test='organisation-permissions-tab'

--- a/frontend/web/components/modals/CreateGroup.tsx
+++ b/frontend/web/components/modals/CreateGroup.tsx
@@ -454,17 +454,10 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
   )
   return isEdit ? (
     <Tabs uncontrolled className='px-0'>
-      <TabItem
-        tabLabel={
-          <div>
-            General
-            {!!edited && <span className='unread'>*</span>}
-          </div>
-        }
-      >
+      <TabItem tabLabel='General' isDirty={!!edited}>
         {editGroupEl}
       </TabItem>
-      <TabItem tabLabel={<div>Permissions</div>}>{editPermissionsEl}</TabItem>
+      <TabItem tabLabel='Permissions'>{editPermissionsEl}</TabItem>
     </Tabs>
   ) : (
     editGroupEl

--- a/frontend/web/components/modals/CreateGroup.tsx
+++ b/frontend/web/components/modals/CreateGroup.tsx
@@ -36,6 +36,7 @@ type CreateGroupType = {
 
 const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
   const [tab, setTab] = useState(0)
+  const [permissionsTab, setPermissionsTab] = useState(0)
   const [edited, setEdited] = useState(false)
   const [externalId, setExternalId] = useState('')
   const [name, setName] = useState('')
@@ -446,7 +447,8 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
     <div className='mt-4'>
       {!!groupData && (
         <PermissionsTabs
-          uncontrolled
+          value={permissionsTab}
+          onChange={setPermissionsTab}
           orgId={AccountStore.getOrganisation()?.id}
           group={group}
         />

--- a/frontend/web/components/modals/CreateGroup.tsx
+++ b/frontend/web/components/modals/CreateGroup.tsx
@@ -35,6 +35,7 @@ type CreateGroupType = {
 }
 
 const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
+  const [tab, setTab] = useState(0)
   const [edited, setEdited] = useState(false)
   const [externalId, setExternalId] = useState('')
   const [name, setName] = useState('')
@@ -453,7 +454,7 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
     </div>
   )
   return isEdit ? (
-    <Tabs uncontrolled className='px-0'>
+    <Tabs value={tab} onChange={setTab} className='px-0'>
       <TabItem tabLabel='General' isDirty={!!edited}>
         {editGroupEl}
       </TabItem>

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -34,6 +34,7 @@ type samlAttributeType = { id: number; label: string; value: AttributeName }
 type samlAttributesType = samlAttributeType[]
 
 const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
+  const [tab, setTab] = useState(0)
   const [previousName, setPreviousName] = useState<string>(samlName || '')
   const [name, setName] = useState<string>(samlName || '')
   const [frontendUrl, setFrontendUrl] = useState<string>(window.location.origin)
@@ -375,7 +376,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
       {!isEdit ? (
         Tab1
       ) : (
-        <Tabs uncontrolled>
+        <Tabs value={tab} onChange={setTab}>
           <TabItem tabLabel='Basic Configuration'>{Tab1}</TabItem>
           <TabItem tabLabel='Attribute Mapping'>
             <div className='create-feature-tab px-3'>

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -503,15 +503,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
           urlParam='segmentTab'
           onChange={(tab: UserTabs) => setTab(tab)}
         >
-          <TabItem
-            tabLabelString='General'
-            tabLabel={
-              <Row className='justify-content-center flex-nowrap'>
-                General{' '}
-                {valueChanged && <div className='unread ml-2 px-1'>{'*'}</div>}
-              </Row>
-            }
-          >
+          <TabItem tabLabel='General' isDirty={valueChanged}>
             <div className='my-4'>
               <CreateSegmentRulesTabForm
                 is4Eyes={is4Eyes}
@@ -564,17 +556,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
             </div>
           </TabItem>
           {metadataEnable && segmentContentType?.id && (
-            <TabItem
-              tabLabelString='Custom Fields'
-              tabLabel={
-                <Row className='justify-content-center flex-nowrap'>
-                  Custom Fields
-                  {metadataValueChanged && (
-                    <div className='unread ml-2 px-1 pt-2'>{'*'}</div>
-                  )}
-                </Row>
-              }
-            >
+            <TabItem tabLabel='Custom Fields' isDirty={metadataValueChanged}>
               <div className='my-4'>{MetadataTab}</div>
             </TabItem>
           )}

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -48,6 +48,7 @@ import CreateSegmentRulesTabForm from './CreateSegmentRulesTabForm'
 import CreateSegmentUsersTabContent from './CreateSegmentUsersTabContent'
 import useDebouncedSearch from 'common/useDebouncedSearch'
 import API from 'project/api'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
 
 type PageType = {
   number: number
@@ -202,6 +203,19 @@ const CreateSegment: FC<CreateSegmentType> = ({
   const { data: supportedContentTypes } = useGetSupportedContentTypeQuery({
     organisation_id: AccountStore.getOrganisation().id,
   })
+
+  // The edit-segment Tabs below mirror this label list — keep in sync if
+  // visibility conditions or labels change.
+  const segmentTabLabels = [
+    'General',
+    segment.feature ? 'Feature' : 'Features',
+    'Identities',
+    ...(metadataEnable ? ['Custom Fields'] : []),
+  ]
+  const [segmentTab, setSegmentTab] = useTabUrlSync(
+    'segmentTab',
+    segmentTabLabels,
+  )
 
   const segmentContentType = useMemo(() => {
     if (supportedContentTypes) {
@@ -497,12 +511,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
         />
       )}
       {isEdit && !condensed && (
-        <Tabs
-          value={tab}
-          theme='pill'
-          urlParam='segmentTab'
-          onChange={(tab: UserTabs) => setTab(tab)}
-        >
+        <Tabs value={segmentTab} onChange={setSegmentTab} theme='pill'>
           <TabItem tabLabel='General' isDirty={valueChanged}>
             <div className='my-4'>
               <CreateSegmentRulesTabForm

--- a/frontend/web/components/modals/create-experiment/index.js
+++ b/frontend/web/components/modals/create-experiment/index.js
@@ -467,17 +467,8 @@ const Index = class extends Component {
                                 >
                                   <TabItem
                                     data-test='value'
-                                    tabLabelString='Value'
-                                    tabLabel={
-                                      <Row className='justify-content-center'>
-                                        Value{' '}
-                                        {this.state.valueChanged && (
-                                          <div className='unread ml-2 px-1'>
-                                            {'*'}
-                                          </div>
-                                        )}
-                                      </Row>
-                                    }
+                                    tabLabel='Value'
+                                    isDirty={this.state.valueChanged}
                                   >
                                     <FeatureValueTab
                                       error={error}

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -38,6 +38,7 @@ import FeatureUpdateSummary from './components/FeatureUpdateSummary'
 import FeatureNameInput from './components/FeatureNameInput'
 import IdentitySaveFooter from './components/IdentitySaveFooter'
 import { ProjectPermission } from 'common/types/permissions.types'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
 import type {
   ChangeRequest,
   FeatureState,
@@ -120,7 +121,6 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
   const [skipSaveProjectFeature, setSkipSaveProjectFeature] = useState(false)
   const [ownerIds, setOwnerIds] = useState<number[]>([])
   const [groupOwnerIds, setGroupOwnerIds] = useState<number[]>([])
-  const [, setTabKey] = useState(0)
 
   const isEdit = !!props.projectFlag
   const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -356,6 +356,33 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
   const isLinksTabEnabled =
     (hasIntegrationWithGithub || hasGitlabIntegration) && !!projectFlag?.id
 
+  const isVersionedForTabs = !!environment?.use_v2_feature_versioning
+  const isVersionedChangeRequestForTabs =
+    !!existingChangeRequest && isVersionedForTabs
+  const hideIdentityOverridesTabForTabs =
+    Utils.getShouldHideIdentityOverridesTab()
+  const flagIdForTabs = props.environmentFlag?.id
+  // Mirrors the conditional rendering of TabItems below — keep in sync if
+  // tab visibility conditions change.
+  const featureTabLabels = [
+    'Value',
+    ...((!existingChangeRequest || isVersionedChangeRequestForTabs) &&
+    updateSegments
+      ? ['Segment Overrides']
+      : []),
+    ...(!existingChangeRequest && !hideIdentityOverridesTabForTabs
+      ? ['Identity Overrides']
+      : []),
+    'Usage',
+    'Health',
+    ...(isLinksTabEnabled ? ['Links'] : []),
+    ...(!existingChangeRequest && flagIdForTabs && isVersionedForTabs
+      ? ['History']
+      : []),
+    ...(!existingChangeRequest ? ['Settings'] : []),
+  ]
+  const [tab, setTab] = useTabUrlSync('tab', featureTabLabels)
+
   const [linkedResources, setLinkedResources] = useState<ExternalResource[]>()
 
   const { permission: createFeaturePermission } = useHasPermission({
@@ -572,11 +599,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                   projectId={`${projectId}`}
                   featureId={projectFlag?.id}
                 />
-                <Tabs
-                  urlParam='tab'
-                  history={props.history}
-                  onChange={() => setTabKey((k) => k + 1)}
-                >
+                <Tabs value={tab} onChange={setTab}>
                   <TabItem
                     data-test='value'
                     tabLabel='Value'

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -579,15 +579,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                 >
                   <TabItem
                     data-test='value'
-                    tabLabelString='Value'
-                    tabLabel={
-                      <Row className='justify-content-center'>
-                        Value{' '}
-                        {valueChanged && (
-                          <div className='unread ml-2 px-1'>{'*'}</div>
-                        )}
-                      </Row>
-                    }
+                    tabLabel='Value'
+                    isDirty={valueChanged}
                   >
                     <FeatureValueTab
                       error={error}
@@ -623,19 +616,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                     updateSegments && (
                       <TabItem
                         data-test='segment_overrides'
-                        tabLabelString='Segment Overrides'
-                        tabLabel={
-                          <Row
-                            className={`justify-content-center ${
-                              segmentsChanged ? 'pr-1' : ''
-                            }`}
-                          >
-                            Segment Overrides{' '}
-                            {segmentsChanged && (
-                              <div className='unread ml-2 px-2'>*</div>
-                            )}
-                          </Row>
-                        }
+                        tabLabel='Segment Overrides'
+                        isDirty={segmentsChanged}
                       >
                         <SegmentOverridesTab
                           projectId={projectId}
@@ -732,15 +714,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                   {!existingChangeRequest && (
                     <TabItem
                       data-test='settings'
-                      tabLabelString='Settings'
-                      tabLabel={
-                        <Row className='justify-content-center'>
-                          Settings{' '}
-                          {settingsChanged && (
-                            <div className='unread ml-2 px-1'>{'*'}</div>
-                          )}
-                        </Row>
-                      }
+                      tabLabel='Settings'
+                      isDirty={settingsChanged}
                     >
                       <FeatureSettings
                         identity={identity}

--- a/frontend/web/components/navigation/TabMenu/TabButton.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabButton.tsx
@@ -27,7 +27,10 @@ const TabButton = React.forwardRef<HTMLButtonElement | null, TabButtonProps>(
           isSelected ? ' tab-active' : ''
         } ${className}`}
       >
-        {child.props.tabLabel}
+        <span className='btn-tab__label'>
+          {child.props.tabLabel}
+          {child.props.isDirty && <span className='unread'>*</span>}
+        </span>
       </Button>
     )
   },

--- a/frontend/web/components/navigation/TabMenu/TabItem.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabItem.tsx
@@ -5,6 +5,10 @@ type TabItemType = {
   tabLabel: ReactNode
   children: ReactNode
   className?: string
+  // Renders an unsaved-changes badge next to the label. Lifted out of consumers
+  // so positioning lives in one place and TabButton can wrap label + badge in
+  // a flex container that prevents the badge from breaking onto a new line.
+  isDirty?: boolean
 }
 
 const TabItem: FC<TabItemType> = ({ children }) => {

--- a/frontend/web/components/navigation/TabMenu/TabItem.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabItem.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react'
 
 type TabItemType = {
+  /** @deprecated Only required when `tabLabel` is JSX and the parent `<Tabs>` uses the legacy `urlParam` prop for slug derivation. New consumers should pass a string `tabLabel` and use `useTabUrlSync` for URL persistence. */
   tabLabelString?: string
   tabLabel: ReactNode
   children: ReactNode

--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -20,14 +20,18 @@ interface TabsProps {
   children: ReactNode | ReactNode[]
   onChange?: (index: number) => void
   theme?: 'tab' | 'pill'
+  /** @deprecated Use a `useState` (or `useTabUrlSync`) in the consumer and pass `value`/`onChange`. */
   uncontrolled?: boolean
   value?: number
   className?: string
+  /** @deprecated Use `useTabUrlSync(paramName, labels)` in the consumer and pass `value`/`onChange`. */
   urlParam?: string
   hideNavOnSingleTab?: boolean
   buttonTheme?: string
   noFocus?: boolean
+  /** @deprecated Domain-specific class hook — push padding to the consuming `TabItem` via `className` instead. */
   isRoles?: boolean
+  /** @deprecated `useTabUrlSync` handles the modal-portal Router fallback internally; this prop is only honoured by the legacy `urlParam` path. */
   history?: any
   cta?: ReactNode
 }

--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -20,8 +20,6 @@ interface TabsProps {
   children: ReactNode | ReactNode[]
   onChange?: (index: number) => void
   theme?: 'tab' | 'pill'
-  /** @deprecated Use a `useState` (or `useTabUrlSync`) in the consumer and pass `value`/`onChange`. */
-  uncontrolled?: boolean
   value?: number
   className?: string
   /** @deprecated Use `useTabUrlSync(paramName, labels)` in the consumer and pass `value`/`onChange`. */
@@ -39,7 +37,10 @@ interface TabsProps {
 // Falls back to tabLabel when it is already a plain string, so consumers
 // only need tabLabelString when tabLabel is JSX.
 const getLabelString = (child: ReactElement): string => {
-  const { tabLabel, tabLabelString } = child.props
+  const { tabLabel, tabLabelString } = child.props as {
+    tabLabel?: ReactNode
+    tabLabelString?: string
+  }
   if (tabLabelString) return tabLabelString
   return typeof tabLabel === 'string' ? tabLabel : ''
 }
@@ -58,18 +59,16 @@ const Tabs: React.FC<TabsProps> = ({
   noFocus,
   onChange,
   theme = 'tab',
-  uncontrolled = false,
   urlParam,
   value: propValue = 0,
 }) => {
   const tabChildren = (Array.isArray(children) ? children : [children]).filter(
     Boolean,
   )
-  const [internalValue, setInternalValue] = useState(0)
   const routerHistory = useHistory() || history
 
   const disableOverflow = theme === 'pill'
-  let value = uncontrolled ? internalValue : propValue
+  let value = propValue
   if (urlParam) {
     const tabParam = Utils.fromParam()[urlParam]
     if (tabParam) {
@@ -129,12 +128,10 @@ const Tabs: React.FC<TabsProps> = ({
           pathname: window.location.pathname,
           search: searchParams.toString(),
         })
-      } else if (uncontrolled) {
-        setInternalValue(i)
       }
       onChange?.(i)
     },
-    [onChange, routerHistory, uncontrolled, urlParam],
+    [onChange, routerHistory, urlParam],
   )
 
   return (

--- a/frontend/web/components/pages/AccountSettingsPage.tsx
+++ b/frontend/web/components/pages/AccountSettingsPage.tsx
@@ -48,6 +48,7 @@ const AccountSettingsPage: FC = () => {
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword1, setNewPassword1] = useState('')
   const [newPassword2, setNewPassword2] = useState('')
+  const [tab, setTab] = useState(0)
 
   useEffect(() => {
     const handleChange = () => {
@@ -188,7 +189,7 @@ const AccountSettingsPage: FC = () => {
         }
         title={'Account Settings'}
       />
-      <Tabs uncontrolled className='mt-0'>
+      <Tabs value={tab} onChange={setTab} className='mt-0'>
         <TabItem tabLabel='General'>
           <div className='mt-4 col-md-8'>
             <SettingTitle>Account Information</SettingTitle>

--- a/frontend/web/components/pages/ChangeRequestsPage.tsx
+++ b/frontend/web/components/pages/ChangeRequestsPage.tsx
@@ -22,6 +22,9 @@ import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import ChangeRequestList from 'components/ChangeRequestsList'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
+
+const CHANGE_REQUESTS_TABS = ['Open', 'Closed']
 
 type ChangeRequestsPageType = {
   router: RouterChildContext['router']
@@ -38,6 +41,7 @@ const ChangeRequestsPage: FC<ChangeRequestsPageType> = ({ match, router }) => {
   const [page, setPage] = useState(1)
   const [pageCommitted, setPageCommitted] = useState(1)
   const history = useHistory()
+  const [tab, setTab] = useTabUrlSync('tab', CHANGE_REQUESTS_TABS)
   const organisationId = AccountStore.getOrganisation()?.id
   const environment = ProjectStore.getEnvironment(
     environmentId,
@@ -162,7 +166,7 @@ export const ChangeRequestsInner: FC<ChangeRequestsInnerType> = ({
           <div>
             {changeRequestsDisabled && <p>{ChangeRequestsDisabledMessage}</p>}
 
-            <Tabs urlParam={'tab'}>
+            <Tabs value={tab} onChange={setTab}>
               <TabItem
                 tabLabelString='Open'
                 tabLabel={

--- a/frontend/web/components/pages/ComparePage.js
+++ b/frontend/web/components/pages/ComparePage.js
@@ -1,5 +1,5 @@
 // import propTypes from 'prop-types';
-import React, { Component } from 'react'
+import React from 'react'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import Tabs from 'components/navigation/TabMenu/Tabs'
 import CompareEnvironments from 'components/CompareEnvironments'
@@ -7,56 +7,49 @@ import CompareFeatures from 'components/CompareFeatures'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import CompareIdentities from 'components/CompareIdentities'
 import PageTitle from 'components/PageTitle'
-import { withRouter } from 'react-router-dom'
+import { useRouteMatch } from 'react-router-dom'
 import { useRouteContext } from 'components/providers/RouteContext'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
 
-class ComparePage extends Component {
-  static displayName = 'ComparePage'
+const COMPARE_TABS = ['Environments', 'Feature Values', 'Identities']
 
-  static propTypes = {}
+const ComparePage = () => {
+  const { projectId } = useRouteContext()
+  const match = useRouteMatch()
+  const [tab, setTab] = useTabUrlSync('tab', COMPARE_TABS)
 
-  constructor(props) {
-    super(props)
-    this.projectId = props.routeContext.projectId
-  }
-
-  render() {
-    return (
-      <div className='app-container container'>
-        <PageTitle className='mb-2' title={'Compare'}>
-          Compare data across your environments, features and identities.
-        </PageTitle>
-        <Tabs className='mt-0' urlParam='tab' history={this.props.history}>
-          <TabItem tabLabel='Environments'>
-            <div className='mt-4'>
-              <CompareEnvironments
-                projectId={this.projectId}
-                environmentId={this.props.match.params.environmentId}
-              />
-            </div>
-          </TabItem>
-          <TabItem tabLabel='Feature Values'>
-            <div className='mt-4'>
-              <CompareFeatures projectId={this.projectId} />
-            </div>
-          </TabItem>
-          <TabItem tabLabel='Identities'>
-            <div className='mt-4'>
-              <CompareIdentities
-                environmentId={this.props.match.params.environmentId}
-                projectId={this.projectId}
-              />
-            </div>
-          </TabItem>
-        </Tabs>
-      </div>
-    )
-  }
+  return (
+    <div className='app-container container'>
+      <PageTitle className='mb-2' title={'Compare'}>
+        Compare data across your environments, features and identities.
+      </PageTitle>
+      <Tabs className='mt-0' value={tab} onChange={setTab}>
+        <TabItem tabLabel='Environments'>
+          <div className='mt-4'>
+            <CompareEnvironments
+              projectId={projectId}
+              environmentId={match.params.environmentId}
+            />
+          </div>
+        </TabItem>
+        <TabItem tabLabel='Feature Values'>
+          <div className='mt-4'>
+            <CompareFeatures projectId={projectId} />
+          </div>
+        </TabItem>
+        <TabItem tabLabel='Identities'>
+          <div className='mt-4'>
+            <CompareIdentities
+              environmentId={match.params.environmentId}
+              projectId={projectId}
+            />
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  )
 }
 
-const ComparePageWithContext = (props) => {
-  const context = useRouteContext()
-  return <ComparePage {...props} routeContext={context} />
-}
+ComparePage.displayName = 'ComparePage'
 
-export default withRouter(ConfigProvider(ComparePageWithContext))
+export default ConfigProvider(ComparePage)

--- a/frontend/web/components/pages/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.tsx
@@ -46,6 +46,15 @@ import { useGetEnvironmentQuery } from 'common/services/useEnvironment'
 import { useRouteContext } from 'components/providers/RouteContext'
 import SettingTitle from 'components/SettingTitle'
 import ChangeRequestsSetting from 'components/ChangeRequestsSetting'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
+
+const ENVIRONMENT_SETTINGS_TABS = [
+  'General',
+  'SDK Settings',
+  'Permissions',
+  'Webhooks',
+  'Custom Fields',
+]
 
 const showDisabledFlagOptions: { label: string; value: boolean | null }[] = [
   { label: 'Inherit from Project', value: null },
@@ -65,6 +74,7 @@ const EnvironmentSettingsPage: React.FC = () => {
     environmentId: string
   }>()
   const { projectId } = useRouteContext()
+  const [tab, setTab] = useTabUrlSync('tab', ENVIRONMENT_SETTINGS_TABS)
   const [currentEnv, setCurrentEnv] = useState<Environment | null>(null)
   const [roles, setRoles] = useState<Role[]>([])
   const [rolesLoaded, setRolesLoaded] = useState(false)
@@ -422,7 +432,7 @@ const EnvironmentSettingsPage: React.FC = () => {
                 </div>
               )}
               {!isLoading && (
-                <Tabs urlParam='tab' className='mt-0' uncontrolled noFocus>
+                <Tabs value={tab} onChange={setTab} className='mt-0' noFocus>
                   <TabItem tabLabel='General'>
                     <div className='mt-4 col-md-8'>
                       <SettingTitle>Environment Information</SettingTitle>

--- a/frontend/web/components/pages/FeatureHistoryDetailPage.tsx
+++ b/frontend/web/components/pages/FeatureHistoryDetailPage.tsx
@@ -19,6 +19,9 @@ import Breadcrumb from 'components/Breadcrumb'
 import { useGetProjectFlagQuery } from 'common/services/useProjectFlag'
 import { useRouteContext } from 'components/providers/RouteContext'
 import getUserDisplayName from 'common/utils/getUserDisplayName'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
+
+const FEATURE_HISTORY_TABS = ['Compare to Previous', 'Compare to Live']
 interface RouteParams {
   id: string
   environmentId: string
@@ -28,6 +31,7 @@ interface RouteParams {
 const FeatureHistoryPage: FC = () => {
   const match = useRouteMatch<RouteParams>()
   const { projectId } = useRouteContext()
+  const [tab, setTab] = useTabUrlSync('compare', FEATURE_HISTORY_TABS)
 
   const env: Environment | undefined = ProjectStore.getEnvironment(
     match.params.environmentId,
@@ -112,7 +116,7 @@ const FeatureHistoryPage: FC = () => {
                   {user ? `${getUserDisplayName(user)} ` : 'System '}
                 </strong>
               </div>
-              <Tabs urlParam='compare' theme='pill' uncontrolled>
+              <Tabs value={tab} onChange={setTab} theme='pill'>
                 {!!data.previous_version_uuid && (
                   <TabItem tabLabel='Compare to Previous'>
                     <div className='mt-4'>

--- a/frontend/web/components/pages/UsersAndPermissionsPage.tsx
+++ b/frontend/web/components/pages/UsersAndPermissionsPage.tsx
@@ -43,6 +43,9 @@ import {
 import OrganisationUsersTable from 'components/users-permissions/OrganisationUsersTable/OrganisationUsersTable'
 import getUserDisplayName from 'common/utils/getUserDisplayName'
 import { OrganisationPermission } from 'common/types/permissions.types'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
+
+const USERS_AND_PERMISSIONS_TABS = ['Members', 'Groups', 'Roles']
 
 type UsersAndPermissionsPageType = {
   router: RouterChildContext['router']
@@ -76,6 +79,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
   })
 
   const history = useHistory()
+  const [tab, setTab] = useTabUrlSync('type', USERS_AND_PERMISSIONS_TABS)
 
   const [deleteUserInvite] = useDeleteUserInviteMutation()
   const [resendUserInvite] = useResendUserInviteMutation()
@@ -190,7 +194,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
               )}
               {!isLoading && (
                 <div>
-                  <Tabs urlParam={'type'} theme='pill' uncontrolled>
+                  <Tabs value={tab} onChange={setTab} theme='pill'>
                     <TabItem tabLabel='Members'>
                       <Row space className='mt-4'>
                         <h5 className='mb-0'>Team Members</h5>
@@ -234,56 +238,68 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                               for your plan.{' '}
                               {usedSeats && (
                                 <>
-                                  {overSeats &&
-                                  (!verifySeatsLimit || !autoSeats) ? (
-                                    <strong>
-                                      If you wish to invite any additional
-                                      members, please{' '}
-                                      {Utils.isSaas() ? (
-                                        <a
-                                          href='#'
-                                          onClick={(e) => {
-                                            e.stopPropagation()
-                                            openChat()
-                                          }}
-                                        >
-                                          contact us
-                                        </a>
-                                      ) : (
-                                        <a
-                                          href='mailto:support@flagsmith.com'
-                                          onClick={(e) => e.stopPropagation()}
-                                        >
-                                          contact us
-                                        </a>
-                                      )}
-                                      .
-                                    </strong>
-                                  ) : needsUpgradeForAdditionalSeats ? (
-                                    <div className='fw-semibold'>
-                                      If you wish to invite any additional
-                                      members, please{' '}
-                                      {
-                                        <a
-                                          href='#'
-                                          onClick={() => {
-                                            history.replace(
-                                              '/organisation-settings?tab=billing',
-                                            )
-                                          }}
-                                        >
-                                          Upgrade your plan
-                                        </a>
-                                      }
-                                      .
-                                    </div>
-                                  ) : (
-                                    <strong>
-                                      You will automatically be charged
-                                      $60/month for each additional member that
-                                      joins your organisation.
-                                    </strong>
-                                  )}
+                                  {(() => {
+                                    if (
+                                      overSeats &&
+                                      (!verifySeatsLimit || !autoSeats)
+                                    ) {
+                                      return (
+                                        <strong>
+                                          If you wish to invite any additional
+                                          members, please{' '}
+                                          {Utils.isSaas() ? (
+                                            <a
+                                              href='#'
+                                              onClick={(e) => {
+                                                e.stopPropagation()
+                                                openChat()
+                                              }}
+                                            >
+                                              contact us
+                                            </a>
+                                          ) : (
+                                            <a
+                                              href='mailto:support@flagsmith.com'
+                                              onClick={(e) =>
+                                                e.stopPropagation()
+                                              }
+                                            >
+                                              contact us
+                                            </a>
+                                          )}
+                                          .
+                                        </strong>
+                                      )
+                                    }
+                                    if (needsUpgradeForAdditionalSeats) {
+                                      return (
+                                        <div className='fw-semibold'>
+                                          If you wish to invite any additional
+                                          members, please{' '}
+                                          {
+                                            <a
+                                              href='#'
+                                              onClick={() => {
+                                                history.replace(
+                                                  '/organisation-settings?tab=billing',
+                                                )
+                                              }}
+                                            >
+                                              Upgrade your plan
+                                            </a>
+                                          }
+                                          .
+                                        </div>
+                                      )
+                                    }
+                                    return (
+                                      <strong>
+                                        You will automatically be charged
+                                        $60/month for each additional member
+                                        that joins your organisation.
+                                      </strong>
+                                    )
+                                  })()}
                                 </>
                               )}
                             </InfoMessage>

--- a/frontend/web/components/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/web/components/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -12,8 +12,17 @@ import Button from 'components/base/forms/Button'
 import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import ErrorMessage from 'components/ErrorMessage'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
+
+const ADMIN_DASHBOARD_TABS = [
+  'Usage',
+  'Release Pipeline',
+  'Flag Lifecycle',
+  'Integrations',
+]
 
 const AdminDashboardPage: FC = () => {
+  const [tab, setTab] = useTabUrlSync('tab', ADMIN_DASHBOARD_TABS)
   const [days, setDays] = useState<30 | 60 | 90>(30)
   const [isStuck, setIsStuck] = useState(false)
   const sentinelRef = useRef<HTMLDivElement>(null)
@@ -114,7 +123,7 @@ const AdminDashboardPage: FC = () => {
           </div>
 
           {/* Tabbed sections */}
-          <Tabs urlParam='tab' uncontrolled>
+          <Tabs value={tab} onChange={setTab}>
             <TabItem tabLabel='Usage'>
               <div className='mt-4'>
                 <div className='mb-4'>

--- a/frontend/web/components/pages/organisation-settings/OrganisationSettingsPage.tsx
+++ b/frontend/web/components/pages/organisation-settings/OrganisationSettingsPage.tsx
@@ -6,6 +6,7 @@ import PageTitle from 'components/PageTitle'
 import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import Constants from 'common/constants'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
 import { GeneralTab } from './tabs/general-tab'
 import { BillingTab } from './tabs/BillingTab'
 import { LicensingTab } from './tabs/LicensingTab'
@@ -35,6 +36,21 @@ const OrganisationSettingsPage: FC = () => {
     { skip: !organisationId },
   )
 
+  // Must mirror the visibility filter applied to `tabs` below — the hook
+  // resolves URL slug → index against this list, so the order/contents
+  // need to match what gets rendered.
+  const isAWS = organisation?.subscription?.payment_method === 'AWS_MARKETPLACE'
+  const visibleTabLabels = [
+    'General',
+    ...(paymentsEnabled && !isAWS ? ['Billing'] : []),
+    ...(isEnterprise ? ['Licensing'] : []),
+    'Custom Fields',
+    'API Keys',
+    'Webhooks',
+    'SAML',
+  ]
+  const [tab, setTab] = useTabUrlSync('tab', visibleTabLabels)
+
   useEffect(() => {
     API.trackPage(Constants.pages.ORGANISATION_SETTINGS)
   }, [])
@@ -62,7 +78,6 @@ const OrganisationSettingsPage: FC = () => {
   }
 
   const isAdmin = organisation.role === 'ADMIN'
-  const isAWS = organisation.subscription?.payment_method === 'AWS_MARKETPLACE'
 
   if (!isAdmin) {
     return (
@@ -82,7 +97,7 @@ const OrganisationSettingsPage: FC = () => {
     },
     {
       component: <BillingTab organisation={organisation} />,
-      isVisible: paymentsEnabled && !isAWS,
+      isVisible: !!paymentsEnabled && !isAWS,
       key: 'billing',
       label: 'Billing',
     },
@@ -121,7 +136,7 @@ const OrganisationSettingsPage: FC = () => {
   return (
     <div className='app-container container'>
       <PageTitle title='Organisation Settings' />
-      <Tabs urlParam='tab' className='mt-0' uncontrolled hideNavOnSingleTab>
+      <Tabs value={tab} onChange={setTab} className='mt-0' hideNavOnSingleTab>
         {tabs.map(({ component, key, label }) => (
           <TabItem key={key} tabLabel={label} data-test={key}>
             {component}

--- a/frontend/web/components/pages/project-settings/ProjectSettingsPage.tsx
+++ b/frontend/web/components/pages/project-settings/ProjectSettingsPage.tsx
@@ -16,6 +16,7 @@ import { ProjectPermissionsTab } from './tabs/ProjectPermissionsTab'
 import { CustomFieldsTab } from './tabs/CustomFieldsTab'
 import { ImportTab } from './tabs/ImportTab'
 import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
+import { useTabUrlSync } from 'common/hooks/useTabUrlSync'
 
 type ProjectSettingsTab = {
   component: ReactNode
@@ -37,6 +38,22 @@ const ProjectSettingsPage = () => {
     { projectId: projectId ?? '' },
     { skip: !projectId },
   )
+
+  // Must mirror the visibility filter applied to `tabs` below — the hook
+  // resolves URL slug → index against this list, so the order/contents
+  // need to match what gets rendered.
+  const hasEnvironmentsForUrl = (environments?.results?.length || 0) > 0
+  const hasFeatureHealthForUrl = Utils.getFlagsmithHasFeature('feature_health')
+  const visibleTabLabels = [
+    'General',
+    'SDK Settings',
+    'Usage',
+    ...(hasFeatureHealthForUrl ? ['Feature Health'] : []),
+    'Permissions',
+    'Custom Fields',
+    ...(hasEnvironmentsForUrl ? ['Import', 'Export'] : []),
+  ]
+  const [tab, setTab] = useTabUrlSync('tab', visibleTabLabels)
 
   useEffect(() => {
     API.trackPage(Constants.pages.PROJECT_SETTINGS)
@@ -143,7 +160,7 @@ const ProjectSettingsPage = () => {
   return (
     <div className='app-container container'>
       <PageTitle title='Project Settings' />
-      <Tabs urlParam='tab' className='mt-0' uncontrolled>
+      <Tabs value={tab} onChange={setTab} className='mt-0'>
         {tabs.map(({ component, key, label, labelString }) => (
           <TabItem
             key={key}

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/OrganisationUsersTable.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/OrganisationUsersTable.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import AppActions from 'common/dispatcher/app-actions'
-import Tabs from 'components/navigation/TabMenu/Tabs'
-import TabItem from 'components/navigation/TabMenu/TabItem'
 import { Organisation, User } from 'common/types/responses'
 import PanelSearch from 'components/PanelSearch'
-import PermissionsTabs from 'components/PermissionsTabs'
-import UsersGroups from 'components/UsersGroups'
-import InspectPermissions from 'components/inspect-permissions/InspectPermissions'
 import Format from 'common/utils/format'
 import OrganisationUsersTableHeader from './components/OrganisationUsersTableHeader'
 import OrganisationUsersTableRow from './components/OrganisationUsersTableRow'
+import EditUserPermissionsModal from './components/EditUserPermissionsModal'
+import InspectUserPermissionsModal from './components/InspectUserPermissionsModal'
 import getUserDisplayName from 'common/utils/getUserDisplayName'
 interface OrganisationUsersTableProps {
   users: User[]
@@ -27,26 +24,7 @@ const OrganisationUsersTable: React.FC<OrganisationUsersTableProps> = ({
       user.first_name || user.last_name
         ? `${user.first_name} ${user.last_name}`
         : `${user.email}`,
-      <div>
-        <Tabs uncontrolled hideNavOnSingleTab className='mt-4 ml-3'>
-          {user.role !== 'ADMIN' && (
-            <TabItem tabLabel='Permissions'>
-              <div className='pt-4'>
-                <PermissionsTabs
-                  uncontrolled
-                  user={user}
-                  orgId={organisationId}
-                />
-              </div>
-            </TabItem>
-          )}
-          <TabItem tabLabel='Groups'>
-            <div className='pt-4'>
-              <UsersGroups user={user} orgId={organisationId} />
-            </div>
-          </TabItem>
-        </Tabs>
-      </div>,
+      <EditUserPermissionsModal user={user} orgId={organisationId} />,
       'p-0 side-modal',
     )
   }
@@ -54,19 +32,7 @@ const OrganisationUsersTable: React.FC<OrganisationUsersTableProps> = ({
   const inspectPermissions = (user: User, organisationId: number) => {
     openModal(
       getUserDisplayName(user),
-      <div>
-        <Tabs uncontrolled hideNavOnSingleTab className='mt-4 ml-3'>
-          <TabItem tabLabel='Permissions'>
-            <div className='pt-4'>
-              <InspectPermissions
-                uncontrolled
-                user={user}
-                orgId={organisationId}
-              />
-            </div>
-          </TabItem>
-        </Tabs>
-      </div>,
+      <InspectUserPermissionsModal user={user} orgId={organisationId} />,
       'p-0 side-modal',
     )
   }

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/components/EditUserPermissionsModal.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/components/EditUserPermissionsModal.tsx
@@ -1,0 +1,43 @@
+import { FC, useState } from 'react'
+import Tabs from 'components/navigation/TabMenu/Tabs'
+import TabItem from 'components/navigation/TabMenu/TabItem'
+import PermissionsTabs from 'components/PermissionsTabs'
+import UsersGroups from 'components/UsersGroups'
+import { User } from 'common/types/responses'
+
+type EditUserPermissionsModalProps = {
+  user: User
+  orgId: number
+}
+
+const EditUserPermissionsModal: FC<EditUserPermissionsModalProps> = ({
+  orgId,
+  user,
+}) => {
+  const [tab, setTab] = useState(0)
+  return (
+    <div>
+      <Tabs
+        value={tab}
+        onChange={setTab}
+        hideNavOnSingleTab
+        className='mt-4 ml-3'
+      >
+        {user.role !== 'ADMIN' && (
+          <TabItem tabLabel='Permissions'>
+            <div className='pt-4'>
+              <PermissionsTabs uncontrolled user={user} orgId={orgId} />
+            </div>
+          </TabItem>
+        )}
+        <TabItem tabLabel='Groups'>
+          <div className='pt-4'>
+            <UsersGroups user={user} orgId={orgId} />
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  )
+}
+
+export default EditUserPermissionsModal

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/components/EditUserPermissionsModal.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/components/EditUserPermissionsModal.tsx
@@ -15,6 +15,7 @@ const EditUserPermissionsModal: FC<EditUserPermissionsModalProps> = ({
   user,
 }) => {
   const [tab, setTab] = useState(0)
+  const [permissionsTab, setPermissionsTab] = useState(0)
   return (
     <div>
       <Tabs
@@ -26,7 +27,12 @@ const EditUserPermissionsModal: FC<EditUserPermissionsModalProps> = ({
         {user.role !== 'ADMIN' && (
           <TabItem tabLabel='Permissions'>
             <div className='pt-4'>
-              <PermissionsTabs uncontrolled user={user} orgId={orgId} />
+              <PermissionsTabs
+                value={permissionsTab}
+                onChange={setPermissionsTab}
+                user={user}
+                orgId={orgId}
+              />
             </div>
           </TabItem>
         )}

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/components/InspectUserPermissionsModal.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/components/InspectUserPermissionsModal.tsx
@@ -1,0 +1,35 @@
+import { FC, useState } from 'react'
+import Tabs from 'components/navigation/TabMenu/Tabs'
+import TabItem from 'components/navigation/TabMenu/TabItem'
+import InspectPermissions from 'components/inspect-permissions/InspectPermissions'
+import { User } from 'common/types/responses'
+
+type InspectUserPermissionsModalProps = {
+  user: User
+  orgId: number
+}
+
+const InspectUserPermissionsModal: FC<InspectUserPermissionsModalProps> = ({
+  orgId,
+  user,
+}) => {
+  const [tab, setTab] = useState(0)
+  return (
+    <div>
+      <Tabs
+        value={tab}
+        onChange={setTab}
+        hideNavOnSingleTab
+        className='mt-4 ml-3'
+      >
+        <TabItem tabLabel='Permissions'>
+          <div className='pt-4'>
+            <InspectPermissions uncontrolled user={user} orgId={orgId} />
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  )
+}
+
+export default InspectUserPermissionsModal

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/components/InspectUserPermissionsModal.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/components/InspectUserPermissionsModal.tsx
@@ -14,6 +14,7 @@ const InspectUserPermissionsModal: FC<InspectUserPermissionsModalProps> = ({
   user,
 }) => {
   const [tab, setTab] = useState(0)
+  const [permissionsTab, setPermissionsTab] = useState(0)
   return (
     <div>
       <Tabs
@@ -24,7 +25,12 @@ const InspectUserPermissionsModal: FC<InspectUserPermissionsModalProps> = ({
       >
         <TabItem tabLabel='Permissions'>
           <div className='pt-4'>
-            <InspectPermissions uncontrolled user={user} orgId={orgId} />
+            <InspectPermissions
+              value={permissionsTab}
+              onChange={setPermissionsTab}
+              user={user}
+              orgId={orgId}
+            />
           </div>
         </TabItem>
       </Tabs>

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -141,6 +141,14 @@
 
 .btn-tab {
   position: relative;
+
+  .btn-tab__label {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 4px;
+  }
+
   .unread {
     padding-left: 0 !important;
     padding-right: 0 !important;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to \`docs/\` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6935. Contributes to #6606 (Design System Audit). Stacked on top of #7386.

This PR consolidates the unsaved-changes badge into Tabs, then takes the rest of the API down to its essentials by moving URL/router concerns out into a hook. \`Tabs\` is now a pure presentational component (\`value\` + \`onChange\`), and consumers compose state in via \`useState\` or the new \`useTabUrlSync\` hook.

### Closes #6935 — \`isDirty\` on \`TabItem\`

The unsaved-changes badge was reimplemented at every call site (\`<Row><div className='unread'>*</div></Row>\` etc.), and one of those reimplementations caused #6935: the badge overflowed below the active-tab underline and stayed visible on inactive tabs.

- Add \`isDirty?: boolean\` to \`TabItem\`. The \`TabButton\` wraps label + badge in an inline-flex \`.btn-tab__label\` container so they always stay on the same line and align vertically (port of the wrapper from #7038 — credit @Zaimwa9 for the original investigation).
- Migrate the seven badged sites in \`CreateGroup\`, \`CreateSegment\` (×2), \`CreateFeature\` (×3), and \`create-experiment\` to \`isDirty\`, dropping the local \`<Row>\`/\`<div>\`/\`unread\` JSX in favour of plain string \`tabLabel\`s.
- New \`WithDirtyMarker\` story for Chromatic.

### Decouple URL/router from Tabs

- New hook **\`common/hooks/useTabUrlSync.ts\`**. Reads/writes a URL search param, slugifies labels, falls back to \`window.history.replaceState\` when called outside a Router (modal portals via \`openModal\`).
- **Migrate 16 function-component consumers** from \`urlParam\` / \`uncontrolled\` to controlled \`<Tabs value onChange>\`:
  - URL-bound (10): AdminDashboardPage, ImportPage, UsersAndPermissionsPage, ChangeRequestsPage, FeatureHistoryDetailPage, EnvironmentSettingsPage, OrganisationSettingsPage, ProjectSettingsPage, CreateSegment, CreateFeature.
  - \`useState\` (6): AccountSettingsPage, CreateGroup, CreateSAML, EnvironmentDocumentCodeHelp, DiffSegmentOverrides.
- **Convert ComparePage** class → function component using the hook.
- **Extract \`OrganisationUsersTable\`'s two \`openModal\` JSX trees** into proper FCs (\`EditUserPermissionsModal\`, \`InspectUserPermissionsModal\`) so the Tabs inside can use \`useState\`.
- **\`PermissionsTabs\` and \`InspectPermissions\`** drop their own pass-through \`uncontrolled\` prop; \`value\` and \`onChange\` are now required, and consumers wire up local state.
- **Drop \`uncontrolled\` from \`Tabs\` entirely.** Tabs is purely controlled now. \`urlParam\`, \`history\`, \`tabLabelString\`, and \`isRoles\` remain on the type but are marked \`@deprecated\` with JSDoc pointing at the hook.
- New \`WithUrlSync\`, \`Controlled\`, and \`HideNavOnSingleTab\` stories.

### Left for follow-up

- **\`create-experiment/index.js\`** is a class component, gated by the \`experimental_flags\` Flagsmith flag. Stays on the legacy \`urlParam\` path. To be migrated when that flag promotes or the modal is converted to a function component.
- Once that lands, the \`@deprecated\` props (\`urlParam\`, \`history\`, \`tabLabelString\`, \`isRoles\`) can be physically removed from Tabs.

### Supersedes #7038

#7038 was the surgical fix for #6935 by @Zaimwa9. Most of its diff is now redundant after this stack (the \`<Row>\` wrappers are gone, badge wrapper lives in TabButton). Plan to close #7038 with a comment pointing here once this lands.

## How did you test this code?

Manually verified:
- **Badge behaviour**: opened Edit Feature modal → toggled values on Value / Segment Overrides / Settings tabs → \`*\` aligns inline, doesn't overflow underline, doesn't persist on inactive tabs.
- **URL sync**: navigated each migrated page (Admin Dashboard, Environment Settings, Project Settings, Org Settings, Change Requests, Users & Permissions, Feature History, Import) → tab switching updates the URL param, deep-linking with \`?tab=foo\` opens the right tab, browser back/forward works.
- **Modals**: \`openModal\` flow for \`OrganisationUsersTable\`'s Edit Permissions / Inspect Permissions still works (Tabs render and switch).
- **Stories**: ran \`npm run storybook\` → \`Default\`, \`PillTheme\`, \`WithDirtyMarker\`, \`HideNavOnSingleTab\`, \`WithUrlSync\`, and \`Controlled\` all render correctly.
- Typecheck error count went *down* by ~13 over baseline (only known new errors are pre-existing tech debt in adjacent files).
- Lint passes on all modified files (lint-staged hook clean).