### PR TITLE
fix: handle non-numeric identity_pk in IdentityFeatureStateViewSet

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -858,7 +858,12 @@ class IdentityFeatureStateViewSet(BaseFeatureStateViewSet):
         if getattr(self, "swagger_fake_view", False):
             return FeatureState.objects.none()
 
-        return super().get_queryset().filter(identity__pk=self.kwargs["identity_pk"])  # type: ignore[no-untyped-call]
+        identity_pk = self.kwargs["identity_pk"]
+        try:
+            int(identity_pk)
+        except (TypeError, ValueError):
+            return FeatureState.objects.none()
+        return super().get_queryset().filter(identity__pk=identity_pk)  # type: ignore[no-untyped-call]
 
     @action(methods=["GET"], detail=False)
     def all(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]

--- a/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
@@ -269,3 +269,24 @@ def test_clone_identity_feature_states__source_has_overrides__clones_correctly(
         environment=environment,
         identity=target_identity,
     ).exists()
+
+
+def test_list_identity_feature_states__non_numeric_identity_pk__returns_empty(
+    environment: Environment,
+    staff_client: APIClient,
+    view_environment_permission: PermissionModel,
+    user_environment_permission: UserEnvironmentPermission,
+) -> None:
+    # Given
+    user_environment_permission.permissions.add(view_environment_permission)
+    url = reverse(
+        "api-v1:environments:identity-featurestates-list",
+        args=(environment.api_key, "org_3COWhASRXfhcdxVrd0wEjpQp4dg"),
+    )
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []


### PR DESCRIPTION
Fixes #7361.

`/api/v1/environments/<key>/identities/<identity_pk>/featurestates/` crashes with ValueError when `identity_pk` is non-numeric (e.g. an external identifier passed through by mistake), because Django's ORM tries to coerce it to int for the `identity__pk` lookup.

This mirrors the approach in #7443: validate the value up front and return an empty queryset for non-numeric ids, so the API responds 200 with `[]` instead of 500.

Contributes to #6809.