### PR TITLE
fix(SCIM): drop service-provider settings django-scim2 ignores

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1069,12 +1069,6 @@ SCIM_INSTALLED = importlib.util.find_spec("scim") is not None
 if SCIM_INSTALLED:
     INSTALLED_APPS += ["django_scim", "scim"]
     SCIM_SERVICE_PROVIDER = {
-        "BULK": {"SUPPORTED": False},
-        "CHANGE_PASSWORD": {"SUPPORTED": False},
-        "ETAG": {"SUPPORTED": False},
-        "FILTER": {"SUPPORTED": True, "MAX_RESULTS": 100},
-        "SORT": {"SUPPORTED": False},
-        "PATCH": {"SUPPORTED": True},
         "AUTHENTICATION_SCHEMES": [
             {
                 "type": "oauthbearertoken",

--- a/api/tests/integration/scim/test_integration_scim.py
+++ b/api/tests/integration/scim/test_integration_scim.py
@@ -22,12 +22,6 @@ def test_scim_settings__scim_installed__wires_apps_and_service_provider() -> Non
     assert "django_scim" in settings.INSTALLED_APPS
     assert "scim" in settings.INSTALLED_APPS
     service_provider: dict[str, Any] = settings.SCIM_SERVICE_PROVIDER
-    assert service_provider["BULK"] == {"SUPPORTED": False}
-    assert service_provider["CHANGE_PASSWORD"] == {"SUPPORTED": False}
-    assert service_provider["ETAG"] == {"SUPPORTED": False}
-    assert service_provider["FILTER"] == {"SUPPORTED": True, "MAX_RESULTS": 100}
-    assert service_provider["SORT"] == {"SUPPORTED": False}
-    assert service_provider["PATCH"] == {"SUPPORTED": True}
     assert (
         service_provider["AUTH_CHECK_MIDDLEWARE"]
         == "scim.middleware.ScimAuthenticationMiddleware"


### PR DESCRIPTION
The api's `SCIM_SERVICE_PROVIDER` block declares six settings (`BULK`, `CHANGE_PASSWORD`, `ETAG`, `FILTER`, `SORT`, `PATCH`) that django-scim2 does not read. Operators tuning them today believe they are shaping the ServiceProviderConfig response; they are not. The actual response shape comes from hardcoded values in django-scim2's own `SCIMServiceProviderConfig.to_dict()`. The matching test asserts a contract that the library does not honour.

## Changes

- [x] Operators no longer carry settings that have no runtime effect

Review effort: 1/5