### PR TITLE
fix(versioning): scope scheduled-FS query by feature in v2 enable

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -110,6 +110,7 @@ def _create_initial_feature_versions(environment: "Environment"):  # type: ignor
         related_feature_segments.update(environment_feature_version=ef_version)
 
         scheduled_feature_states = FeatureState.objects.filter(
+            feature=feature,
             live_from__gt=now,
             change_request__isnull=False,
             change_request__committed_at__isnull=False,

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -396,6 +396,79 @@ def test_enable_v2_versioning__scheduled_changes_exist__converts_published_sched
     )
 
 
+def test_enable_v2_versioning__multi_feature_scheduled_changes__each_efv_matches_feature(
+    environment: Environment,
+    project: Project,
+    feature: Feature,
+    staff_user: FFAdminUser,
+) -> None:
+    # Regression for `_create_initial_feature_versions`' scheduled-FS query
+    # at `api/features/versioning/tasks.py:112-118`: it is missing a
+    # `feature=feature` filter, so scheduled FSes get bound to an EFV of the
+    # wrong feature. The fixture's `feature` anchors the first iteration so
+    # the bug binds the scheduled FSes to its EFV instead of feature_b /
+    # feature_c.
+
+    # Given
+    now = timezone.now()
+    one_hour_from_now = now + timedelta(hours=1)
+    two_hours_from_now = now + timedelta(hours=2)
+
+    feature_b = Feature.objects.create(name="feature_b", project=project)
+    feature_c = Feature.objects.create(name="feature_c", project=project)
+
+    cr_b = ChangeRequest.objects.create(
+        environment=environment,
+        title="Scheduled change for feature_b",
+        user=staff_user,
+    )
+    scheduled_fs_b = FeatureState.objects.create(
+        feature=feature_b,
+        enabled=True,
+        environment=environment,
+        live_from=one_hour_from_now,
+        change_request=cr_b,
+        version=None,
+    )
+    cr_b.commit(staff_user)
+
+    cr_c = ChangeRequest.objects.create(
+        environment=environment,
+        title="Scheduled change for feature_c",
+        user=staff_user,
+    )
+    scheduled_fs_c = FeatureState.objects.create(
+        feature=feature_c,
+        enabled=True,
+        environment=environment,
+        live_from=two_hours_from_now,
+        change_request=cr_c,
+        version=None,
+    )
+    cr_c.commit(staff_user)
+
+    # When
+    enable_v2_versioning(environment.id)
+
+    # Then
+    scheduled_fs_b.refresh_from_db()
+    scheduled_fs_c.refresh_from_db()
+
+    assert scheduled_fs_b.environment_feature_version is not None
+    assert scheduled_fs_b.environment_feature_version.feature_id == feature_b.id, (
+        f"scheduled FS for feature_b is bound to an EFV for "
+        f"feature_id={scheduled_fs_b.environment_feature_version.feature_id}; "
+        f"expected {feature_b.id}"
+    )
+
+    assert scheduled_fs_c.environment_feature_version is not None
+    assert scheduled_fs_c.environment_feature_version.feature_id == feature_c.id, (
+        f"scheduled FS for feature_c is bound to an EFV for "
+        f"feature_id={scheduled_fs_c.environment_feature_version.feature_id}; "
+        f"expected {feature_c.id}"
+    )
+
+
 def test_publish_version_change_set__conflict_with_scheduled_change__sends_conflict_email_to_owner(
     feature: Feature,
     environment_v2_versioning: Environment,

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -402,13 +402,6 @@ def test_enable_v2_versioning__multi_feature_scheduled_changes__each_efv_matches
     feature: Feature,
     staff_user: FFAdminUser,
 ) -> None:
-    # Regression for `_create_initial_feature_versions`' scheduled-FS query
-    # at `api/features/versioning/tasks.py:112-118`: it is missing a
-    # `feature=feature` filter, so scheduled FSes get bound to an EFV of the
-    # wrong feature. The fixture's `feature` anchors the first iteration so
-    # the bug binds the scheduled FSes to its EFV instead of feature_b /
-    # feature_c.
-
     # Given
     now = timezone.now()
     one_hour_from_now = now + timedelta(hours=1)


### PR DESCRIPTION
Fixes #7450.

## Summary

- `_create_initial_feature_versions` filtered scheduled FSes by environment (closed in #4872) but not by feature, so the per-feature loop returned scheduled FSes belonging to other features and bound them to an `EnvironmentFeatureVersion` with the wrong `feature_id`. The mis-binding propagated silently through `add_existing_feature_states` on subsequent edits.
- One-line fix: add `feature=feature` to the query at `api/features/versioning/tasks.py:113`.
- New regression test (`test_enable_v2_versioning__multi_feature_scheduled_changes__each_efv_matches_feature`) covering the multi-feature case. It fails on `main` and passes with the fix.

## Production impact

Audit query run on production: 3 affected rows total, all on Flagsmith's internal testing project. **No customer data affected.** The 3 internal rows can be cleaned up manually via Django shell; no data migration required.

## Why migration `0005` did not catch this

`feature_versioning/0005_fix_scheduled_fs_data_issue_caused_by_enabling_versioning` repaired only environments where `use_v2_feature_versioning=False` — i.e. the cross-environment leak that #4872 closed. It does not run against environments already on v2, so the cross-feature variant of the same bug class went unrepaired.

## Test plan

- [x] New regression test fails on `main`, passes with the fix
- [x] Existing scheduled-changes test (`test_enable_v2_versioning__scheduled_changes_exist__converts_published_scheduled_changes`) still passes — the `environment` filter from #4872 is preserved
- [x] Existing happy-path enable + disable tests still pass
- [x] Production audit query: `SELECT count(*) FROM features_featurestate fs JOIN feature_versioning_environmentfeatureversion v ON fs.environment_feature_version_id = v.uuid WHERE fs.feature_id <> v.feature_id;` — 3 rows, internal only