### PR TITLE
fix: improved list features mcp description

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -137,7 +137,7 @@ def get_feature_by_uuid(request, uuid):  # type: ignore[no-untyped-def]
         extensions={
             "x-gram": {
                 "name": "list_project_features",
-                "description": "Retrieves all feature flags within the specified project with pagination.",
+                "description": "Lists a project's feature flags (paginated). Pass `environment=<id>` to also get each feature's live state for that environment in `environment_feature_state`, along with override counts. Works for both v1 and v2 versioned environments.",
             },
         },
     ),


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
While testing out the MCP locally, my client struggled to list all the feature states for an environment.  The description was too vague and the environment field wasn't surfaced enough.
- Fixing pre-emptively as the description will be re-used in MCP v3 

## How did you test this code?
1. Ask MCP to grab an organization
2. choose one project
3. choose one environment and list the features states
 
It would iterate on each feature
