### PR TITLE
 exploratory-review(segment-membership-ui): proposed fixes for PR #7467 -

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -28,7 +28,7 @@ import {
 } from 'common/services/useSegment'
 import Utils from 'common/utils/utils'
 import AssociatedSegmentOverrides from 'components/segments/AssociatedSegmentOverrides'
-import { SegmentMembershipTotalBadge } from 'components/segments/SegmentMembershipBadge'
+import { SegmentMembershipTabCount } from 'components/segments/SegmentMembershipBadge'
 import Button from 'components/base/forms/Button'
 import InfoMessage from 'components/InfoMessage'
 import InputGroup from 'components/base/forms/InputGroup'
@@ -588,10 +588,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
             tabLabel={
               <>
                 Identities
-                <SegmentMembershipTotalBadge
-                  compact
-                  memberships={segment.memberships}
-                />
+                <SegmentMembershipTabCount memberships={segment.memberships} />
               </>
             }
           >

--- a/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
+++ b/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
@@ -11,9 +11,9 @@ import {
   identitySegmentService,
   useGetIdentitySegmentsQuery,
 } from 'common/services/useIdentitySegment'
+import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import { getStore } from 'common/store'
-import ProjectStore from 'common/stores/project-store'
-import { SegmentMembershipEnvBadge } from 'components/segments/SegmentMembershipBadge'
+import { SegmentMembershipEnvCount } from 'components/segments/SegmentMembershipBadge'
 
 interface CreateSegmentUsersTabContentProps {
   projectId: string | number
@@ -99,6 +99,10 @@ const CreateSegmentUsersTabContent: React.FC<
   setPage,
   setSearchInput,
 }) => {
+  const { data: envsData } = useGetEnvironmentsQuery({
+    projectId: `${projectId}`,
+  })
+
   const membershipByEnvId = React.useMemo(() => {
     const map = new Map<number, SegmentMembership>()
     ;(memberships ?? []).forEach((m) => map.set(m.environment, m))
@@ -111,12 +115,12 @@ const CreateSegmentUsersTabContent: React.FC<
       ? membershipByEnvId.get(environment.id)
       : undefined
     return (
-      <span className='d-flex align-items-center'>
+      <span className='d-flex align-items-center justify-content-between flex-grow-1'>
         <span>{label}</span>
         {environment && membership && (
-          <SegmentMembershipEnvBadge
+          <SegmentMembershipEnvCount
             membership={membership}
-            environment={environment}
+            envApiKey={environment.api_key}
           />
         )}
       </span>
@@ -125,10 +129,9 @@ const CreateSegmentUsersTabContent: React.FC<
 
   const selectedMembership = React.useMemo(() => {
     if (!environmentId) return null
-    const envs = (ProjectStore.getEnvs() as Environment[] | null) || []
-    const env = envs.find((e) => e.api_key === environmentId)
+    const env = envsData?.results.find((e) => e.api_key === environmentId)
     return env ? membershipByEnvId.get(env.id) ?? null : null
-  }, [environmentId, membershipByEnvId])
+  }, [environmentId, envsData?.results, membershipByEnvId])
 
   return (
     <>

--- a/frontend/web/components/segments/SegmentMembershipBadge.tsx
+++ b/frontend/web/components/segments/SegmentMembershipBadge.tsx
@@ -1,89 +1,65 @@
 import React, { FC } from 'react'
 
-import { Environment, SegmentMembership } from 'common/types/responses'
-import ProjectStore from 'common/stores/project-store'
+import { SegmentMembership } from 'common/types/responses'
 import UsersIcon from 'components/icons/UsersIcon'
 
-const shortAgo = (iso: string): string => {
-  const diffSec = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 1000))
-  if (diffSec < 60) return `${diffSec}s ago`
-  const diffMin = Math.round(diffSec / 60)
-  if (diffMin < 60) return `${diffMin}m ago`
-  const diffHr = Math.round(diffMin / 60)
-  if (diffHr < 24) return `${diffHr}h ago`
-  return `${Math.round(diffHr / 24)}d ago`
-}
+const sumCounts = (memberships: SegmentMembership[]): number =>
+  memberships.reduce((sum, m) => sum + m.count, 0)
 
-type ChipProps = {
-  count: number
-  ago?: string
-  dataTest?: string
-  compact?: boolean
-}
-
-const Chip: FC<ChipProps> = ({ ago, compact, count, dataTest }) => {
-  const noun = count === 1 ? 'identity' : 'identities'
-  return (
-    <span
-      className='chip chip--xs bg-primary text-white ms-3'
-      style={{ border: 'none', alignSelf: 'center', verticalAlign: 'middle' }}
-      data-test={dataTest}
-    >
-      <UsersIcon className='chip-svg-icon' />
-      <span>
-        {count}
-        {compact ? '' : ` ${noun}`}
-        {ago ? ` ~${ago}` : ''}
-      </span>
-    </span>
-  )
-}
+const identityNoun = (count: number): string =>
+  count === 1 ? 'identity' : 'identities'
 
 type TotalProps = {
   memberships: SegmentMembership[] | undefined
-  compact?: boolean
 }
 
 export const SegmentMembershipTotalBadge: FC<TotalProps> = ({
-  compact,
   memberships,
 }) => {
   if (!memberships?.length) {
     return null
   }
-  const total = memberships.reduce((sum, m) => sum + m.count, 0)
-  const latest = memberships.reduce(
-    (acc, m) => (!acc || m.last_synced_at > acc ? m.last_synced_at : acc),
-    '',
-  )
+  const total = sumCounts(memberships)
   return (
-    <Chip
-      compact={compact}
-      count={total}
-      ago={latest ? shortAgo(latest) : undefined}
-      dataTest='segment-membership-total'
-    />
+    <span
+      className='chip chip--xs chip--filled ms-2'
+      data-test='segment-membership-total'
+    >
+      <UsersIcon className='chip-svg-icon' />
+      <span>
+        {total} {identityNoun(total)}
+      </span>
+    </span>
+  )
+}
+
+export const SegmentMembershipTabCount: FC<TotalProps> = ({ memberships }) => {
+  if (!memberships?.length) {
+    return null
+  }
+  return (
+    <span
+      className='ms-2 text-muted fw-normal'
+      data-test='segment-membership-total'
+    >
+      ({sumCounts(memberships)})
+    </span>
   )
 }
 
 type EnvProps = {
   membership: SegmentMembership
-  environment?: Environment
+  envApiKey: string
 }
 
-export const SegmentMembershipEnvBadge: FC<EnvProps> = ({
-  environment,
+export const SegmentMembershipEnvCount: FC<EnvProps> = ({
+  envApiKey,
   membership,
-}) => {
-  const envs = (ProjectStore.getEnvs() as Environment[] | null) || []
-  const env = environment ?? envs.find((e) => e.id === membership.environment)
-  if (!env) {
-    return null
-  }
-  return (
-    <Chip
-      count={membership.count}
-      dataTest={`segment-membership-${env.api_key}`}
-    />
-  )
-}
+}) => (
+  <span
+    className='text-muted fs-small ms-auto ps-2'
+    data-test={`segment-membership-${envApiKey}`}
+  >
+    {membership.count} {identityNoun(membership.count)}
+  </span>
+)

--- a/frontend/web/styles/components/_chip.scss
+++ b/frontend/web/styles/components/_chip.scss
@@ -27,7 +27,7 @@
 .chip {
   display: flex;
   align-items: center;
-  align-self: flex-start;
+  align-self: flex-start !important;
   background-color: $primary-alfa-8;
   border: 1px solid $primary-alfa-24;
   padding: 5px 12px;
@@ -38,6 +38,11 @@
   font-weight: normal;
   text-wrap: nowrap;
   color: $primary600;
+  &--filled {
+    background-color: $primary;
+    border-color: $primary;
+    color: $white;
+  }
   &-secondary {
     background-color: $bg-light300;
     color: $text-icon-grey;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Stacked on top of #7467 (`feat/segment-membership-counts-ui`). Proposed fixes for the review concerns raised on that PR — opening as a PR so the diff is reviewable side-by-side. Cherry-pick what resonates, drop what doesn't.

### Design-system / SCSS

- **Restore `!important` on `.chip { align-self }`.** Was removed in #7467 only so the new badge's inline `alignSelf: 'center'` could win. Reverting it avoids a global regression risk for every other `.chip` consumer (`Feature-Specific` on the segment row, `BetaFlag`, `FeatureHistory`, `SegmentOverrides`, …).
- **Add `.chip--filled` modifier** for the borderless filled variant. Removes the need for inline `style={{ border: 'none', alignSelf: 'center', verticalAlign: 'middle' }}` overrides on the badge.

### Component shape

- **Drop the private `<Chip>` wrapper** in `SegmentMembershipBadge.tsx`. The codebase already uses `.chip chip--xs` directly with bg utility classes everywhere else — half-introducing a private wrapper inside a feature file was the worst of both worlds (not extracted to `components/base/`, but also no longer matching the inline pattern). Now the badge composes `.chip chip--xs chip--filled` inline like its neighbours.
- **Split tab vs. row.** Two components instead of one with a `compact` prop:
  - `SegmentMembershipTotalBadge` — filled chip on the segments-list row (unchanged appearance besides losing `~ago`).
  - `SegmentMembershipTabCount` — muted `(71)` count next to the Identities tab label. **Fixes the purple-on-purple contrast issue on the active Identities tab**, and matches the visual weight of a tab badge convention.
- **Remove the `compact` prop.** It only dropped the noun, not the `~ago`, so the "compact" tab badge still rendered as `71 ~23s ago` — not compact, and misleading-named.

### Behaviour

- **Drop `shortAgo` / `~Xs ago`.** It froze on render (`Date.now()` evaluated once), and duplicated the precise `Last synced: 7th May 2026 14:23:01` line that already lives below the env select in the Identities tab. The full timestamp is the right surface for freshness.
- **`ProjectStore.getEnvs()` → `useGetEnvironmentsQuery`** in `CreateSegmentUsersTabContent.tsx`. `EnvironmentSelect` already uses the same hook, so RTK Query caches the result — no extra request. Also drops the dead-code `ProjectStore` fallback in `SegmentMembershipEnvBadge` (the only caller always passed `environment`).

### Env dropdown options

- **Right-align the count** with `justify-content-between flex-grow-1` on the option row. Fixes the visual misalignment when env names vary in length (the `t` row in the screenshot vs. `Development`).
- **`SegmentMembershipEnvBadge` → `SegmentMembershipEnvCount`** — switches from a filled chip to muted right-aligned text. Inverts the visual hierarchy so the env name is the primary read and the count is secondary metadata. Matches the convention used elsewhere for in-option counts.

### Not addressed (out of scope, worth a follow-up discussion)

- **What does the total "71" actually mean?** Summing memberships across envs double-counts identities that are in the segment in multiple envs. Either rename (`Across N envs`), scope to one env, or accept-and-document. Asking on #7467 directly.
- **Missing vs. zero ambiguity in the env dropdown.** If `memberships` omits an env entirely, no chip renders — but the user can't distinguish "0 identities" from "not yet synced". Probably wants a backend contract decision (always emit a row per env with `count: 0`?).
- **Sort order of env options.** Alphabetical today; reach-by-count might be more useful for this inspector. Out of scope.

### E2E test

The existing `e2e/tests/segment-membership-test.pw.ts` selectors (`[data-test="segment-membership-total"]`, `[data-test="segment-membership-${api_key}"]`) are preserved so the spec keeps passing without modification.

## How did you test this code?

Manually with a local `transformResponse` mock injecting synthetic `memberships` into the segments responses (since the backend PR isn't merged yet). Verified:
- Segments list row chip — filled chip, no `~ago` suffix.
- Identities tab label — muted `(N)` count, readable on both inactive (light) and active (purple) tab states.
- Env dropdown options — name on the left, muted count right-aligned to the column.
- Selected env → `Last synced:` line populates with the precise timestamp.
- Singular copy (`1 identity`) when count is 1.
- Empty memberships → no chip/count rendered anywhere.

Existing Playwright spec (`segment-membership-test.pw.ts`) was inspected to confirm `data-test` selectors still match — not re-run because it requires the seeded segments project.