### PR TITLE
feat(SCIM): Wire flagsmith-private SCIM app into the api

### DIFF
--- a/.github/actions/codeartifact-login/action.yml
+++ b/.github/actions/codeartifact-login/action.yml
@@ -1,0 +1,32 @@
+name: CodeArtifact login
+description: |
+  Assume the production CodeArtifact role via OIDC, fetch an
+  authorisation token, and export uv credentials for the
+  `flagsmith-pypi-production` index.
+
+outputs:
+  token:
+    description: CodeArtifact authorisation token
+    value: ${{ steps.codeartifact.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials for CodeArtifact
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::084060095745:role/codeartifact-github-actions-production
+        aws-region: eu-west-2
+
+    - name: Fetch CodeArtifact authorisation token
+      id: codeartifact
+      shell: bash
+      run: |
+        token=$(aws codeartifact get-authorization-token \
+          --domain flagsmith-production \
+          --domain-owner 084060095745 \
+          --query authorizationToken --output text)
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"
+        echo "UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws" >> "$GITHUB_ENV"
+        echo "UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD=$token" >> "$GITHUB_ENV"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,20 @@
 
 
 version: 2
+registries:
+  flagsmith-pypi-production:
+    type: python-index
+    url: https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/
+    aws-region: eu-west-2
+    account-id: '084060095745'
+    role-name: codeartifact-github-actions-production
+    domain: flagsmith-production
+    domain-owner: '084060095745'
+
 updates:
   - package-ecosystem: "uv"
+    registries:
+      - flagsmith-pypi-production
     # we only want security updates from dependabot, so we set the limit to 0
     # for regular updates. See documentation for further information here:
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-

--- a/.github/workflows/.reusable-deploy-ecs.yml
+++ b/.github/workflows/.reusable-deploy-ecs.yml
@@ -54,6 +54,10 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
 
+      - name: Authenticate with CodeArtifact
+        id: codeartifact
+        uses: ./.github/actions/codeartifact-login
+
       - name: Build saas-api image
         uses: depot/build-push-action@v1
         with:
@@ -62,6 +66,7 @@ jobs:
           build-args: CI_COMMIT_SHA=${{ github.sha }}
           secrets: |
             github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
+            codeartifact_token=${{ steps.codeartifact.outputs.token }}
             "sse_pgp_pkey=${{ secrets.SSE_PGP_PRIVATE_KEY }}"
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -59,6 +59,11 @@ on:
         type: string
         description: Trivy Java Database OCI specifier
         default: ghcr.io/flagsmith/trivy-java-db:latest
+      codeartifact-login:
+        type: boolean
+        description: Authenticate with the prod CodeArtifact PyPI before building
+        required: false
+        default: false
     outputs:
       image:
         description: Resulting image specifier
@@ -105,6 +110,11 @@ jobs:
             ${{ inputs.registry-url }}/flagsmith/${{ inputs.image-name }}
           tags: ${{ inputs.tags }}
 
+      - name: Authenticate with CodeArtifact
+        if: inputs.codeartifact-login
+        id: codeartifact
+        uses: ./.github/actions/codeartifact-login
+
       - name: Build and push image
         id: build
         uses: depot/build-push-action@v1
@@ -113,7 +123,9 @@ jobs:
           save: ${{ inputs.ephemeral }}
           push: ${{ !inputs.ephemeral }}
           platforms: linux/amd64,linux/arm64
-          secrets: ${{ secrets.secrets }}
+          secrets: |
+            ${{ secrets.secrets }}
+            ${{ inputs.codeartifact-login && format('codeartifact_token={0}', steps.codeartifact.outputs.token) || '' }}
           target: ${{ inputs.target }}
           build-args: |
             CI_COMMIT_SHA=${{ github.sha }}

--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -24,6 +24,9 @@ jobs:
     needs: deploy-ecs
     name: Push MCP Schema to Gram
     runs-on: depot-ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         working-directory: api
@@ -35,11 +38,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Authenticate with CodeArtifact
+        uses: ./.github/actions/codeartifact-login
+
       - name: Install dependencies
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--extra saml --extra auth-controller --extra workflows --extra release-pipelines"
+          make install-packages opts="--extra saml --extra auth-controller --extra workflows --extra release-pipelines --extra scim"
           make install-private-modules
           rm -rf ${HOME}/.git-credentials
 

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -2,7 +2,7 @@ name: API Pull Request with Private Packages
 
 permissions:
   contents: read # For actions/checkout
-  id-token: write # For Codecov OIDC
+  id-token: write # For Codecov + CodeArtifact OIDC
 
 on:
   pull_request:
@@ -48,12 +48,15 @@ jobs:
       - name: Install SAML Dependencies
         run: sudo apt-get install -y xmlsec1
 
+      - name: Authenticate with CodeArtifact
+        uses: ./.github/actions/codeartifact-login
+
       - name: Install packages and Tests
         shell: bash
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--extra dev --extra saml --extra auth-controller --extra workflows"
+          make install-packages opts="--extra dev --extra saml --extra auth-controller --extra workflows --extra scim"
           make install-private-modules
           make integrate-private-tests
           rm -rf ${HOME}/.git-credentials

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -36,6 +36,7 @@ jobs:
     with:
       target: private-cloud-api
       image-name: flagsmith-private-cloud-api
+      codeartifact-login: true
     secrets:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
@@ -46,6 +47,7 @@ jobs:
     with:
       target: private-cloud-unified
       image-name: flagsmith-private-cloud
+      codeartifact-login: true
     secrets:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
@@ -65,6 +67,7 @@ jobs:
       target: api-private-test
       image-name: flagsmith-api-private-test
       scan: false
+      codeartifact-login: true
     secrets:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -113,6 +113,7 @@ jobs:
       target: api-private-test
       image-name: flagsmith-api-private-test
       scan: false
+      codeartifact-login: true
     secrets:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
@@ -138,6 +139,7 @@ jobs:
       target: private-cloud-unified
       image-name: flagsmith-private-cloud
       comment: true
+      codeartifact-login: true
     secrets:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,11 +110,14 @@ FROM build-python AS build-python-private
 # and integrate private modules
 ARG SAML_REVISION
 ARG RBAC_REVISION
-ARG EXTRAS="--extra saml --extra auth-controller --extra ldap --extra workflows --extra licensing --extra release-pipelines"
+ARG EXTRAS="--extra saml --extra auth-controller --extra ldap --extra workflows --extra licensing --extra release-pipelines --extra scim"
 RUN --mount=type=secret,id=github_private_cloud_token \
+  --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
   echo "https://$(cat /run/secrets/github_private_cloud_token):@github.com" > ${HOME}/.git-credentials && \
   git config --global credential.helper store && \
+  UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws \
+  UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD="$(cat /run/secrets/codeartifact_token)" \
   make install-packages opts="--no-install-project ${EXTRAS}" && \
   make install-private-modules
 
@@ -173,8 +176,11 @@ FROM build-python-private AS api-private-test
 
 COPY api /build/
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-  make install-packages opts='--extra dev --extra saml --extra auth-controller --extra ldap --extra workflows --extra licensing --extra release-pipelines' && \
+RUN --mount=type=secret,id=codeartifact_token \
+  --mount=type=cache,target=/root/.cache/uv \
+  UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws \
+  UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD="$(cat /run/secrets/codeartifact_token)" \
+  make install-packages opts='--extra dev --extra saml --extra auth-controller --extra ldap --extra workflows --extra licensing --extra release-pipelines --extra scim' && \
   make integrate-private-tests && \
   git config --global --unset credential.helper && \
   rm -f ${HOME}/.git-credentials

--- a/api/Makefile
+++ b/api/Makefile
@@ -15,7 +15,16 @@ RBAC_REVISION ?= v0.13.0
 OPENAPI_FORMAT_VERSION ?= 1.23.0
 
 -include .env-local
+-include .env-codeartifact
 -include $(DOTENV_OVERRIDE_FILE)
+
+.PHONY: codeartifact-login
+codeartifact-login:
+	@token=$$(aws codeartifact get-authorization-token \
+		--domain flagsmith-production --domain-owner 084060095745 \
+		--region eu-west-2 \
+		--query authorizationToken --output text) && \
+	printf 'UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws\nUV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD=%s\n' "$$token" > .env-codeartifact
 
 .PHONY: install-pip
 install-pip:

--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ The project assumes the following tools installed:
 - [GNU Make](https://www.gnu.org/software/make/).
 - Docker or a compatible tool like [Podman](https://podman.io/). We recommend [OrbStack](https://orbstack.dev/) for macOS.
 
-To install dev dependencies, run `make install`.
+To install dev dependencies, run `make install`. Only Flagsmith maintainers can run `uv lock` due to private dependencies.
 
 To run linters, run `make lint`.
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1065,6 +1065,31 @@ IS_RBAC_INSTALLED = importlib.util.find_spec("rbac") is not None
 if IS_RBAC_INSTALLED:
     INSTALLED_APPS.append("rbac")
 
+SCIM_INSTALLED = importlib.util.find_spec("scim") is not None
+if SCIM_INSTALLED:
+    from urllib.parse import urlsplit
+
+    INSTALLED_APPS += ["django_scim", "scim"]
+    _flagsmith_api_url = urlsplit(FLAGSMITH_API_URL)
+    SCIM_SERVICE_PROVIDER = {
+        "BULK": {"SUPPORTED": False},
+        "CHANGE_PASSWORD": {"SUPPORTED": False},
+        "ETAG": {"SUPPORTED": False},
+        "FILTER": {"SUPPORTED": True, "MAX_RESULTS": 100},
+        "SORT": {"SUPPORTED": False},
+        "PATCH": {"SUPPORTED": True},
+        "SCHEME": _flagsmith_api_url.scheme or "https",
+        "NETLOC": _flagsmith_api_url.netloc,
+        "AUTHENTICATION_SCHEMES": [
+            {
+                "type": "oauthbearertoken",
+                "name": "OAuth Bearer Token",
+                "description": "Per-organisation bearer token issued via the SCIM configuration API.",
+            },
+        ],
+        "AUTH_CHECK_MIDDLEWARE": "scim.middleware.ScimAuthenticationMiddleware",
+    }
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Used to keep edge identities in sync by forwarding the http requests

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1067,10 +1067,7 @@ if IS_RBAC_INSTALLED:
 
 SCIM_INSTALLED = importlib.util.find_spec("scim") is not None
 if SCIM_INSTALLED:
-    from urllib.parse import urlsplit
-
     INSTALLED_APPS += ["django_scim", "scim"]
-    _flagsmith_api_url = urlsplit(FLAGSMITH_API_URL)
     SCIM_SERVICE_PROVIDER = {
         "BULK": {"SUPPORTED": False},
         "CHANGE_PASSWORD": {"SUPPORTED": False},
@@ -1078,8 +1075,6 @@ if SCIM_INSTALLED:
         "FILTER": {"SUPPORTED": True, "MAX_RESULTS": 100},
         "SORT": {"SUPPORTED": False},
         "PATCH": {"SUPPORTED": True},
-        "SCHEME": _flagsmith_api_url.scheme or "https",
-        "NETLOC": _flagsmith_api_url.netloc,
         "AUTHENTICATION_SCHEMES": [
             {
                 "type": "oauthbearertoken",
@@ -1088,6 +1083,7 @@ if SCIM_INSTALLED:
             },
         ],
         "AUTH_CHECK_MIDDLEWARE": "scim.middleware.ScimAuthenticationMiddleware",
+        "BASE_LOCATION_GETTER": "core.helpers.get_request_base_url",
     }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -109,6 +109,15 @@ if settings.SAML_INSTALLED:  # pragma: no cover
         path("api/v1/auth/saml/", include("saml.urls")),
     ]
 
+if settings.SCIM_INSTALLED:  # pragma: no cover
+    urlpatterns += [
+        path("api/v1/scim/v2/", include("django_scim.urls")),
+        path(
+            "api/v1/organisations/<int:organisation_pk>/scim/",
+            include("scim.urls"),
+        ),
+    ]
+
 if settings.WORKFLOWS_LOGIC_INSTALLED:  # pragma: no cover
     workflow_views = importlib.import_module("workflows_logic.views")
     urlpatterns += [

--- a/api/core/helpers.py
+++ b/api/core/helpers.py
@@ -35,6 +35,12 @@ def get_current_site_url(request: HttpRequest | Request | None = None) -> str:
     return f"{scheme}://{domain}"
 
 
+def get_request_base_url(request: HttpRequest | Request | None = None) -> str:
+    if request is None:
+        return ""
+    return request.build_absolute_uri("/")
+
+
 def get_ip_address_from_request(request: Request) -> Any | None:
     x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
     return (

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -110,7 +110,10 @@ licensing = [
     "cryptography>=44.0.1",
 ]
 release-pipelines = [
-    "flagsmith-private",
+    "flagsmith-private>=0.5.1,<1",
+]
+scim = [
+    "flagsmith-private>=0.5.1,<1",
 ]
 dev = [
     "django-test-migrations>=1.2.0,<2.0.0",
@@ -171,12 +174,17 @@ exclude = ["build*", "dist*", "static*", "staticfiles*", "venv*", ".venv*", "scr
 [tool.setuptools.package-data]
 "*" = ["*.*"]
 
+[[tool.uv.index]]
+name = "flagsmith-pypi-production"
+url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/"
+explicit = true
+
 [tool.uv.sources]
 auth-controller = { git = "https://github.com/flagsmith/flagsmith-auth-controller", tag = "v0.2.0" }
 flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v0.1.2" }
 workflows-logic = { git = "https://github.com/flagsmith/flagsmith-workflows", tag = "v3.4.0" }
 licensing = { git = "https://github.com/flagsmith/licensing", tag = "v0.3.0" }
-flagsmith-private = { git = "https://github.com/Flagsmith/flagsmith-private", tag = "v0.4.4" }
+flagsmith-private = { index = "flagsmith-pypi-production" }
 
 [tool.uv]
 required-version = "==0.8.14"
@@ -538,6 +546,17 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["openfeature_flagsmith.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["scim.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Suppresses `no-any-return` when the `scim` package isn't installed (which
+# happens on the public PR workflow that runs mypy without the `--extra scim`
+# extra). With the extra installed, the bearer fixtures return the real `str`.
+module = ["tests.integration.scim.conftest"]
+warn_return_any = false
 
 [tool.django-stubs]
 django_settings_module = "app.settings.local"

--- a/api/tests/integration/scim/conftest.py
+++ b/api/tests/integration/scim/conftest.py
@@ -1,0 +1,48 @@
+from typing import cast
+
+from django.conf import settings
+
+if settings.SCIM_INSTALLED:
+    import pytest
+    from pytest_mock import MockerFixture
+    from rest_framework.test import APIClient
+    from scim.mappers import map_issued_token_to_bearer
+    from scim.services import create_scim_configuration_for_organisation
+
+    from organisations.models import Organisation
+
+    @pytest.fixture()
+    def scim_organisation(db: None) -> Organisation:
+        return cast(Organisation, Organisation.objects.create(name="SCIM Org"))
+
+    @pytest.fixture()
+    def enterprise_scim_organisation(
+        scim_organisation: Organisation, mocker: MockerFixture
+    ) -> Organisation:
+        mocker.patch.object(
+            Organisation, "has_enterprise_subscription", return_value=True
+        )
+        return scim_organisation
+
+    @pytest.fixture()
+    def scim_bearer_for_enterprise_org(
+        enterprise_scim_organisation: Organisation,
+    ) -> str:
+        issued = create_scim_configuration_for_organisation(
+            enterprise_scim_organisation
+        )
+        return map_issued_token_to_bearer(issued.issued_token)
+
+    @pytest.fixture()
+    def scim_bearer_for_non_enterprise_org(
+        scim_organisation: Organisation, mocker: MockerFixture
+    ) -> str:
+        mocker.patch.object(
+            Organisation, "has_enterprise_subscription", return_value=False
+        )
+        issued = create_scim_configuration_for_organisation(scim_organisation)
+        return map_issued_token_to_bearer(issued.issued_token)
+
+    @pytest.fixture()
+    def scim_client() -> APIClient:
+        return APIClient()

--- a/api/tests/integration/scim/test_integration_scim.py
+++ b/api/tests/integration/scim/test_integration_scim.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from django.conf import settings
 from django.urls import resolve
+from pytest_django.fixtures import SettingsWrapper
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -115,3 +116,28 @@ def test_scim_protocol_endpoint__valid_bearer_for_non_enterprise_org__returns_40
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_scim_service_provider_config__custom_host__uses_request_host_for_location(
+    scim_client: "APIClient",
+    scim_bearer_for_enterprise_org: str,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.ALLOWED_HOSTS = ["scim.example.com", "testserver"]
+    scim_client.credentials(
+        HTTP_AUTHORIZATION=f"Bearer {scim_bearer_for_enterprise_org}"
+    )
+
+    # When
+    response = scim_client.get(
+        "/api/v1/scim/v2/ServiceProviderConfig",
+        HTTP_HOST="scim.example.com",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        response.json()["meta"]["location"]
+        == "http://scim.example.com/api/v1/scim/v2/ServiceProviderConfig"
+    )

--- a/api/tests/integration/scim/test_integration_scim.py
+++ b/api/tests/integration/scim/test_integration_scim.py
@@ -1,0 +1,117 @@
+from typing import Any
+
+import pytest
+from django.conf import settings
+from django.urls import resolve
+from rest_framework import status
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.skipif(
+    not settings.SCIM_INSTALLED,
+    reason="scim module not installed (private package extra)",
+)
+
+
+def test_scim_settings__scim_installed__wires_apps_and_service_provider() -> None:
+    # Given / When
+    # Settings are imported at module load time.
+
+    # Then
+    assert settings.SCIM_INSTALLED is True
+    assert "django_scim" in settings.INSTALLED_APPS
+    assert "scim" in settings.INSTALLED_APPS
+    service_provider: dict[str, Any] = settings.SCIM_SERVICE_PROVIDER
+    assert service_provider["BULK"] == {"SUPPORTED": False}
+    assert service_provider["CHANGE_PASSWORD"] == {"SUPPORTED": False}
+    assert service_provider["ETAG"] == {"SUPPORTED": False}
+    assert service_provider["FILTER"] == {"SUPPORTED": True, "MAX_RESULTS": 100}
+    assert service_provider["SORT"] == {"SUPPORTED": False}
+    assert service_provider["PATCH"] == {"SUPPORTED": True}
+    assert (
+        service_provider["AUTH_CHECK_MIDDLEWARE"]
+        == "scim.middleware.ScimAuthenticationMiddleware"
+    )
+    assert service_provider["AUTHENTICATION_SCHEMES"][0]["type"] == "oauthbearertoken"
+
+
+@pytest.mark.parametrize(
+    "path, expected_url_name",
+    [
+        ("/api/v1/scim/v2/ServiceProviderConfig", "service-provider-config"),
+        ("/api/v1/scim/v2/Schemas", "schemas"),
+        ("/api/v1/scim/v2/ResourceTypes", "resource-types"),
+        ("/api/v1/organisations/1/scim/", "scim-configuration"),
+        (
+            "/api/v1/organisations/1/scim/regenerate-token/",
+            "scim-configuration-regenerate-token",
+        ),
+    ],
+)
+def test_scim_urls__scim_installed__resolve(path: str, expected_url_name: str) -> None:
+    # Given / When
+    match = resolve(path)
+
+    # Then
+    assert match.url_name == expected_url_name
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/scim/v2/ServiceProviderConfig",
+        "/api/v1/scim/v2/Schemas",
+        "/api/v1/scim/v2/ResourceTypes",
+    ],
+)
+def test_scim_protocol_endpoint__no_bearer__returns_401(
+    path: str,
+) -> None:
+    # Given
+    client = APIClient()
+
+    # When
+    response = client.get(path)
+
+    # Then
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/scim/v2/ServiceProviderConfig",
+        "/api/v1/scim/v2/Schemas",
+        "/api/v1/scim/v2/ResourceTypes",
+    ],
+)
+def test_scim_protocol_endpoint__valid_bearer_for_enterprise_org__returns_200(
+    scim_client: "APIClient",
+    scim_bearer_for_enterprise_org: str,
+    path: str,
+) -> None:
+    # Given
+    scim_client.credentials(
+        HTTP_AUTHORIZATION=f"Bearer {scim_bearer_for_enterprise_org}"
+    )
+
+    # When
+    response = scim_client.get(path)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_scim_protocol_endpoint__valid_bearer_for_non_enterprise_org__returns_403(
+    scim_client: "APIClient",
+    scim_bearer_for_non_enterprise_org: str,
+) -> None:
+    # Given
+    scim_client.credentials(
+        HTTP_AUTHORIZATION=f"Bearer {scim_bearer_for_non_enterprise_org}"
+    )
+
+    # When
+    response = scim_client.get("/api/v1/scim/v2/ServiceProviderConfig")
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/api/tests/unit/core/test_helpers.py
+++ b/api/tests/unit/core/test_helpers.py
@@ -2,8 +2,9 @@ import typing
 
 import pytest
 from django.contrib.sites.models import Site
+from django.test import RequestFactory
 
-from core.helpers import get_current_site_url
+from core.helpers import get_current_site_url, get_request_base_url
 
 if typing.TYPE_CHECKING:
     from pytest_django.fixtures import DjangoAssertNumQueries, SettingsWrapper
@@ -136,3 +137,26 @@ def test_get_current_site__localhost__return_expected(
 
     # Then
     assert url == f"http://{expected_domain}"
+
+
+def test_get_request_base_url__no_request__returns_empty_string() -> None:
+    # Given / When
+    url = get_request_base_url()
+
+    # Then
+    assert url == ""
+
+
+def test_get_request_base_url__request__returns_absolute_base_url(
+    rf: RequestFactory,
+    settings: "SettingsWrapper",
+) -> None:
+    # Given
+    settings.ALLOWED_HOSTS = ["some-host.example.com"]
+    request = rf.get("/api/v1/some/path", HTTP_HOST="some-host.example.com")
+
+    # When
+    url = get_request_base_url(request)
+
+    # Then
+    assert url == "http://some-host.example.com/"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1037,6 +1037,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-scim2"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "scim2-filter-parser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/59/da3061607de7be41d7e5bf484acb13510d631f8fcfcecd9f5e02dc5bf4f1/django_scim2-0.19.1.tar.gz", hash = "sha256:8126111160e76a880f6699babc5259f0345c9316c8018ce5dcc3f7579ccb9e89", size = 26988, upload-time = "2023-05-18T01:13:04.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/24/ca2cab008049239585434f7451a42757d7d258bf741316fd16587e564b74/django_scim2-0.19.1-py3-none-any.whl", hash = "sha256:845eaa64e72e4ddfe2aa54d21865721f8c1d59ecd9c06e72341eeb03ed6ba94e", size = 32072, upload-time = "2023-05-18T01:13:01.751Z" },
+]
+
+[[package]]
 name = "django-ses"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1494,6 +1507,9 @@ release-pipelines = [
 saml = [
     { name = "pysaml2" },
 ]
+scim = [
+    { name = "flagsmith-private" },
+]
 workflows = [
     { name = "workflows-logic" },
 ]
@@ -1552,7 +1568,8 @@ requires-dist = [
     { name = "flagsmith-common", extras = ["test-tools"], marker = "extra == 'dev'" },
     { name = "flagsmith-flag-engine", specifier = ">=10.1.0,<11.0.0" },
     { name = "flagsmith-ldap", marker = "extra == 'ldap'", git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2" },
-    { name = "flagsmith-private", marker = "extra == 'release-pipelines'", git = "https://github.com/Flagsmith/flagsmith-private?tag=v0.4.4" },
+    { name = "flagsmith-private", marker = "extra == 'release-pipelines'", specifier = ">=0.5.1,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
+    { name = "flagsmith-private", marker = "extra == 'scim'", specifier = ">=0.5.1,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
     { name = "google-api-python-client", specifier = ">=1.12.5,<1.13.0" },
     { name = "google-re2", specifier = ">=1.0,<2.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0,<23.1.0" },
@@ -1617,7 +1634,7 @@ requires-dist = [
     { name = "whitenoise", specifier = ">=6.0.0,<6.1.0" },
     { name = "workflows-logic", marker = "extra == 'workflows'", git = "https://github.com/flagsmith/flagsmith-workflows?tag=v3.4.0" },
 ]
-provides-extras = ["auth-controller", "saml", "ldap", "workflows", "licensing", "release-pipelines", "dev"]
+provides-extras = ["auth-controller", "saml", "ldap", "workflows", "licensing", "release-pipelines", "scim", "dev"]
 
 [[package]]
 name = "flagsmith-common"
@@ -1692,8 +1709,15 @@ source = { git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2#2456465
 
 [[package]]
 name = "flagsmith-private"
-version = "0.1.0"
-source = { git = "https://github.com/Flagsmith/flagsmith-private?tag=v0.4.4#a5318e69b5712307e3204a57ecebb64995526200" }
+version = "0.5.1"
+source = { registry = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" }
+dependencies = [
+    { name = "django-scim2" },
+]
+sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.5.1/flagsmith_private-0.5.1.tar.gz", hash = "sha256:5f9a69f0b9f692c34ebfc6f3357026b803e1922d8f37f6291cbd2e43d82fd385" }
+wheels = [
+    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.5.1/flagsmith_private-0.5.1-py3-none-any.whl", hash = "sha256:45e157ce9322480e3b706261b6ada5b0ab2a1c0d3155e2772fc728789ef8dc19" },
+]
 
 [[package]]
 name = "freezegun"
@@ -3626,6 +3650,18 @@ wheels = [
 ]
 
 [[package]]
+name = "scim2-filter-parser"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/c0/2f4d5caee8faa8f0d0979584c4aab95fa69d626d6f9d211dd6bb7089bc2f/scim2_filter_parser-0.7.0.tar.gz", hash = "sha256:1e11dbe2e186fc1be6d93732b467a3bbaa9deff272dfeb3a0540394cfab7030c", size = 21358, upload-time = "2024-07-20T16:38:23.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/54/b54961bfc5018fa593758c439fe0d4a22fbadfabff49a7559850af9a79e1/scim2_filter_parser-0.7.0-py3-none-any.whl", hash = "sha256:a74f90a2d52a77e0f1bc4d77e84b79f88749469f6f7192d64a4f92e4fe50ab69", size = 23409, upload-time = "2024-07-20T16:38:21.525Z" },
+]
+
+[[package]]
 name = "segment-analytics-python"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3739,6 +3775,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/4f/b1c5ef4ca6f619212e56739d0c97e0fdcf30c342c890f3f80bbe3fbde3a7/slack_sdk-3.9.1.tar.gz", hash = "sha256:a14e76cd237c501e1aca8cd510a11ed63a3ba8bfa323a3c655906dd099ad9afe", size = 192631, upload-time = "2021-08-17T11:05:27.547Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/74/7ba1e759c091e302eb48894efad853076936144777fc05f0baa851794de4/slack_sdk-3.9.1-py2.py3-none-any.whl", hash = "sha256:8c4b553d63ee18d72e67b80bec3257bab4feef17653374dbd877fa59f5b5aa2f", size = 250593, upload-time = "2021-08-17T11:05:25.526Z" },
+]
+
+[[package]]
+name = "sly"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/8a/59e943f7b27904c7756a7b565ffbd55f3841f5cd3d2da2b2b0713c49e488/sly-0.5.tar.gz", hash = "sha256:251d42015e8507158aec2164f06035df4a82b0314ce6450f457d7125e7649024", size = 66702, upload-time = "2022-10-25T14:35:30.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/4d/c96d807295183f2360329cd8d8bf5e8072c53d664125b3858c04153f026e/sly-0.5-py3-none-any.whl", hash = "sha256:20485483259eec7f6ba85ff4d2e96a4e50c6621902667fc2695cc8bc2a3e5133", size = 28864, upload-time = "2022-10-25T14:35:28.054Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7150.

Conditionally registers the SCIM Django app shipped by `flagsmith-private` when the `scim` module is importable: adds `django_scim` and `scim` to `INSTALLED_APPS`, sets the django-scim2 `SCIM_SERVICE_PROVIDER` settings (with `AUTH_CHECK_MIDDLEWARE` pointed at `scim.middleware.ScimAuthenticationMiddleware`), and mounts the protocol URLs at `/api/v1/scim/v2/` plus the configuration management URLs at `/api/v1/organisations/<int:organisation_pk>/scim/`.

`flagsmith-private` is now installed from the prod CodeArtifact PyPI repository (`flagsmith-pypi-production`) rather than a git ref, pinned to `>=0.5.1,<1`. The new `.github/actions/codeartifact-login` composite action assumes the `codeartifact-github-actions-production` role via OIDC, fetches a token, and exports it as `UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_*`. Every CI job and Dockerfile stage that installs the `scim` / `release-pipelines` extras runs the login step first. For local dev, `make codeartifact-login` writes the same env vars to a git-ignored `.env-codeartifact` file that the Makefile auto-includes.

Dependabot is wired to the same index via its [native OIDC support for CodeArtifact](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configuring-access-to-private-registries-for-dependabot#using-oidc-for-authentication) — a `registries:` block in `.github/dependabot.yml` reuses the same IAM role (its trust policy already accepts `repo:Flagsmith/*`). No cron-based token refresh required.

## How did you test this code?

Integration tests under `api/tests/integration/scim/` cover:

- `GET /api/v1/scim/v2/{ServiceProviderConfig,Schemas,ResourceTypes}` with a valid SCIM bearer for an Enterprise org → 200.
- Same endpoints without a bearer → 401.
- Same endpoints with a bearer for a non-Enterprise org → 403.
- URL routing for the management endpoints under `/api/v1/organisations/{pk}/scim/`.
- Settings assertions: `SCIM_INSTALLED`, `INSTALLED_APPS` entries, and `SCIM_SERVICE_PROVIDER` shape.

Tests are gated on `settings.SCIM_INSTALLED` and skip on the public PR job (which doesn't install `--extra scim`).