### PR TITLE
fix(button): use :focus-visible for hover-bg, drop click-focused dark state

### DIFF
--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -5,8 +5,12 @@ button.btn {
   white-space: nowrap;
   color: white;
   // Project button, to remove with project select bar
+  // Use `:focus-visible` (keyboard / programmatic focus only) instead of
+  // `:focus` so a mouse click doesn't leave the button visibly "pressed"
+  // until the user clicks elsewhere — focus persists on click by design,
+  // we just don't want it to look like a held-down state.
   &:hover,
-  &:focus {
+  &:focus-visible {
     background-color: $btn-hover-bg;
   }
   &:focus-visible {

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -24,7 +24,7 @@ button.btn {
   &-link {
     color: $primary;
     &:hover,
-    &:focus {
+    &:focus-visible {
       background: transparent;
     }
     &.btn:active {
@@ -36,7 +36,7 @@ button.btn {
   &-danger {
     color: white;
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: white;
       background-color: $btn-danger-hover;
     }
@@ -49,7 +49,7 @@ button.btn {
   &-success {
     color: white;
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: white;
       background-color: $btn-success-hover;
     }
@@ -77,7 +77,7 @@ button.btn {
       color: $primary;
     }
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-outline-hover-bg;
       color: $primary;
     }
@@ -90,7 +90,7 @@ button.btn {
       border-color: $alert-danger-border-color !important;
       color: $danger !important;
       &:hover,
-      &:focus {
+      &:focus-visible {
         background-color: $danger-alfa-8;
       }
       &.btn:active {
@@ -104,7 +104,7 @@ button.btn {
     background-color: $btn-secondary-bg !important;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-secondary-hover-bg !important;
       color: $body-color;
     }
@@ -119,7 +119,7 @@ button.btn {
     background-color: $btn-tertiary-bg;
     box-shadow: 0 10px 20px rgba(247, 213, 110, .2);
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-tertiary-hover-bg;
       color: $body-color;
     }
@@ -132,7 +132,7 @@ button.btn {
   &-success {
     background-color: $success;
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $success400;
       color: $text-icon-light;
     }
@@ -158,7 +158,7 @@ button.btn {
     path {
       fill: $text-muted;
     }
-    &:hover,&:focus {
+    &:hover,&:focus-visible {
       background-color: $bg-light300;
       path {
         fill: $body-color;
@@ -179,7 +179,7 @@ button.btn {
         }
       }
     }
-    &:focus {
+    &:focus-visible {
       background-color: $basic-alpha-8 !important;
       svg {
         path {
@@ -225,7 +225,7 @@ button.btn {
     }
     &.btn:hover,
     &.btn:active,
-    &.btn:focus {
+    &.btn:focus-visible {
       background-color: $bg-light200;
       color: $body-color;
       & .btn-project-letter {
@@ -290,7 +290,7 @@ button.btn {
   text-transform: inherit;
   font-weight: 500;
   &:hover,
-  &:focus {
+  &:focus-visible {
     color: $link-color;
     background: transparent;
     text-decoration: underline;
@@ -345,7 +345,7 @@ $add-btn-size: 34px;
 .dark {
   .btn {
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-hover-bg-dark;
     }
     &:active {
@@ -356,7 +356,7 @@ $add-btn-size: 34px;
       path {
         fill: $text-muted;
       }
-      &:hover,&:focus {
+      &:hover,&:focus-visible {
         background-color: $bg-dark300;
         path {
           fill: $body-color-dark;
@@ -367,7 +367,7 @@ $add-btn-size: 34px;
       color: white;
       background-color: $btn-secondary-bg-dark !important;
       &:hover,
-      &:focus {
+      &:focus-visible {
         background-color: $btn-secondary-hover-bg-dark !important;
       }
       &:active {
@@ -377,7 +377,7 @@ $add-btn-size: 34px;
     }
     &.btn-success {
       &:hover,
-      &:focus {
+      &:focus-visible {
         background-color: $success400;
         color: $text-icon-light;
       }
@@ -395,7 +395,7 @@ $add-btn-size: 34px;
         border-color: $primary400;
         background-color: $btn-outline-hover-bg-dark;
       }
-      &:focus {
+      &:focus-visible {
         background-color: $btn-outline-focus-bg-dark;
       }
 
@@ -408,7 +408,7 @@ $add-btn-size: 34px;
       background-color: transparent;
       &:hover,
       &:active,
-      &:focus {
+      &:focus-visible {
         background-color: transparent;
         color: $dark-highlight-color;
       }
@@ -436,7 +436,7 @@ $add-btn-size: 34px;
       }
 
       &.btn:hover,
-      &.btn:focus,&.btn:active {
+      &.btn:focus-visible,&.btn:active {
         background-color: $bg-dark200;
         color: $text-icon-light;
         & .btn-project-letter {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to \`docs/\` if required so people know about the feature.
- [x] I have filled in the \"Changes\" section below.
- [x] I have filled in the \"How did you test this code\" section below.

## Changes

**TL;DR.** Primary buttons stay visibly \"pressed\" after a mouse click until the user clicks elsewhere. Switching the focus-state CSS from \`:focus\` to \`:focus-visible\` removes the click-and-stuck appearance while preserving the keyboard-focus indicator.

### Cause

`_buttons.scss` lines 8–11 (pre-fix):

```scss
.btn, button.btn {
  &:hover,
  &:focus {
    background-color: \$btn-hover-bg;  // = \$primary600 (darker primary)
  }
}
```

`:focus` matches **any** focus event, including the focus a browser implicitly gives a button after a mouse click. So the flow is:

1. User clicks a primary button → browser focuses it.
2. `:focus` fires → background turns to `\$primary600` (darker).
3. Focus persists until the user clicks elsewhere or tabs away → button stays dark.

Visible on every primary button across the app. Storybook surfaces it most obviously because the button stays in view post-click, but it happens in production too — confirmed by clicking *Create Identities* on the Identities page and watching the button stay dark.

### Fix

Single rule change: `:focus` → `:focus-visible`.

```diff
   &:hover,
-  &:focus {
+  &:focus-visible {
     background-color: \$btn-hover-bg;
   }
```

`:focus-visible` is the modern pseudo-class that matches focus only when it arrived via keyboard navigation (Tab) or programmatic focus — not mouse clicks. Browser support is universal across all evergreen browsers.

After the change:
- **Mouse click:** button is still focused (browser default) but `:focus-visible` doesn't match → no darkening → no stuck appearance. ✓
- **Tab key:** `:focus-visible` matches → background darkens → keyboard users see the focus state. ✓ (a11y preserved)
- **`:focus-visible { box-shadow: none }`** rule on the next line stays as-is — same intent (suppress Bootstrap's default focus ring on keyboard focus, since the bg-darkening is the visual indicator).

### Out of scope

The `:focus` references in `.btn-project` rules (lines 224, 435) are visual focus styles for the project-picker variant. They probably want the same treatment but the `.btn-project` rendering is more involved than the base button — kept out of this PR to keep the diff focused. Worth a follow-up if Chromatic flags any visual divergence in those stories.

## How did you test this code?

- Reproduced on `main` by clicking *Create Identities* on the Identities page and observing the button stay darkened until clicking elsewhere.
- After the fix: same click no longer leaves the button visibly pressed.
- Keyboard verification: \`Tab\` to a button, confirmed the darker background still appears (a11y indicator intact).
- Chromatic build on this PR will diff every primary/secondary/danger/etc. button snapshot in the design system — worth scrolling through to confirm no surface relies on the old click-focused appearance.