### PR TITLE
fix(versioning): include multivariate values in v2 webhook payloads

### DIFF
--- a/api/features/versioning/schemas.py
+++ b/api/features/versioning/schemas.py
@@ -19,9 +19,29 @@ class _UserSchema(Schema):
 class _FeatureStateSchema(Schema):
     enabled = fields.Bool()
     value = fields.Method(serialize="get_feature_state_value")
+    multivariate_feature_state_values = fields.Method(
+        serialize="get_multivariate_feature_state_values"
+    )
 
     def get_feature_state_value(self, obj: FeatureState) -> Any:
         return obj.get_feature_state_value()
+
+    def get_multivariate_feature_state_values(
+        self, obj: FeatureState
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": mv.id,
+                "multivariate_feature_option": {
+                    "id": mv.multivariate_feature_option_id,
+                    "value": mv.multivariate_feature_option.value,
+                },
+                "percentage_allocation": mv.percentage_allocation,
+            }
+            for mv in obj.multivariate_feature_state_values.select_related(
+                "multivariate_feature_option"
+            ).all()
+        ]
 
 
 class EnvironmentFeatureVersionWebhookDataSerializer(Schema):

--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -32,6 +32,7 @@ from webhooks.webhooks import WebhookEventType
 
 if typing.TYPE_CHECKING:
     from environments.models import Environment
+    from features.multivariate.models import MultivariateFeatureStateValue
 
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,16 @@ def _create_initial_feature_versions(environment: "Environment"):  # type: ignor
         )
 
 
+def _get_multivariate_values(
+    feature_state: FeatureState,
+) -> list["MultivariateFeatureStateValue"]:
+    return list(
+        feature_state.multivariate_feature_state_values.select_related(
+            "multivariate_feature_option"
+        ).all()
+    )
+
+
 def _trigger_feature_state_webhooks_for_version(
     environment_feature_version: EnvironmentFeatureVersion,
 ) -> None:
@@ -182,6 +193,7 @@ def _trigger_feature_state_webhooks_for_version(
             identity_id=feature_state.identity_id,
             identity_identifier=getattr(feature_state.identity, "identifier", None),
             feature_segment=feature_state.feature_segment,
+            multivariate_feature_state_values=_get_multivariate_values(feature_state),
         )
 
         # Build webhook data
@@ -210,6 +222,7 @@ def _trigger_feature_state_webhooks_for_version(
                 identity_id=previous_fs.identity_id,
                 identity_identifier=getattr(previous_fs.identity, "identifier", None),
                 feature_segment=previous_fs.feature_segment,
+                multivariate_feature_state_values=_get_multivariate_values(previous_fs),
             )
             data["previous_state"] = previous_state
 

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -392,9 +392,7 @@ def test_trigger_update_version_webhooks__multivariate_feature__includes_mv_valu
 
     # NEW_VERSION_PUBLISHED summary event should also carry mv values.
     new_version_body = json.loads(responses.calls[1].request.body)  # type: ignore[union-attr]
-    assert (
-        new_version_body["event_type"] == WebhookEventType.NEW_VERSION_PUBLISHED.name
-    )
+    assert new_version_body["event_type"] == WebhookEventType.NEW_VERSION_PUBLISHED.name
     summary_mv_payload = new_version_body["data"]["feature_states"][0][
         "multivariate_feature_state_values"
     ]

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -216,6 +216,16 @@ def test_trigger_update_version_webhooks__version_with_changes__triggers_flag_up
         flag_updated_env_body["data"]["previous_state"]["feature_state_value"]
         == v1_fs.get_feature_state_value()
     )
+    assert (
+        flag_updated_env_body["data"]["new_state"]["multivariate_feature_state_values"]
+        == []
+    )
+    assert (
+        flag_updated_env_body["data"]["previous_state"][
+            "multivariate_feature_state_values"
+        ]
+        == []
+    )
     assert flag_updated_env_body["data"]["changed_by"] == staff_user.email
     assert "timestamp" in flag_updated_env_body["data"]
 
@@ -235,6 +245,7 @@ def test_trigger_update_version_webhooks__version_with_changes__triggers_flag_up
                 {
                     "enabled": v2_fs.enabled,
                     "value": v2_fs.get_feature_state_value(),
+                    "multivariate_feature_state_values": [],
                 }
             ],
         },
@@ -284,10 +295,116 @@ def test_trigger_update_version_webhooks__version_without_changes__triggers_only
                 {
                     "enabled": v2.feature_states.first().enabled,
                     "value": v2.feature_states.first().get_feature_state_value(),
+                    "multivariate_feature_state_values": [],
                 }
             ],
         },
     }
+
+
+@responses.activate
+def test_trigger_update_version_webhooks__multivariate_feature__includes_mv_values_in_payloads(
+    multivariate_feature: Feature,
+    environment_v2_versioning: Environment,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    v1 = EnvironmentFeatureVersion.objects.get(
+        feature=multivariate_feature, environment=environment_v2_versioning
+    )
+    v1_fs = v1.feature_states.first()
+
+    # Bump one option's allocation in v2 so we count as a change and so
+    # previous/new mv values differ.
+    v2 = EnvironmentFeatureVersion.objects.create(
+        environment=environment_v2_versioning, feature=multivariate_feature
+    )
+    v2_fs = v2.feature_states.first()
+    v2_mv_values = list(
+        v2_fs.multivariate_feature_state_values.select_related(
+            "multivariate_feature_option"
+        ).order_by("multivariate_feature_option_id")
+    )
+    bumped_mv_value = v2_mv_values[0]
+    original_allocation = bumped_mv_value.percentage_allocation
+    bumped_mv_value.percentage_allocation = original_allocation + 5
+    bumped_mv_value.save()
+    v2.publish(published_by=staff_user)
+
+    environment_webhook_url = "https://example.com/env-webhook/"
+    Webhook.objects.create(
+        environment=environment_v2_versioning,
+        url=environment_webhook_url,
+        enabled=True,
+    )
+    responses.post(url=environment_webhook_url, status=200)
+
+    # When
+    trigger_update_version_webhooks(str(v2.uuid))
+
+    # Then
+    flag_updated_body = json.loads(responses.calls[0].request.body)  # type: ignore[union-attr]
+    assert flag_updated_body["event_type"] == WebhookEventType.FLAG_UPDATED.name
+
+    expected_new_mv_payload = [
+        {
+            "id": mv.id,
+            "multivariate_feature_option": {
+                "id": mv.multivariate_feature_option_id,
+                "value": mv.multivariate_feature_option.value,
+            },
+            "percentage_allocation": mv.percentage_allocation,
+        }
+        for mv in v2_fs.multivariate_feature_state_values.select_related(
+            "multivariate_feature_option"
+        ).order_by("multivariate_feature_option_id")
+    ]
+    assert (
+        sorted(
+            flag_updated_body["data"]["new_state"]["multivariate_feature_state_values"],
+            key=lambda mv: mv["multivariate_feature_option"]["id"],
+        )
+        == expected_new_mv_payload
+    )
+
+    expected_previous_mv_payload = [
+        {
+            "id": mv.id,
+            "multivariate_feature_option": {
+                "id": mv.multivariate_feature_option_id,
+                "value": mv.multivariate_feature_option.value,
+            },
+            "percentage_allocation": mv.percentage_allocation,
+        }
+        for mv in v1_fs.multivariate_feature_state_values.select_related(
+            "multivariate_feature_option"
+        ).order_by("multivariate_feature_option_id")
+    ]
+    assert (
+        sorted(
+            flag_updated_body["data"]["previous_state"][
+                "multivariate_feature_state_values"
+            ],
+            key=lambda mv: mv["multivariate_feature_option"]["id"],
+        )
+        == expected_previous_mv_payload
+    )
+
+    # NEW_VERSION_PUBLISHED summary event should also carry mv values.
+    new_version_body = json.loads(responses.calls[1].request.body)  # type: ignore[union-attr]
+    assert (
+        new_version_body["event_type"] == WebhookEventType.NEW_VERSION_PUBLISHED.name
+    )
+    summary_mv_payload = new_version_body["data"]["feature_states"][0][
+        "multivariate_feature_state_values"
+    ]
+    assert (
+        sorted(
+            summary_mv_payload,
+            key=lambda mv: mv["multivariate_feature_option"]["id"],
+        )
+        == expected_new_mv_payload
+    )
 
 
 def test_enable_v2_versioning__scheduled_changes_exist__converts_published_scheduled_changes(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7495

`FLAG_UPDATED` webhooks fired from Feature Versioning v2 environments were omitting the `multivariate_feature_state_values` kwarg when building both `new_state` and `previous_state`, so the field was always serialised as an empty array even for multivariate flags with populated options. `NEW_VERSION_PUBLISHED` summary events carried no multivariate context at all.

- `api/features/versioning/tasks.py`: pass `multivariate_feature_state_values` through both `Webhook.generate_webhook_feature_state_data` call sites in `_trigger_feature_state_webhooks_for_version`, via a small `_get_multivariate_values` helper.
- `api/features/versioning/schemas.py`: extend `_FeatureStateSchema` (used by `EnvironmentFeatureVersionWebhookDataSerializer`) with a `multivariate_feature_state_values` field, shape-identical to the per-flag payload so consumers can parse both events with one code path.

Additive change to the `NEW_VERSION_PUBLISHED` payload — existing consumers reading `enabled`/`value` are unaffected. No docs change required.

## How did you test this code?

Automated:

- `pytest tests/unit/features/versioning/test_unit_versioning_tasks.py` — existing tests updated to assert the new (empty) field on non-multivariate flows; new `test_trigger_update_version_webhooks__multivariate_feature__includes_mv_values_in_payloads` covers `new_state`, `previous_state`, and the summary event for a multivariate flag.
- `mypy` clean on touched files.

Manual smoke against a v2 env with a multivariate flag:

1. Enabled v2 versioning on an environment with a 3-option multivariate flag (30/30/40 allocation).
2. Created a new `EnvironmentFeatureVersion`, bumped option 1 to 35%, published.
3. Triggered `trigger_update_version_webhooks` and captured the outgoing webhook payloads.

Confirmed:
- `FLAG_UPDATED.new_state.multivariate_feature_state_values` → 35/30/40.
- `FLAG_UPDATED.previous_state.multivariate_feature_state_values` → 30/30/40.
- `NEW_VERSION_PUBLISHED.feature_states[0].multivariate_feature_state_values` matches `new_state`.