### PR TITLE
fix: align Core API feature_segment shape with Edge API

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -53,8 +53,14 @@ from .feature_segments.limits import (
 from .feature_segments.serializers import (
     CustomCreateSegmentOverrideFeatureSegmentSerializer,
 )
-from .models import Feature, FeatureState
+from .models import Feature, FeatureSegment, FeatureState
 from .multivariate.serializers import NestedMultivariateFeatureOptionSerializer
+
+
+class _FeatureSegmentPrioritySerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
+    class Meta:
+        model = FeatureSegment
+        fields = ("priority",)
 
 
 class FeatureStateSerializerSmall(serializers.ModelSerializer):  # type: ignore[type-arg]
@@ -537,6 +543,7 @@ class SDKFeatureSerializer(HideSensitiveFieldsSerializerMixin, FeatureSerializer
 class FeatureStateSerializerFull(serializers.ModelSerializer):  # type: ignore[type-arg]
     feature = FeatureSerializer()
     feature_state_value = serializers.SerializerMethodField()
+    feature_segment = _FeatureSegmentPrioritySerializer(read_only=True)
 
     class Meta:
         model = FeatureState

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -468,6 +468,56 @@ def test_sdk_identities_get__feature_specified__returns_single_flag(
     assert response.data["feature"]["name"] == feature_1.name
 
 
+def test_sdk_identities_get__identity_in_segment__feature_segment_returns_priority(
+    identity: Identity,
+    api_client: APIClient,
+    environment: Environment,
+    segment: Segment,
+) -> None:
+    # Given
+    trait_key = "trait_key"
+    trait_value = "trait_value"
+    Trait.objects.create(
+        identity=identity,
+        trait_key=trait_key,
+        value_type=STRING,
+        string_value=trait_value,
+    )
+    segment_rule = SegmentRule.objects.create(
+        segment=segment, type=SegmentRule.ALL_RULE
+    )
+    Condition.objects.create(
+        operator="EQUAL", property=trait_key, value=trait_value, rule=segment_rule
+    )
+    feature = Feature.objects.create(
+        project=environment.project, name="segment_priority_feature"
+    )
+    feature_segment = FeatureSegment.objects.create(
+        segment=segment,
+        feature=feature,
+        environment=environment,
+        priority=1,
+    )
+    FeatureState.objects.create(
+        feature=feature,
+        feature_segment=feature_segment,
+        environment=environment,
+        enabled=True,
+    )
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    url = reverse("api-v1:sdk-identities") + "?identifier=" + identity.identifier
+
+    # When
+    response = api_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    segment_flag = next(
+        f for f in response.data["flags"] if f["feature_segment"] is not None
+    )
+    assert segment_flag["feature_segment"] == {"priority": 1}
+
+
 @mock.patch("integrations.amplitude.amplitude.AmplitudeWrapper.identify_user_async")
 def test_sdk_identities_get__identity_in_segment__returns_segment_override(
     mock_amplitude_wrapper: mock.MagicMock,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #7456 
<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

  - api/features/serializers.py:
       - Introduced _FeatureSegmentPrioritySerializer to handle the nested
         serialization of the priority field for feature segments.
       - Updated FeatureStateSerializerFull to use this new serializer for
         the feature_segment field.
       - This change ensures that the Core API's SDK-facing endpoints (and
         any other endpoints using FeatureStateSerializerFull) return the
         same data shape as the Edge API, providing the priority information
         that was previously missing.
   - api/tests/unit/environments/identities/test_unit_identities_views.py:
       - Added a new test case
        
## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Automated Tests: Added a new unit test in
     `api/tests/unit/environments/identities/test_unit_identities_views.py`     that specifically sets up a segment override with a defined priority
     and asserts that the /api/v1/identities/ response contains the
     feature_segment as an object: {"priority": 1}.
   - Manual Verification: Analyzed the serializer inheritance chain to
     ensure the change correctly propagates to the SDK identities and flags
     endpoints while minimizing impact on write operations (as the field is
     marked as read_only=True in the "Full" serializer).
