### PR TITLE
docs: add vulnerability response policy to support page

### DIFF
--- a/docs/docs/support/index.mdx
+++ b/docs/docs/support/index.mdx
@@ -32,6 +32,20 @@ Beyond that, many issues have already been solved. A quick search can save you t
   - [Rust](https://github.com/Flagsmith/flagsmith-rust-client)
   - [Elixir](https://github.com/Flagsmith/flagsmith-elixir-client)
 
+## CVEs and Vulnerability Reports
+
+### Remediation SLAs
+
+Severity is assigned using CVSS together with the exploitability of the component as Flagsmith uses it.
+
+| Severity      | Remediation SLA |
+| ------------- | --------------- |
+| Critical/High | 30 days         |
+| Medium        | 60 days         |
+| Low           | 90 days         |
+
+Flagsmith evaluates exploitability for each reported finding.
+
 ## What We Need From You
 
 When you do reach out, including the right information from the start makes a big difference. Here's what helps us


### PR DESCRIPTION
## Summary

- Add a "CVEs and Vulnerability Reports" section to `docs/docs/support/index.mdx`.
- Document Flagsmith's CVE remediation SLAs (30/60/90 days for critical/high, medium, and low) and the severity model based on CVSS together with exploitability as Flagsmith uses the component.