### PR TITLE
fix(breadcrumb): align current-page item with links and separators

### DIFF
--- a/frontend/web/components/Breadcrumb.tsx
+++ b/frontend/web/components/Breadcrumb.tsx
@@ -24,7 +24,7 @@ const Breadcrumb: FC<BreadcrumbType> = ({
       ))}
       {isCurrentPageMuted ? (
         <div
-          className='active h6 text-muted lh-sm '
+          className='active h6 text-muted mb-0'
           aria-current='page'
           style={{ opacity: 0.6 }}
         >


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to a review comment on #7100 ([thread](https://github.com/Flagsmith/flagsmith/pull/7100#discussion_r3172884764)) — the breadcrumb's current-page item sat on a different baseline than the link/separator items, visible as the trailing label being slightly higher or lower than the rest of the trail.

## How did you test this code?

- Storybook → `Components/Navigation/Breadcrumb` → confirmed all three items (link / `/` / current) sit on the same baseline.
- Light + dark mode visually verified.
- Chromatic snapshot diff (this PR) shows the alignment correction on the existing Breadcrumb stories.
