### PR TITLE
fix(sentry): emit change-tracking events for v2-versioning environments

### DIFF
--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -230,21 +230,13 @@ def send_feature_flag_went_live_signal(sender, instance, **kwargs):  # type: ign
     feature_state_change_went_live.send(feature_state)
 
 
-def _get_sentry_config_or_none(
-    environment: Any,
-) -> SentryChangeTrackingConfiguration | None:
-    config: SentryChangeTrackingConfiguration | None = (
-        SentryChangeTrackingConfiguration.objects.filter(
-            environment=environment,
-            deleted_at__isnull=True,
-        ).first()
-    )
-    return config
-
-
 @receiver(feature_state_change_went_live)
 def send_audit_log_event_to_sentry(sender: FeatureState, **kwargs: Any) -> None:
-    if not (config := _get_sentry_config_or_none(sender.environment)):
+    config = SentryChangeTrackingConfiguration.objects.filter(
+        environment=sender.environment,
+        deleted_at__isnull=True,
+    ).first()
+    if not config:
         return
     sentry = SentryChangeTracking(
         webhook_url=config.webhook_url,

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -250,6 +250,157 @@ def send_audit_log_event_to_sentry(
     _track_event_async(audit_log, sentry_change_tracking)  # type: ignore[no-untyped-call]
 
 
+@receiver(post_save, sender=AuditLog)
+@track_only([RelatedObjectType.EF_VERSION])
+def send_efv_audit_log_event_to_sentry(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
+    """
+    Sentry's flag-log API needs per-FS payloads. v2 EFV publish emits a single
+    EF_VERSION-typed audit row representing N feature state changes, so expand
+    it into per-FS Sentry entries and send them as a single batched payload.
+    """
+    from features.versioning.models import EnvironmentFeatureVersion
+    from features.versioning.versioning_service import (
+        get_updated_feature_states_for_version,
+    )
+
+    try:
+        sentry_configuration = SentryChangeTrackingConfiguration.objects.get(
+            environment=instance.environment,
+            deleted_at__isnull=True,
+        )
+    except SentryChangeTrackingConfiguration.DoesNotExist:
+        return
+
+    if not instance.related_object_uuid:
+        return
+
+    try:
+        efv = EnvironmentFeatureVersion.objects.select_related("feature").get(
+            uuid=instance.related_object_uuid,
+        )
+    except EnvironmentFeatureVersion.DoesNotExist:
+        return
+
+    changed_feature_states = get_updated_feature_states_for_version(efv)
+    if not changed_feature_states:
+        return
+
+    previous_version = efv.get_previous_version()
+    previous_fs_keys: set[tuple[int | None, int | None]] = set()
+    if previous_version:
+        previous_fs_keys = {
+            (
+                fs.identity_id,
+                fs.feature_segment.segment_id if fs.feature_segment else None,
+            )
+            for fs in previous_version.feature_states.all()
+        }
+
+    timestamp = (efv.live_from or efv.published_at or instance.created_date)
+    author_email = getattr(instance.author, "email", "app@flagsmith.com")
+
+    events: list[dict[str, Any]] = []
+    for fs in changed_feature_states:
+        key = (
+            fs.identity_id,
+            fs.feature_segment.segment_id if fs.feature_segment else None,
+        )
+        action = "updated" if key in previous_fs_keys else "created"
+        events.append(
+            {
+                "action": action,
+                "flag": efv.feature.name,
+                "created_at": timestamp.isoformat(timespec="seconds"),
+                "created_by": {
+                    "id": author_email,
+                    "type": "email",
+                },
+                "change_id": str(fs.pk),
+            }
+        )
+
+    sentry_change_tracking = SentryChangeTracking(
+        webhook_url=sentry_configuration.webhook_url,
+        secret=sentry_configuration.secret,
+    )
+    sentry_change_tracking.track_events_async(events)
+
+
+@receiver(post_save, sender=FeatureState)
+def send_v2_initial_feature_state_event_to_sentry(  # type: ignore[no-untyped-def]
+    sender,
+    instance: FeatureState,
+    created: bool,
+    **kwargs: Any,
+) -> None:
+    """
+    v2 envs suppress FS-typed audit rows for auto-created initial FeatureStates,
+    and `create_initial_version` doesn't fire `environment_feature_version_published`,
+    so Sentry has no audit row to latch onto for flag-create in v2 envs.
+    Listen directly to FS post_save for v2 env-default FSes that belong to an
+    initial (no-previous-version) EFV and emit a Sentry "created" event with the
+    FS pk as change_id. The author is recovered from the FEATURE audit row
+    written moments earlier in the same flow.
+    """
+    if not created:
+        return
+    if instance.environment_feature_version_id is None:
+        return
+    if instance.feature_segment_id or instance.identity_id:
+        return
+
+    efv = instance.environment_feature_version
+    if efv is None or efv.get_previous_version() is not None:
+        return
+
+    try:
+        sentry_configuration = SentryChangeTrackingConfiguration.objects.get(
+            environment=instance.environment,
+            deleted_at__isnull=True,
+        )
+    except SentryChangeTrackingConfiguration.DoesNotExist:
+        return
+
+    feature_audit_log = (
+        AuditLog.objects.filter(
+            related_object_type=RelatedObjectType.FEATURE.name,
+            related_object_id=instance.feature_id,
+        )
+        .order_by("-id")
+        .first()
+    )
+    author_email = (
+        feature_audit_log.author.email
+        if feature_audit_log and feature_audit_log.author
+        else "app@flagsmith.com"
+    )
+
+    timestamp = (
+        max(instance.live_from, instance.updated_at)
+        if instance.live_from
+        else instance.updated_at
+    )
+
+    events = [
+        {
+            "action": "created",
+            "flag": instance.feature.name,
+            "created_at": timestamp.isoformat(timespec="seconds"),
+            "created_by": {
+                "id": author_email,
+                "type": "email",
+            },
+            "change_id": str(instance.pk),
+        }
+    ]
+
+    sentry_change_tracking = SentryChangeTracking(
+        webhook_url=sentry_configuration.webhook_url,
+        secret=sentry_configuration.secret,
+    )
+    sentry_change_tracking.track_events_async(events)
+
+
 @receiver(feature_state_change_went_live)
 def trigger_feature_state_change_webhooks(
     sender: FeatureState,

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -365,6 +365,15 @@ def send_v2_initial_feature_state_event_to_sentry(  # type: ignore[no-untyped-de
     if efv is None or efv.get_previous_version() is not None:
         return
 
+    # Mirror v1's suppression rule from FeatureState.get_create_log_message:
+    # env-create / env-clone (where the env didn't exist when the feature was
+    # created) doesn't notify Sentry in v1, so don't introduce divergence here.
+    if (
+        instance.environment is None
+        or instance.environment.created_date > instance.feature.created_date
+    ):
+        return
+
     if not (config := _get_sentry_config_or_none(instance.environment)):
         return
 

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -243,9 +243,7 @@ def _get_sentry_config_or_none(
 
 
 @receiver(feature_state_change_went_live)
-def send_audit_log_event_to_sentry(
-    sender: FeatureState, **kwargs: Any
-) -> None:
+def send_audit_log_event_to_sentry(sender: FeatureState, **kwargs: Any) -> None:
     if not (config := _get_sentry_config_or_none(sender.environment)):
         return
     sentry = SentryChangeTracking(

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -36,6 +36,7 @@ AuditLogIntegrationAttrName = Literal[
     "dynatrace_config",
     "grafana_config",
     "new_relic_config",
+    "sentry_change_tracking_configuration",
     "slack_config",
 ]
 
@@ -195,6 +196,19 @@ def send_audit_log_event_to_grafana(sender, instance, **kwargs):  # type: ignore
 
 @receiver(post_save, sender=AuditLog)
 @track_only_feature_related_events
+def send_audit_log_event_to_sentry_v2(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
+    """
+    v2 Sentry receiver. Single entry point for all feature-related audit rows
+    in v2-versioning environments. Delegates all Sentry-side processing to
+    ``integrations.sentry.change_tracking.process_audit_log``.
+    """
+    from integrations.sentry.change_tracking import process_audit_log
+
+    process_audit_log(instance)
+
+
+@receiver(post_save, sender=AuditLog)
+@track_only_feature_related_events
 def send_audit_log_event_to_slack(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     slack_project_config = _get_integration_config(instance, "slack_config")
     if not slack_project_config:
@@ -230,9 +244,6 @@ def send_feature_flag_went_live_signal(sender, instance, **kwargs):  # type: ign
     feature_state_change_went_live.send(feature_state, audit_log=instance)
 
 
-_DEFAULT_SENTRY_AUTHOR_EMAIL = "app@flagsmith.com"
-
-
 def _get_sentry_config_or_none(
     environment: Any,
 ) -> SentryChangeTrackingConfiguration | None:
@@ -243,24 +254,6 @@ def _get_sentry_config_or_none(
         ).first()
     )
     return config
-
-
-def _audit_log_author_email(audit_log: AuditLog | None) -> str:
-    if audit_log is None:
-        return _DEFAULT_SENTRY_AUTHOR_EMAIL
-    return getattr(audit_log.author, "email", _DEFAULT_SENTRY_AUTHOR_EMAIL)
-
-
-def _send_sentry_events(
-    config: SentryChangeTrackingConfiguration,
-    events: list[dict[str, Any]],
-) -> None:
-    if not events:
-        return
-    SentryChangeTracking(
-        webhook_url=config.webhook_url,
-        secret=config.secret,
-    ).track_events_async(events)
 
 
 @receiver(feature_state_change_went_live)
@@ -274,134 +267,6 @@ def send_audit_log_event_to_sentry(
         secret=config.secret,
     )
     _track_event_async(audit_log, sentry_change_tracking)  # type: ignore[no-untyped-call]
-
-
-@receiver(post_save, sender=AuditLog)
-@track_only([RelatedObjectType.EF_VERSION])
-def send_efv_audit_log_event_to_sentry(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
-    """
-    Sentry's flag-log API needs per-FS payloads. v2 EFV publish emits a single
-    EF_VERSION-typed audit row representing N feature state changes, so expand
-    it into per-FS Sentry entries and send them as a single batched payload.
-    """
-    from features.versioning.models import EnvironmentFeatureVersion
-    from features.versioning.versioning_service import (
-        get_feature_state_match_key,
-        get_updated_feature_states_for_version,
-    )
-
-    if not (config := _get_sentry_config_or_none(instance.environment)):
-        return
-
-    if not instance.related_object_uuid:
-        return
-
-    try:
-        efv = EnvironmentFeatureVersion.objects.select_related("feature").get(
-            uuid=instance.related_object_uuid,
-        )
-    except EnvironmentFeatureVersion.DoesNotExist:
-        return
-
-    changed_feature_states = get_updated_feature_states_for_version(efv)
-    if not changed_feature_states:
-        return
-
-    previous_version = efv.get_previous_version()
-    previous_fs_keys = (
-        {
-            get_feature_state_match_key(fs)
-            for fs in previous_version.feature_states.all()
-        }
-        if previous_version
-        else set()
-    )
-
-    timestamp = efv.live_from or efv.published_at or instance.created_date
-    author_email = _audit_log_author_email(instance)
-    flag_name = efv.feature.name
-
-    events = [
-        SentryChangeTracking.build_payload_entry(
-            action=(
-                "updated"
-                if get_feature_state_match_key(fs) in previous_fs_keys
-                else "created"
-            ),
-            flag_name=flag_name,
-            change_id=fs.pk,
-            timestamp=timestamp,
-            author_email=author_email,
-        )
-        for fs in changed_feature_states
-    ]
-    _send_sentry_events(config, events)
-
-
-@receiver(post_save, sender=FeatureState)
-def send_v2_initial_feature_state_event_to_sentry(  # type: ignore[no-untyped-def]
-    sender,
-    instance: FeatureState,
-    created: bool,
-    **kwargs: Any,
-) -> None:
-    """
-    v2 envs suppress FS-typed audit rows for auto-created initial FeatureStates,
-    and `create_initial_version` doesn't fire `environment_feature_version_published`,
-    so Sentry has no audit row to latch onto for flag-create in v2 envs.
-    Listen directly to FS post_save for v2 env-default FSes that belong to an
-    initial (no-previous-version) EFV and emit a Sentry "created" event with the
-    FS pk as change_id. The author is recovered from the FEATURE audit row
-    written moments earlier in the same flow.
-    """
-    if not created:
-        return
-    if instance.environment_feature_version_id is None:
-        return
-    if instance.feature_segment_id or instance.identity_id:
-        return
-
-    efv = instance.environment_feature_version
-    if efv is None or efv.get_previous_version() is not None:
-        return
-
-    # Mirror v1's suppression rule from FeatureState.get_create_log_message:
-    # env-create / env-clone (where the env didn't exist when the feature was
-    # created) doesn't notify Sentry in v1, so don't introduce divergence here.
-    if (
-        instance.environment is None
-        or instance.environment.created_date > instance.feature.created_date
-    ):
-        return
-
-    if not (config := _get_sentry_config_or_none(instance.environment)):
-        return
-
-    feature_audit_log = (
-        AuditLog.objects.filter(
-            related_object_type=RelatedObjectType.FEATURE.name,
-            related_object_id=instance.feature_id,
-        )
-        .order_by("-id")
-        .first()
-    )
-
-    timestamp = (
-        max(instance.live_from, instance.updated_at)
-        if instance.live_from
-        else instance.updated_at
-    )
-
-    events = [
-        SentryChangeTracking.build_payload_entry(
-            action="created",
-            flag_name=instance.feature.name,
-            change_id=instance.pk,
-            timestamp=timestamp,
-            author_email=_audit_log_author_email(feature_audit_log),
-        )
-    ]
-    _send_sentry_events(config, events)
 
 
 @receiver(feature_state_change_went_live)

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -309,7 +309,10 @@ def send_efv_audit_log_event_to_sentry(sender, instance, **kwargs):  # type: ign
 
     previous_version = efv.get_previous_version()
     previous_fs_keys = (
-        {get_feature_state_match_key(fs) for fs in previous_version.feature_states.all()}
+        {
+            get_feature_state_match_key(fs)
+            for fs in previous_version.feature_states.all()
+        }
         if previous_version
         else set()
     )

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -230,23 +230,49 @@ def send_feature_flag_went_live_signal(sender, instance, **kwargs):  # type: ign
     feature_state_change_went_live.send(feature_state, audit_log=instance)
 
 
+_DEFAULT_SENTRY_AUTHOR_EMAIL = "app@flagsmith.com"
+
+
+def _get_sentry_config_or_none(
+    environment: Any,
+) -> SentryChangeTrackingConfiguration | None:
+    config: SentryChangeTrackingConfiguration | None = (
+        SentryChangeTrackingConfiguration.objects.filter(
+            environment=environment,
+            deleted_at__isnull=True,
+        ).first()
+    )
+    return config
+
+
+def _audit_log_author_email(audit_log: AuditLog | None) -> str:
+    if audit_log is None:
+        return _DEFAULT_SENTRY_AUTHOR_EMAIL
+    return getattr(audit_log.author, "email", _DEFAULT_SENTRY_AUTHOR_EMAIL)
+
+
+def _send_sentry_events(
+    config: SentryChangeTrackingConfiguration,
+    events: list[dict[str, Any]],
+) -> None:
+    if not events:
+        return
+    SentryChangeTracking(
+        webhook_url=config.webhook_url,
+        secret=config.secret,
+    ).track_events_async(events)
+
+
 @receiver(feature_state_change_went_live)
 def send_audit_log_event_to_sentry(
     sender: FeatureState, audit_log: AuditLog, **kwargs: Any
 ) -> None:
-    try:
-        sentry_configuration = SentryChangeTrackingConfiguration.objects.get(
-            environment=audit_log.environment,
-            deleted_at__isnull=True,
-        )
-    except SentryChangeTrackingConfiguration.DoesNotExist:
+    if not (config := _get_sentry_config_or_none(audit_log.environment)):
         return
-
     sentry_change_tracking = SentryChangeTracking(
-        webhook_url=sentry_configuration.webhook_url,
-        secret=sentry_configuration.secret,
+        webhook_url=config.webhook_url,
+        secret=config.secret,
     )
-
     _track_event_async(audit_log, sentry_change_tracking)  # type: ignore[no-untyped-call]
 
 
@@ -260,15 +286,11 @@ def send_efv_audit_log_event_to_sentry(sender, instance, **kwargs):  # type: ign
     """
     from features.versioning.models import EnvironmentFeatureVersion
     from features.versioning.versioning_service import (
+        get_feature_state_match_key,
         get_updated_feature_states_for_version,
     )
 
-    try:
-        sentry_configuration = SentryChangeTrackingConfiguration.objects.get(
-            environment=instance.environment,
-            deleted_at__isnull=True,
-        )
-    except SentryChangeTrackingConfiguration.DoesNotExist:
+    if not (config := _get_sentry_config_or_none(instance.environment)):
         return
 
     if not instance.related_object_uuid:
@@ -286,44 +308,31 @@ def send_efv_audit_log_event_to_sentry(sender, instance, **kwargs):  # type: ign
         return
 
     previous_version = efv.get_previous_version()
-    previous_fs_keys: set[tuple[int | None, int | None]] = set()
-    if previous_version:
-        previous_fs_keys = {
-            (
-                fs.identity_id,
-                fs.feature_segment.segment_id if fs.feature_segment else None,
-            )
-            for fs in previous_version.feature_states.all()
-        }
+    previous_fs_keys = (
+        {get_feature_state_match_key(fs) for fs in previous_version.feature_states.all()}
+        if previous_version
+        else set()
+    )
 
     timestamp = efv.live_from or efv.published_at or instance.created_date
-    author_email = getattr(instance.author, "email", "app@flagsmith.com")
+    author_email = _audit_log_author_email(instance)
+    flag_name = efv.feature.name
 
-    events: list[dict[str, Any]] = []
-    for fs in changed_feature_states:
-        key = (
-            fs.identity_id,
-            fs.feature_segment.segment_id if fs.feature_segment else None,
+    events = [
+        SentryChangeTracking.build_payload_entry(
+            action=(
+                "updated"
+                if get_feature_state_match_key(fs) in previous_fs_keys
+                else "created"
+            ),
+            flag_name=flag_name,
+            change_id=fs.pk,
+            timestamp=timestamp,
+            author_email=author_email,
         )
-        action = "updated" if key in previous_fs_keys else "created"
-        events.append(
-            {
-                "action": action,
-                "flag": efv.feature.name,
-                "created_at": timestamp.isoformat(timespec="seconds"),
-                "created_by": {
-                    "id": author_email,
-                    "type": "email",
-                },
-                "change_id": str(fs.pk),
-            }
-        )
-
-    sentry_change_tracking = SentryChangeTracking(
-        webhook_url=sentry_configuration.webhook_url,
-        secret=sentry_configuration.secret,
-    )
-    sentry_change_tracking.track_events_async(events)
+        for fs in changed_feature_states
+    ]
+    _send_sentry_events(config, events)
 
 
 @receiver(post_save, sender=FeatureState)
@@ -353,12 +362,7 @@ def send_v2_initial_feature_state_event_to_sentry(  # type: ignore[no-untyped-de
     if efv is None or efv.get_previous_version() is not None:
         return
 
-    try:
-        sentry_configuration = SentryChangeTrackingConfiguration.objects.get(
-            environment=instance.environment,
-            deleted_at__isnull=True,
-        )
-    except SentryChangeTrackingConfiguration.DoesNotExist:
+    if not (config := _get_sentry_config_or_none(instance.environment)):
         return
 
     feature_audit_log = (
@@ -369,11 +373,6 @@ def send_v2_initial_feature_state_event_to_sentry(  # type: ignore[no-untyped-de
         .order_by("-id")
         .first()
     )
-    author_email = (
-        feature_audit_log.author.email
-        if feature_audit_log and feature_audit_log.author
-        else "app@flagsmith.com"
-    )
 
     timestamp = (
         max(instance.live_from, instance.updated_at)
@@ -382,23 +381,15 @@ def send_v2_initial_feature_state_event_to_sentry(  # type: ignore[no-untyped-de
     )
 
     events = [
-        {
-            "action": "created",
-            "flag": instance.feature.name,
-            "created_at": timestamp.isoformat(timespec="seconds"),
-            "created_by": {
-                "id": author_email,
-                "type": "email",
-            },
-            "change_id": str(instance.pk),
-        }
+        SentryChangeTracking.build_payload_entry(
+            action="created",
+            flag_name=instance.feature.name,
+            change_id=instance.pk,
+            timestamp=timestamp,
+            author_email=_audit_log_author_email(feature_audit_log),
+        )
     ]
-
-    sentry_change_tracking = SentryChangeTracking(
-        webhook_url=sentry_configuration.webhook_url,
-        secret=sentry_configuration.secret,
-    )
-    sentry_change_tracking.track_events_async(events)
+    _send_sentry_events(config, events)
 
 
 @receiver(feature_state_change_went_live)

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -36,7 +36,6 @@ AuditLogIntegrationAttrName = Literal[
     "dynatrace_config",
     "grafana_config",
     "new_relic_config",
-    "sentry_change_tracking_configuration",
     "slack_config",
 ]
 
@@ -196,19 +195,6 @@ def send_audit_log_event_to_grafana(sender, instance, **kwargs):  # type: ignore
 
 @receiver(post_save, sender=AuditLog)
 @track_only_feature_related_events
-def send_audit_log_event_to_sentry_v2(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
-    """
-    v2 Sentry receiver. Single entry point for all feature-related audit rows
-    in v2-versioning environments. Delegates all Sentry-side processing to
-    ``integrations.sentry.change_tracking.process_audit_log``.
-    """
-    from integrations.sentry.change_tracking import process_audit_log
-
-    process_audit_log(instance)
-
-
-@receiver(post_save, sender=AuditLog)
-@track_only_feature_related_events
 def send_audit_log_event_to_slack(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     slack_project_config = _get_integration_config(instance, "slack_config")
     if not slack_project_config:
@@ -241,7 +227,7 @@ def send_feature_flag_went_live_signal(sender, instance, **kwargs):  # type: ign
     if feature_state.is_scheduled:
         return  # This is handled by audit.tasks.create_feature_state_went_live_audit_log
 
-    feature_state_change_went_live.send(feature_state, audit_log=instance)
+    feature_state_change_went_live.send(feature_state)
 
 
 def _get_sentry_config_or_none(
@@ -258,15 +244,16 @@ def _get_sentry_config_or_none(
 
 @receiver(feature_state_change_went_live)
 def send_audit_log_event_to_sentry(
-    sender: FeatureState, audit_log: AuditLog, **kwargs: Any
+    sender: FeatureState, **kwargs: Any
 ) -> None:
-    if not (config := _get_sentry_config_or_none(audit_log.environment)):
+    if not (config := _get_sentry_config_or_none(sender.environment)):
         return
-    sentry_change_tracking = SentryChangeTracking(
+    sentry = SentryChangeTracking(
         webhook_url=config.webhook_url,
         secret=config.secret,
     )
-    _track_event_async(audit_log, sentry_change_tracking)  # type: ignore[no-untyped-call]
+    if event_data := sentry.generate_event_data(sender):
+        sentry.track_event_async(event=event_data)
 
 
 @receiver(feature_state_change_went_live)

--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -296,7 +296,7 @@ def send_efv_audit_log_event_to_sentry(sender, instance, **kwargs):  # type: ign
             for fs in previous_version.feature_states.all()
         }
 
-    timestamp = (efv.live_from or efv.published_at or instance.created_date)
+    timestamp = efv.live_from or efv.published_at or instance.created_date
     author_email = getattr(instance.author, "email", "app@flagsmith.com")
 
     events: list[dict[str, Any]] = []

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -917,7 +917,8 @@ class FeatureState(
         fire the signal directly so consumers like Sentry are notified.
         """
         if (
-            self.environment.use_v2_feature_versioning
+            self.environment is not None
+            and self.environment.use_v2_feature_versioning
             and self.environment.created_date <= self.feature.created_date
         ):
             feature_state_change_went_live.send(self)

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -56,12 +56,14 @@ from features.feature_states.models import AbstractBaseFeatureValueModel
 from features.feature_types import FEATURE_TYPE_CHOICES, MULTIVARIATE, STANDARD
 from features.helpers import get_correctly_typed_value
 from features.managers import (
+
     FeatureManager,
     FeatureSegmentManager,
     FeatureStateManager,
     FeatureStateValueManager,
 )
 from features.multivariate.models import MultivariateFeatureStateValue
+from features.signals import feature_state_change_went_live
 from features.utils import (
     get_boolean_from_string,
     get_integer_from_string,
@@ -904,7 +906,18 @@ class FeatureState(
                 )
             )
 
-        cls.objects.create(**kwargs)
+        feature_state = cls.objects.create(**kwargs)
+
+        # v2 suppresses the FS audit row that v1 uses to drive
+        # `feature_state_change_went_live` (see get_skip_create_audit_log).
+        # For the flag-create case (env existed when the feature was created
+        # — env-create / env-clone are excluded by the date check below),
+        # fire the signal directly so consumers like Sentry are notified.
+        if (
+            environment.use_v2_feature_versioning
+            and environment.created_date <= feature.created_date
+        ):
+            feature_state_change_went_live.send(feature_state)
 
     @classmethod
     def get_next_version_number(  # type: ignore[no-untyped-def]

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -56,7 +56,6 @@ from features.feature_states.models import AbstractBaseFeatureValueModel
 from features.feature_types import FEATURE_TYPE_CHOICES, MULTIVARIATE, STANDARD
 from features.helpers import get_correctly_typed_value
 from features.managers import (
-
     FeatureManager,
     FeatureSegmentManager,
     FeatureStateManager,

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -906,17 +906,21 @@ class FeatureState(
             )
 
         feature_state = cls.objects.create(**kwargs)
+        feature_state._send_change_went_live_for_v2_feature_create()
 
-        # v2 suppresses the FS audit row that v1 uses to drive
-        # `feature_state_change_went_live` (see get_skip_create_audit_log).
-        # For the flag-create case (env existed when the feature was created
-        # — env-create / env-clone are excluded by the date check below),
-        # fire the signal directly so consumers like Sentry are notified.
+    def _send_change_went_live_for_v2_feature_create(self) -> None:
+        """
+        v2 suppresses the FS audit row that v1 uses to drive
+        `feature_state_change_went_live` (see get_skip_create_audit_log).
+        For the feature-create case (env existed when the feature was
+        created — env-create / env-clone are excluded by the date check),
+        fire the signal directly so consumers like Sentry are notified.
+        """
         if (
-            environment.use_v2_feature_versioning
-            and environment.created_date <= feature.created_date
+            self.environment.use_v2_feature_versioning
+            and self.environment.created_date <= self.feature.created_date
         ):
-            feature_state_change_went_live.send(feature_state)
+            feature_state_change_went_live.send(self)
 
     @classmethod
     def get_next_version_number(  # type: ignore[no-untyped-def]

--- a/api/features/versioning/receivers.py
+++ b/api/features/versioning/receivers.py
@@ -3,11 +3,15 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from environments.tasks import rebuild_environment_document
+from features.signals import feature_state_change_went_live
 from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.signals import environment_feature_version_published
 from features.versioning.tasks import (
     create_environment_feature_version_published_audit_log_task,
     trigger_update_version_webhooks,
+)
+from features.versioning.versioning_service import (
+    get_updated_feature_states_for_version,
 )
 
 
@@ -62,3 +66,18 @@ def create_environment_feature_version_published_audit_log(  # type: ignore[no-u
     create_environment_feature_version_published_audit_log_task.delay(
         kwargs={"environment_feature_version_uuid": str(instance.uuid)}
     )
+
+
+@receiver(environment_feature_version_published, sender=EnvironmentFeatureVersion)
+def fire_feature_state_change_went_live(  # type: ignore[no-untyped-def]
+    instance: EnvironmentFeatureVersion, **kwargs
+) -> None:
+    """
+    Fire `feature_state_change_went_live` for each FS that changed in this
+    version so consumers of that signal (e.g. Sentry) are notified for v2
+    publishes. v1 drives this signal via the FS-typed AuditLog row; v2
+    suppresses that row by design (see FeatureState.get_skip_create_audit_log),
+    so this receiver bridges the gap.
+    """
+    for fs in get_updated_feature_states_for_version(instance):
+        feature_state_change_went_live.send(fs)

--- a/api/features/versioning/receivers.py
+++ b/api/features/versioning/receivers.py
@@ -69,7 +69,7 @@ def create_environment_feature_version_published_audit_log(  # type: ignore[no-u
 
 
 @receiver(environment_feature_version_published, sender=EnvironmentFeatureVersion)
-def fire_feature_state_change_went_live(  # type: ignore[no-untyped-def]
+def trigger_feature_state_change_went_live_signal(  # type: ignore[no-untyped-def]
     instance: EnvironmentFeatureVersion, **kwargs
 ) -> None:
     """

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -455,16 +455,24 @@ def _delete_segment_override_v2(
     new_version.publish(published_by=author.user, published_by_api_key=author.api_key)
 
 
+def get_feature_state_match_key(
+    fs: FeatureState,
+) -> tuple[int | None, int | None]:
+    """
+    Stable identity for a feature state within a version: the (identity_id,
+    segment_id) tuple that distinguishes env-default, segment-override, and
+    identity-override states for the same (feature, environment).
+    """
+    segment_id = fs.feature_segment.segment_id if fs.feature_segment else None
+    return (fs.identity_id, segment_id)
+
+
 def get_updated_feature_states_for_version(
     version: EnvironmentFeatureVersion,
 ) -> list[FeatureState]:
     """
     Returns feature states that changed compared to the previous version.
     """
-
-    def get_match_key(fs: FeatureState) -> tuple[int | None, int | None]:
-        segment_id = fs.feature_segment.segment_id if fs.feature_segment else None
-        return (fs.identity_id, segment_id)
 
     def multivariate_values_changed(
         fs: FeatureState, previous_fs: FeatureState
@@ -481,14 +489,19 @@ def get_updated_feature_states_for_version(
 
     previous_version = version.get_previous_version()
     previous_feature_states_map = (
-        {get_match_key(fs): fs for fs in previous_version.feature_states.all()}
+        {
+            get_feature_state_match_key(fs): fs
+            for fs in previous_version.feature_states.all()
+        }
         if previous_version
         else {}
     )
 
     changed_feature_states = []
     for feature_state in version.feature_states.all():
-        previous_fs = previous_feature_states_map.get(get_match_key(feature_state))
+        previous_fs = previous_feature_states_map.get(
+            get_feature_state_match_key(feature_state)
+        )
 
         if previous_fs is None or (
             feature_state.enabled != previous_fs.enabled

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -455,24 +455,16 @@ def _delete_segment_override_v2(
     new_version.publish(published_by=author.user, published_by_api_key=author.api_key)
 
 
-def get_feature_state_match_key(
-    fs: FeatureState,
-) -> tuple[int | None, int | None]:
-    """
-    Stable identity for a feature state within a version: the (identity_id,
-    segment_id) tuple that distinguishes env-default, segment-override, and
-    identity-override states for the same (feature, environment).
-    """
-    segment_id = fs.feature_segment.segment_id if fs.feature_segment else None
-    return (fs.identity_id, segment_id)
-
-
 def get_updated_feature_states_for_version(
     version: EnvironmentFeatureVersion,
 ) -> list[FeatureState]:
     """
     Returns feature states that changed compared to the previous version.
     """
+
+    def get_match_key(fs: FeatureState) -> tuple[int | None, int | None]:
+        segment_id = fs.feature_segment.segment_id if fs.feature_segment else None
+        return (fs.identity_id, segment_id)
 
     def multivariate_values_changed(
         fs: FeatureState, previous_fs: FeatureState
@@ -489,19 +481,14 @@ def get_updated_feature_states_for_version(
 
     previous_version = version.get_previous_version()
     previous_feature_states_map = (
-        {
-            get_feature_state_match_key(fs): fs
-            for fs in previous_version.feature_states.all()
-        }
+        {get_match_key(fs): fs for fs in previous_version.feature_states.all()}
         if previous_version
         else {}
     )
 
     changed_feature_states = []
     for feature_state in version.feature_states.all():
-        previous_fs = previous_feature_states_map.get(
-            get_feature_state_match_key(feature_state)
-        )
+        previous_fs = previous_feature_states_map.get(get_match_key(feature_state))
 
         if previous_fs is None or (
             feature_state.enabled != previous_fs.enabled

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import Any
 
 import requests
@@ -13,6 +14,8 @@ from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 from util.util import postpone
 
 logger = structlog.get_logger("sentry_change_tracking")
+
+_DEFAULT_AUTHOR_EMAIL = "app@flagsmith.com"
 
 
 class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
@@ -32,6 +35,24 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         self.secret = secret
 
     @staticmethod
+    def build_payload_entry(
+        *,
+        action: str,
+        flag_name: str,
+        change_id: Any,
+        timestamp: datetime,
+        author_email: str,
+    ) -> dict[str, Any]:
+        """Shared shape for a single `data[]` entry in a Sentry flag-log payload."""
+        return {
+            "action": action,
+            "flag": flag_name,
+            "created_at": timestamp.isoformat(timespec="seconds"),
+            "created_by": {"id": author_email, "type": "email"},
+            "change_id": str(change_id),
+        }
+
+    @staticmethod
     def generate_event_data(audit_log_record: AuditLog) -> dict[str, Any]:
         feature_state = get_audited_instance_from_audit_log_record(audit_log_record)
         if not isinstance(feature_state, FeatureState):  # pragma: no cover
@@ -40,7 +61,7 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
             )
             return {}
 
-        update_published_at = feature_state.deleted_at or (
+        timestamp = feature_state.deleted_at or (
             max(feature_state.live_from, feature_state.updated_at)
             if feature_state.live_from
             else feature_state.updated_at
@@ -52,18 +73,15 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
             "~": "updated",
         }[audit_log_record.history_record.history_type]  # type: ignore[union-attr]
 
-        inner_payload = {
-            "action": action,
-            "flag": feature_state.feature.name,
-            "created_at": update_published_at.isoformat(timespec="seconds"),
-            "created_by": {
-                "id": getattr(audit_log_record.author, "email", "app@flagsmith.com"),
-                "type": "email",
-            },
-            "change_id": str(feature_state.pk),
-        }
-
-        return inner_payload
+        return SentryChangeTracking.build_payload_entry(
+            action=action,
+            flag_name=feature_state.feature.name,
+            change_id=feature_state.pk,
+            timestamp=timestamp,
+            author_email=getattr(
+                audit_log_record.author, "email", _DEFAULT_AUTHOR_EMAIL
+            ),
+        )
 
     def _track_event(self, event: dict[str, Any]) -> None:
         self._send_events([event])

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 from typing import Any
 
 import requests
@@ -32,24 +31,6 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         self.secret = secret
 
     @staticmethod
-    def build_payload_entry(
-        *,
-        action: str,
-        flag_name: str,
-        change_id: Any,
-        timestamp: datetime,
-        author_email: str,
-    ) -> dict[str, Any]:
-        """Shared shape for a single `data[]` entry in a Sentry flag-log payload."""
-        return {
-            "action": action,
-            "flag": flag_name,
-            "created_at": timestamp.isoformat(timespec="seconds"),
-            "created_by": {"id": author_email, "type": "email"},
-            "change_id": str(change_id),
-        }
-
-    @staticmethod
     def generate_event_data(feature_state: FeatureState) -> dict[str, Any]:
         timestamp = feature_state.deleted_at or (
             max(feature_state.live_from, feature_state.updated_at)
@@ -67,15 +48,18 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
             "~": "updated",
         }[history_record.history_type]
 
-        return SentryChangeTracking.build_payload_entry(
-            action=action,
-            flag_name=feature_state.feature.name,
-            change_id=feature_state.pk,
-            timestamp=timestamp,
-            author_email=getattr(
-                history_record.history_user, "email", _DEFAULT_AUTHOR_EMAIL
-            ),
-        )
+        return {
+            "action": action,
+            "flag": feature_state.feature.name,
+            "created_at": timestamp.isoformat(timespec="seconds"),
+            "created_by": {
+                "id": getattr(
+                    history_record.history_user, "email", _DEFAULT_AUTHOR_EMAIL
+                ),
+                "type": "email",
+            },
+            "change_id": str(feature_state.pk),
+        }
 
     def _track_event(self, event: dict[str, Any]) -> None:
         action = event["action"]

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -6,182 +6,14 @@ import requests
 import structlog
 from django.core.serializers.json import DjangoJSONEncoder
 
-from audit.models import AuditLog
-from audit.related_object_type import RelatedObjectType
-from audit.services import get_audited_instance_from_audit_log_record
 from core.signing import sign_payload
 from features.models import FeatureState
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
-from integrations.sentry.models import SentryChangeTrackingConfiguration
 from util.util import postpone
 
 logger = structlog.get_logger("sentry_change_tracking")
 
 _DEFAULT_AUTHOR_EMAIL = "app@flagsmith.com"
-
-
-def process_audit_log(audit_log: AuditLog) -> None:
-    """
-    Public entry point for v2 Sentry change tracking. Given an audit log row
-    from any feature-related event, dispatches to the right handler and posts
-    per-FS Sentry events. The signal handler in ``audit.signals`` just passes
-    the audit log; the rest of the orchestration lives here.
-    """
-    if audit_log.related_object_type == RelatedObjectType.EF_VERSION.name:
-        _process_efv_audit_log(audit_log)
-    elif audit_log.related_object_type == RelatedObjectType.FEATURE.name:
-        _process_feature_audit_log(audit_log)
-
-
-def _process_efv_audit_log(audit_log: AuditLog) -> None:
-    """v2 publish (env-default toggle, segment override, scheduled change)."""
-    from features.versioning.models import EnvironmentFeatureVersion
-    from features.versioning.versioning_service import (
-        get_feature_state_match_key,
-        get_updated_feature_states_for_version,
-    )
-
-    if (
-        audit_log.environment is None
-        or not audit_log.environment.use_v2_feature_versioning
-    ):
-        return
-
-    config = _get_config_for_environment(audit_log.environment)
-    if not config:
-        return
-
-    if not audit_log.related_object_uuid:
-        return
-
-    try:
-        efv = EnvironmentFeatureVersion.objects.select_related("feature").get(
-            uuid=audit_log.related_object_uuid,
-        )
-    except EnvironmentFeatureVersion.DoesNotExist:
-        return
-
-    changed_feature_states = get_updated_feature_states_for_version(efv)
-    if not changed_feature_states:
-        return
-
-    previous_version = efv.get_previous_version()
-    previous_fs_keys = (
-        {
-            get_feature_state_match_key(fs)
-            for fs in previous_version.feature_states.all()
-        }
-        if previous_version
-        else set()
-    )
-
-    timestamp = efv.live_from or efv.published_at or audit_log.created_date
-    author_email = _author_email_for_audit_log(audit_log)
-    flag_name = efv.feature.name
-
-    events = [
-        SentryChangeTracking.build_payload_entry(
-            action=(
-                "updated"
-                if get_feature_state_match_key(fs) in previous_fs_keys
-                else "created"
-            ),
-            flag_name=flag_name,
-            change_id=fs.pk,
-            timestamp=timestamp,
-            author_email=author_email,
-        )
-        for fs in changed_feature_states
-    ]
-    _post_events(config, events)
-
-
-def _process_feature_audit_log(audit_log: AuditLog) -> None:
-    """
-    v2 flag-create. The FEATURE audit row is project-wide, so fan out per
-    v2 env in the project that has Sentry configured. The audit-log task
-    runs ~1s after feature creation in production (see
-    ``core.signals.create_audit_log_from_historical_record``'s ``delay_until``),
-    so by the time this runs, the FSes exist.
-    """
-    from features.models import Feature
-
-    history_record = audit_log.history_record
-    if history_record is None or history_record.history_type != "+":
-        return
-
-    feature = get_audited_instance_from_audit_log_record(audit_log)
-    if not isinstance(feature, Feature):
-        return
-
-    if not audit_log.project_id:
-        return
-
-    sentry_configs = SentryChangeTrackingConfiguration.objects.filter(
-        environment__project_id=audit_log.project_id,
-        environment__use_v2_feature_versioning=True,
-        deleted_at__isnull=True,
-    ).select_related("environment")
-
-    author_email = _author_email_for_audit_log(audit_log)
-
-    for config in sentry_configs:
-        # Mirror v1's env-create suppression from
-        # FeatureState.get_create_log_message: skip when the env was created
-        # after the feature (env-create / env-clone scenarios).
-        if config.environment.created_date > feature.created_date:
-            continue
-
-        fs = FeatureState.objects.filter(
-            feature=feature,
-            environment=config.environment,
-            feature_segment__isnull=True,
-            identity__isnull=True,
-        ).first()
-        if not fs:
-            continue
-
-        timestamp = max(fs.live_from, fs.updated_at) if fs.live_from else fs.updated_at
-        events = [
-            SentryChangeTracking.build_payload_entry(
-                action="created",
-                flag_name=feature.name,
-                change_id=fs.pk,
-                timestamp=timestamp,
-                author_email=author_email,
-            )
-        ]
-        _post_events(config, events)
-
-
-def _get_config_for_environment(
-    environment: Any,
-) -> SentryChangeTrackingConfiguration | None:
-    config: SentryChangeTrackingConfiguration | None = (
-        SentryChangeTrackingConfiguration.objects.filter(
-            environment=environment,
-            deleted_at__isnull=True,
-        ).first()
-    )
-    return config
-
-
-def _author_email_for_audit_log(audit_log: AuditLog | None) -> str:
-    if audit_log is None:
-        return _DEFAULT_AUTHOR_EMAIL
-    return getattr(audit_log.author, "email", _DEFAULT_AUTHOR_EMAIL)
-
-
-def _post_events(
-    config: SentryChangeTrackingConfiguration,
-    events: list[dict[str, Any]],
-) -> None:
-    if not events:
-        return
-    SentryChangeTracking(
-        webhook_url=config.webhook_url,
-        secret=config.secret,
-    ).track_events_async(events)
 
 
 class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
@@ -219,25 +51,22 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         }
 
     @staticmethod
-    def generate_event_data(audit_log_record: AuditLog) -> dict[str, Any]:
-        feature_state = get_audited_instance_from_audit_log_record(audit_log_record)
-        if not isinstance(feature_state, FeatureState):  # pragma: no cover
-            logger.warning(
-                f"{type(feature_state)} is not supported by Sentry Change Tracking integration."
-            )
-            return {}
-
+    def generate_event_data(feature_state: FeatureState) -> dict[str, Any]:
         timestamp = feature_state.deleted_at or (
             max(feature_state.live_from, feature_state.updated_at)
             if feature_state.live_from
             else feature_state.updated_at
         )
 
+        history_record = feature_state.history.first()
+        if history_record is None:  # pragma: no cover
+            return {}
+
         action = {
             "+": "created",
             "-": "deleted",
             "~": "updated",
-        }[audit_log_record.history_record.history_type]  # type: ignore[union-attr]
+        }[history_record.history_type]
 
         return SentryChangeTracking.build_payload_entry(
             action=action,
@@ -245,7 +74,7 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
             change_id=feature_state.pk,
             timestamp=timestamp,
             author_email=getattr(
-                audit_log_record.author, "email", _DEFAULT_AUTHOR_EMAIL
+                history_record.history_user, "email", _DEFAULT_AUTHOR_EMAIL
             ),
         )
 

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -9,7 +9,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 from core.signing import sign_payload
 from features.models import FeatureState
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
-from util.util import postpone
 
 logger = structlog.get_logger("sentry_change_tracking")
 
@@ -79,20 +78,8 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         )
 
     def _track_event(self, event: dict[str, Any]) -> None:
-        self._send_events([event])
-
-    @postpone  # type: ignore[misc]
-    def track_events_async(self, events: list[dict[str, Any]]) -> None:
-        self._send_events(events)
-
-    def _send_events(self, events: list[dict[str, Any]]) -> None:
-        if not events:
-            return
-
-        # All entries in a batched payload share the same flag (one EFV = one feature).
-        first_event = events[0]
-        action = first_event["action"]
-        feature_name = first_event["flag"]
+        action = event["action"]
+        feature_name = event["flag"]
 
         log = logger.bind(
             sentry_action=action,
@@ -100,7 +87,7 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         )
 
         payload = {
-            "data": events,
+            "data": [event],
             "meta": {"version": 1},
         }
         json_payload = json.dumps(payload, sort_keys=True, cls=DjangoJSONEncoder)

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -141,9 +141,7 @@ def _process_feature_audit_log(audit_log: AuditLog) -> None:
         if not fs:
             continue
 
-        timestamp = (
-            max(fs.live_from, fs.updated_at) if fs.live_from else fs.updated_at
-        )
+        timestamp = max(fs.live_from, fs.updated_at) if fs.live_from else fs.updated_at
         events = [
             SentryChangeTracking.build_payload_entry(
                 action="created",

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -7,15 +7,183 @@ import structlog
 from django.core.serializers.json import DjangoJSONEncoder
 
 from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
 from audit.services import get_audited_instance_from_audit_log_record
 from core.signing import sign_payload
 from features.models import FeatureState
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
+from integrations.sentry.models import SentryChangeTrackingConfiguration
 from util.util import postpone
 
 logger = structlog.get_logger("sentry_change_tracking")
 
 _DEFAULT_AUTHOR_EMAIL = "app@flagsmith.com"
+
+
+def process_audit_log(audit_log: AuditLog) -> None:
+    """
+    Public entry point for v2 Sentry change tracking. Given an audit log row
+    from any feature-related event, dispatches to the right handler and posts
+    per-FS Sentry events. The signal handler in ``audit.signals`` just passes
+    the audit log; the rest of the orchestration lives here.
+    """
+    if audit_log.related_object_type == RelatedObjectType.EF_VERSION.name:
+        _process_efv_audit_log(audit_log)
+    elif audit_log.related_object_type == RelatedObjectType.FEATURE.name:
+        _process_feature_audit_log(audit_log)
+
+
+def _process_efv_audit_log(audit_log: AuditLog) -> None:
+    """v2 publish (env-default toggle, segment override, scheduled change)."""
+    from features.versioning.models import EnvironmentFeatureVersion
+    from features.versioning.versioning_service import (
+        get_feature_state_match_key,
+        get_updated_feature_states_for_version,
+    )
+
+    if (
+        audit_log.environment is None
+        or not audit_log.environment.use_v2_feature_versioning
+    ):
+        return
+
+    config = _get_config_for_environment(audit_log.environment)
+    if not config:
+        return
+
+    if not audit_log.related_object_uuid:
+        return
+
+    try:
+        efv = EnvironmentFeatureVersion.objects.select_related("feature").get(
+            uuid=audit_log.related_object_uuid,
+        )
+    except EnvironmentFeatureVersion.DoesNotExist:
+        return
+
+    changed_feature_states = get_updated_feature_states_for_version(efv)
+    if not changed_feature_states:
+        return
+
+    previous_version = efv.get_previous_version()
+    previous_fs_keys = (
+        {
+            get_feature_state_match_key(fs)
+            for fs in previous_version.feature_states.all()
+        }
+        if previous_version
+        else set()
+    )
+
+    timestamp = efv.live_from or efv.published_at or audit_log.created_date
+    author_email = _author_email_for_audit_log(audit_log)
+    flag_name = efv.feature.name
+
+    events = [
+        SentryChangeTracking.build_payload_entry(
+            action=(
+                "updated"
+                if get_feature_state_match_key(fs) in previous_fs_keys
+                else "created"
+            ),
+            flag_name=flag_name,
+            change_id=fs.pk,
+            timestamp=timestamp,
+            author_email=author_email,
+        )
+        for fs in changed_feature_states
+    ]
+    _post_events(config, events)
+
+
+def _process_feature_audit_log(audit_log: AuditLog) -> None:
+    """
+    v2 flag-create. The FEATURE audit row is project-wide, so fan out per
+    v2 env in the project that has Sentry configured. The audit-log task
+    runs ~1s after feature creation in production (see
+    ``core.signals.create_audit_log_from_historical_record``'s ``delay_until``),
+    so by the time this runs, the FSes exist.
+    """
+    from features.models import Feature
+
+    history_record = audit_log.history_record
+    if history_record is None or history_record.history_type != "+":
+        return
+
+    feature = get_audited_instance_from_audit_log_record(audit_log)
+    if not isinstance(feature, Feature):
+        return
+
+    if not audit_log.project_id:
+        return
+
+    sentry_configs = SentryChangeTrackingConfiguration.objects.filter(
+        environment__project_id=audit_log.project_id,
+        environment__use_v2_feature_versioning=True,
+        deleted_at__isnull=True,
+    ).select_related("environment")
+
+    author_email = _author_email_for_audit_log(audit_log)
+
+    for config in sentry_configs:
+        # Mirror v1's env-create suppression from
+        # FeatureState.get_create_log_message: skip when the env was created
+        # after the feature (env-create / env-clone scenarios).
+        if config.environment.created_date > feature.created_date:
+            continue
+
+        fs = FeatureState.objects.filter(
+            feature=feature,
+            environment=config.environment,
+            feature_segment__isnull=True,
+            identity__isnull=True,
+        ).first()
+        if not fs:
+            continue
+
+        timestamp = (
+            max(fs.live_from, fs.updated_at) if fs.live_from else fs.updated_at
+        )
+        events = [
+            SentryChangeTracking.build_payload_entry(
+                action="created",
+                flag_name=feature.name,
+                change_id=fs.pk,
+                timestamp=timestamp,
+                author_email=author_email,
+            )
+        ]
+        _post_events(config, events)
+
+
+def _get_config_for_environment(
+    environment: Any,
+) -> SentryChangeTrackingConfiguration | None:
+    config: SentryChangeTrackingConfiguration | None = (
+        SentryChangeTrackingConfiguration.objects.filter(
+            environment=environment,
+            deleted_at__isnull=True,
+        ).first()
+    )
+    return config
+
+
+def _author_email_for_audit_log(audit_log: AuditLog | None) -> str:
+    if audit_log is None:
+        return _DEFAULT_AUTHOR_EMAIL
+    return getattr(audit_log.author, "email", _DEFAULT_AUTHOR_EMAIL)
+
+
+def _post_events(
+    config: SentryChangeTrackingConfiguration,
+    events: list[dict[str, Any]],
+) -> None:
+    if not events:
+        return
+    SentryChangeTracking(
+        webhook_url=config.webhook_url,
+        secret=config.secret,
+    ).track_events_async(events)
 
 
 class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):

--- a/api/integrations/sentry/change_tracking.py
+++ b/api/integrations/sentry/change_tracking.py
@@ -10,6 +10,7 @@ from audit.services import get_audited_instance_from_audit_log_record
 from core.signing import sign_payload
 from features.models import FeatureState
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
+from util.util import postpone
 
 logger = structlog.get_logger("sentry_change_tracking")
 
@@ -65,8 +66,20 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         return inner_payload
 
     def _track_event(self, event: dict[str, Any]) -> None:
-        action = event["action"]
-        feature_name = event["flag"]
+        self._send_events([event])
+
+    @postpone  # type: ignore[misc]
+    def track_events_async(self, events: list[dict[str, Any]]) -> None:
+        self._send_events(events)
+
+    def _send_events(self, events: list[dict[str, Any]]) -> None:
+        if not events:
+            return
+
+        # All entries in a batched payload share the same flag (one EFV = one feature).
+        first_event = events[0]
+        action = first_event["action"]
+        feature_name = first_event["flag"]
 
         log = logger.bind(
             sentry_action=action,
@@ -74,7 +87,7 @@ class SentryChangeTracking(AbstractBaseEventIntegrationWrapper):
         )
 
         payload = {
-            "data": [event],
+            "data": events,
             "meta": {"version": 1},
         }
         json_payload = json.dumps(payload, sort_keys=True, cls=DjangoJSONEncoder)

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -105,6 +105,14 @@ def environment(
 
 
 @pytest.fixture()
+def environment_v2_versioning(environment: int) -> int:
+    from features.versioning.tasks import enable_v2_versioning
+
+    enable_v2_versioning(environment_id=environment)
+    return environment
+
+
+@pytest.fixture()
 def dynamo_enabled_environment(
     admin_client: APIClient,
     dynamo_enabled_project: int,

--- a/api/tests/integration/features/versioning/test_integration_v2_versioning.py
+++ b/api/tests/integration/features/versioning/test_integration_v2_versioning.py
@@ -59,19 +59,6 @@ def get_identity_flags_response_json(  # type: ignore[no-untyped-def]
     return _get_identity_flags_response_json  # type: ignore[return-value]
 
 
-@pytest.fixture()
-def environment_v2_versioning(
-    admin_client: "APIClient", environment: int, environment_api_key: str
-) -> int:
-    environment_update_url = reverse(
-        "api-v1:environments:environment-enable-v2-versioning",
-        args=[environment_api_key],
-    )
-    environment_update_response = admin_client.post(environment_update_url)
-    assert environment_update_response.status_code == status.HTTP_202_ACCEPTED
-    return environment
-
-
 def test_v2_versioning__publish_and_revert__returns_consistent_flags(  # type: ignore[no-untyped-def]  # noqa: FT004
     admin_client: "APIClient",
     environment: int,

--- a/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
+++ b/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
@@ -6,12 +6,14 @@ from unittest.mock import ANY
 
 import freezegun
 import pytest
+from django.urls import reverse
 from pytest_structlog import StructuredLogCapture
 from responses import RequestsMock
 from rest_framework.test import APIClient
 
 from audit.tasks import create_feature_state_updated_by_change_request_audit_log
 from features.models import FeatureState
+from features.versioning.tasks import enable_v2_versioning
 from features.workflows.core.models import ChangeRequest
 from integrations.sentry.models import SentryChangeTrackingConfiguration
 from users.models import FFAdminUser
@@ -28,9 +30,21 @@ def sentry_configuration(environment: int) -> SentryChangeTrackingConfiguration:
     return configuration
 
 
+@pytest.fixture()
+def v2_versioned_environment(environment: int) -> int:
+    enable_v2_versioning(environment_id=environment)
+    return environment
+
+
+@pytest.mark.parametrize(
+    "use_v2_versioning",
+    [pytest.param(False, id="v1"), pytest.param(True, id="v2")],
+)
 def test_sentry_change_tracking__flag_created__sends_update_to_sentry(
+    use_v2_versioning: bool,
     admin_client: APIClient,
     admin_user: FFAdminUser,
+    environment: int,
     feature_name: str,
     log: StructuredLogCapture,
     project: int,
@@ -38,6 +52,8 @@ def test_sentry_change_tracking__flag_created__sends_update_to_sentry(
     sentry_configuration: SentryChangeTrackingConfiguration,
 ) -> None:
     # Given
+    if use_v2_versioning:
+        enable_v2_versioning(environment_id=environment)
     responses.post(sentry_configuration.webhook_url, status=200, body="")
 
     # When
@@ -148,6 +164,110 @@ def test_sentry_change_tracking__flag_state_change__sends_update_to_sentry(
     ]
 
 
+def test_sentry_change_tracking__flag_state_change__v2_versioning__sends_update_to_sentry(
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
+    environment: int,
+    feature: int,
+    feature_name: str,
+    log: StructuredLogCapture,
+    responses: RequestsMock,
+    sentry_configuration: SentryChangeTrackingConfiguration,
+    v2_versioned_environment: int,
+) -> None:
+    # Given
+    responses.post(sentry_configuration.webhook_url, status=200, body="")
+
+    create_ef_version_url = reverse(
+        "api-v1:versioning:environment-feature-versions-list",
+        args=[environment, feature],
+    )
+    list_ef_version_fs_url_template = (
+        "api-v1:versioning:environment-feature-version-featurestates-list"
+    )
+    detail_ef_version_fs_url_template = (
+        "api-v1:versioning:environment-feature-version-featurestates-detail"
+    )
+
+    # When
+    with freezegun.freeze_time("2199-01-01T00:00:00.500000+00:00"):
+        # Create a new EFV draft
+        create_response = admin_client.post(create_ef_version_url)
+        assert create_response.status_code == 201, create_response.content
+        ef_version_uuid = create_response.json()["uuid"]
+
+        # Look up the cloned feature state on the new EFV
+        list_fs_response = admin_client.get(
+            reverse(
+                list_ef_version_fs_url_template,
+                args=[environment, feature, ef_version_uuid],
+            )
+        )
+        assert list_fs_response.status_code == 200, list_fs_response.content
+        new_feature_state_id = list_fs_response.json()[0]["id"]
+
+        # Toggle the flag enabled in the new version
+        update_response = admin_client.patch(
+            reverse(
+                detail_ef_version_fs_url_template,
+                args=[
+                    environment,
+                    feature,
+                    ef_version_uuid,
+                    new_feature_state_id,
+                ],
+            ),
+            data=json.dumps({"enabled": True}),
+            content_type="application/json",
+        )
+        assert update_response.status_code == 200, update_response.content
+
+        # Publish the new version
+        publish_response = admin_client.post(
+            reverse(
+                "api-v1:versioning:environment-feature-versions-publish",
+                args=[environment, feature, ef_version_uuid],
+            )
+        )
+        assert publish_response.status_code == 200, publish_response.content
+
+    # Then
+    assert len(responses.calls) == 1
+    update_request = responses.calls[0].request  # type: ignore[union-attr]
+    assert update_request.url == sentry_configuration.webhook_url
+    assert update_request.headers["Content-Type"] == "application/json"
+    assert re.match(r"^[0-9a-f]{64}$", update_request.headers["X-Sentry-Signature"])
+    assert json.loads(update_request.body) == {
+        "data": [
+            {
+                "action": "updated",
+                "created_at": "2199-01-01T00:00:00+00:00",
+                "created_by": {"id": admin_user.email, "type": "email"},
+                "change_id": str(new_feature_state_id),
+                "flag": feature_name,
+            },
+        ],
+        "meta": {"version": 1},
+    }
+    assert log.events == [
+        {
+            "event": "sending",
+            "feature_name": feature_name,
+            "headers": ANY,
+            "level": "debug",
+            "payload": ANY,
+            "sentry_action": "updated",
+            "url": sentry_configuration.webhook_url,
+        },
+        {
+            "event": "success",
+            "feature_name": feature_name,
+            "level": "info",
+            "sentry_action": "updated",
+        },
+    ]
+
+
 def test_sentry_change_tracking__flag_state_schedule__sends_update_to_sentry(
     admin_user: FFAdminUser,
     feature_name: str,
@@ -218,9 +338,93 @@ def test_sentry_change_tracking__flag_state_schedule__sends_update_to_sentry(
     ]
 
 
-def test_sentry_change_tracking__flag_deleted__sends_update_to_sentry(
+def test_sentry_change_tracking__flag_state_schedule__v2_versioning__sends_update_to_sentry(
     admin_client: APIClient,
     admin_user: FFAdminUser,
+    environment: int,
+    feature: int,
+    feature_name: str,
+    log: StructuredLogCapture,
+    responses: RequestsMock,
+    sentry_configuration: SentryChangeTrackingConfiguration,
+    v2_versioned_environment: int,
+) -> None:
+    # Given
+    responses.post(sentry_configuration.webhook_url, status=200, body="")
+
+    create_ef_version_url = reverse(
+        "api-v1:versioning:environment-feature-versions-list",
+        args=[environment, feature],
+    )
+
+    # When — author + publish a scheduled v2 change with a future live_from
+    with freezegun.freeze_time("2199-01-01T00:00:00.500000+00:00"):
+        create_response = admin_client.post(create_ef_version_url)
+        assert create_response.status_code == 201, create_response.content
+        ef_version_uuid = create_response.json()["uuid"]
+
+        list_fs_response = admin_client.get(
+            reverse(
+                "api-v1:versioning:environment-feature-version-featurestates-list",
+                args=[environment, feature, ef_version_uuid],
+            )
+        )
+        assert list_fs_response.status_code == 200, list_fs_response.content
+        new_feature_state_id = list_fs_response.json()[0]["id"]
+
+        update_response = admin_client.patch(
+            reverse(
+                "api-v1:versioning:environment-feature-version-featurestates-detail",
+                args=[
+                    environment,
+                    feature,
+                    ef_version_uuid,
+                    new_feature_state_id,
+                ],
+            ),
+            data=json.dumps({"enabled": True}),
+            content_type="application/json",
+        )
+        assert update_response.status_code == 200, update_response.content
+
+        # Publish the version with a future live_from (one hour ahead)
+        publish_response = admin_client.post(
+            reverse(
+                "api-v1:versioning:environment-feature-versions-publish",
+                args=[environment, feature, ef_version_uuid],
+            ),
+            data=json.dumps({"live_from": "2199-01-01T01:00:00+00:00"}),
+            content_type="application/json",
+        )
+        assert publish_response.status_code == 200, publish_response.content
+
+    # Then — Sentry should be notified about the scheduled v2 change
+    # (timing relative to live_from is left to the implementation; this test
+    # asserts that the notification happens at all)
+    assert len(responses.calls) == 1
+    update_request = responses.calls[0].request  # type: ignore[union-attr]
+    assert update_request.url == sentry_configuration.webhook_url
+    assert update_request.headers["Content-Type"] == "application/json"
+    assert re.match(r"^[0-9a-f]{64}$", update_request.headers["X-Sentry-Signature"])
+    payload = json.loads(update_request.body)
+    assert payload["data"][0]["action"] == "updated"
+    assert payload["data"][0]["change_id"] == str(new_feature_state_id)
+    assert payload["data"][0]["flag"] == feature_name
+    assert payload["data"][0]["created_by"] == {
+        "id": admin_user.email,
+        "type": "email",
+    }
+
+
+@pytest.mark.parametrize(
+    "use_v2_versioning",
+    [pytest.param(False, id="v1"), pytest.param(True, id="v2")],
+)
+def test_sentry_change_tracking__flag_deleted__sends_update_to_sentry(
+    use_v2_versioning: bool,
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
+    environment: int,
     environment_api_key: str,
     feature_name: str,
     feature_state: int,
@@ -229,6 +433,8 @@ def test_sentry_change_tracking__flag_deleted__sends_update_to_sentry(
     sentry_configuration: SentryChangeTrackingConfiguration,
 ) -> None:
     # Given
+    if use_v2_versioning:
+        enable_v2_versioning(environment_id=environment)
     responses.post(sentry_configuration.webhook_url, status=200, body="")
     # When
     with freezegun.freeze_time("2199-01-01T00:00:00+00:00"):

--- a/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
+++ b/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
@@ -164,7 +164,7 @@ def test_sentry_change_tracking__flag_state_change__sends_update_to_sentry(
     ]
 
 
-def test_sentry_change_tracking__flag_state_change__v2_versioning__sends_update_to_sentry(
+def test_sentry_change_tracking__flag_state_change_in_v2_environment__sends_update_to_sentry(
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment: int,
@@ -338,7 +338,7 @@ def test_sentry_change_tracking__flag_state_schedule__sends_update_to_sentry(
     ]
 
 
-def test_sentry_change_tracking__flag_state_schedule__v2_versioning__sends_update_to_sentry(
+def test_sentry_change_tracking__flag_state_schedule_in_v2_environment__sends_update_to_sentry(
     admin_client: APIClient,
     admin_user: FFAdminUser,
     environment: int,

--- a/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
+++ b/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
@@ -30,12 +30,6 @@ def sentry_configuration(environment: int) -> SentryChangeTrackingConfiguration:
     return configuration
 
 
-@pytest.fixture()
-def v2_versioned_environment(environment: int) -> int:
-    enable_v2_versioning(environment_id=environment)
-    return environment
-
-
 @pytest.mark.parametrize(
     "use_v2_versioning",
     [pytest.param(False, id="v1"), pytest.param(True, id="v2")],
@@ -173,7 +167,7 @@ def test_sentry_change_tracking__flag_state_change_in_v2_environment__sends_upda
     log: StructuredLogCapture,
     responses: RequestsMock,
     sentry_configuration: SentryChangeTrackingConfiguration,
-    v2_versioned_environment: int,
+    environment_v2_versioning: int,
 ) -> None:
     # Given
     responses.post(sentry_configuration.webhook_url, status=200, body="")
@@ -347,7 +341,7 @@ def test_sentry_change_tracking__flag_state_schedule_in_v2_environment__sends_up
     log: StructuredLogCapture,
     responses: RequestsMock,
     sentry_configuration: SentryChangeTrackingConfiguration,
-    v2_versioned_environment: int,
+    environment_v2_versioning: int,
 ) -> None:
     # Given
     responses.post(sentry_configuration.webhook_url, status=200, body="")
@@ -426,10 +420,6 @@ def test_sentry_change_tracking__flag_deleted__sends_update_to_sentry(
     responses: RequestsMock,
     sentry_configuration: SentryChangeTrackingConfiguration,
 ) -> None:
-    # Note: v2-versioning coverage for FS delete is intentionally absent — the
-    # v1 FS DELETE endpoint shouldn't accept a v2-versioned FS in the first
-    # place. That gap is tracked separately.
-
     # Given
     responses.post(sentry_configuration.webhook_url, status=200, body="")
     # When

--- a/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
+++ b/api/tests/integration/sentry/test_change_tracking_webhook_integration.py
@@ -416,15 +416,9 @@ def test_sentry_change_tracking__flag_state_schedule__v2_versioning__sends_updat
     }
 
 
-@pytest.mark.parametrize(
-    "use_v2_versioning",
-    [pytest.param(False, id="v1"), pytest.param(True, id="v2")],
-)
 def test_sentry_change_tracking__flag_deleted__sends_update_to_sentry(
-    use_v2_versioning: bool,
     admin_client: APIClient,
     admin_user: FFAdminUser,
-    environment: int,
     environment_api_key: str,
     feature_name: str,
     feature_state: int,
@@ -432,9 +426,11 @@ def test_sentry_change_tracking__flag_deleted__sends_update_to_sentry(
     responses: RequestsMock,
     sentry_configuration: SentryChangeTrackingConfiguration,
 ) -> None:
+    # Note: v2-versioning coverage for FS delete is intentionally absent — the
+    # v1 FS DELETE endpoint shouldn't accept a v2-versioned FS in the first
+    # place. That gap is tracked separately.
+
     # Given
-    if use_v2_versioning:
-        enable_v2_versioning(environment_id=environment)
     responses.post(sentry_configuration.webhook_url, status=200, body="")
     # When
     with freezegun.freeze_time("2199-01-01T00:00:00+00:00"):

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -512,7 +512,7 @@ def test_send_feature_flag_went_live_signal__feature_state__sends_signal(
     send_feature_flag_went_live_signal(sender=AuditLog, instance=audit_log)
 
     # Then
-    mock_signal_send.assert_called_once_with(feature_state, audit_log=audit_log)
+    mock_signal_send.assert_called_once_with(feature_state)
 
 
 def test_send_feature_flag_went_live_signal__feature_state_value__sends_signal(
@@ -541,7 +541,7 @@ def test_send_feature_flag_went_live_signal__feature_state_value__sends_signal(
 
     # Then
     # The signal should be called with the parent FeatureState extracted from FeatureStateValue
-    mock_signal_send.assert_called_once_with(feature_state, audit_log=audit_log)
+    mock_signal_send.assert_called_once_with(feature_state)
 
 
 def test_send_feature_flag_went_live_signal__scheduled_feature_state__skips_signal(

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -339,7 +339,7 @@ Attributes:
 ### `sentry_change_tracking.integration_error`
 
 Logged at `warning` from:
- - `api/integrations/sentry/change_tracking.py:125`
+ - `api/integrations/sentry/change_tracking.py:109`
 
 Attributes:
  - `feature_name`
@@ -350,7 +350,7 @@ Attributes:
 ### `sentry_change_tracking.request_failure`
 
 Logged at `warning` from:
- - `api/integrations/sentry/change_tracking.py:115`
+ - `api/integrations/sentry/change_tracking.py:99`
 
 Attributes:
  - `error`
@@ -360,7 +360,7 @@ Attributes:
 ### `sentry_change_tracking.sending`
 
 Logged at `debug` from:
- - `api/integrations/sentry/change_tracking.py:100`
+ - `api/integrations/sentry/change_tracking.py:84`
 
 Attributes:
  - `feature_name`
@@ -372,7 +372,7 @@ Attributes:
 ### `sentry_change_tracking.success`
 
 Logged at `info` from:
- - `api/integrations/sentry/change_tracking.py:122`
+ - `api/integrations/sentry/change_tracking.py:106`
 
 Attributes:
  - `feature_name`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -339,7 +339,7 @@ Attributes:
 ### `sentry_change_tracking.integration_error`
 
 Logged at `warning` from:
- - `api/integrations/sentry/change_tracking.py:112`
+ - `api/integrations/sentry/change_tracking.py:138`
 
 Attributes:
  - `feature_name`
@@ -350,7 +350,7 @@ Attributes:
 ### `sentry_change_tracking.request_failure`
 
 Logged at `warning` from:
- - `api/integrations/sentry/change_tracking.py:102`
+ - `api/integrations/sentry/change_tracking.py:128`
 
 Attributes:
  - `error`
@@ -360,7 +360,7 @@ Attributes:
 ### `sentry_change_tracking.sending`
 
 Logged at `debug` from:
- - `api/integrations/sentry/change_tracking.py:87`
+ - `api/integrations/sentry/change_tracking.py:113`
 
 Attributes:
  - `feature_name`
@@ -372,7 +372,7 @@ Attributes:
 ### `sentry_change_tracking.success`
 
 Logged at `info` from:
- - `api/integrations/sentry/change_tracking.py:109`
+ - `api/integrations/sentry/change_tracking.py:135`
 
 Attributes:
  - `feature_name`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -339,7 +339,7 @@ Attributes:
 ### `sentry_change_tracking.integration_error`
 
 Logged at `warning` from:
- - `api/integrations/sentry/change_tracking.py:138`
+ - `api/integrations/sentry/change_tracking.py:125`
 
 Attributes:
  - `feature_name`
@@ -350,7 +350,7 @@ Attributes:
 ### `sentry_change_tracking.request_failure`
 
 Logged at `warning` from:
- - `api/integrations/sentry/change_tracking.py:128`
+ - `api/integrations/sentry/change_tracking.py:115`
 
 Attributes:
  - `error`
@@ -360,7 +360,7 @@ Attributes:
 ### `sentry_change_tracking.sending`
 
 Logged at `debug` from:
- - `api/integrations/sentry/change_tracking.py:113`
+ - `api/integrations/sentry/change_tracking.py:100`
 
 Attributes:
  - `feature_name`
@@ -372,7 +372,7 @@ Attributes:
 ### `sentry_change_tracking.success`
 
 Logged at `info` from:
- - `api/integrations/sentry/change_tracking.py:135`
+ - `api/integrations/sentry/change_tracking.py:122`
 
 Attributes:
  - `feature_name`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7491

Sentry change-tracking silently disabled itself for any environment using v2 feature versioning. v2 suppresses the `FEATURE_STATE`-typed audit row that the v1 Sentry receiver consumed (see `FeatureState.get_skip_create_audit_log`), so the integration received nothing for env-default toggles, segment-override edits, scheduled publishes, or new flags created in v2 envs. Identity overrides kept working because they're excluded from EFV by design.

Approach: decouple Sentry from the audit log, then bridge the two v2 paths that don't fire the FS-driven signal today.

- `SentryChangeTracking.generate_event_data` now takes a `FeatureState` directly and derives `action` / `author` from `feature_state.history.first()`. The audit log was only being used as a denormalised envelope around the history record — every field the wrapper consumed was recoverable from the FS itself.
- Drop the `audit_log` kwarg from `feature_state_change_went_live`. The signal becomes a single contract: any consumer hooks it and gets the FS; how it was triggered is no longer leaked into the contract.
- Fire `feature_state_change_went_live` from two new places to cover v2:
  - `FeatureState._create_initial_feature_state` for v2 flag-create (gated by `env.created_date <= feature.created_date` to mirror v1's env-create-vs-flag-create suppression in `get_create_log_message`).
  - A new receiver `trigger_feature_state_change_went_live_signal` in `features/versioning/receivers.py` on `environment_feature_version_published`, firing per changed FS in the published version — covers env-default, segment-override and scheduled publishes.
- Tests: parametrise the existing Sentry integration tests across v1/v2 for flag-create; add new v2-only tests for env-default toggle and scheduled publish. Promote `environment_v2_versioning` fixture into `tests/integration/conftest.py` so it can be shared.

## How did you test this code?

- All 9 Sentry integration tests in `api/tests/integration/sentry/test_change_tracking_webhook_integration.py` pass: v1 baseline + new v2 coverage for flag-create, env-default change, and scheduled publish. Existing v1 tests for state-change, schedule, deleted, and failing-integration are unchanged.
- Broader sweep across audit, versioning, features, envs, and sentry-unit suites stays green.
- 100% diff coverage on touched files (`audit/signals.py`, `integrations/sentry/change_tracking.py`, `features/models.py`, `features/versioning/receivers.py`).