### PR TITLE
fix: allow project admins to create and manage project-scoped custom fields

### DIFF
--- a/api/metadata/permissions.py
+++ b/api/metadata/permissions.py
@@ -76,8 +76,8 @@ class MetadataModelFieldPermissions(IsAuthenticated):
 
                     return (organisation_pk == field.organisation.id) and (
                         request.user.is_organisation_admin(organisation_pk)
-                        or (project_id := field.project)
-                        and request.user.is_project_admin(project_id)
+                        or (project := field.project)
+                        and request.user.is_project_admin(project)
                     )
 
         return False
@@ -89,8 +89,8 @@ class MetadataModelFieldPermissions(IsAuthenticated):
         if view.action in ("update", "destroy", "partial_update"):
             return (
                 request.user.is_organisation_admin(obj.field.organisation)
-                or (project_id := obj.field.project)
-                and request.user.is_project_admin(project_id)
+                or (project := obj.field.project)
+                and request.user.is_project_admin(project)
             )
 
         return False

--- a/api/metadata/permissions.py
+++ b/api/metadata/permissions.py
@@ -74,10 +74,14 @@ class MetadataModelFieldPermissions(IsAuthenticated):
                 if view.action == "create":
                     field = MetadataField.objects.get(id=request.data.get("field"))
 
-                    return (
-                        request.user.is_organisation_admin(organisation_pk)
-                        and organisation_pk == field.organisation.id
-                    )
+                    if organisation_pk != field.organisation.id:
+                        return False
+
+                    if request.user.is_organisation_admin(organisation_pk):
+                        return True
+
+                    if field.project is not None:
+                        return request.user.is_project_admin(field.project)
 
         return False
 
@@ -86,6 +90,10 @@ class MetadataModelFieldPermissions(IsAuthenticated):
             return request.user.belongs_to(obj.field.organisation.id)
 
         if view.action in ("update", "destroy", "partial_update"):
-            return request.user.is_organisation_admin(obj.field.organisation)
+            if request.user.is_organisation_admin(obj.field.organisation):
+                return True
+
+            if obj.field.project is not None:
+                return request.user.is_project_admin(obj.field.project)
 
         return False

--- a/api/metadata/permissions.py
+++ b/api/metadata/permissions.py
@@ -74,14 +74,11 @@ class MetadataModelFieldPermissions(IsAuthenticated):
                 if view.action == "create":
                     field = MetadataField.objects.get(id=request.data.get("field"))
 
-                    if organisation_pk != field.organisation.id:
-                        return False
-
-                    if request.user.is_organisation_admin(organisation_pk):
-                        return True
-
-                    if field.project is not None:
-                        return request.user.is_project_admin(field.project)
+                    return (organisation_pk == field.organisation.id) and (
+                        request.user.is_organisation_admin(organisation_pk)
+                        or (project_id := field.project)
+                        and request.user.is_project_admin(project_id)
+                    )
 
         return False
 
@@ -90,10 +87,10 @@ class MetadataModelFieldPermissions(IsAuthenticated):
             return request.user.belongs_to(obj.field.organisation.id)
 
         if view.action in ("update", "destroy", "partial_update"):
-            if request.user.is_organisation_admin(obj.field.organisation):
-                return True
-
-            if obj.field.project is not None:
-                return request.user.is_project_admin(obj.field.project)
+            return (
+                request.user.is_organisation_admin(obj.field.organisation)
+                or (project_id := obj.field.project)
+                and request.user.is_project_admin(project_id)
+            )
 
         return False

--- a/api/tests/unit/metadata/test_views.py
+++ b/api/tests/unit/metadata/test_views.py
@@ -1007,7 +1007,7 @@ def test_create_model_metadata_field__project_admin__returns_201(
     assert response.json()["field"] == project_field.id
 
 
-def test_create_model_metadata_field__project_admin__org_scoped_field__returns_403(
+def test_create_model_metadata_field__project_admin_org_scoped_field__returns_403(
     staff_user: FFAdminUser,
     staff_client: APIClient,
     organisation: Organisation,

--- a/api/tests/unit/metadata/test_views.py
+++ b/api/tests/unit/metadata/test_views.py
@@ -14,7 +14,7 @@ from metadata.models import (
 )
 from metadata.views import SUPPORTED_REQUIREMENTS_MAPPING  # type: ignore[attr-defined]
 from organisations.models import Organisation
-from projects.models import Project
+from projects.models import Project, UserProjectPermission
 from users.models import FFAdminUser
 
 
@@ -511,8 +511,6 @@ def test_create_metadata_field__project_admin__returns_201(
     project: Project,
 ) -> None:
     # Given
-    from projects.models import UserProjectPermission
-
     UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
 
     url = reverse("api-v1:metadata:metadata-fields-list")
@@ -942,8 +940,6 @@ def test_modify_metadata_field__project_admin__permission_check(
     request: pytest.FixtureRequest,
 ) -> None:
     # Given
-    from projects.models import UserProjectPermission
-
     UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
     field_project = (
         request.getfixturevalue(field_project_attr) if field_project_attr else None
@@ -979,8 +975,6 @@ def test_create_model_metadata_field__project_admin__returns_201(
     feature_content_type: ContentType,
 ) -> None:
     # Given - a project-scoped MetadataField and a user who is project admin (not org admin)
-    from projects.models import UserProjectPermission
-
     UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
     project_field = MetadataField.objects.create(
         name="proj_field",
@@ -1015,8 +1009,6 @@ def test_create_model_metadata_field__project_admin_org_scoped_field__returns_40
     feature_content_type: ContentType,
 ) -> None:
     # Given - an org-scoped MetadataField (project=None) and a user who is project admin only
-    from projects.models import UserProjectPermission
-
     UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
     org_field = MetadataField.objects.create(
         name="org_field",
@@ -1042,25 +1034,19 @@ def test_create_model_metadata_field__project_admin_org_scoped_field__returns_40
 
 
 @pytest.mark.parametrize(
-    "field_project_attr, action, expected_status",
+    "field_project_attr, expected_status",
     [
-        ("project", "put", status.HTTP_200_OK),
-        ("project", "delete", status.HTTP_204_NO_CONTENT),
-        (None, "put", status.HTTP_403_FORBIDDEN),
-        (None, "delete", status.HTTP_403_FORBIDDEN),
-        ("project_b", "put", status.HTTP_403_FORBIDDEN),
-        ("project_b", "delete", status.HTTP_403_FORBIDDEN),
+        ("project", status.HTTP_200_OK),
+        (None, status.HTTP_403_FORBIDDEN),
+        ("project_b", status.HTTP_403_FORBIDDEN),
     ],
     ids=[
-        "own_project_field_update_allowed",
-        "own_project_field_delete_allowed",
-        "org_scoped_field_update_denied",
-        "org_scoped_field_delete_denied",
-        "other_project_field_update_denied",
-        "other_project_field_delete_denied",
+        "own_project_field_allowed",
+        "org_scoped_field_denied",
+        "other_project_field_denied",
     ],
 )
-def test_modify_model_metadata_field__project_admin__permission_check(
+def test_update_model_metadata_field__project_admin__returns_expected_status(
     staff_user: FFAdminUser,
     staff_client: APIClient,
     organisation: Organisation,
@@ -1068,14 +1054,66 @@ def test_modify_model_metadata_field__project_admin__permission_check(
     project_b: Project,
     feature_content_type: ContentType,
     field_project_attr: str | None,
-    action: str,
     expected_status: int,
     request: pytest.FixtureRequest,
 ) -> None:
     # Given - a project admin for `project`, and a MetadataModelField whose parent
     # MetadataField belongs to one of: `project`, `project_b`, or the org (None)
-    from projects.models import UserProjectPermission
+    UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
+    field_project = (
+        request.getfixturevalue(field_project_attr) if field_project_attr else None
+    )
+    field = MetadataField.objects.create(
+        name="model_field", type="int", organisation=organisation, project=field_project
+    )
+    model_field = MetadataModelField.objects.create(
+        field=field, content_type=feature_content_type
+    )
+    url = reverse(
+        "api-v1:organisations:metadata-model-fields-detail",
+        args=[organisation.id, model_field.id],
+    )
+    data = {
+        "field": field.id,
+        "content_type": feature_content_type.id,
+        "is_required_for": [],
+    }
 
+    # When
+    response = staff_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    "field_project_attr, expected_status",
+    [
+        ("project", status.HTTP_204_NO_CONTENT),
+        (None, status.HTTP_403_FORBIDDEN),
+        ("project_b", status.HTTP_403_FORBIDDEN),
+    ],
+    ids=[
+        "own_project_field_allowed",
+        "org_scoped_field_denied",
+        "other_project_field_denied",
+    ],
+)
+def test_delete_model_metadata_field__project_admin__returns_expected_status(
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+    project_b: Project,
+    feature_content_type: ContentType,
+    field_project_attr: str | None,
+    expected_status: int,
+    request: pytest.FixtureRequest,
+) -> None:
+    # Given - a project admin for `project`, and a MetadataModelField whose parent
+    # MetadataField belongs to one of: `project`, `project_b`, or the org (None)
     UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
     field_project = (
         request.getfixturevalue(field_project_attr) if field_project_attr else None
@@ -1092,17 +1130,7 @@ def test_modify_model_metadata_field__project_admin__permission_check(
     )
 
     # When
-    if action == "put":
-        data = {
-            "field": field.id,
-            "content_type": feature_content_type.id,
-            "is_required_for": [],
-        }
-        response = staff_client.put(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-    else:
-        response = staff_client.delete(url)
+    response = staff_client.delete(url)
 
     # Then
     assert response.status_code == expected_status

--- a/api/tests/unit/metadata/test_views.py
+++ b/api/tests/unit/metadata/test_views.py
@@ -969,3 +969,140 @@ def test_modify_metadata_field__project_admin__permission_check(
 
     # Then
     assert response.status_code == expected_status
+
+
+def test_create_model_metadata_field__project_admin__returns_201(
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+    feature_content_type: ContentType,
+) -> None:
+    # Given - a project-scoped MetadataField and a user who is project admin (not org admin)
+    from projects.models import UserProjectPermission
+
+    UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
+    project_field = MetadataField.objects.create(
+        name="proj_field",
+        type="int",
+        organisation=organisation,
+        project=project,
+    )
+    url = reverse(
+        "api-v1:organisations:metadata-model-fields-list", args=[organisation.id]
+    )
+    data = {
+        "field": project_field.id,
+        "content_type": feature_content_type.id,
+        "is_required_for": [],
+    }
+
+    # When
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then - project admin should be allowed to bind a project-scoped field
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["field"] == project_field.id
+
+
+def test_create_model_metadata_field__project_admin__org_scoped_field__returns_403(
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+    feature_content_type: ContentType,
+) -> None:
+    # Given - an org-scoped MetadataField (project=None) and a user who is project admin only
+    from projects.models import UserProjectPermission
+
+    UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
+    org_field = MetadataField.objects.create(
+        name="org_field",
+        type="int",
+        organisation=organisation,
+    )
+    url = reverse(
+        "api-v1:organisations:metadata-model-fields-list", args=[organisation.id]
+    )
+    data = {
+        "field": org_field.id,
+        "content_type": feature_content_type.id,
+        "is_required_for": [],
+    }
+
+    # When
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then - project admin must not be able to bind org-scoped fields
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.parametrize(
+    "field_project_attr, action, expected_status",
+    [
+        ("project", "put", status.HTTP_200_OK),
+        ("project", "delete", status.HTTP_204_NO_CONTENT),
+        (None, "put", status.HTTP_403_FORBIDDEN),
+        (None, "delete", status.HTTP_403_FORBIDDEN),
+        ("project_b", "put", status.HTTP_403_FORBIDDEN),
+        ("project_b", "delete", status.HTTP_403_FORBIDDEN),
+    ],
+    ids=[
+        "own_project_field_update_allowed",
+        "own_project_field_delete_allowed",
+        "org_scoped_field_update_denied",
+        "org_scoped_field_delete_denied",
+        "other_project_field_update_denied",
+        "other_project_field_delete_denied",
+    ],
+)
+def test_modify_model_metadata_field__project_admin__permission_check(
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+    project_b: Project,
+    feature_content_type: ContentType,
+    field_project_attr: str | None,
+    action: str,
+    expected_status: int,
+    request: pytest.FixtureRequest,
+) -> None:
+    # Given - a project admin for `project`, and a MetadataModelField whose parent
+    # MetadataField belongs to one of: `project`, `project_b`, or the org (None)
+    from projects.models import UserProjectPermission
+
+    UserProjectPermission.objects.create(user=staff_user, project=project, admin=True)
+    field_project = (
+        request.getfixturevalue(field_project_attr) if field_project_attr else None
+    )
+    field = MetadataField.objects.create(
+        name="model_field", type="int", organisation=organisation, project=field_project
+    )
+    model_field = MetadataModelField.objects.create(
+        field=field, content_type=feature_content_type
+    )
+    url = reverse(
+        "api-v1:organisations:metadata-model-fields-detail",
+        args=[organisation.id, model_field.id],
+    )
+
+    # When
+    if action == "put":
+        data = {
+            "field": field.id,
+            "content_type": feature_content_type.id,
+            "is_required_for": [],
+        }
+        response = staff_client.put(
+            url, data=json.dumps(data), content_type="application/json"
+        )
+    else:
+        response = staff_client.delete(url)
+
+    # Then
+    assert response.status_code == expected_status


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [X] I have added information to `docs/` if required so people know about the feature.
- [X] I have filled in the "Changes" section below.
- [X] I have filled in the "How did you test this code" section below.

## Changes

Closes #7424 

##Issue Description
When a user with Project Administrator role (non-org-admin) created a project-scoped custom field via Project Settings → Custom Fields, the save flow partially failed:

1. `POST /api/v1/metadata/fields/` → 201 (MetadataField created)
2. `POST /api/v1/organisations/{id}/metadata-model-fields/` → 403 (binding fails, field left orphaned)

**Root cause:** `MetadataModelFieldPermissions` only checked `is_organisation_admin` for `create`, `update`, and `destroy` actions. `MetadataFieldPermissions` already had the correct project-admin path, but its sibling class did not.

**Fix:** Extended `MetadataModelFieldPermissions` in `api/metadata/permissions.py` to allow project admins to create, update, and delete `MetadataModelField` bindings for project-scoped fields. Org-scoped fields remain restricted to org admins only.

## How did you test this code?

Reproduced the bug via direct API calls as a project-admin user (org role = `USER`, project `admin = true`):

**Before fix:**
- `POST /api/v1/organisations/1/metadata-model-fields/` → `403`{"detail": "You do not have permission to perform this action."}`
<img width="1000" height="101" alt="Before fix" src="https://github.com/user-attachments/assets/53d07467-09c0-4a85-8110-2396c9ad83cc" />
<img width="1000" height="101" alt="Before fix" src="https://github.com/user-attachments/assets/53d07467-09c0-4a85-8110-2396c9ad83cc" />


**After fix:**
- `POST /api/v1/organisations/1/metadata-model-fields/` → `201`{"id": 2, "field": 2, "content_type": 55, "is_required_for": []}`
<img width="959" height="138" alt="After Fix" src="https://github.com/user-attachments/assets/4e9e18e5-2373-4de9-b74c-11b970cde942" />
<img width="959" height="138" alt="After Fix" src="https://github.com/user-attachments/assets/4e9e18e5-2373-4de9-b74c-11b970cde942" />


**Regression tests added **
- Project admin can bind a project-scoped field to a content type (the bug case)
- Project admin cannot bind an org-scoped field (security boundary)
- Project admin can update/delete bindings for their own project's fields
- Project admin cannot update/delete bindings for other projects' or org-scoped fields

Since I cannot access the Enterprise plan I tried to fix it via the API calls. I hope it fixes the issue.