### PR TITLE
fix(tabs): unsaved-changes badge positioning

### DIFF
--- a/frontend/documentation/components/Tabs.stories.tsx
+++ b/frontend/documentation/components/Tabs.stories.tsx
@@ -50,3 +50,27 @@ export const PillTheme: Story = {
     </Tabs>
   ),
 }
+
+export const WithDirtyMarker: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Set `isDirty` on a `TabItem` to show an unsaved-changes badge next to its label. The badge sits inside an inline-flex wrapper so it never breaks onto a second line and stays vertically aligned with the label.',
+      },
+    },
+  },
+  render: () => (
+    <Tabs uncontrolled>
+      <TabItem tabLabel='Value' isDirty>
+        <p className='mt-3'>This tab has unsaved changes.</p>
+      </TabItem>
+      <TabItem tabLabel='Segment Overrides' isDirty>
+        <p className='mt-3'>This tab also has unsaved changes.</p>
+      </TabItem>
+      <TabItem tabLabel='Settings'>
+        <p className='mt-3'>No unsaved changes here.</p>
+      </TabItem>
+    </Tabs>
+  ),
+}

--- a/frontend/documentation/components/Tabs.stories.tsx
+++ b/frontend/documentation/components/Tabs.stories.tsx
@@ -5,7 +5,27 @@ import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import { withRouter } from './_decorators'
 
-const meta: Meta = {
+const DIRTY_MARKER_TABS = ['Value', 'Segment Overrides', 'Settings'] as const
+type DirtyMarkerTab = (typeof DIRTY_MARKER_TABS)[number]
+
+type DirtyMarkerArgs = {
+  theme: 'tab' | 'pill'
+  dirtyTabs: DirtyMarkerTab[]
+}
+
+const meta: Meta<DirtyMarkerArgs> = {
+  argTypes: {
+    dirtyTabs: {
+      control: 'check',
+      description: 'Which tabs show the unsaved-changes badge.',
+      options: DIRTY_MARKER_TABS,
+    },
+    theme: {
+      control: 'radio',
+      description: 'Visual variant of the tab bar.',
+      options: ['tab', 'pill'],
+    },
+  },
   decorators: [withRouter],
   parameters: {
     docs: {
@@ -20,7 +40,7 @@ const meta: Meta = {
 }
 export default meta
 
-type Story = StoryObj
+type Story = StoryObj<DirtyMarkerArgs>
 
 export const Default: Story = {
   render: () => (
@@ -52,25 +72,49 @@ export const PillTheme: Story = {
 }
 
 export const WithDirtyMarker: Story = {
+  args: {
+    dirtyTabs: ['Value', 'Segment Overrides'],
+    theme: 'tab',
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Set `isDirty` on a `TabItem` to show an unsaved-changes badge next to its label. The badge sits inside an inline-flex wrapper so it never breaks onto a second line and stays vertically aligned with the label.',
+          'Set `isDirty` on a `TabItem` to surface an unsaved-changes indicator on its label. Use the controls to toggle dirty state per tab and switch between the default and pill themes.',
       },
     },
   },
-  render: () => (
-    <Tabs uncontrolled>
-      <TabItem tabLabel='Value' isDirty>
-        <p className='mt-3'>This tab has unsaved changes.</p>
-      </TabItem>
-      <TabItem tabLabel='Segment Overrides' isDirty>
-        <p className='mt-3'>This tab also has unsaved changes.</p>
-      </TabItem>
-      <TabItem tabLabel='Settings'>
-        <p className='mt-3'>No unsaved changes here.</p>
-      </TabItem>
+  render: ({ dirtyTabs, theme }) => (
+    <Tabs theme={theme} uncontrolled>
+      {DIRTY_MARKER_TABS.map((label) => (
+        <TabItem
+          key={label}
+          tabLabel={label}
+          isDirty={dirtyTabs.includes(label)}
+        >
+          <p className='mt-3'>
+            {dirtyTabs.includes(label)
+              ? 'This tab has unsaved changes.'
+              : 'No unsaved changes here.'}
+          </p>
+        </TabItem>
+      ))}
     </Tabs>
   ),
+}
+
+export const WithDirtyMarkerOnPillTheme: Story = {
+  ...WithDirtyMarker,
+  args: {
+    dirtyTabs: ['Value', 'Segment Overrides'],
+    theme: 'pill',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same `isDirty` pattern as the default theme, in the pill variant.',
+      },
+    },
+  },
 }

--- a/frontend/web/components/modals/CreateGroup.tsx
+++ b/frontend/web/components/modals/CreateGroup.tsx
@@ -454,17 +454,10 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
   )
   return isEdit ? (
     <Tabs uncontrolled className='px-0'>
-      <TabItem
-        tabLabel={
-          <div>
-            General
-            {!!edited && <span className='unread'>*</span>}
-          </div>
-        }
-      >
+      <TabItem tabLabel='General' isDirty={!!edited}>
         {editGroupEl}
       </TabItem>
-      <TabItem tabLabel={<div>Permissions</div>}>{editPermissionsEl}</TabItem>
+      <TabItem tabLabel='Permissions'>{editPermissionsEl}</TabItem>
     </Tabs>
   ) : (
     editGroupEl

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -503,15 +503,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
           urlParam='segmentTab'
           onChange={(tab: UserTabs) => setTab(tab)}
         >
-          <TabItem
-            tabLabelString='General'
-            tabLabel={
-              <Row className='justify-content-center flex-nowrap'>
-                General{' '}
-                {valueChanged && <div className='unread ml-2 px-1'>{'*'}</div>}
-              </Row>
-            }
-          >
+          <TabItem tabLabel='General' isDirty={valueChanged}>
             <div className='my-4'>
               <CreateSegmentRulesTabForm
                 is4Eyes={is4Eyes}
@@ -564,17 +556,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
             </div>
           </TabItem>
           {metadataEnable && segmentContentType?.id && (
-            <TabItem
-              tabLabelString='Custom Fields'
-              tabLabel={
-                <Row className='justify-content-center flex-nowrap'>
-                  Custom Fields
-                  {metadataValueChanged && (
-                    <div className='unread ml-2 px-1 pt-2'>{'*'}</div>
-                  )}
-                </Row>
-              }
-            >
+            <TabItem tabLabel='Custom Fields' isDirty={metadataValueChanged}>
               <div className='my-4'>{MetadataTab}</div>
             </TabItem>
           )}

--- a/frontend/web/components/modals/create-experiment/index.js
+++ b/frontend/web/components/modals/create-experiment/index.js
@@ -468,17 +468,8 @@ const Index = class extends Component {
                                 >
                                   <TabItem
                                     data-test='value'
-                                    tabLabelString='Value'
-                                    tabLabel={
-                                      <Row className='justify-content-center'>
-                                        Value{' '}
-                                        {this.state.valueChanged && (
-                                          <div className='unread ml-2 px-1'>
-                                            {'*'}
-                                          </div>
-                                        )}
-                                      </Row>
-                                    }
+                                    tabLabel='Value'
+                                    isDirty={this.state.valueChanged}
                                   >
                                     <FeatureValueTab
                                       error={error}

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -580,15 +580,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                 >
                   <TabItem
                     data-test='value'
-                    tabLabelString='Value'
-                    tabLabel={
-                      <Row className='justify-content-center'>
-                        Value{' '}
-                        {valueChanged && (
-                          <div className='unread ml-2 px-1'>{'*'}</div>
-                        )}
-                      </Row>
-                    }
+                    tabLabel='Value'
+                    isDirty={valueChanged}
                   >
                     <FeatureValueTab
                       error={error}
@@ -624,19 +617,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                     updateSegments && (
                       <TabItem
                         data-test='segment_overrides'
-                        tabLabelString='Segment Overrides'
-                        tabLabel={
-                          <Row
-                            className={`justify-content-center ${
-                              segmentsChanged ? 'pr-1' : ''
-                            }`}
-                          >
-                            Segment Overrides{' '}
-                            {segmentsChanged && (
-                              <div className='unread ml-2 px-2'>*</div>
-                            )}
-                          </Row>
-                        }
+                        tabLabel='Segment Overrides'
+                        isDirty={segmentsChanged}
                       >
                         <SegmentOverridesTab
                           projectId={projectId}
@@ -745,15 +727,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                   {!existingChangeRequest && (
                     <TabItem
                       data-test='settings'
-                      tabLabelString='Settings'
-                      tabLabel={
-                        <Row className='justify-content-center'>
-                          Settings{' '}
-                          {settingsChanged && (
-                            <div className='unread ml-2 px-1'>{'*'}</div>
-                          )}
-                        </Row>
-                      }
+                      tabLabel='Settings'
+                      isDirty={settingsChanged}
                     >
                       <FeatureSettings
                         identity={identity}

--- a/frontend/web/components/navigation/TabMenu/TabButton.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabButton.tsx
@@ -27,7 +27,10 @@ const TabButton = React.forwardRef<HTMLButtonElement | null, TabButtonProps>(
           isSelected ? ' tab-active' : ''
         } ${className}`}
       >
-        {child.props.tabLabel}
+        <span className='btn-tab__label'>
+          {child.props.tabLabel}
+          {child.props.isDirty && <span className='unread'>*</span>}
+        </span>
       </Button>
     )
   },

--- a/frontend/web/components/navigation/TabMenu/TabButton.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabButton.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { themeClassNames } from 'components/base/forms/Button'
 
 import Button from 'components/base/forms/Button'
+import ColorSwatch from 'components/ColorSwatch'
+import { colorIconWarning } from 'common/theme/tokens'
 
 interface TabButtonProps {
   noFocus?: boolean
@@ -29,7 +31,11 @@ const TabButton = React.forwardRef<HTMLButtonElement | null, TabButtonProps>(
       >
         <span className='btn-tab__label'>
           {child.props.tabLabel}
-          {child.props.isDirty && <span className='unread'>*</span>}
+          {child.props.isDirty && (
+            <span role='status' aria-label='Unsaved changes'>
+              <ColorSwatch color={colorIconWarning} shape='circle' size='sm' />
+            </span>
+          )}
         </span>
       </Button>
     )

--- a/frontend/web/components/navigation/TabMenu/TabItem.tsx
+++ b/frontend/web/components/navigation/TabMenu/TabItem.tsx
@@ -5,6 +5,10 @@ type TabItemType = {
   tabLabel: ReactNode
   children: ReactNode
   className?: string
+  // Renders an unsaved-changes badge next to the label. Lifted out of consumers
+  // so positioning lives in one place and TabButton can wrap label + badge in
+  // a flex container that prevents the badge from breaking onto a new line.
+  isDirty?: boolean
 }
 
 const TabItem: FC<TabItemType> = ({ children }) => {

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -141,6 +141,14 @@
 
 .btn-tab {
   position: relative;
+
+  .btn-tab__label {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 4px;
+  }
+
   .unread {
     padding-left: 0 !important;
     padding-right: 0 !important;

--- a/frontend/web/styles/components/_tabs.scss
+++ b/frontend/web/styles/components/_tabs.scss
@@ -149,17 +149,6 @@
     gap: 4px;
   }
 
-  .unread {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    width: 16px;
-    height: 16px;
-    line-height: 15px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
   &.btn-no-focus {
     &:focus {
       box-shadow: none !important;
@@ -167,9 +156,4 @@
       background-color: transparent !important;
     }
   }
-}
-
-.pill .btn-tab .unread {
-  margin-left: calc($spacer / 2);
-  position: static;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to \`docs/\` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6935 

The unsaved-changes badge was reimplemented at every call site as a JSX `tabLabel` containing a `<div className='unread'>*</div>`. Each site had its own slightly different wrapper (`<Row>`, `<div>`, varying margin/padding classes), and one of those reimplementations caused #6935 — the badge overflowed below the active-tab underline and stayed visible on inactive tabs.

This PR lifts the badge into Tabs:

- Add `isDirty?: boolean` to `TabItem`.
- `TabButton` wraps label + badge in an inline-flex `.btn-tab__label` container so they always stay on the same line and align vertically.
- Migrate seven badged sites in \`CreateGroup\`, \`CreateSegment\` (×2), \`CreateFeature\` (×3), and \`create-experiment\` from inline JSX wrappers to \`tabLabel='Foo' isDirty={x}\`.
- New \`WithDirtyMarker\` story in \`Tabs.stories.tsx\` for Chromatic coverage.

8 files, +52 / −72.

The broader Tabs API cleanup (URL-sync hook, drop \`uncontrolled\`, etc.) is parked in #7386 and #7387 and will follow up on this.

## How did you test this code?

Manually verified:

1. Open a feature in the Edit Feature modal.
2. Toggle a value on the **Value** tab → \`*\` badge appears inline with the label, no overflow below the underline.
3. Switch to **Identity Overrides** → previous tab's badge is no longer visible (regression from #6935 fixed).
4. Repeat on **Segment Overrides** and **Settings** tabs (each tracks its own dirty state).
5. Verified **Edit Group** ▸ General, **Create Segment** ▸ General / Custom Fields, and **Create Experiment** ▸ Value still render the badge correctly.
6. Pill-themed tabs and overflow dropdown unaffected (sanity-checked on Permissions modals and Diff Segment Overrides).

Typecheck error count unchanged from baseline; lint passes on all touched files.