### PR TITLE
Fix/replace axios with fetch slack

### DIFF
--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -153,7 +153,6 @@ jobs:
           cd e2e
           zip -r playwright-report.zip playwright-report/ || echo "Failed to zip report"
           cd ..
-          npm install --no-save @slack/web-api
           npx -y tsx e2e/slack-e2e-reporter.ts
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/frontend/api/slack-client.js
+++ b/frontend/api/slack-client.js
@@ -1,22 +1,26 @@
-const { WebClient } = require('@slack/web-api')
-
 if (!process.env.SLACK_TOKEN) {
   return
 }
 
-const web = new WebClient(process.env.SLACK_TOKEN)
+const SLACK_TOKEN = process.env.SLACK_TOKEN
 
 async function toChannel(message, channel) {
   // eslint-disable-next-line
-    console.log(`sending to channel: ${channel} message: ${message}`);
+  console.log(`sending to channel: ${channel} message: ${message}`)
   try {
-    await web.chat.postMessage({
-      channel: `#${channel}`,
-      text: message,
+    const res = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${SLACK_TOKEN}`,
+      },
+      body: JSON.stringify({ channel: `#${channel}`, text: message }),
     })
+    const data = await res.json()
+    if (!data.ok) throw new Error(data.error)
   } catch (error) {
     // eslint-disable-next-line
-        console.log(`Error posting to Slack:${error}`);
+    console.log(`Error posting to Slack:${error}`)
   }
 }
 

--- a/frontend/e2e/slack-e2e-reporter.ts
+++ b/frontend/e2e/slack-e2e-reporter.ts
@@ -1,12 +1,25 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { WebClient } from '@slack/web-api';
 
 const SLACK_TOKEN = process.env.SLACK_TOKEN;
 const CHANNEL_ID = 'C0102JZRG3G'; // infra_tests channel ID
 const failedJsonPath = path.join(__dirname, 'test-results', 'failed.json');
 const failedData = JSON.parse(fs.readFileSync(failedJsonPath, 'utf-8'));
 const failedCount = failedData.failedTests?.length || 0;
+
+async function slackPost(endpoint: string, body: Record<string, unknown>): Promise<unknown> {
+  const res = await fetch(`https://slack.com/api/${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      Authorization: `Bearer ${SLACK_TOKEN}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json() as { ok: boolean; error?: string };
+  if (!data.ok) throw new Error(`Slack ${endpoint} error: ${data.error}`);
+  return data;
+}
 
 async function uploadFile(filePath: string): Promise<void> {
   if (!SLACK_TOKEN) {
@@ -16,14 +29,28 @@ async function uploadFile(filePath: string): Promise<void> {
 
   const epoch = Date.now();
   const filename = `playwright-report-${epoch}.zip`;
+  const fileBytes = fs.readFileSync(filePath);
+  const fileSize = fileBytes.byteLength;
 
   console.log(`Uploading ${filePath}`);
-
-  const slackClient = new WebClient(SLACK_TOKEN);
-  await slackClient.files.uploadV2({
-    channel_id: CHANNEL_ID,
-    file: fs.createReadStream(filePath),
+  const urlRes = await slackPost('files.getUploadURLExternal', {
     filename,
+    length: fileSize,
+  }) as { upload_url: string; file_id: string };
+
+
+  const uploadRes = await fetch(urlRes.upload_url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: fileBytes,
+  });
+  if (!uploadRes.ok) {
+    throw new Error(`Upload to pre-signed URL failed: ${uploadRes.status} ${uploadRes.statusText}`);
+  }
+
+  await slackPost('files.completeUploadExternal', {
+    files: [{ id: urlRes.file_id, title: filename }],
+    channel_id: CHANNEL_ID,
   });
 }
 
@@ -33,17 +60,10 @@ function postMessage(message: string): Promise<unknown> {
     return Promise.resolve();
   }
 
-  const slackClient = new WebClient(SLACK_TOKEN);
-  return slackClient.chat.postMessage({
-    channel: CHANNEL_ID,
-    text: message,
-  });
+  return slackPost('chat.postMessage', { channel: CHANNEL_ID, text: message });
 }
 
-function notifyFailure(
-  failedCount: number,
-  failedTests: any[],
-): Promise<unknown> {
+function notifyFailure(failedCount: number, failedTests: any[]): Promise<unknown> {
   const actionUrl = process.env.GITHUB_ACTION_URL || '';
   if (!actionUrl) {
     console.log('No GITHUB_ACTION_URL set, skipping Slack notification');
@@ -56,16 +76,11 @@ function notifyFailure(
   const prTitle = process.env.PR_TITLE;
   const prUrl = process.env.PR_URL;
 
-  // Build PR info line
   const prInfo = prNumber && prUrl
     ? `*PR:* <${prUrl}|#${prNumber}>${prTitle ? ` - ${prTitle}` : ''}\n`
     : '';
 
-  // Build failed tests list (inline, limit to first 3)
-  const testNames = failedTests
-    .slice(0, 3)
-    .map((test) => test.title)
-    .join(', ');
+  const testNames = failedTests.slice(0, 3).map((t) => t.title).join(', ');
   const moreTests = failedCount > 3 ? ` +${failedCount - 3} more` : '';
 
   const message = `❌ E2E Tests Failed
@@ -94,7 +109,6 @@ async function main() {
   await notifyFailure(failedCount, failedData.failedTests || []);
   console.log('Slack notification sent successfully');
 
-  // Upload HTML report if zip file exists
   const reportZipPath = path.join(__dirname, 'playwright-report.zip');
   if (fs.existsSync(reportZipPath)) {
     console.log('Uploading HTML report...');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,8 +44,7 @@
     "react": "$react",
     "react-dom": "$react-dom",
     "@types/react": "$@types/react",
-    "@types/react-dom": "$@types/react-dom",
-    "axios": "^1.16.0"
+    "@types/react-dom": "$@types/react-dom"
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.11.3",
@@ -74,7 +73,6 @@
     "@rspack/plugin-react-refresh": "^1.6.2",
     "@sentry/browser": "^7.119.1",
     "@sentry/webpack-plugin": "2.22.7",
-    "@slack/web-api": "^6.9.1",
     "array-find-index": "^1.0.2",
     "body-parser": "^2.2.2",
     "bootstrap": "5.2.2",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #7431 
<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->
Replace @slack/web-api with native fetch calls to eliminate transitive Axios dependency which triggered multiple critical/high CVEs.
1)Rewrote api/slack-client.js to use fetch directly instead of WebClient.chat.postMessage
2)Rewrote e2e/slack-e2e-reporter.ts to replace postMessage and files.uploadV2 with direct Slack API calls (3-step upload flow: get upload URL → upload bytes → complete upload)
3)Removed axios override from package.json overrides block

No functional behaviour changes — all Slack messaging and file upload behaviour is preserved.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1)Confirmed package.json no longer contains the axios override
2)The existing E2E pipeline will exercise slack-e2e-reporter.ts naturally on the next test run with failures
3)api/slack-client.js can be smoke tested by triggering a Slack message in a dev/staging environment with SLACK_TOKEN set