### PR TITLE
feat: use flag value to display sdk message

### DIFF
--- a/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
+++ b/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
@@ -202,27 +202,35 @@ const CreateSegmentRulesTabForm: React.FC<CreateSegmentRulesTabFormProps> = ({
         {!readOnly &&
         setTopLevelRuleType &&
         Utils.getFlagsmithHasFeature('segment_any_rule_type') ? (
-          <Row className='mb-3 align-items-center gap-2'>
-            <label className='control-label mb-0'>Include users when</label>
-            <InlinePillToggle
-              data-test='top-level-rule-type'
-              size='medium'
-              options={[
-                { label: 'ALL', value: 'ALL' },
-                { label: 'ANY', value: 'ANY' },
-              ]}
-              value={topLevelRuleType}
-              onChange={setTopLevelRuleType}
-            />
-            <label className='control-label mb-0'>
-              of the following rules apply:
-            </label>
-          </Row>
+          <>
+            <Row className='mb-2 align-items-center gap-2'>
+              <label className='control-label mb-0'>Include users when</label>
+              <InlinePillToggle
+                data-test='top-level-rule-type'
+                size='medium'
+                options={[
+                  { label: 'ALL', value: 'ALL' },
+                  { label: 'ANY', value: 'ANY' },
+                ]}
+                value={topLevelRuleType}
+                onChange={setTopLevelRuleType}
+              />
+              <label className='control-label mb-0'>
+                of the following rules apply
+              </label>
+            </Row>
+            {topLevelRuleType === 'ANY' &&
+              Utils.getFlagsmithValue('segment_any_rule_type') && (
+                <div className='fs-small fst-italic text-muted mb-3'>
+                  {Utils.getFlagsmithValue('segment_any_rule_type')}
+                </div>
+              )}
+          </>
         ) : (
           <Flex className='mb-3'>
             <label className='cols-sm-2 control-label mb-1'>
               Include users when {topLevelRuleType === 'ANY' ? 'any' : 'all'} of
-              the following rules apply:
+              the following rules apply
             </label>
           </Flex>
         )}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- When `segment_any_rule_type` is enabled the value of the flag is used as a warning to update the SDK for **local evaluation** to work

## How did you test this code?
**Staging**
<img width="1113" height="263" alt="image" src="https://github.com/user-attachments/assets/6e79a9b2-b9aa-443a-be18-f5399d44e470" />
