### PR TITLE
fix(versioning): reject legacy feature-state writes on v2 environments

### DIFF
--- a/api/features/exceptions.py
+++ b/api/features/exceptions.py
@@ -13,5 +13,3 @@ class FeatureStateVersionAlreadyExistsError(FeatureStateVersionError):
         super(FeatureStateVersionAlreadyExistsError, self).__init__(
             f"Version {version} already exists for FeatureState."
         )
-
-

--- a/api/features/exceptions.py
+++ b/api/features/exceptions.py
@@ -13,3 +13,20 @@ class FeatureStateVersionAlreadyExistsError(FeatureStateVersionError):
         super(FeatureStateVersionAlreadyExistsError, self).__init__(
             f"Version {version} already exists for FeatureState."
         )
+
+
+class FeatureStateV2VersioningRequiredError(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_code = "v2_feature_versioning_required"
+
+    def __init__(
+        self, environment_api_key: str, feature_id: int | None = None
+    ) -> None:
+        feature_path = str(feature_id) if feature_id is not None else "<feature-id>"
+        super().__init__(
+            detail=(
+                "This environment uses v2 feature versioning. Create a new "
+                "environment feature version via POST /api/v1/environments/"
+                f"{environment_api_key}/features/{feature_path}/versions/."
+            )
+        )

--- a/api/features/exceptions.py
+++ b/api/features/exceptions.py
@@ -15,16 +15,3 @@ class FeatureStateVersionAlreadyExistsError(FeatureStateVersionError):
         )
 
 
-class FeatureStateV2VersioningRequiredError(APIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    default_code = "v2_feature_versioning_required"
-
-    def __init__(self, environment_api_key: str, feature_id: int | None = None) -> None:
-        feature_path = str(feature_id) if feature_id is not None else "<feature-id>"
-        super().__init__(
-            detail=(
-                "This environment uses v2 feature versioning. Create a new "
-                "environment feature version via POST /api/v1/environments/"
-                f"{environment_api_key}/features/{feature_path}/versions/."
-            )
-        )

--- a/api/features/exceptions.py
+++ b/api/features/exceptions.py
@@ -19,9 +19,7 @@ class FeatureStateV2VersioningRequiredError(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
     default_code = "v2_feature_versioning_required"
 
-    def __init__(
-        self, environment_api_key: str, feature_id: int | None = None
-    ) -> None:
+    def __init__(self, environment_api_key: str, feature_id: int | None = None) -> None:
         feature_path = str(feature_id) if feature_id is not None else "<feature-id>"
         super().__init__(
             detail=(

--- a/api/features/versioning/exceptions.py
+++ b/api/features/versioning/exceptions.py
@@ -12,3 +12,9 @@ class FeatureVersionDeleteError(FeatureVersioningError):
 
 class CannotModifyLiveVersionError(FeatureVersioningError):
     status_code = status.HTTP_400_BAD_REQUEST
+
+
+class DirectFeatureStateWriteNotAllowedError(FeatureVersioningError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_code = "direct_feature_state_write_not_allowed"
+    default_detail = "This environment uses v2 feature versioning. Use the environment feature version endpoint instead."

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -26,6 +26,11 @@ def require_direct_state_write(
 
 
 def require_direct_state_write_for_state(feature_state: FeatureState) -> None:
+    # FS rows attached to an unpublished EFV are a draft, so direct mutation is
+    # part of the versioning flow rather than a bypass of it.
+    efv = feature_state.environment_feature_version
+    if efv is not None and not efv.published:
+        return
     require_direct_state_write(
         environment=feature_state.environment,  # type: ignore[arg-type]
         is_identity_override=feature_state.identity_id is not None,

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -20,9 +20,6 @@ from features.versioning.models import EnvironmentFeatureVersion
 def require_direct_state_write(
     environment: Environment, *, is_identity_override: bool
 ) -> None:
-    # Direct writes against an environment or segment-override FeatureState on a
-    # v2 environment bypass the version graph and are silently lost on rollback.
-    # Identity overrides are not part of the version graph, so allow them.
     if is_identity_override or not environment.use_v2_feature_versioning:
         return
     raise DirectFeatureStateWriteNotAllowedError()

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -13,7 +13,26 @@ from features.versioning.dataclasses import (
     FlagChangeSet,
     FlagChangeSetV2,
 )
+from features.versioning.exceptions import DirectFeatureStateWriteNotAllowedError
 from features.versioning.models import EnvironmentFeatureVersion
+
+
+def require_direct_state_write(
+    environment: Environment, *, is_identity_override: bool
+) -> None:
+    # Direct writes against an environment or segment-override FeatureState on a
+    # v2 environment bypass the version graph and are silently lost on rollback.
+    # Identity overrides are not part of the version graph, so allow them.
+    if is_identity_override or not environment.use_v2_feature_versioning:
+        return
+    raise DirectFeatureStateWriteNotAllowedError()
+
+
+def require_direct_state_write_for_state(feature_state: FeatureState) -> None:
+    require_direct_state_write(
+        environment=feature_state.environment,  # type: ignore[arg-type]
+        is_identity_override=feature_state.identity_id is not None,
+    )
 
 
 def get_environment_flags_queryset(

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -71,7 +71,6 @@ from users.models import FFAdminUser, UserPermissionGroup
 from webhooks.webhooks import WebhookEventType
 
 from .constants import INTERSECTION, UNION
-from .exceptions import FeatureStateV2VersioningRequiredError
 from .features_service import get_overrides_data
 from .models import Feature, FeatureSegment, FeatureState
 from .multivariate.serializers import (
@@ -107,6 +106,8 @@ from .serializers import (  # type: ignore[attr-defined]
 )
 from .tasks import trigger_feature_state_change_webhooks
 from .versioning.versioning_service import (
+    require_direct_state_write,
+    require_direct_state_write_for_state,
     get_environment_flags_list,
     get_environment_flags_queryset,
 )
@@ -630,33 +631,6 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         return queryset
 
 
-def _ensure_legacy_write_allowed(
-    environment: Environment,
-    *,
-    is_identity_override: bool,
-    feature_id: int | None = None,
-) -> None:
-    # Direct writes against an environment or segment-override FeatureState on a
-    # v2 environment bypass the version graph and are silently lost on rollback.
-    # Identity overrides are not part of the version graph, so allow them.
-    if is_identity_override or not environment.use_v2_feature_versioning:
-        return
-    raise FeatureStateV2VersioningRequiredError(
-        environment_api_key=environment.api_key,
-        feature_id=feature_id,
-    )
-
-
-def _ensure_feature_state_legacy_write_allowed(
-    feature_state: FeatureState,
-) -> None:
-    _ensure_legacy_write_allowed(
-        environment=feature_state.environment,  # type: ignore[arg-type]
-        is_identity_override=feature_state.identity_id is not None,
-        feature_id=feature_state.feature_id,
-    )
-
-
 @method_decorator(
     name="list",
     decorator=extend_schema(
@@ -768,10 +742,9 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         if identity_pk:
             data["identity"] = identity_pk
 
-        _ensure_legacy_write_allowed(
+        require_direct_state_write(
             environment=environment,
             is_identity_override=bool(identity_pk),
-            feature_id=data.get("feature"),
         )
 
         serializer = self.get_serializer(data=data)
@@ -797,7 +770,7 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         feature state value.
         """
         feature_state_to_update = self.get_object()
-        _ensure_feature_state_legacy_write_allowed(feature_state_to_update)
+        require_direct_state_write_for_state(feature_state_to_update)
         feature_state_data = request.data
 
         # Check if feature state value was provided with request data. If so, create / update
@@ -833,7 +806,7 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         return self.update(request, *args, **kwargs)  # type: ignore[no-untyped-call]
 
     def destroy(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
-        _ensure_feature_state_legacy_write_allowed(self.get_object())
+        require_direct_state_write_for_state(self.get_object())
         return super().destroy(request, *args, **kwargs)
 
     def update_feature_state_value(self, value, feature_state):  # type: ignore[no-untyped-def]
@@ -973,15 +946,14 @@ class SimpleFeatureStateViewSet(
         environment_id = request.data.get("environment")
         if environment_id:
             environment = get_object_or_404(Environment, id=environment_id)
-            _ensure_legacy_write_allowed(
+            require_direct_state_write(
                 environment=environment,
                 is_identity_override=bool(request.data.get("identity")),
-                feature_id=request.data.get("feature"),
             )
         return super().create(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
-        _ensure_feature_state_legacy_write_allowed(self.get_object())
+        require_direct_state_write_for_state(self.get_object())
         return super().update(request, *args, **kwargs)
 
     def get_queryset(self):  # type: ignore[no-untyped-def]

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -71,6 +71,7 @@ from users.models import FFAdminUser, UserPermissionGroup
 from webhooks.webhooks import WebhookEventType
 
 from .constants import INTERSECTION, UNION
+from .exceptions import FeatureStateV2VersioningRequiredError
 from .features_service import get_overrides_data
 from .models import Feature, FeatureSegment, FeatureState
 from .multivariate.serializers import (
@@ -629,6 +630,33 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         return queryset
 
 
+def _ensure_legacy_write_allowed(
+    environment: Environment,
+    *,
+    is_identity_override: bool,
+    feature_id: int | None = None,
+) -> None:
+    # Direct writes against an environment or segment-override FeatureState on a
+    # v2 environment bypass the version graph and are silently lost on rollback.
+    # Identity overrides are not part of the version graph, so allow them.
+    if is_identity_override or not environment.use_v2_feature_versioning:
+        return
+    raise FeatureStateV2VersioningRequiredError(
+        environment_api_key=environment.api_key,
+        feature_id=feature_id,
+    )
+
+
+def _ensure_feature_state_legacy_write_allowed(
+    feature_state: FeatureState,
+) -> None:
+    _ensure_legacy_write_allowed(
+        environment=feature_state.environment,  # type: ignore[arg-type]
+        is_identity_override=feature_state.identity_id is not None,
+        feature_id=feature_state.feature_id,
+    )
+
+
 @method_decorator(
     name="list",
     decorator=extend_schema(
@@ -740,6 +768,12 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         if identity_pk:
             data["identity"] = identity_pk
 
+        _ensure_legacy_write_allowed(
+            environment=environment,
+            is_identity_override=bool(identity_pk),
+            feature_id=data.get("feature"),
+        )
+
         serializer = self.get_serializer(data=data)
 
         if serializer.is_valid(raise_exception=True):
@@ -763,6 +797,7 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         feature state value.
         """
         feature_state_to_update = self.get_object()
+        _ensure_feature_state_legacy_write_allowed(feature_state_to_update)
         feature_state_data = request.data
 
         # Check if feature state value was provided with request data. If so, create / update
@@ -929,6 +964,21 @@ class SimpleFeatureStateViewSet(
     serializer_class = WritableNestedFeatureStateSerializer
     permission_classes = [FeatureStatePermissions]
     filterset_fields = ["environment", "feature", "feature_segment"]
+
+    def create(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        environment_id = request.data.get("environment")
+        if environment_id:
+            environment = get_object_or_404(Environment, id=environment_id)
+            _ensure_legacy_write_allowed(
+                environment=environment,
+                is_identity_override=bool(request.data.get("identity")),
+                feature_id=request.data.get("feature"),
+            )
+        return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        _ensure_feature_state_legacy_write_allowed(self.get_object())
+        return super().update(request, *args, **kwargs)
 
     def get_queryset(self):  # type: ignore[no-untyped-def]
         if getattr(self, "swagger_fake_view", False):

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -832,6 +832,10 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         """
         return self.update(request, *args, **kwargs)  # type: ignore[no-untyped-call]
 
+    def destroy(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        _ensure_feature_state_legacy_write_allowed(self.get_object())
+        return super().destroy(request, *args, **kwargs)
+
     def update_feature_state_value(self, value, feature_state):  # type: ignore[no-untyped-def]
         feature_state_value_dict = feature_state.generate_feature_state_value_data(
             value

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -944,7 +944,8 @@ class SimpleFeatureStateViewSet(
 
     def create(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         environment_id = request.data.get("environment")
-        if environment_id:
+        targets_version = bool(request.data.get("environment_feature_version"))
+        if environment_id and not targets_version:
             environment = get_object_or_404(Environment, id=environment_id)
             require_direct_state_write(
                 environment=environment,

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -106,10 +106,10 @@ from .serializers import (  # type: ignore[attr-defined]
 )
 from .tasks import trigger_feature_state_change_webhooks
 from .versioning.versioning_service import (
-    require_direct_state_write,
-    require_direct_state_write_for_state,
     get_environment_flags_list,
     get_environment_flags_queryset,
+    require_direct_state_write,
+    require_direct_state_write_for_state,
 )
 
 logger = logging.getLogger(__name__)

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3035,6 +3035,57 @@ def test_create_feature_state__v2_versioning_env__identity_override__allowed(
     assert response.status_code == status.HTTP_201_CREATED
 
 
+def test_delete_feature_state__v2_versioning_env__nested_endpoint__returns_400(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+) -> None:
+    # Given - the live env-default FS attached to the current EFV
+    live_fs = FeatureState.objects.get(
+        environment=environment_v2_versioning,
+        feature=feature,
+        identity=None,
+        feature_segment=None,
+    )
+    url = reverse(
+        "api-v1:environments:environment-featurestates-detail",
+        args=[environment_v2_versioning.api_key, live_fs.id],
+    )
+
+    # When
+    response = admin_client_new.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert FeatureState.objects.filter(id=live_fs.id).exists()
+
+
+def test_delete_feature_state__v2_versioning_env__identity_override__allowed(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    identity: Identity,
+) -> None:
+    # Given - identity overrides live outside the version graph
+    identity_fs = FeatureState.objects.create(
+        feature=feature,
+        environment=environment_v2_versioning,
+        identity=identity,
+        enabled=False,
+    )
+    url = reverse(
+        "api-v1:environments:identity-featurestates-detail",
+        args=[environment_v2_versioning.api_key, identity.id, identity_fs.id],
+    )
+
+    # When
+    response = admin_client_new.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not FeatureState.objects.filter(id=identity_fs.id).exists()
+
+
 def test_update_feature_state__change_feature__returns_400(
     admin_client_new: APIClient,
     environment: Environment,

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -2920,6 +2920,7 @@ def test_update_feature_state__v2_versioning_env__nested_endpoint__returns_400(
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "v2 feature versioning" in response.json()["detail"]
 
 
 def test_update_feature_state__v2_versioning_env__identity_override__allowed(
@@ -3004,6 +3005,7 @@ def test_create_feature_state__v2_versioning_env__nested_endpoint__returns_400(
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "v2 feature versioning" in response.json()["detail"]
 
 
 def test_create_feature_state__v2_versioning_env__identity_override__allowed(
@@ -3054,6 +3056,7 @@ def test_delete_feature_state__v2_versioning_env__nested_endpoint__returns_400(
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "v2 feature versioning" in response.json()["detail"]
     assert FeatureState.objects.filter(id=live_fs.id).exists()
 
 

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3034,6 +3034,75 @@ def test_create_feature_state__v2_env_identity_override__returns_201(
     assert response.status_code == status.HTTP_201_CREATED
 
 
+def test_create_feature_state__v2_env_targets_version__returns_201(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    project: Project,
+) -> None:
+    # Given - a draft EFV plus a feature_segment attached to it
+    draft_version = EnvironmentFeatureVersion.objects.create(
+        feature=feature, environment=environment_v2_versioning
+    )
+    segment = Segment.objects.create(name="seg_targets_version", project=project)
+    feature_segment = FeatureSegment.objects.create(
+        feature=feature,
+        segment=segment,
+        environment=environment_v2_versioning,
+        environment_feature_version=draft_version,
+        priority=1,
+    )
+    url = reverse("api-v1:features:featurestates-list")
+    data = {
+        "enabled": True,
+        "feature_state_value": {"type": "unicode", "string_value": "override"},
+        "environment": environment_v2_versioning.id,
+        "feature": feature.id,
+        "feature_segment": feature_segment.id,
+        "environment_feature_version": str(draft_version.uuid),
+    }
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_update_feature_state__v2_env_draft_version__returns_200(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+) -> None:
+    # Given - a new draft EFV (post_save clones the previous version's FSes)
+    draft_version = EnvironmentFeatureVersion.objects.create(
+        feature=feature, environment=environment_v2_versioning
+    )
+    draft_fs = FeatureState.objects.get(
+        environment_feature_version=draft_version,
+        identity=None,
+        feature_segment=None,
+    )
+    url = reverse("api-v1:features:featurestates-detail", args=[draft_fs.id])
+    data = {
+        "id": draft_fs.id,
+        "enabled": True,
+        "feature_state_value": {"type": "unicode", "string_value": "draft-update"},
+        "environment": environment_v2_versioning.id,
+        "feature": feature.id,
+    }
+
+    # When
+    response = admin_client_new.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+
 def test_delete_feature_state__v2_env_via_nested_endpoint__returns_400(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -2856,6 +2856,185 @@ def test_update_feature_state__no_fsv_history__returns_200(
     assert response.status_code == status.HTTP_200_OK
 
 
+def test_update_feature_state__v2_versioning_env__simple_endpoint__returns_400(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+) -> None:
+    # Given
+    live_fs = FeatureState.objects.get(
+        environment=environment_v2_versioning,
+        feature=feature,
+        identity=None,
+        feature_segment=None,
+    )
+    url = reverse("api-v1:features:featurestates-detail", args=[live_fs.id])
+    data = {
+        "id": live_fs.id,
+        "enabled": True,
+        "feature_state_value": {"type": "unicode", "string_value": "should-be-blocked"},
+        "environment": environment_v2_versioning.id,
+        "feature": feature.id,
+    }
+
+    # When
+    response = admin_client_new.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    detail = response.json()["detail"]
+    assert "v2 feature versioning" in detail
+    assert environment_v2_versioning.api_key in detail
+    assert f"/features/{feature.id}/versions/" in detail
+
+
+def test_update_feature_state__v2_versioning_env__nested_endpoint__returns_400(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+) -> None:
+    # Given
+    live_fs = FeatureState.objects.get(
+        environment=environment_v2_versioning,
+        feature=feature,
+        identity=None,
+        feature_segment=None,
+    )
+    url = reverse(
+        "api-v1:environments:environment-featurestates-detail",
+        args=[environment_v2_versioning.api_key, live_fs.id],
+    )
+    data = {
+        "id": live_fs.id,
+        "enabled": True,
+        "feature_state_value": "should-be-blocked",
+        "environment": environment_v2_versioning.id,
+        "feature": feature.id,
+        "identity": None,
+        "feature_segment": None,
+    }
+
+    # When
+    response = admin_client_new.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_update_feature_state__v2_versioning_env__identity_override__allowed(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    identity: Identity,
+) -> None:
+    # Given - identity overrides live outside the version graph in v2
+    identity_fs = FeatureState.objects.create(
+        feature=feature,
+        environment=environment_v2_versioning,
+        identity=identity,
+        enabled=False,
+    )
+    url = reverse("api-v1:features:featurestates-detail", args=[identity_fs.id])
+    data = {
+        "id": identity_fs.id,
+        "enabled": True,
+        "feature_state_value": {"type": "unicode", "string_value": "identity-override"},
+        "environment": environment_v2_versioning.id,
+        "feature": feature.id,
+        "identity": identity.id,
+    }
+
+    # When
+    response = admin_client_new.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_feature_state__v2_versioning_env__simple_endpoint__returns_400(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+) -> None:
+    # Given
+    url = reverse("api-v1:features:featurestates-list")
+    data = {
+        "enabled": True,
+        "feature_state_value": {"type": "unicode", "string_value": "blocked"},
+        "environment": environment_v2_versioning.id,
+        "feature": feature.id,
+    }
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "v2 feature versioning" in response.json()["detail"]
+
+
+def test_create_feature_state__v2_versioning_env__nested_endpoint__returns_400(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    project: Project,
+) -> None:
+    # Given - create a feature_segment so the create has somewhere to go
+    segment = Segment.objects.create(name="new_override_segment", project=project)
+    url = reverse(
+        "api-v1:environments:environment-featurestates-list",
+        args=[environment_v2_versioning.api_key],
+    )
+    data = {
+        "enabled": True,
+        "feature_state_value": "blocked",
+        "feature": feature.id,
+        "feature_segment": {"segment": segment.id, "priority": 1},
+    }
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_create_feature_state__v2_versioning_env__identity_override__allowed(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    identity: Identity,
+) -> None:
+    # Given - identity FS creates are not part of the version graph
+    url = reverse(
+        "api-v1:environments:identity-featurestates-list",
+        args=[environment_v2_versioning.api_key, identity.id],
+    )
+    data = {
+        "enabled": True,
+        "feature_state_value": "identity-create",
+        "feature": feature.id,
+    }
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 def test_update_feature_state__change_feature__returns_400(
     admin_client_new: APIClient,
     environment: Environment,

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -2884,10 +2884,7 @@ def test_update_feature_state__v2_versioning_env__simple_endpoint__returns_400(
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    detail = response.json()["detail"]
-    assert "v2 feature versioning" in detail
-    assert environment_v2_versioning.api_key in detail
-    assert f"/features/{feature.id}/versions/" in detail
+    assert "v2 feature versioning" in response.json()["detail"]
 
 
 def test_update_feature_state__v2_versioning_env__nested_endpoint__returns_400(

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -2856,7 +2856,7 @@ def test_update_feature_state__no_fsv_history__returns_200(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_update_feature_state__v2_versioning_env__simple_endpoint__returns_400(
+def test_update_feature_state__v2_env_via_simple_endpoint__returns_400(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -2887,7 +2887,7 @@ def test_update_feature_state__v2_versioning_env__simple_endpoint__returns_400(
     assert "v2 feature versioning" in response.json()["detail"]
 
 
-def test_update_feature_state__v2_versioning_env__nested_endpoint__returns_400(
+def test_update_feature_state__v2_env_via_nested_endpoint__returns_400(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -2923,7 +2923,7 @@ def test_update_feature_state__v2_versioning_env__nested_endpoint__returns_400(
     assert "v2 feature versioning" in response.json()["detail"]
 
 
-def test_update_feature_state__v2_versioning_env__identity_override__allowed(
+def test_update_feature_state__v2_env_identity_override__returns_200(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -2955,7 +2955,7 @@ def test_update_feature_state__v2_versioning_env__identity_override__allowed(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_create_feature_state__v2_versioning_env__simple_endpoint__returns_400(
+def test_create_feature_state__v2_env_via_simple_endpoint__returns_400(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -2979,7 +2979,7 @@ def test_create_feature_state__v2_versioning_env__simple_endpoint__returns_400(
     assert "v2 feature versioning" in response.json()["detail"]
 
 
-def test_create_feature_state__v2_versioning_env__nested_endpoint__returns_400(
+def test_create_feature_state__v2_env_via_nested_endpoint__returns_400(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -3008,7 +3008,7 @@ def test_create_feature_state__v2_versioning_env__nested_endpoint__returns_400(
     assert "v2 feature versioning" in response.json()["detail"]
 
 
-def test_create_feature_state__v2_versioning_env__identity_override__allowed(
+def test_create_feature_state__v2_env_identity_override__returns_201(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -3034,7 +3034,7 @@ def test_create_feature_state__v2_versioning_env__identity_override__allowed(
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_delete_feature_state__v2_versioning_env__nested_endpoint__returns_400(
+def test_delete_feature_state__v2_env_via_nested_endpoint__returns_400(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,
@@ -3060,7 +3060,7 @@ def test_delete_feature_state__v2_versioning_env__nested_endpoint__returns_400(
     assert FeatureState.objects.filter(id=live_fs.id).exists()
 
 
-def test_delete_feature_state__v2_versioning_env__identity_override__allowed(
+def test_delete_feature_state__v2_env_identity_override__returns_204(
     admin_client_new: APIClient,
     environment_v2_versioning: Environment,
     feature: Feature,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7487

The non-versioning feature-state endpoints mutated the live `FeatureState` row in place on v2-versioned environments — bypassing the version graph (no new `EnvironmentFeatureVersion`, no audit row, no `NEW_VERSION_PUBLISHED` webhook) and silently losing the change on rollback.

This PR rejects `POST`/`PUT`/`PATCH`/`DELETE` against those endpoints with `HTTP 400` on v2 environments and points callers at the versioning endpoint. Identity overrides remain allowed (they are not part of the version graph in v2).

Blocked routes (on v2 envs unless identity-scoped):
- `POST`/`PUT`/`PATCH`/`DELETE /api/v1/environments/{api_key}/featurestates/[{id}/]`
- `POST`/`PUT`/`PATCH /api/v1/features/featurestates/[{id}/]`

## How did you test this code?

8 new unit tests in `api/tests/unit/features/test_unit_features_views.py` cover:
- `POST`/`PUT` on both endpoints → 400 on v2
- `DELETE` on the nested endpoint → 400 on v2 (row still exists)
- Identity-scoped writes → still 200/201/204
- The response detail mentions v2 feature versioning

Each blocking test is parametrised over `admin_client` and `admin_master_api_key_client`. mypy clean on the touched files.