### PR TITLE
fix(projects): validate organisation query param is numeric

### DIFF
--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -100,6 +100,10 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
 
         organisation_id = self.request.query_params.get("organisation")
         if organisation_id:
+            try:
+                int(organisation_id)
+            except (TypeError, ValueError):
+                raise ValidationError({"organisation": "Must be a valid integer."})
             queryset = queryset.filter(organisation__id=organisation_id)
 
         project_uuid = self.request.query_params.get("uuid")

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -695,6 +695,20 @@ def test_list_projects__uuid_filter__returns_matching_project(  # type: ignore[n
     assert response.json()[0]["uuid"] == str(project.uuid)
 
 
+def test_list_projects__non_numeric_organisation__returns_400(  # type: ignore[no-untyped-def]
+    admin_client,
+):
+    # Given
+    base_url = reverse("api-v1:projects:project-list")
+    url = f"{base_url}?organisation=A60ZG9cp5WC53RRZHDkIlUiWuAL57Jhi"
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
 @pytest.mark.parametrize(
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to \`docs/\` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7426

\`ProjectViewSet.get_queryset\` passed the raw \`?organisation=\` query string straight into \`queryset.filter(organisation__id=...)\`. A non-numeric value bubbled up as an unhandled \`ValueError\` from \`IntegerField.get_prep_value\`, producing a 500 in Sentry (FLAGSMITH-API-5NT).

Validate the parameter is an integer and raise DRF \`ValidationError\` (400) otherwise. Mirrors the same pattern used elsewhere in the codebase.

## How did you test this code?

Added \`test_list_projects__non_numeric_organisation__returns_400\` to \`test_unit_projects_views.py\` covering the exact Sentry repro string.