### PR TITLE
fix(infra): Drop SECURE_PROXY_SSL_HEADER_NAME override

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -138,10 +138,6 @@
                     "value": "flagsmith_project_metadata"
                 },
                 {
-                    "name": "SECURE_PROXY_SSL_HEADER_NAME",
-                    "value": "HTTP_CLOUDFRONT_FORWARDED_PROTO"
-                },
-                {
                     "name": "SENDER_EMAIL",
                     "value": "Flagsmith <support@flagsmith.com>"
                 },


### PR DESCRIPTION
The task definition pinned `SECURE_PROXY_SSL_HEADER_NAME` to `HTTP_CLOUDFRONT_FORWARDED_PROTO`, so Django only detected HTTPS when the request came through CloudFront. Requests via the internal ALB (no CloudFront in the path) had no such header, so `is_secure()` returned False and Google SSO callbacks were generated as `http://`, which Google rejects.

Removing the override falls back to the default in `api/app/settings/common.py`: `HTTP_X_FORWARDED_PROTO`. Both ALBs stamp `X-Forwarded-Proto` on their HTTPS listener, so Django detects HTTPS regardless of CloudFront presence.

Contributes to https://github.com/Flagsmith/flagsmith/issues/7282