### PR TITLE
feat: bypass pre versioning scaleup unlimited audit and feature visibility

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1389,11 +1389,6 @@ ORG_SUBSCRIPTION_CANCELLED_ALERT_RECIPIENT_LIST = env.list(
     default=[],
 )
 
-# Date on which versioning is released. This is used to give any scale up
-# subscriptions created before this date full audit log and versioning
-# history.
-VERSIONING_RELEASE_DATE = env.date("VERSIONING_RELEASE_DATE", default=None)
-
 SUBSCRIPTION_LICENCE_PUBLIC_KEY = env.str(
     "SUBSCRIPTION_LICENCE_PUBLIC_KEY",
     """

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -424,12 +424,9 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         # cache values.
         is_scale_up = self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
         is_scale_up_v4 = (self.plan or "").startswith("scale-up-v4")
-        is_sub_before_versioning_release = (
-            settings.VERSIONING_RELEASE_DATE is None
-            or (
-                self.subscription_date is not None
-                and self.subscription_date < settings.VERSIONING_RELEASE_DATE
-            )
+        is_sub_before_versioning_release = settings.VERSIONING_RELEASE_DATE is None or (
+            self.subscription_date is not None
+            and self.subscription_date < settings.VERSIONING_RELEASE_DATE
         )
         if is_scale_up and not is_scale_up_v4 and is_sub_before_versioning_release:
             cb_metadata.audit_log_visibility_days = None

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -1,3 +1,4 @@
+import re
 from datetime import timedelta
 from typing import Any
 
@@ -294,12 +295,10 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
     def is_enterprise(self) -> bool:
         return self.subscription_plan_family == SubscriptionPlanFamily.ENTERPRISE
 
-    @property
-    def is_sub_before_versioning_release(self) -> bool:
-        return settings.VERSIONING_RELEASE_DATE is None or (
-            self.subscription_date is not None
-            and self.subscription_date < settings.VERSIONING_RELEASE_DATE
-        )
+    def get_scaleup_plan_version(self) -> int:
+        if match := re.match(r"scale-up-v(\d+)", self.plan or ""):
+            return int(match.group(1))
+        return 1
 
     @hook(AFTER_SAVE, when="plan", has_changed=True)
     def update_api_limit_access_block(self):  # type: ignore[no-untyped-def]
@@ -426,14 +425,11 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         else:
             cb_metadata = get_subscription_metadata_from_id(self.subscription_id)  # type: ignore[assignment,arg-type]
 
-        # Grandfather old Scale-Up customers with unlimited audit log and
-        # feature history. Scale-Up v4 (and later) plans always honour the
-        # cache values.
+        # Pre-v4 Scale-Up customers keep unlimited audit log. Feature
+        # history always honours the cache value.
         is_scale_up = self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
-        is_scale_up_v4 = (self.plan or "").startswith("scale-up-v4")
-        if is_scale_up and not is_scale_up_v4 and self.is_sub_before_versioning_release:
+        if is_scale_up and self.get_scaleup_plan_version() < 4:
             cb_metadata.audit_log_visibility_days = None
-            cb_metadata.feature_history_visibility_days = None
 
         return cb_metadata
 

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -294,6 +294,13 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
     def is_enterprise(self) -> bool:
         return self.subscription_plan_family == SubscriptionPlanFamily.ENTERPRISE
 
+    @property
+    def is_sub_before_versioning_release(self) -> bool:
+        return settings.VERSIONING_RELEASE_DATE is None or (
+            self.subscription_date is not None
+            and self.subscription_date < settings.VERSIONING_RELEASE_DATE
+        )
+
     @hook(AFTER_SAVE, when="plan", has_changed=True)
     def update_api_limit_access_block(self):  # type: ignore[no-untyped-def]
         if not getattr(self.organisation, "api_limit_access_block", None):
@@ -424,14 +431,11 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         # cache values.
         is_scale_up = self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
         is_scale_up_v4 = (self.plan or "").startswith("scale-up-v4")
-        is_sub_before_versioning_release = (
-            settings.VERSIONING_RELEASE_DATE is None
-            or (
-                self.subscription_date is not None
-                and self.subscription_date < settings.VERSIONING_RELEASE_DATE
-            )
-        )
-        if is_scale_up and not is_scale_up_v4 and is_sub_before_versioning_release:
+        if (
+            is_scale_up
+            and not is_scale_up_v4
+            and self.is_sub_before_versioning_release
+        ):
             cb_metadata.audit_log_visibility_days = None
             cb_metadata.feature_history_visibility_days = None
 

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -419,15 +419,19 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         else:
             cb_metadata = get_subscription_metadata_from_id(self.subscription_id)  # type: ignore[assignment,arg-type]
 
-        if self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP and (
+        # Grandfather old Scale-Up customers with unlimited audit log and
+        # feature history. Scale-Up v4 (and later) plans always honour the
+        # cache values.
+        is_scale_up = self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
+        is_scale_up_v4 = (self.plan or "").startswith("scale-up-v4")
+        is_sub_before_versioning_release = (
             settings.VERSIONING_RELEASE_DATE is None
             or (
                 self.subscription_date is not None
                 and self.subscription_date < settings.VERSIONING_RELEASE_DATE
             )
-        ):
-            # Logic to grandfather old scale up plan customers to give them
-            # full access to audit log and feature history.
+        )
+        if is_scale_up and not is_scale_up_v4 and is_sub_before_versioning_release:
             cb_metadata.audit_log_visibility_days = None
             cb_metadata.feature_history_visibility_days = None
 

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -430,7 +430,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         # feature history. Scale-Up v4 (and later) plans always honour the
         # cache values.
         is_scale_up = self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
-        is_scale_up_v4 = (self.plan or "").startswith("scale-up-v4")
+        is_scale_up_v4 = self.plan and self.plan.startswith("scale-up-v4")
         if is_scale_up and not is_scale_up_v4 and self.is_sub_before_versioning_release:
             cb_metadata.audit_log_visibility_days = None
             cb_metadata.feature_history_visibility_days = None

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -416,8 +416,6 @@ def test_get_subscription_metadata__scale_up_v4_plan__returns_cache_visibility_v
     )
     organisation.subscription.refresh_from_db()
 
-    # VERSIONING_RELEASE_DATE unset would normally grandfather a Scale-Up
-    # subscription; v4 plans must bypass that and honour the cache values.
     settings.VERSIONING_RELEASE_DATE = None
 
     # When

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -381,6 +381,52 @@ def test_get_subscription_metadata__after_versioning_release__returns_unlimited_
     assert subscription_metadata == expected_metadata
 
 
+def test_get_subscription_metadata__scale_up_v4_plan__returns_cache_visibility_values(  # type: ignore[no-untyped-def]
+    organisation: Organisation,
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+):
+    # Given
+    seats = 10
+    api_calls = 50000000
+    projects = 10
+    audit_log_visibility_days = 14
+    feature_history_visibility_days = 14
+
+    OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        allowed_seats=seats,
+        allowed_30d_api_calls=api_calls,
+        allowed_projects=projects,
+        audit_log_visibility_days=audit_log_visibility_days,
+        feature_history_visibility_days=feature_history_visibility_days,
+    )
+    expected_metadata = ChargebeeObjMetadata(
+        seats=seats,
+        api_calls=api_calls,
+        projects=projects,
+        audit_log_visibility_days=audit_log_visibility_days,
+        feature_history_visibility_days=feature_history_visibility_days,
+    )
+    mocker.patch("organisations.models.is_saas", return_value=True)
+    Subscription.objects.filter(organisation=organisation).update(
+        plan="scale-up-v4-monthly",
+        subscription_id="subscription-id",
+        payment_method=CHARGEBEE,
+    )
+    organisation.subscription.refresh_from_db()
+
+    # VERSIONING_RELEASE_DATE unset would normally grandfather a Scale-Up
+    # subscription; v4 plans must bypass that and honour the cache values.
+    settings.VERSIONING_RELEASE_DATE = None
+
+    # When
+    subscription_metadata = organisation.subscription.get_subscription_metadata()
+
+    # Then
+    assert subscription_metadata == expected_metadata
+
+
 def test_get_subscription_metadata__xero_subscription__returns_xero_metadata(  # type: ignore[no-untyped-def]
     mocker: MockerFixture,
 ):

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -242,6 +242,35 @@ def test_is_auto_seat_upgrade_available__given_plan_and_seat_count__returns_expe
     assert result is expected
 
 
+@pytest.mark.parametrize(
+    "plan, expected_version",
+    [
+        ("scale-up-v4-monthly", 4),
+        ("scale-up-v4", 4),
+        ("scale-up-v2", 2),
+        ("scale-up-v10-annual", 10),
+        ("scale-up", 1),
+        ("startup-v2", 1),
+        (None, 1),
+    ],
+)
+def test_get_scaleup_plan_version__given_plan__returns_expected(
+    organisation: Organisation,
+    plan: str | None,
+    expected_version: int,
+) -> None:
+    # Given
+    subscription = organisation.subscription
+    subscription.plan = plan
+    subscription.save()
+
+    # When
+    version = subscription.get_scaleup_plan_version()
+
+    # Then
+    assert version == expected_version
+
+
 def test_is_auto_seat_upgrade_available__not_saas__returns_false(
     organisation: Organisation,
 ) -> None:
@@ -299,14 +328,11 @@ def test_is_paid__cancelled_subscription__returns_false(  # type: ignore[no-unty
 def test_get_subscription_metadata__chargebee_subscription__returns_chargebee_metadata(  # type: ignore[no-untyped-def]
     organisation: Organisation,
     mocker: MockerFixture,
-    settings: SettingsWrapper,
 ):
     # Given
     seats = 10
     api_calls = 50000000
     projects = 10
-
-    settings.VERSIONING_RELEASE_DATE = timezone.now() - timedelta(days=1)
 
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
@@ -319,7 +345,7 @@ def test_get_subscription_metadata__chargebee_subscription__returns_chargebee_me
     )
     mocker.patch("organisations.models.is_saas", return_value=True)
     Subscription.objects.filter(organisation=organisation).update(
-        plan="scale-up-v2",
+        plan="scale-up-v4-monthly",
         subscription_id="subscription-id",
         payment_method=CHARGEBEE,
     )
@@ -332,47 +358,38 @@ def test_get_subscription_metadata__chargebee_subscription__returns_chargebee_me
     assert subscription_metadata == expected_metadata
 
 
-def test_get_subscription_metadata__after_versioning_release__returns_unlimited_audit_and_versions(  # type: ignore[no-untyped-def]  # noqa: E501
+def test_get_subscription_metadata__scale_up_v2_plan__keeps_unlimited_audit_log_only(  # type: ignore[no-untyped-def]  # noqa: E501
     organisation: Organisation,
     mocker: MockerFixture,
-    settings: SettingsWrapper,
 ):
     # Given
     seats = 10
     api_calls = 50000000
     projects = 10
-    now = timezone.now()
-    yesterday = now - timedelta(days=1)
-    two_days_ago = now - timedelta(days=2)
+    feature_history_visibility_days = 14
 
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
         allowed_seats=seats,
         allowed_30d_api_calls=api_calls,
         allowed_projects=projects,
-        # values from here should be overridden
         audit_log_visibility_days=30,
-        feature_history_visibility_days=30,
+        feature_history_visibility_days=feature_history_visibility_days,
     )
     expected_metadata = ChargebeeObjMetadata(
         seats=seats,
         api_calls=api_calls,
         projects=projects,
-        # the following values are patched on based on the
-        # VERSIONING_RELEASE_DATE setting
         audit_log_visibility_days=None,
-        feature_history_visibility_days=None,
+        feature_history_visibility_days=feature_history_visibility_days,
     )
     mocker.patch("organisations.models.is_saas", return_value=True)
     Subscription.objects.filter(organisation=organisation).update(
         plan="scale-up-v2",
         subscription_id="subscription-id",
         payment_method=CHARGEBEE,
-        subscription_date=two_days_ago,
     )
     organisation.subscription.refresh_from_db()
-
-    settings.VERSIONING_RELEASE_DATE = yesterday
 
     # When
     subscription_metadata = organisation.subscription.get_subscription_metadata()
@@ -384,7 +401,6 @@ def test_get_subscription_metadata__after_versioning_release__returns_unlimited_
 def test_get_subscription_metadata__scale_up_v4_plan__returns_cache_visibility_values(  # type: ignore[no-untyped-def]
     organisation: Organisation,
     mocker: MockerFixture,
-    settings: SettingsWrapper,
 ):
     # Given
     seats = 10
@@ -415,8 +431,6 @@ def test_get_subscription_metadata__scale_up_v4_plan__returns_cache_visibility_v
         payment_method=CHARGEBEE,
     )
     organisation.subscription.refresh_from_db()
-
-    settings.VERSIONING_RELEASE_DATE = None
 
     # When
     subscription_metadata = organisation.subscription.get_subscription_metadata()

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -1047,7 +1047,6 @@ def test_get_subscription_metadata__cache_exists__returns_cached_data(
     expected_api_calls = 100
     expected_chargebee_email = "test@example.com"
 
-    settings.VERSIONING_RELEASE_DATE = timezone.now() - timedelta(days=1)
     expected_feature_history_visibility_days = 30
     expected_audit_log_visibility_days = 30
 
@@ -1096,7 +1095,6 @@ def test_get_subscription_metadata__no_cache__fetches_from_chargebee(
     expected_api_calls = 100
     expected_chargebee_email = "test@example.com"
 
-    settings.VERSIONING_RELEASE_DATE = timezone.now() - timedelta(days=1)
     expected_feature_history_visibility_days = DEFAULT_VERSION_LIMIT_DAYS
     expected_audit_log_visibility_days = 0
 

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -1050,6 +1050,9 @@ def test_get_subscription_metadata__cache_exists__returns_cached_data(
     expected_feature_history_visibility_days = 30
     expected_audit_log_visibility_days = 30
 
+    chargebee_subscription.plan = "scale-up-v4-monthly"
+    chargebee_subscription.save()
+
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
         allowed_seats=expected_seats,
@@ -1083,6 +1086,55 @@ def test_get_subscription_metadata__cache_exists__returns_cached_data(
     }
 
 
+def test_get_subscription_metadata__cache_exists__scale_up_v2__preserves_old_plan_audit_log(
+    organisation: Organisation,
+    admin_client: APIClient,
+    chargebee_subscription: Subscription,
+    mocker: MagicMock,
+) -> None:
+    # Given
+    expected_seats = 10
+    expected_projects = 3
+    expected_api_calls = 100
+    expected_chargebee_email = "test@example.com"
+    expected_feature_history_visibility_days = 14
+
+    chargebee_subscription.plan = "scale-up-v2"
+    chargebee_subscription.save()
+
+    OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        allowed_seats=expected_seats,
+        allowed_projects=expected_projects,
+        allowed_30d_api_calls=expected_api_calls,
+        chargebee_email=expected_chargebee_email,
+        feature_history_visibility_days=expected_feature_history_visibility_days,
+        audit_log_visibility_days=30,
+    )
+
+    url = reverse(
+        "api-v1:organisations:organisation-get-subscription-metadata",
+        args=[organisation.pk],
+    )
+
+    mocker.patch("organisations.models.is_saas", return_value=True)
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "max_seats": expected_seats,
+        "max_projects": expected_projects,
+        "max_api_calls": expected_api_calls,
+        "payment_source": CHARGEBEE,
+        "chargebee_email": expected_chargebee_email,
+        "feature_history_visibility_days": expected_feature_history_visibility_days,
+        "audit_log_visibility_days": None,
+    }
+
+
 def test_get_subscription_metadata__no_cache__fetches_from_chargebee(
     mocker: MockerFixture,
     organisation: Organisation,
@@ -1097,6 +1149,9 @@ def test_get_subscription_metadata__no_cache__fetches_from_chargebee(
 
     expected_feature_history_visibility_days = DEFAULT_VERSION_LIMIT_DAYS
     expected_audit_log_visibility_days = 0
+
+    chargebee_subscription.plan = "scale-up-v4-monthly"
+    chargebee_subscription.save()
 
     mocker.patch("organisations.models.is_saas", return_value=True)
     get_subscription_metadata = mocker.patch(

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -1086,7 +1086,7 @@ def test_get_subscription_metadata__cache_exists__returns_cached_data(
     }
 
 
-def test_get_subscription_metadata__cache_exists__scale_up_v2__preserves_old_plan_audit_log(
+def test_get_subscription_metadata__scale_up_v2_with_cache__preserves_old_plan_audit_log(
     organisation: Organisation,
     admin_client: APIClient,
     chargebee_subscription: Subscription,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- `scale-up-v4` plans branch out of the `VERSIONING_RELEASE_DATE` to use the real subscription_metadata_cache related to audit log and feature history
- Audit log and feature history were previously set to unlimited for old subscriptions

## How did you test this code?
- New tests