### PR TITLE
fix: dedupe integration list in onboarding select

### DIFF
--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -508,11 +508,6 @@ const Constants = {
     },
     {
       categories: ['CI/CD'],
-      image: '/static/images/integrations/gitlab.svg',
-      title: 'GitLab',
-    },
-    {
-      categories: ['CI/CD'],
       image: '/static/images/integrations/azure-devops.svg',
       title: 'Azure DevOps',
     },

--- a/frontend/web/components/IntegrationSelect.tsx
+++ b/frontend/web/components/IntegrationSelect.tsx
@@ -6,7 +6,7 @@ import {
 } from './pages/IntegrationsPage'
 import Input from './base/forms/Input'
 import Utils from 'common/utils/utils'
-import { sortBy } from 'lodash'
+import { sortBy, uniqBy } from 'lodash'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Button from './base/forms/Button'
 import classNames from 'classnames'
@@ -36,9 +36,12 @@ const IntegrationSelect: FC<IntegrationSelectType> = ({ onComplete }) => {
     if (!integrationsData) {
       return [] as typeof Constants.integrationSummaries
     }
-    const parsedCategories = Object.values(JSON.parse(integrationsData)).concat(
-      Constants.integrationSummaries,
-    ) as IntegrationSummary[]
+    const parsedCategories = uniqBy(
+      Object.values(JSON.parse(integrationsData)).concat(
+        Constants.integrationSummaries,
+      ) as IntegrationSummary[],
+      (v) => v.title.toLowerCase(),
+    )
 
     const filtered = parsedCategories.filter((v) => {
       const matchesCategory =


### PR DESCRIPTION
integration_data flag and Constants.integrationSummaries both list some tools (e.g. GitLab), causing duplicates on the "Use Feature Flags with your favourite tools" picker. Dedupe by title.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes duplicate GitLab integration showing, due to us having one!

<img width="1406" height="732" alt="image" src="https://github.com/user-attachments/assets/b29bc817-78de-4a4c-b94a-5939a21510a7" />




## How did you test this code?

Viewed onboarding