### PR TITLE
fix(hubspot): restore orgid_unique write on company

### DIFF
--- a/api/integrations/lead_tracking/hubspot/constants.py
+++ b/api/integrations/lead_tracking/hubspot/constants.py
@@ -5,3 +5,23 @@ HUBSPOT_FORM_ID_SELF_HOSTED = "e79b8eca-a727-4188-a5ed-8f71c707ac50"
 HUBSPOT_ROOT_FORM_URL = "https://api.hsforms.com/submissions/v3/integration/submit"
 HUBSPOT_API_LEAD_SOURCE_SELF_HOSTED = "self-hosted"
 HUBSPOT_ACTIVE_SUBSCRIPTION_SELF_HOSTED = "free-opensource"
+
+# Personal email providers - users signing up with these do not identify a unique
+# company in HubSpot, so we skip the organisation-id write for them.
+GENERIC_EMAIL_DOMAINS = frozenset(
+    {
+        "gmail.com",
+        "yahoo.com",
+        "hotmail.com",
+        "outlook.com",
+        "icloud.com",
+        "protonmail.com",
+        "proton.me",
+        "mail.com",
+        "aol.com",
+        "live.com",
+        "me.com",
+        "yandex.com",
+        "gmx.com",
+    }
+)

--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -5,13 +5,23 @@ from typing import Any
 from django.conf import settings
 
 from integrations.lead_tracking.lead_tracking import LeadTracker
-from organisations.models import Organisation
+from organisations.models import HubspotOrganisation, Organisation
 from users.models import FFAdminUser, HubspotLead, HubspotTracker
 
 from .client import HubspotClient
-from .constants import HUBSPOT_FORM_ID_SAAS
+from .constants import GENERIC_EMAIL_DOMAINS, HUBSPOT_FORM_ID_SAAS
 
 logger = logging.getLogger(__name__)
+
+
+def _company_domain_from_email(email: str) -> str | None:
+    """Return the corporate domain from a user email, or None if generic/personal."""
+    if not email or "@" not in email:
+        return None
+    domain = email.split("@", 1)[1].lower()
+    if domain in GENERIC_EMAIL_DOMAINS:
+        return None
+    return domain
 
 
 class HubspotLeadTracker(LeadTracker):
@@ -49,9 +59,49 @@ class HubspotLeadTracker(LeadTracker):
         return hubspot_contact_id
 
     def create_lead(self, user: FFAdminUser, organisation: Organisation) -> None:
-        # Only create the contact. HubSpot handles company creation and
-        # association automatically from the contact's email domain.
+        # Create the contact. HubSpot handles company creation and association
+        # automatically from the contact's email domain.
         self._get_or_create_user_hubspot_id(user)
+        # Stamp the Flagsmith organisation id onto the (auto-created) HubSpot
+        # company. This is the only company-level write we do; name and
+        # subscription data are owned by HubSpot enrichment and the
+        # ChargeBee -> HubSpot sync respectively.
+        self._link_organisation_to_hubspot_company(user, organisation)
+
+    def _link_organisation_to_hubspot_company(
+        self, user: FFAdminUser, organisation: Organisation
+    ) -> None:
+        """Write the Flagsmith organisation id onto the HubSpot company matched
+        by the user's email domain. Idempotent: once a HubspotOrganisation row
+        exists for this Flagsmith organisation we skip subsequent writes."""
+        if HubspotOrganisation.objects.filter(organisation=organisation).exists():
+            return
+
+        domain = _company_domain_from_email(user.email)
+        if not domain:
+            return
+
+        company = self.client.get_company_by_domain(domain)
+        if not company:
+            logger.info(
+                "No HubSpot company found for domain %s; skipping orgid write for organisation %s",
+                domain,
+                organisation.id,
+            )
+            return
+
+        # Passing only flagsmith_organisation_id ensures the payload contains
+        # only orgid_unique - no name overwrite, no subscription writes. This
+        # is the constraint that PR #7147 removed for the wrong reasons; this
+        # restores the orgid sync without bringing back the original problems.
+        self.client.update_company(
+            hubspot_company_id=company["id"],
+            flagsmith_organisation_id=organisation.id,
+        )
+        HubspotOrganisation.objects.get_or_create(
+            organisation=organisation,
+            defaults={"hubspot_id": company["id"]},
+        )
 
     def _get_new_contact_with_retry(
         self, user: FFAdminUser, max_retries: int = 3

--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -91,9 +91,7 @@ class HubspotLeadTracker(LeadTracker):
             return
 
         # Passing only flagsmith_organisation_id ensures the payload contains
-        # only orgid_unique - no name overwrite, no subscription writes. This
-        # is the constraint that PR #7147 removed for the wrong reasons; this
-        # restores the orgid sync without bringing back the original problems.
+        # only orgid_unique - no name overwrite, no subscription writes.
         self.client.update_company(
             hubspot_company_id=company["id"],
             flagsmith_organisation_id=organisation.id,

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -15,7 +15,10 @@ from integrations.lead_tracking.hubspot.constants import (
     HUBSPOT_PORTAL_ID,
     HUBSPOT_ROOT_FORM_URL,
 )
-from integrations.lead_tracking.hubspot.lead_tracker import HubspotLeadTracker
+from integrations.lead_tracking.hubspot.lead_tracker import (
+    HubspotLeadTracker,
+    _company_domain_from_email,
+)
 from integrations.lead_tracking.hubspot.services import (
     register_hubspot_tracker_and_track_user,
 )
@@ -281,6 +284,13 @@ def test_create_user_hubspot_contact__get_contact_retries__returns_expected_id(
         is hubspot_leads_exists
     )
     assert mock_client.get_contact.call_count == expected_call_count
+
+
+@pytest.mark.parametrize("email", ["", "no-at-symbol", None])
+def test_company_domain_from_email__malformed_input__returns_none(email: str | None) -> None:
+    """Defensive return-None on empty/malformed email - protects against
+    callers that bypass the Django EmailField validation."""
+    assert _company_domain_from_email(email) is None  # type: ignore[arg-type]
 
 
 def test_create_lead__corporate_email_with_matching_company__writes_orgid_only(

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -287,7 +287,9 @@ def test_create_user_hubspot_contact__get_contact_retries__returns_expected_id(
 
 
 @pytest.mark.parametrize("email", ["", "no-at-symbol", None])
-def test_company_domain_from_email__malformed_input__returns_none(email: str | None) -> None:
+def test_company_domain_from_email__malformed_input__returns_none(
+    email: str | None,
+) -> None:
     """Defensive return-None on empty/malformed email - protects against
     callers that bypass the Django EmailField validation."""
     assert _company_domain_from_email(email) is None  # type: ignore[arg-type]

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -52,6 +52,9 @@ def mock_client_existing_contact(mocker: MockerFixture) -> MagicMock:
     mock_client.create_company.return_value = {
         "id": HUBSPOT_COMPANY_ID,
     }
+    # Default to no company match - tests that need a matched company should
+    # override this on the returned mock.
+    mock_client.get_company_by_domain.return_value = None
     mocker.patch(
         "integrations.lead_tracking.hubspot.lead_tracker.HubspotClient",
         return_value=mock_client,
@@ -278,6 +281,157 @@ def test_create_user_hubspot_contact__get_contact_retries__returns_expected_id(
         is hubspot_leads_exists
     )
     assert mock_client.get_contact.call_count == expected_call_count
+
+
+def test_create_lead__corporate_email_with_matching_company__writes_orgid_only(
+    organisation: Organisation,
+    mocker: MockerFixture,
+) -> None:
+    """The orgid_unique write must contain ONLY the org id - no name, no
+    subscription. This is the regression guard for PR #7147 which bundled
+    these together and was later reverted because the bundle was wrong."""
+    # Given
+    user = FFAdminUser.objects.create(
+        email="user@example.com",
+        first_name="Frank",
+        last_name="Louis",
+        marketing_consent_given=True,
+    )
+    HubspotLead.objects.create(user=user, hubspot_id=HUBSPOT_USER_ID)
+
+    mock_client = mocker.MagicMock()
+    mock_client.get_company_by_domain.return_value = {"id": HUBSPOT_COMPANY_ID}
+    mocker.patch(
+        "integrations.lead_tracking.hubspot.lead_tracker.HubspotLeadTracker._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    tracker = HubspotLeadTracker()
+    tracker.create_lead(user=user, organisation=organisation)
+
+    # Then
+    mock_client.get_company_by_domain.assert_called_once_with("example.com")
+    mock_client.update_company.assert_called_once_with(
+        hubspot_company_id=HUBSPOT_COMPANY_ID,
+        flagsmith_organisation_id=organisation.id,
+    )
+    # Regression: must NOT pass a name or subscription - these were the two
+    # things that made the previous integration overwrite enriched data.
+    call_kwargs = mock_client.update_company.call_args.kwargs
+    assert "name" not in call_kwargs
+    assert "active_subscription" not in call_kwargs
+    # The HubspotOrganisation row should be persisted so we do not re-write.
+    assert HubspotOrganisation.objects.filter(
+        organisation=organisation, hubspot_id=HUBSPOT_COMPANY_ID
+    ).exists()
+
+
+def test_create_lead__existing_hubspot_organisation__skips_company_lookup(
+    organisation: Organisation,
+    mocker: MockerFixture,
+) -> None:
+    """Once a Flagsmith organisation is linked to a HubSpot company we do not
+    re-write the orgid (which would burn API calls and risk overwriting if
+    multiple Flagsmith orgs share a company)."""
+    # Given
+    user = FFAdminUser.objects.create(
+        email="user@example.com",
+        first_name="Frank",
+        last_name="Louis",
+        marketing_consent_given=True,
+    )
+    HubspotLead.objects.create(user=user, hubspot_id=HUBSPOT_USER_ID)
+    HubspotOrganisation.objects.create(
+        organisation=organisation, hubspot_id=HUBSPOT_COMPANY_ID
+    )
+
+    mock_client = mocker.MagicMock()
+    mocker.patch(
+        "integrations.lead_tracking.hubspot.lead_tracker.HubspotLeadTracker._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    tracker = HubspotLeadTracker()
+    tracker.create_lead(user=user, organisation=organisation)
+
+    # Then
+    mock_client.get_company_by_domain.assert_not_called()
+    mock_client.update_company.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "user@gmail.com",
+        "user@yahoo.com",
+        "user@hotmail.com",
+        "user@outlook.com",
+        "user@proton.me",
+    ],
+)
+def test_create_lead__generic_email_domain__skips_orgid_write(
+    organisation: Organisation,
+    mocker: MockerFixture,
+    email: str,
+) -> None:
+    """Personal email domains do not identify a unique company so we skip
+    the company lookup entirely."""
+    # Given
+    user = FFAdminUser.objects.create(
+        email=email,
+        first_name="Frank",
+        last_name="Louis",
+        marketing_consent_given=True,
+    )
+    HubspotLead.objects.create(user=user, hubspot_id=HUBSPOT_USER_ID)
+
+    mock_client = mocker.MagicMock()
+    mocker.patch(
+        "integrations.lead_tracking.hubspot.lead_tracker.HubspotLeadTracker._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    tracker = HubspotLeadTracker()
+    tracker.create_lead(user=user, organisation=organisation)
+
+    # Then
+    mock_client.get_company_by_domain.assert_not_called()
+    mock_client.update_company.assert_not_called()
+    assert not HubspotOrganisation.objects.filter(organisation=organisation).exists()
+
+
+def test_create_lead__no_hubspot_company_for_domain__skips_update(
+    organisation: Organisation,
+    mocker: MockerFixture,
+) -> None:
+    """If HubSpot has not yet auto-created a company for the user's domain we
+    skip the update silently - the next user joining the same org will retry."""
+    # Given
+    user = FFAdminUser.objects.create(
+        email="user@example.com",
+        first_name="Frank",
+        last_name="Louis",
+        marketing_consent_given=True,
+    )
+    HubspotLead.objects.create(user=user, hubspot_id=HUBSPOT_USER_ID)
+
+    mock_client = mocker.MagicMock()
+    mock_client.get_company_by_domain.return_value = None
+    mocker.patch(
+        "integrations.lead_tracking.hubspot.lead_tracker.HubspotLeadTracker._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    tracker = HubspotLeadTracker()
+    tracker.create_lead(user=user, organisation=organisation)
+
+    # Then
+    mock_client.update_company.assert_not_called()
+    assert not HubspotOrganisation.objects.filter(organisation=organisation).exists()
 
 
 def test_register_hubspot_tracker_and_track_user__no_explicit_user__falls_back_to_request_user(

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -295,13 +295,12 @@ def test_company_domain_from_email__malformed_input__returns_none(
     assert _company_domain_from_email(email) is None  # type: ignore[arg-type]
 
 
-def test_create_lead__corporate_email_with_matching_company__writes_orgid_only(
+def test_create_lead__matching_hubspot_company__links_organisation(
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
-    """The orgid_unique write must contain ONLY the org id - no name, no
-    subscription. This is the regression guard for PR #7147 which bundled
-    these together and was later reverted because the bundle was wrong."""
+    """The orgid_unique write must contain only the org id - no name, no
+    subscription - so it does not overwrite HubSpot-enriched company data."""
     # Given
     user = FFAdminUser.objects.create(
         email="user@example.com",
@@ -328,8 +327,6 @@ def test_create_lead__corporate_email_with_matching_company__writes_orgid_only(
         hubspot_company_id=HUBSPOT_COMPANY_ID,
         flagsmith_organisation_id=organisation.id,
     )
-    # Regression: must NOT pass a name or subscription - these were the two
-    # things that made the previous integration overwrite enriched data.
     call_kwargs = mock_client.update_company.call_args.kwargs
     assert "name" not in call_kwargs
     assert "active_subscription" not in call_kwargs

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -292,7 +292,11 @@ def test_company_domain_from_email__malformed_input__returns_none(
 ) -> None:
     """Defensive return-None on empty/malformed email - protects against
     callers that bypass the Django EmailField validation."""
-    assert _company_domain_from_email(email) is None  # type: ignore[arg-type]
+    # Given / When
+    result = _company_domain_from_email(email)  # type: ignore[arg-type]
+
+    # Then
+    assert result is None
 
 
 def test_create_lead__matching_hubspot_company__links_organisation(


### PR DESCRIPTION
The HubSpot lead tracking integration stopped writing `orgid_unique` after #7147, which removed the company-update path entirely. The `orgid_unique` write got swept up in that removal even though it wasn't part of the underlying problem.

Alex (sales ops) has been manually maintaining `orgid_unique` on every paying customer since. This restores the write - tightly scoped to address @Zaimwa9's concerns on #7147.

## What this PR does
- In `create_lead`, after the contact is created, look up the HubSpot company by the user's email domain and PATCH **only** `orgid_unique` onto it
- Persist a `HubspotOrganisation` row so subsequent users joining the same Flagsmith org don't redo the lookup
- Skip for generic email domains (gmail/yahoo/etc.)

## No duplication with ChargeBee → HubSpot sync
The duplication concern in #7147 was specifically about `active_subscription` - both the Flagsmith integration's `update_company_active_subscription` and the ChargeBee sync were writing the plan id, and the Flagsmith side couldn't distinguish trial from paid, so it caused workflow misclassification.

This PR writes **only `orgid_unique`**. ChargeBee sync writes 12 billing/subscription properties, none of which is `orgid_unique`. Disjoint sets, no overlap:

| System | Properties written |
|--------|--------------------|
| This PR (Flagsmith integration) | `orgid_unique` |
| ChargeBee → HubSpot sync | `subscription_id__chargebee__unique`, `active_subscription`, `current_mrr`, `currency`, `customer_since`, `contract_start`, `contract_end_date`, `billing_status__backend_`, `chargebee_customer_id`, `chargebee_billing_period_unit`, `chargebee_city_country`, `sync_date___cb` |

The regression test `test_create_lead__corporate_email_with_matching_company__writes_orgid_only` asserts the `update_company` kwargs contain no `name` and no `active_subscription`, so a future change can't accidentally re-bundle them.

## Wadi's other concerns from #7147, revisited
- **\"using the domain is too fragile\"** - mitigated, not eliminated. Falls back silently when no company matches (next user retries). Generic-email filter prevents misrouting. The same domain lookup approach was used historically and HubSpot itself deduplicates by domain. Once linked, the `HubspotOrganisation` row prevents redoing the lookup.
- **Name overwrites** - explicit regression test asserts `name` is never in the payload.

## Why now and not in #7147
@Zaimwa9 proposed this exact scope in his April 9 review. I declined because at the time the duplication concern (on `active_subscription`) outweighed the lost `orgid_unique` write. Three weeks of manual maintenance on the CS side surfaced that the org_id signal matters more than I weighted it. Re-instating it with the original problem (`active_subscription` overwrite) explicitly excluded.

## What still works (unchanged from #7147)
Contacts via form submission. HubSpot owns company name/enrichment. ChargeBee sync owns billing/MRR/plan.

## Test plan
- [x] New unit tests pass: \`tests/unit/integrations/lead_tracking/hubspot/\` (35/35)
- [x] Lint clean: \`ruff check integrations/lead_tracking/hubspot/ tests/unit/integrations/lead_tracking/hubspot/\`
- [ ] Manual smoke test in staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)