### PR TITLE
feat: added v1 versioning segment updates tools

### DIFF
--- a/api/features/feature_segments/views.py
+++ b/api/features/feature_segments/views.py
@@ -27,7 +27,28 @@ logger = logging.getLogger(__name__)
 
 @method_decorator(
     name="list",
-    decorator=extend_schema(parameters=[FeatureSegmentQuerySerializer]),
+    decorator=extend_schema(
+        tags=["mcp"],
+        parameters=[FeatureSegmentQuerySerializer],
+        extensions={
+            "x-gram": {
+                "name": "list_feature_segments",
+                "description": "Lists segment overrides for a feature in an environment.",
+            },
+        },
+    ),
+)
+@method_decorator(
+    name="create",
+    decorator=extend_schema(
+        tags=["mcp"],
+        extensions={
+            "x-gram": {
+                "name": "create_feature_segment",
+                "description": "Creates a segment override binding for a feature in an environment. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false), then create a feature state referencing the returned id to set its value.",
+            },
+        },
+    ),
 )
 class FeatureSegmentViewSet(
     viewsets.ModelViewSet,  # type: ignore[type-arg]

--- a/api/features/feature_segments/views.py
+++ b/api/features/feature_segments/views.py
@@ -39,13 +39,13 @@ logger = logging.getLogger(__name__)
     ),
 )
 @method_decorator(
-    name="create",
+    name="destroy",
     decorator=extend_schema(
         tags=["mcp"],
         extensions={
             "x-gram": {
-                "name": "create_feature_segment",
-                "description": "Creates a segment override binding for a feature in an environment. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false), then create a feature state referencing the returned id to set its value.",
+                "name": "delete_feature_segment",
+                "description": "Deletes a segment override. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
             },
         },
     ),

--- a/api/features/versioning/views.py
+++ b/api/features/versioning/views.py
@@ -54,7 +54,7 @@ from users.models import FFAdminUser
         extensions={
             "x-gram": {
                 "name": "get_environment_feature_versions",
-                "description": "Retrieves version information for a feature flag in a specific environment. Use this for environments with v2 feature versioning.",
+                "description": "Retrieves version information for a feature flag in a specific environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
             },
         },
     ),
@@ -66,7 +66,7 @@ from users.models import FFAdminUser
         extensions={
             "x-gram": {
                 "name": "create_environment_feature_version",
-                "description": "Creates a new version for a feature flag in a specific environment. Use this for environments with v2 feature versioning.",
+                "description": "Creates a new version for a feature flag in a specific environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
             },
         },
     ),
@@ -163,7 +163,7 @@ class EnvironmentFeatureVersionViewSet(
         extensions={
             "x-gram": {
                 "name": "publish_environment_feature_version",
-                "description": "Publishes a feature version to make it live in the environment. Use this for environments with v2 feature versioning.",
+                "description": "Publishes a feature version to make it live in the environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
             },
         },
     )
@@ -226,7 +226,7 @@ class EnvironmentFeatureVersionRetrieveAPIView(RetrieveAPIView):  # type: ignore
         extensions={
             "x-gram": {
                 "name": "get_environment_feature_version_states",
-                "description": "Retrieves feature state information for a specific version in an environment. Use this for environments with v2 feature versioning.",
+                "description": "Retrieves feature state information for a specific version in an environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
             },
         },
     ),
@@ -238,7 +238,7 @@ class EnvironmentFeatureVersionRetrieveAPIView(RetrieveAPIView):  # type: ignore
         extensions={
             "x-gram": {
                 "name": "create_environment_feature_version_state",
-                "description": "Creates a new feature state for a specific version in an environment. Use this for environments with v2 feature versioning.",
+                "description": "Creates a new feature state for a specific version in an environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
             },
         },
     ),
@@ -250,7 +250,7 @@ class EnvironmentFeatureVersionRetrieveAPIView(RetrieveAPIView):  # type: ignore
         extensions={
             "x-gram": {
                 "name": "update_environment_feature_version_state",
-                "description": "Updates an existing feature state for a specific version in an environment. Use this for environments with v2 feature versioning.",
+                "description": "Updates an existing feature state for a specific version in an environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
             },
         },
     ),

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -921,25 +921,13 @@ class IdentityFeatureStateViewSet(BaseFeatureStateViewSet):
     ),
 )
 @method_decorator(
-    name="create",
-    decorator=extend_schema(
-        tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_feature_state",
-                "description": "Creates a feature state in an environment. Pass `feature_segment` to set a segment override value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
-            },
-        },
-    ),
-)
-@method_decorator(
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
         extensions={
             "x-gram": {
                 "name": "update_feature_state",
-                "description": "Updates a feature state, including its enabled status and value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
+                "description": "Updates a feature state, including its enabled status and value. Use this tool to update a segment override's value for environments without v2 feature versioning (use_v2_feature_versioning: false).",
             },
         },
     ),
@@ -1179,8 +1167,15 @@ def organisation_has_got_feature(request, organisation):  # type: ignore[no-unty
 
 
 @extend_schema(
+    tags=["mcp"],
     request=CustomCreateSegmentOverrideFeatureStateSerializer(),
     responses={201: CustomCreateSegmentOverrideFeatureStateSerializer()},
+    extensions={
+        "x-gram": {
+            "name": "create_segment_override",
+            "description": "Creates a segment override for a feature in an environment in a single call, setting both the segment binding and its value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
+        },
+    },
 )
 @api_view(["POST"])
 @permission_classes([CreateSegmentOverridePermissions])

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -829,7 +829,7 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         extensions={
             "x-gram": {
                 "name": "update_environment_feature_state",
-                "description": "Updates a feature state in an environment, including enabled status and value. Use this for environments without v2 feature versioning.",
+                "description": "Updates a feature state in an environment, including enabled status and value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
             },
         },
     ),
@@ -918,6 +918,30 @@ class IdentityFeatureStateViewSet(BaseFeatureStateViewSet):
                 type=int,
             ),
         ]
+    ),
+)
+@method_decorator(
+    name="create",
+    decorator=extend_schema(
+        tags=["mcp"],
+        extensions={
+            "x-gram": {
+                "name": "create_feature_state",
+                "description": "Creates a feature state in an environment. Pass `feature_segment` to set a segment override value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
+            },
+        },
+    ),
+)
+@method_decorator(
+    name="update",
+    decorator=extend_schema(
+        tags=["mcp"],
+        extensions={
+            "x-gram": {
+                "name": "update_feature_state",
+                "description": "Updates a feature state, including its enabled status and value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
+            },
+        },
     ),
 )
 class SimpleFeatureStateViewSet(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
MCP segment overrides were only enabled for environments using v2 versioning.
- Tagged endpoints for creating overrides with v1 environments

## How did you test this code?
- Tests