### PR TITLE
ci(chromatic): skip Chromatic on Dependabot PRs

### DIFF
--- a/.github/workflows/frontend-chromatic.yml
+++ b/.github/workflows/frontend-chromatic.yml
@@ -23,7 +23,12 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    # Dependabot PRs use a separate secrets store, so they can't read
+    # CHROMATIC_PROJECT_TOKEN. main's post-merge push runs Chromatic
+    # with full secrets, so coverage isn't lost.
+    if: |
+      github.actor != 'dependabot[bot]'
+      && (github.event_name == 'push' || github.event.pull_request.draft == false)
 
     defaults:
       run:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to a question raised on #7375 by @Zaimwa9 — Chromatic CI is currently failing on every Dependabot npm PR with `✖ Missing project token`.

**TL;DR.** Dependabot PRs can't read `CHROMATIC_PROJECT_TOKEN` (separate secrets store), so Chromatic fails with "Missing project token". This skips Chromatic on Dependabot PRs only. main's post-merge push still runs Chromatic with full secrets, so coverage isn't lost.

### Cause

GitHub runs Dependabot PRs with a separate secrets store (`Settings → Secrets and variables → Dependabot`) that doesn't include the `CHROMATIC_PROJECT_TOKEN` we have in the regular Actions secrets. The Chromatic action then aborts with `Missing project token`.

This isn't a misconfiguration — it's the platform protecting us. If Actions secrets were exposed to Dependabot PRs, a malicious `package-lock.json` poisoned dep could exfiltrate them via `postinstall` scripts (see e.g. the [Codecov 2021 incident](https://about.codecov.io/security-update/) for the canonical version of this attack).

Confirmed via the workflow logs of #7375's last run:

```
Secret source: Dependabot
✖ Missing project token
```

### Fix

Skip the Chromatic job when `github.actor == 'dependabot[bot]'`:

```yaml
if: |
  github.actor != 'dependabot[bot]'
  && (github.event_name == 'push' || github.event.pull_request.draft == false)
```

When the Dependabot PR eventually merges into `main`, the push event runs Chromatic with the parent's secrets — so any visual regression a bump introduces is still caught, one merge later instead of pre-merge. Trade-off accepted given dep bumps rarely change visual output.

### Alternatives considered

- **Add `CHROMATIC_PROJECT_TOKEN` to Dependabot secrets store.** Would make Chromatic run on Dependabot PRs the same as any other. Rejected: widens the secret-access surface for the bot whose PRs are most likely to bring in arbitrary transitive deps.
- **Switch to `pull_request_target` event.** Foot-gun. Gives PR code access to the base repo's secrets — exactly the attack vector the platform-level isolation is preventing. Hard pass.

## How did you test this code?

- Cause confirmed via the workflow logs of #7375's failed run (cited above).
- Fix follows GitHub's documented `github.actor` behaviour for Dependabot PRs ([Actions context docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), [Dependabot secret-isolation behaviour](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets)).
- Verifiable post-merge by re-running CI on #7375 — the Chromatic job should skip cleanly instead of erroring on the missing token.
