### PR TITLE
fix(button): centre icons natively, fix hover and disabled states

### DIFF
--- a/frontend/documentation/components/Button.stories.tsx
+++ b/frontend/documentation/components/Button.stories.tsx
@@ -7,6 +7,7 @@ import {
   sizeClassNames,
 } from 'components/base/forms/Button'
 import type { ButtonType } from 'components/base/forms/Button'
+import { Icon } from 'components/icons'
 
 const themeOptions = Object.keys(themeClassNames) as Array<
   keyof typeof themeClassNames
@@ -19,7 +20,7 @@ const meta: Meta<ButtonType> = {
   argTypes: {
     children: {
       control: 'text',
-      description: 'Button label content.',
+      description: 'Button label content. Compose icons via `<Icon>` children.',
     },
     disabled: {
       control: 'boolean',
@@ -73,8 +74,8 @@ export const Variants: Story = {
       <Button theme='success'>Success</Button>
       <Button theme='tertiary'>Tertiary</Button>
       <Button theme='text'>Text</Button>
-      <Button theme='icon' iconLeft='copy'>
-        {''}
+      <Button theme='icon'>
+        <Icon name='copy' />
       </Button>
       <Button theme='project'>Project</Button>
     </div>
@@ -130,20 +131,47 @@ export const WithIcons: Story = {
     docs: {
       description: {
         story:
-          'Buttons support `iconLeft` and `iconRight` props. Pass any `IconName` from the icon system.',
+          'Icons compose via children — pass `<Icon>` JSX directly. Spacing between icon and label is handled by the button wrapper (`display: flex; gap: 0.5rem`).',
       },
     },
   },
   render: () => (
     <div className='d-flex align-items-center flex-wrap gap-2'>
-      <Button theme='primary' iconLeft='plus'>
+      <Button theme='primary'>
+        <Icon name='plus' />
         Add Item
       </Button>
-      <Button theme='danger' iconLeft='trash-2'>
+      <Button theme='danger'>
+        <Icon name='trash-2' />
         Delete
       </Button>
-      <Button theme='outline' iconRight='chevron-right'>
+      <Button theme='outline'>
         Next
+        <Icon name='chevron-right' />
+      </Button>
+    </div>
+  ),
+}
+
+export const IconOnly: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only buttons via `theme="icon"` (32×32) or `className="btn-with-icon"` (table-row affordances). Pass the icon as children.',
+      },
+    },
+  },
+  render: () => (
+    <div className='d-flex align-items-center flex-wrap gap-2'>
+      <Button theme='icon'>
+        <Icon name='copy' />
+      </Button>
+      <Button className='btn btn-with-icon' type='button'>
+        <Icon name='trash-2' width={20} />
+      </Button>
+      <Button className='btn btn-with-icon' type='button'>
+        <Icon name='edit' width={20} />
       </Button>
     </div>
   ),

--- a/frontend/documentation/components/Button.stories.tsx
+++ b/frontend/documentation/components/Button.stories.tsx
@@ -61,7 +61,7 @@ export const Variants: Story = {
     docs: {
       description: {
         story:
-          'All available button themes. Use `primary` for main actions, `secondary` for alternatives, `outline` for low-emphasis actions, `danger` for destructive actions, and `success` for positive confirmations. `icon` is for icon-only buttons (copy, action triggers in tables); `project` is the avatar-style button used in the project picker.',
+          'All available button themes. Use `primary` for main actions, `secondary` for alternatives, `outline` for low-emphasis actions, `danger` for destructive actions, and `success` for positive confirmations. `icon` is for icon-only buttons (copy, action triggers in tables).',
       },
     },
   },
@@ -77,7 +77,6 @@ export const Variants: Story = {
       <Button theme='icon'>
         <Icon name='copy' />
       </Button>
-      <Button theme='project'>Project</Button>
     </div>
   ),
 }

--- a/frontend/documentation/components/Button.stories.tsx
+++ b/frontend/documentation/components/Button.stories.tsx
@@ -61,7 +61,7 @@ export const Variants: Story = {
     docs: {
       description: {
         story:
-          'All available button themes. Use `primary` for main actions, `secondary` for alternatives, `outline` for low-emphasis actions, `danger` for destructive actions, and `success` for positive confirmations. `icon` is for icon-only buttons (copy, action triggers in tables).',
+          'All available button themes. Use `primary` for main actions, `secondary` for alternatives, `outline` for low-emphasis actions, `danger` for destructive actions, and `success` for positive confirmations.',
       },
     },
   },
@@ -85,7 +85,7 @@ export const Sizes: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Button sizes from large to extra small.',
+        story: 'Button sizes from large to extra-extra small.',
       },
     },
   },
@@ -95,6 +95,7 @@ export const Sizes: Story = {
       <Button size='default'>Default</Button>
       <Button size='small'>Small</Button>
       <Button size='xSmall'>Extra Small</Button>
+      <Button size='xxSmall'>XX Small</Button>
     </div>
   ),
 }
@@ -147,30 +148,6 @@ export const WithIcons: Story = {
       <Button theme='outline'>
         Next
         <Icon name='chevron-right' />
-      </Button>
-    </div>
-  ),
-}
-
-export const IconOnly: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Icon-only buttons via `theme="icon"` (32×32) or `className="btn-with-icon"` (table-row affordances). Pass the icon as children.',
-      },
-    },
-  },
-  render: () => (
-    <div className='d-flex align-items-center flex-wrap gap-2'>
-      <Button theme='icon'>
-        <Icon name='copy' />
-      </Button>
-      <Button className='btn btn-with-icon' type='button'>
-        <Icon name='trash-2' width={20} />
-      </Button>
-      <Button className='btn btn-with-icon' type='button'>
-        <Icon name='edit' width={20} />
       </Button>
     </div>
   ),

--- a/frontend/documentation/components/Button.stories.tsx
+++ b/frontend/documentation/components/Button.stories.tsx
@@ -131,7 +131,7 @@ export const WithIcons: Story = {
     docs: {
       description: {
         story:
-          'Icons compose via children — pass `<Icon>` JSX directly. Spacing between icon and label is handled by the button wrapper (`display: flex; gap: 0.5rem`).',
+          'Icons compose via children — pass `<Icon>` JSX directly alongside the label. Button handles icon+label spacing internally.',
       },
     },
   },

--- a/frontend/web/components/EditIdentity.tsx
+++ b/frontend/web/components/EditIdentity.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useRef, useState } from 'react'
 import { Identity } from 'common/types/responses'
 import { useUpdateIdentityMutation } from 'common/services/useIdentity'
 import Button from './base/forms/Button'
+import { Icon } from './icons'
 import ErrorMessage from './ErrorMessage'
 import GhostInput from './base/forms/GhostInput'
 
@@ -62,15 +63,13 @@ const EditIdentity: FC<EditIdentityType> = ({ data, environmentId }) => {
       />
       <Button
         disabled={!data}
-        iconSize={16}
         theme='text'
         style={{ lineHeight: 'inherit' }}
         className='text-primary d-flex align-items-center'
-        iconRightColour='primary'
-        iconRight={'edit'}
         onClick={handleFocus}
       >
         Edit
+        <Icon name='edit' width={16} />
       </Button>
       <ErrorMessage>{error}</ErrorMessage>
     </>

--- a/frontend/web/components/EditIdentity.tsx
+++ b/frontend/web/components/EditIdentity.tsx
@@ -64,8 +64,7 @@ const EditIdentity: FC<EditIdentityType> = ({ data, environmentId }) => {
       <Button
         disabled={!data}
         theme='text'
-        style={{ lineHeight: 'inherit' }}
-        className='text-primary d-flex align-items-center'
+        className='text-primary'
         onClick={handleFocus}
       >
         Edit

--- a/frontend/web/components/GoogleButton.tsx
+++ b/frontend/web/components/GoogleButton.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { TokenResponse, useGoogleLogin } from '@react-oauth/google'
 import Button from './base/forms/Button'
+import { Icon } from './icons'
 
 type GoogleButtonProps = {
   className?: string
@@ -22,10 +23,10 @@ const GoogleButton: FC<GoogleButtonProps> = ({ className, onSuccess }) => {
     <Button
       className={className}
       theme='secondary'
-      iconLeft='google'
       key='google'
       onClick={() => login()}
     >
+      <Icon name='google' />
       Google
     </Button>
   )

--- a/frontend/web/components/JSONReference.tsx
+++ b/frontend/web/components/JSONReference.tsx
@@ -5,7 +5,7 @@ import Highlight from './Highlight'
 import Button from './base/forms/Button'
 import Switch from './Switch'
 import flagsmith from '@flagsmith/flagsmith'
-import Icon from './icons/Icon'
+import { Icon } from './icons'
 import Utils from 'common/utils/utils'
 
 type JSONReferenceType = {
@@ -146,9 +146,8 @@ const JSONReference: FC<JSONReferenceType> = ({
                   Utils.copyToClipboard(condensed ? idsOnly : value)
                 }}
                 size='xSmall'
-                iconLeft='copy'
-                iconLeftColour='white'
               >
+                <Icon name='copy' />
                 Copy JSON
               </Button>
             </Row>

--- a/frontend/web/components/ViewDocs.tsx
+++ b/frontend/web/components/ViewDocs.tsx
@@ -7,8 +7,8 @@ type ViewDocsType = ButtonType & {}
 const ViewDocs: FC<ViewDocsType> = (props) => {
   return (
     <Button {...props} target='_blank' className='fw-bold' theme='text'>
-      <Icon style={{ marginTop: -5 }} fill={'#6837fc'} name={'file-text'} />
-      <span style={{ lineHeight: '24px' }}> View docs</span>
+      <Icon fill={'#6837fc'} name={'file-text'} />
+      View docs
     </Button>
   )
 }

--- a/frontend/web/components/ViewDocs.tsx
+++ b/frontend/web/components/ViewDocs.tsx
@@ -7,7 +7,7 @@ type ViewDocsType = ButtonType & {}
 const ViewDocs: FC<ViewDocsType> = (props) => {
   return (
     <Button {...props} target='_blank' className='fw-bold' theme='text'>
-      <Icon fill={'#6837fc'} name={'file-text'} />
+      <Icon name='file-text' />
       View docs
     </Button>
   )

--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -1,14 +1,6 @@
 import React from 'react'
 import cn from 'classnames'
 import { ButtonHTMLAttributes, HTMLAttributeAnchorTarget } from 'react'
-import Icon, { IconName } from 'components/icons/Icon'
-
-const iconColours = {
-  primary: '#6837fc',
-  white: '#ffffff',
-} as const
-
-export type IconColour = keyof typeof iconColours
 
 export const themeClassNames = {
   danger: 'btn btn-danger',
@@ -31,15 +23,10 @@ export const sizeClassNames = {
 }
 
 export type ButtonType = ButtonHTMLAttributes<HTMLButtonElement> & {
-  iconRight?: IconName
-  iconRightColour?: IconColour
-  iconLeftColour?: IconColour
-  iconLeft?: IconName
   href?: string
   target?: HTMLAttributeAnchorTarget
   theme?: keyof typeof themeClassNames
   size?: keyof typeof sizeClassNames
-  iconSize?: number
 }
 
 export const Button = React.forwardRef<
@@ -51,11 +38,6 @@ export const Button = React.forwardRef<
       children,
       className,
       href,
-      iconLeft,
-      iconLeftColour,
-      iconRight,
-      iconRightColour,
-      iconSize = 24,
       onMouseUp,
       size = 'default',
       target,
@@ -65,6 +47,11 @@ export const Button = React.forwardRef<
     },
     ref,
   ) => {
+    const content = (
+      <span className='d-flex h-100 align-items-center justify-content-center gap-2'>
+        {children}
+      </span>
+    )
     return href ? (
       <a
         onClick={rest.onClick as React.MouseEventHandler}
@@ -74,24 +61,7 @@ export const Button = React.forwardRef<
         rel='noreferrer'
         ref={ref as React.RefObject<HTMLAnchorElement>}
       >
-        <div className='d-flex h-100 align-items-center justify-content-center gap-2'>
-          {!!iconLeft && (
-            <Icon
-              fill={iconLeftColour ? iconColours[iconLeftColour] : undefined}
-              name={iconLeft}
-              width={iconSize}
-            />
-          )}
-          {children}
-        </div>
-        {!!iconRight && (
-          <Icon
-            fill={iconRightColour ? iconColours[iconRightColour] : undefined}
-            className='ml-2'
-            name={iconRight}
-            width={iconSize}
-          />
-        )}
+        {content}
       </a>
     ) : (
       <button
@@ -106,23 +76,7 @@ export const Button = React.forwardRef<
         )}
         ref={ref as React.RefObject<HTMLButtonElement>}
       >
-        {!!iconLeft && (
-          <Icon
-            fill={iconLeftColour ? iconColours[iconLeftColour] : undefined}
-            className='mr-2'
-            name={iconLeft}
-            width={iconSize}
-          />
-        )}
-        {children}
-        {!!iconRight && (
-          <Icon
-            fill={iconRightColour ? iconColours[iconRightColour] : undefined}
-            className='ml-2'
-            name={iconRight}
-            width={iconSize}
-          />
-        )}
+        {content}
       </button>
     )
   },

--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -7,7 +7,6 @@ export const themeClassNames = {
   icon: 'btn-icon',
   outline: 'btn--outline',
   primary: 'btn-primary',
-  project: 'btn-project',
   secondary: 'btn btn-secondary',
   success: 'btn btn-success',
   tertiary: 'btn-tertiary',

--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -47,11 +47,14 @@ export const Button = React.forwardRef<
     },
     ref,
   ) => {
-    const content = (
-      <span className='d-flex h-100 align-items-center justify-content-center gap-2'>
-        {children}
-      </span>
-    )
+    const content =
+      React.Children.count(children) > 1 ? (
+        <span className='d-flex h-100 align-items-center justify-content-center gap-2'>
+          {children}
+        </span>
+      ) : (
+        children
+      )
     return href ? (
       <a
         onClick={rest.onClick as React.MouseEventHandler}

--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -3,12 +3,12 @@ import cn from 'classnames'
 import { ButtonHTMLAttributes, HTMLAttributeAnchorTarget } from 'react'
 
 export const themeClassNames = {
-  danger: 'btn btn-danger',
+  danger: 'btn-danger',
   icon: 'btn-icon',
   outline: 'btn--outline',
   primary: 'btn-primary',
-  secondary: 'btn btn-secondary',
-  success: 'btn btn-success',
+  secondary: 'btn-secondary',
+  success: 'btn-success',
   tertiary: 'btn-tertiary',
   text: 'btn-link',
 }
@@ -46,39 +46,32 @@ export const Button = React.forwardRef<
     },
     ref,
   ) => {
-    const content =
-      React.Children.count(children) > 1 ? (
-        <span className='d-flex h-100 align-items-center justify-content-center gap-2'>
-          {children}
-        </span>
-      ) : (
-        children
-      )
+    const classes = cn(
+      'btn',
+      className,
+      themeClassNames[theme],
+      sizeClassNames[size],
+    )
     return href ? (
       <a
         onClick={rest.onClick as React.MouseEventHandler}
-        className={cn(className, themeClassNames[theme], sizeClassNames[size])}
+        className={classes}
         target={target}
         href={href}
         rel='noreferrer'
         ref={ref as React.RefObject<HTMLAnchorElement>}
       >
-        {content}
+        {children}
       </a>
     ) : (
       <button
         {...rest}
         type={type}
         onMouseUp={onMouseUp}
-        className={cn(
-          { btn: true },
-          className,
-          themeClassNames[theme],
-          sizeClassNames[size],
-        )}
+        className={classes}
         ref={ref as React.RefObject<HTMLButtonElement>}
       >
-        {content}
+        {children}
       </button>
     )
   },

--- a/frontend/web/components/icons/index.ts
+++ b/frontend/web/components/icons/index.ts
@@ -1,0 +1,2 @@
+export { default as Icon } from './Icon'
+export type { IconName } from './Icon'

--- a/frontend/web/components/modals/InviteUsers.tsx
+++ b/frontend/web/components/modals/InviteUsers.tsx
@@ -3,7 +3,6 @@ import Button from 'components/base/forms/Button'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Constants from 'common/constants'
 import Icon from 'components/icons/Icon'
-import { add } from 'ionicons/icons'
 import { IonIcon } from '@ionic/react'
 import { getPlanBasedOption } from 'components/PlanBasedAccess'
 import InputGroup from 'components/base/forms/InputGroup'
@@ -282,14 +281,8 @@ const InviteUsers: FC = () => {
                     ])
                   }
                 >
-                  <Row>
-                    <span className='pl-2 icon'>
-                      <IonIcon icon={add} style={{ fontSize: '13px' }} />
-                    </span>
-                    <span>
-                      {isSaving ? 'Sending' : 'Invite additional member'}
-                    </span>
-                  </Row>
+                  <Icon name='plus' width={16} />
+                  {isSaving ? 'Sending' : 'Invite additional member'}
                 </Button>
               </div>
 

--- a/frontend/web/components/modals/InviteUsers.tsx
+++ b/frontend/web/components/modals/InviteUsers.tsx
@@ -258,7 +258,7 @@ const InviteUsers: FC = () => {
                         onClick={() => deleteInvite(invite.temporaryId)}
                         className='btn btn-with-icon mb-2'
                       >
-                        <Icon name='trash-2' width={20} fill='#656D7B' />
+                        <Icon name='trash-2' width={20} />
                       </Button>
                     </div>
                   ) : (

--- a/frontend/web/components/modals/base/ModalConfirm.tsx
+++ b/frontend/web/components/modals/base/ModalConfirm.tsx
@@ -1,5 +1,6 @@
 import { Modal, ModalBody, ModalFooter } from 'reactstrap'
 import Button from 'components/base/forms/Button'
+import { Icon } from 'components/icons'
 import React, { FC, ReactNode } from 'react'
 import ModalHeader from './ModalHeader'
 import ModalHR from 'components/modals/ModalHR'
@@ -68,10 +69,10 @@ const Confirm: FC<Confirm> = ({
             theme='danger'
             id='confirm-btn-yes'
             disabled={disabled || disabledYes}
-            iconRight='fas fa-trash'
             onClick={yes}
           >
             {yesText}
+            <Icon name='trash-2' />
           </Button>
         ) : (
           <Button

--- a/frontend/web/components/modals/base/ModalConfirm.tsx
+++ b/frontend/web/components/modals/base/ModalConfirm.tsx
@@ -1,6 +1,5 @@
 import { Modal, ModalBody, ModalFooter } from 'reactstrap'
 import Button from 'components/base/forms/Button'
-import { Icon } from 'components/icons'
 import React, { FC, ReactNode } from 'react'
 import ModalHeader from './ModalHeader'
 import ModalHR from 'components/modals/ModalHR'
@@ -72,7 +71,6 @@ const Confirm: FC<Confirm> = ({
             onClick={yes}
           >
             {yesText}
-            <Icon name='trash-2' />
           </Button>
         ) : (
           <Button

--- a/frontend/web/components/pages/FlagEnvironmentsPage.tsx
+++ b/frontend/web/components/pages/FlagEnvironmentsPage.tsx
@@ -271,7 +271,8 @@ const FlagEnvironmentsPage: FC = () => {
                 : '',
             }}
           >
-            <Button theme='text' size='small' iconLeft='arrow-left'>
+            <Button theme='text' size='small'>
+              <Icon name='arrow-left' width={16} />
               Back to Release Manager
             </Button>
           </Link>

--- a/frontend/web/components/pages/FlagEnvironmentsPage.tsx
+++ b/frontend/web/components/pages/FlagEnvironmentsPage.tsx
@@ -6,7 +6,7 @@ import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import { useGetFeatureStatesQuery } from 'common/services/useFeatureState'
 import { useGetProjectQuery } from 'common/services/useProject'
 import Panel from 'components/base/grid/Panel'
-import Icon from 'components/icons/Icon'
+import { Icon } from 'components/icons'
 import TagValues from 'components/tags/TagValues'
 import Switch from 'components/Switch'
 import Button from 'components/base/forms/Button'
@@ -271,7 +271,8 @@ const FlagEnvironmentsPage: FC = () => {
                 : '',
             }}
           >
-            <Button theme='text' size='small' iconLeft='arrow-left'>
+            <Button theme='text' size='small'>
+              <Icon name='arrow-left' />
               Back to Release Manager
             </Button>
           </Link>

--- a/frontend/web/components/pages/FlagEnvironmentsPage.tsx
+++ b/frontend/web/components/pages/FlagEnvironmentsPage.tsx
@@ -6,7 +6,7 @@ import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import { useGetFeatureStatesQuery } from 'common/services/useFeatureState'
 import { useGetProjectQuery } from 'common/services/useProject'
 import Panel from 'components/base/grid/Panel'
-import { Icon } from 'components/icons'
+import Icon from 'components/icons/Icon'
 import TagValues from 'components/tags/TagValues'
 import Switch from 'components/Switch'
 import Button from 'components/base/forms/Button'
@@ -271,8 +271,7 @@ const FlagEnvironmentsPage: FC = () => {
                 : '',
             }}
           >
-            <Button theme='text' size='small'>
-              <Icon name='arrow-left' />
+            <Button theme='text' size='small' iconLeft='arrow-left'>
               Back to Release Manager
             </Button>
           </Link>

--- a/frontend/web/components/pages/HomePage.tsx
+++ b/frontend/web/components/pages/HomePage.tsx
@@ -11,6 +11,7 @@ import Button from 'components/base/forms/Button'
 import PasswordRequirements from 'components/PasswordRequirements'
 import { informationCircleOutline } from 'ionicons/icons'
 import { IonIcon } from '@ionic/react'
+import { Icon } from 'components/icons'
 import classNames from 'classnames'
 import InfoMessage from 'components/InfoMessage'
 import OnboardingPage from './OnboardingPage'
@@ -206,9 +207,9 @@ const HomePage: React.FC = () => {
           <Button
             theme='secondary'
             className='w-100'
-            iconLeft='github'
             href={JSON.parse(Utils.getFlagsmithValue('oauth_github')).url}
           >
+            <Icon name='github' />
             GitHub
           </Button>
         </div>,

--- a/frontend/web/components/pages/IdentityPage.tsx
+++ b/frontend/web/components/pages/IdentityPage.tsx
@@ -167,7 +167,7 @@ const IdentityPage: FC = () => {
                         />
                       </span>
                       {showAliases && (
-                        <h6 className='d-flex mb-0 align-items-end gap-1'>
+                        <h6 className='d-flex mb-0 align-items-baseline gap-1'>
                           <Tooltip
                             title={
                               <span className='user-select-none'>Alias: </span>

--- a/frontend/web/components/release-pipelines/PipelineStageActions.tsx
+++ b/frontend/web/components/release-pipelines/PipelineStageActions.tsx
@@ -4,6 +4,7 @@ import { StageActionBody, StageActionRequest } from 'common/types/requests'
 import { useMemo } from 'react'
 import SinglePipelineStageAction from './SinglePipelineStageAction'
 import Button from 'components/base/forms/Button'
+import { Icon } from 'components/icons'
 import { StageActionType } from 'common/types/responses'
 
 interface PipelineStageActionsProps {
@@ -60,7 +61,8 @@ const PipelineStageActions = ({
           onRemoveAction={index > 0 ? onRemoveAction : undefined}
         />
       ))}
-      <Button iconLeft='plus' className='w-100' onClick={onAddAction}>
+      <Button className='w-100' onClick={onAddAction}>
+        <Icon name='plus' />
         Add Flag Action
       </Button>
     </>

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -152,12 +152,12 @@ button.btn {
       height: 18px;
     }
     path {
-      fill: $text-muted;
+      fill: var(--color-icon-secondary);
     }
     &:hover,&:focus {
       background-color: $bg-light300;
       path {
-        fill: $body-color;
+        fill: var(--color-icon-default);
       }
     }
   }
@@ -349,14 +349,8 @@ $add-btn-size: 34px;
     }
     &.btn-icon {
       color: $body-color-dark;
-      path {
-        fill: $text-muted;
-      }
       &:hover,&:focus {
         background-color: $bg-dark300;
-        path {
-          fill: $body-color-dark;
-        }
       }
     }
     &.btn-secondary {

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -190,8 +190,6 @@ button.btn {
     }
   }
   &-project {
-    // Opt out of .btn's inline-flex/gap/44px-height — this is a tile-shaped
-    // surface, layout of letter+title is handled by the inner <Row>.
     display: inline-block;
     background-color: $bg-light200;
     color: $body-color;
@@ -273,8 +271,11 @@ button.btn {
   }
 }
 
-.btn-link {
-  display: inline-block;
+.btn-link,
+button.btn-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   text-decoration: none !important;
   vertical-align: baseline;
   font-family: $font-family;
@@ -284,6 +285,7 @@ button.btn {
   border: none;
   box-shadow: none;
   padding: 0;
+  height: auto;
   line-height: $line-height-base;
   text-transform: inherit;
   font-weight: 500;

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -122,15 +122,15 @@ button.btn {
     }
   }
   &-success {
-    background-color: $success;
+    background-color: $btn-success;
     &:hover,
     &:focus {
-      background-color: $success400;
+      background-color: $btn-success-hover;
       color: $text-icon-light;
     }
 
     &.btn:active {
-      background-color: $success600;
+      background-color: $btn-success-active;
       color: $text-icon-light;
     }
   }
@@ -363,9 +363,14 @@ $add-btn-size: 34px;
       }
     }
     &.btn-success {
+      background-color: $btn-success;
       &:hover,
       &:focus {
-        background-color: $success400;
+        background-color: $btn-success-hover;
+        color: $text-icon-light;
+      }
+      &:active {
+        background-color: $btn-success-active;
         color: $text-icon-light;
       }
     }
@@ -384,6 +389,10 @@ $add-btn-size: 34px;
       }
       &:focus {
         background-color: $btn-outline-focus-bg-dark;
+      }
+      &:active {
+        background-color: $btn-outline-active-bg;
+        color: $primary400;
       }
 
       &-danger {

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -190,6 +190,9 @@ button.btn {
     }
   }
   &-project {
+    // Opt out of .btn's inline-flex/gap/44px-height — this is a tile-shaped
+    // surface, layout of letter+title is handled by the inner <Row>.
+    display: inline-block;
     background-color: $bg-light200;
     color: $body-color;
     padding: 0px 8px;

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -36,6 +36,9 @@ button.btn {
       color: white;
       background-color: $btn-danger-active;
     }
+    &:disabled {
+      color: white;
+    }
   }
 
   &-success {
@@ -131,6 +134,9 @@ button.btn {
 
     &.btn:active {
       background-color: $btn-success-active;
+      color: $text-icon-light;
+    }
+    &:disabled {
       color: $text-icon-light;
     }
   }

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -165,6 +165,9 @@ button.btn {
     padding: 0 14px;
     background-color: $basic-alpha-8;
     border-radius: $border-radius;
+    svg path {
+      fill: var(--color-icon-secondary);
+    }
     &:hover,
     &:active,
     &:disabled {

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -2,19 +2,15 @@
 
 .btn,
 button.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: $btn-line-height;
   white-space: nowrap;
   color: white;
-  // Project button, to remove with project select bar
-  &:hover,
-  &:focus {
-    background-color: $btn-hover-bg;
-  }
   &:focus-visible {
     box-shadow: none;
-  }
-
-  &.btn:active {
-    background-color: $btn-active-bg;
   }
 
   &-link {
@@ -343,13 +339,6 @@ $add-btn-size: 34px;
 
 .dark {
   .btn {
-    &:hover,
-    &:focus {
-      background-color: $btn-hover-bg-dark;
-    }
-    &:active {
-      background-color: $primary;
-    }
     &.btn-icon {
       color: $body-color-dark;
       &:hover,&:focus {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to a review comment on #7100 — icon-only buttons (`theme='icon'`) rendered with the icon visibly off-centre. The cause was margin-based spacing: `iconLeft` and `iconRight` props applied `mr-2` / `ml-2` directly to the icon. On icon-only variants (32×32 with `justify-content: center`), the trailing margin pushed the icon a few pixels off-centre — flexbox re-centres the item itself, but the margin still shifts the content inside.

Rather than patching the margin, this PR drops the icon-position props and lets `.btn` handle spacing natively.

**Button API**
- Drop `iconLeft` / `iconRight` props. Icons now compose as children alongside the label.

**`.btn` layout**
- Switch from Bootstrap-default `inline-block` to `inline-flex` with `align-items: center; gap: 0.5rem` — siblings space themselves, no wrapper span or margin tricks, icon-only buttons centre by construction.
- Pin `height: $btn-line-height` so default-size buttons keep their 44px box (inline-flex would otherwise collapse to content height).
- Drop the legacy `.btn:hover` / `.btn:active` rules (and their `.dark` counterparts) that forced a purple background on every variant — they were project-picker leftovers leaking onto Danger / Tertiary / Success in both modes.

**Variant adjustments**
- `.btn-link` (`theme='text'`) is now `inline-flex` with `vertical-align: baseline` and `height: auto`, so it flows inline with surrounding text instead of rendering as a 44px box.
- `.btn-project` (project picker tiles) opts out of the new flex layout — it's a 76px tile surface, not a button-shaped affordance.

**Consumer cleanups**
- `InviteUsers` `+` icon: drop the broken `<Row>` + padding wrapper, swap IonIcon for the project's `<Icon name='plus'>` at 16px (the small-button norm).
- `ViewDocs`: drop the manual `marginTop: -5` / `lineHeight: 24px` alignment hacks now that `.btn` does centring natively.
- Hardcoded hex `fill` values on icons in the touched files → semantic tokens (or dropped where the parent's `color` already drives the icon via `currentColor`).

**Storybook**
- Add the missing `xxSmall` variant to the Sizes story.
- Trim the Variants story description so it doesn't point readers at `theme='icon'` for table actions (a future `IconButton` primitive will own that pattern).

## How did you test this code?

- Storybook → `Components/Button` → walked through Variants / Sizes / Disabled / WithIcons.
- Light + dark mode hover sweep across Primary / Secondary / Outline / Danger / Success / Tertiary / Text — variant hovers all win, no purple bleed.
- Identity page → alias `Edit` button baseline-aligned with the surrounding text.
- Project picker → letter sizing consistent across all tiles.
- Invite Users modal → `+` icon spaced cleanly from the label.
- Chromatic snapshot diff shows the centring correction on the existing button stories with no regressions on other variants.
