### PR TITLE
docs: fix broken OpenAPI spec links on Admin API page

### DIFF
--- a/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/index.md
+++ b/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/index.md
@@ -9,7 +9,7 @@ This API is designed for automation, integrations, and building custom workflows
 
 ## API Explorer
 
-You can explore the full Admin API via Swagger at [https://api.flagsmith.com/api/v1/docs/](https://api.flagsmith.com/api/v1/docs/). You can also get the OpenAPI specification in [JSON](https://api.flagsmith.com/api/v1/docs/?format=.json) or [YAML](https://api.flagsmith.com/api/v1/docs/?format=.yaml) format.
+You can explore the full Admin API via Swagger at [https://api.flagsmith.com/api/v1/docs/](https://api.flagsmith.com/api/v1/docs/). You can also get the OpenAPI specification in [JSON](https://api.flagsmith.com/api/v1/swagger.json) or [YAML](https://api.flagsmith.com/api/v1/swagger.yaml) format.
 
 We also have a [Postman Collection](https://www.postman.com/flagsmith/workspace/flagsmith/overview) that you can use to experiment with the API.
 


### PR DESCRIPTION
## Summary

The Admin API docs page links to the OpenAPI spec in JSON and YAML, but both links 404.

- Page: https://docs.flagsmith.com/integrating-with-flagsmith/flagsmith-api-overview/admin-api
- Current (broken): `https://api.flagsmith.com/api/v1/docs/?format=.json` / `?format=.yaml`
- Fixed: `https://api.flagsmith.com/api/v1/swagger.json` / `swagger.yaml` — these return 200 and are the same URLs the Swagger UI on `/api/v1/docs/` already loads internally.

## Test plan

- [x] `curl` both new URLs returns `200` with `application/vnd.oai.openapi+json` and `application/vnd.oai.openapi` content types
- [x] `curl` the old URLs returns `404`
- [ ] Confirm rendered docs page links resolve after deploy