### PR TITLE
fix: handle non-numeric organisation query parameter gracefully - Issue #7426

### DIFF
--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -100,7 +100,13 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
 
         organisation_id = self.request.query_params.get("organisation")
         if organisation_id:
-            queryset = queryset.filter(organisation__id=organisation_id)
+            try:
+                # Validate that organisation_id is numeric before filtering
+                int(organisation_id)
+                queryset = queryset.filter(organisation__id=organisation_id)
+            except (ValueError, TypeError):
+                # Return empty queryset if organisation_id is not a valid integer
+                return Project.objects.none()
 
         project_uuid = self.request.query_params.get("uuid")
         if project_uuid:

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1079,7 +1079,10 @@ def test_list_projects__non_numeric_organisation_parameter_with_valid_projects__
 ) -> None:
     # Given - a request with non-numeric organisation query parameter
     # even though there are projects in the system
-    url = reverse("api-v1:projects:project-list") + f"?organisation=invalid_id_{organisation.id}"
+    url = (
+        reverse("api-v1:projects:project-list")
+        + f"?organisation=invalid_id_{organisation.id}"
+    )
 
     # When
     response = admin_client.get(url)

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1055,3 +1055,35 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
     assert len(response.json()) > 0
     assert "enforce_feature_owners" in response.json()[0]
     assert response.json()[0]["enforce_feature_owners"] is False
+
+
+def test_list_projects__non_numeric_organisation_parameter__returns_empty_list(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given - a request with non-numeric organisation query parameter
+    url = reverse("api-v1:projects:project-list") + "?organisation=invalid_string"
+
+    # When
+    response = admin_client.get(url)
+
+    # Then - should return 200 with empty list, not crash with 500
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+
+
+def test_list_projects__non_numeric_organisation_parameter_with_valid_projects__returns_empty_list(
+    admin_client: APIClient,
+    project: Project,
+    organisation: Organisation,
+) -> None:
+    # Given - a request with non-numeric organisation query parameter
+    # even though there are projects in the system
+    url = reverse("api-v1:projects:project-list") + f"?organisation=invalid_id_{organisation.id}"
+
+    # When
+    response = admin_client.get(url)
+
+    # Then - should return 200 with empty list, not crash with 500
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []


### PR DESCRIPTION
Fixes Issue #7426: API crash on /api/v1/projects/ with non-numeric organisation query parameter

## Problem
The API endpoint `/api/v1/projects/` crashes with a `ValueError` when the `organisation` query parameter is provided with a non-numeric value.

### Error Details
```
ValueError: invalid literal for int() with base 10: 'A60ZG9cp5WC53RRZHDkIlUiWuAL57Jhi'
File "django/db/models/fields/__init__.py", line 2128, in get_prep_value
    return int(value)
File "api/projects/views.py", line 103, in get_queryset
    queryset = queryset.filter(organisation__id=organisation_id)
```

### Root Cause
The `ProjectViewSet.get_queryset()` method directly uses the `organisation` query parameter for database filtering without validating that it's a valid integer. Django's ORM attempts to convert it to an integer for the field lookup, which fails with a traceback instead of returning a proper 4xx response.

## Solution
Added input validation to check that the `organisation_id` parameter is numeric before using it for filtering:

1. Attempt to convert `organisation_id` to int
2. If conversion succeeds, proceed with the filter
3. If conversion fails (ValueError/TypeError), return an empty queryset
4. This returns a 200 response with an empty array instead of a 500 error

### Implementation
```python
organisation_id = self.request.query_params.get("organisation")
if organisation_id:
    try:
        int(organisation_id)  # Validate it's numeric
        queryset = queryset.filter(organisation__id=organisation_id)
    except (ValueError, TypeError):
        return Project.objects.none()  # Invalid ID, return empty queryset
```

## Behavior Changes
- **Before:** `/api/v1/projects/?organisation=invalid` → 500 Internal Server Error
- **After:** `/api/v1/projects/?organisation=invalid` → 200 OK with empty array `[]`

## Testing Checklist

- [x] Verify fix compiles/lints successfully
- [x] Valid numeric organisation IDs still work correctly
- [x] Invalid non-numeric organisation IDs return empty queryset (not crash)
- [x] Empty organisation parameter works as before
- [x] No organisation parameter works as before
- [x] Other query parameters (uuid, etc.) still work
- [x] Response is valid JSON for all scenarios
- [x] No database errors in test suite