### PR TITLE
feat: add isLoading state to Button component

### DIFF
--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -40,6 +40,8 @@ export type ButtonType = ButtonHTMLAttributes<HTMLButtonElement> & {
   theme?: keyof typeof themeClassNames
   size?: keyof typeof sizeClassNames
   iconSize?: number
+  isLoading?: boolean
+  loadingLabel?: string
 }
 
 export const Button = React.forwardRef<
@@ -50,12 +52,15 @@ export const Button = React.forwardRef<
     {
       children,
       className,
+      disabled,
       href,
       iconLeft,
       iconLeftColour,
       iconRight,
       iconRightColour,
       iconSize = 24,
+      isLoading = false,
+      loadingLabel = 'Saving...',
       onMouseUp,
       size = 'default',
       target,
@@ -65,6 +70,33 @@ export const Button = React.forwardRef<
     },
     ref,
   ) => {
+    const buttonContent = isLoading ? (
+      <div className='d-flex align-items-center justify-content-center gap-2'>
+        <Loader width='15px' height='15px' />
+        <span>{loadingLabel}</span>
+      </div>
+    ) : (
+      <>
+        {!!iconLeft && (
+          <Icon
+            fill={iconLeftColour ? iconColours[iconLeftColour] : undefined}
+            className='mr-2'
+            name={iconLeft}
+            width={iconSize}
+          />
+        )}
+        {children}
+        {!!iconRight && (
+          <Icon
+            fill={iconRightColour ? iconColours[iconRightColour] : undefined}
+            className='ml-2'
+            name={iconRight}
+            width={iconSize}
+          />
+        )}
+      </>
+    )
+
     return href ? (
       <a
         onClick={rest.onClick as React.MouseEventHandler}
@@ -96,6 +128,8 @@ export const Button = React.forwardRef<
     ) : (
       <button
         {...rest}
+        aria-busy={isLoading}
+        disabled={isLoading || disabled}
         type={type}
         onMouseUp={onMouseUp}
         className={cn(
@@ -106,23 +140,7 @@ export const Button = React.forwardRef<
         )}
         ref={ref as React.RefObject<HTMLButtonElement>}
       >
-        {!!iconLeft && (
-          <Icon
-            fill={iconLeftColour ? iconColours[iconLeftColour] : undefined}
-            className='mr-2'
-            name={iconLeft}
-            width={iconSize}
-          />
-        )}
-        {children}
-        {!!iconRight && (
-          <Icon
-            fill={iconRightColour ? iconColours[iconRightColour] : undefined}
-            className='ml-2'
-            name={iconRight}
-            width={iconSize}
-          />
-        )}
+        {buttonContent}
       </button>
     )
   },

--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -129,6 +129,7 @@ export const Button = React.forwardRef<
       <button
         {...rest}
         aria-busy={isLoading}
+        aria-live='polite'
         disabled={isLoading || disabled}
         type={type}
         onMouseUp={onMouseUp}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7384

Extends the existing `Button` component with an `isLoading` prop to consolidate the async-action pattern currently duplicated across 20+ call sites.

- Added `isLoading?: boolean` prop — shows a spinner and auto-disables the button while loading
- Added `loadingLabel?: string` prop — optional label shown during loading (defaults to `'Saving...'`)
- Added `aria-busy={isLoading}` for screen reader accessibility
- Added `aria-live='polite'` to announce loading state changes to assistive technology
- Added `disabled={isLoading || disabled}` to prevent double-submits
- Uses the existing global `<Loader width='15px' height='15px' />` component — no new dependencies

This is Step 1 of the migration plan described in the issue: landing the `isLoading` API on `Button` first with no consumer changes required.

## How did you test this code?

- Ran `npm run typecheck` — no new TypeScript errors introduced by this change
- Change is purely additive — no existing consumers are modified so no regression risk