### PR TITLE
ci: use production settings for mcp schema generation

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Generate MCP schema
         env:
+          DJANGO_SETTINGS_MODULE: app.settings.production
           FLAGSMITH_API_URL: 'https://api.flagsmith.com'
           FLAGSMITH_FRONTEND_URL: 'https://app.flagsmith.com'
         run: make generate-mcp-spec


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Use production settings in push to gram workflow

## How did you test this code?
Ran locally
```
  DJANGO_SETTINGS_MODULE=app.settings.production \
  FLAGSMITH_API_URL='https://api.flagsmith.com' \
  FLAGSMITH_FRONTEND_URL='https://app.flagsmith.com' \
  make generate-mcp-spec
```