### PR TITLE
fix: removed api logout call

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -368,10 +368,9 @@ const controller = {
         return
       }
 
-      //Skip logout in E2E since parallel sessions may be using a shared token
-      ;(E2E
-        ? Promise.resolve()
-        : data.post(`${Project.api}auth/logout/`, {})
+      ;(Project.cookieAuthEnabled && !E2E
+        ? data.post(`${Project.api}auth/logout/`, {})
+        : Promise.resolve()
       ).finally(() => {
         API.setCookie('t', '')
         data.setToken(null)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
As logging out from the API invalidate the user token, we reverted to not calling the API when logging out from dashboard

## How did you test this code?
