### PR TITLE
fix: multiple environmnet document queued

### DIFF
--- a/api/core/workflows_services.py
+++ b/api/core/workflows_services.py
@@ -4,10 +4,8 @@ import structlog
 from django.db import transaction
 from django.utils import timezone
 
-from environments.tasks import rebuild_environment_document
 from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.signals import environment_feature_version_published
-from features.versioning.tasks import trigger_update_version_webhooks
 from features.workflows.core.exceptions import ChangeRequestNotApprovedError
 
 if TYPE_CHECKING:

--- a/api/core/workflows_services.py
+++ b/api/core/workflows_services.py
@@ -86,18 +86,6 @@ class ChangeRequestCommitService:
             )
 
             for environment_feature_version in environment_feature_versions:
-                trigger_update_version_webhooks.delay(
-                    kwargs={
-                        "environment_feature_version_uuid": str(
-                            environment_feature_version.uuid
-                        )
-                    },
-                    delay_until=environment_feature_version.live_from,
-                )
-                rebuild_environment_document.delay(
-                    kwargs={"environment_id": self.change_request.environment_id},
-                    delay_until=environment_feature_version.live_from,
-                )
                 environment_feature_version_published.send(
                     EnvironmentFeatureVersion, instance=environment_feature_version
                 )

--- a/api/features/versioning/receivers.py
+++ b/api/features/versioning/receivers.py
@@ -44,7 +44,10 @@ def cache_fields(instance: EnvironmentFeatureVersion, **kwargs):  # type: ignore
 
 
 @receiver(environment_feature_version_published, sender=EnvironmentFeatureVersion)
-def update_environment_document(instance: EnvironmentFeatureVersion, **kwargs):  # type: ignore[no-untyped-def]
+def update_environment_document(instance: EnvironmentFeatureVersion, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    now = timezone.now()
+    if not instance.live_from or instance.live_from <= now:
+        return
     rebuild_environment_document.delay(
         kwargs={"environment_id": instance.environment_id},
         delay_until=instance.live_from,

--- a/api/tests/unit/features/versioning/test_unit_versioning_receiver.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_receiver.py
@@ -6,7 +6,9 @@ from django.utils import timezone
 from features.versioning.receivers import update_environment_document
 
 
-def test_update_environment_document__immediate_publish__does_not_schedule_rebuild() -> None:
+def test_update_environment_document__immediate_publish__does_not_schedule_rebuild() -> (
+    None
+):
     # Given
     mock_instance = mock.MagicMock()
     mock_instance.live_from = timezone.now() - timedelta(seconds=1)
@@ -22,7 +24,9 @@ def test_update_environment_document__immediate_publish__does_not_schedule_rebui
     mock_rebuild.delay.assert_not_called()
 
 
-def test_update_environment_document__scheduled_publish__schedules_rebuild_at_live_from() -> None:
+def test_update_environment_document__scheduled_publish__schedules_rebuild_at_live_from() -> (
+    None
+):
     # Given
     future = timezone.now() + timedelta(hours=1)
     mock_instance = mock.MagicMock()

--- a/api/tests/unit/features/versioning/test_unit_versioning_receiver.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_receiver.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.utils import timezone
+
+from features.versioning.receivers import update_environment_document
+
+
+def test_update_environment_document__immediate_publish__does_not_schedule_rebuild() -> None:
+    # Given
+    mock_instance = mock.MagicMock()
+    mock_instance.live_from = timezone.now() - timedelta(seconds=1)
+    mock_instance.environment_id = 1
+
+    # When
+    with mock.patch(
+        "features.versioning.receivers.rebuild_environment_document"
+    ) as mock_rebuild:
+        update_environment_document(instance=mock_instance)
+
+    # Then
+    mock_rebuild.delay.assert_not_called()
+
+
+def test_update_environment_document__scheduled_publish__schedules_rebuild_at_live_from() -> None:
+    # Given
+    future = timezone.now() + timedelta(hours=1)
+    mock_instance = mock.MagicMock()
+    mock_instance.live_from = future
+    mock_instance.environment_id = 1
+
+    # When
+    with mock.patch(
+        "features.versioning.receivers.rebuild_environment_document"
+    ) as mock_rebuild:
+        update_environment_document(instance=mock_instance)
+
+    # Then
+    mock_rebuild.delay.assert_called_once_with(
+        kwargs={"environment_id": 1},
+        delay_until=future,
+    )

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -699,11 +699,8 @@ def test_change_request_commit__v2_versioning__publishes_environment_feature_ver
 
     change_request.environment_feature_versions.add(environment_feature_version)
 
-    mock_rebuild_environment_document_task = mocker.patch(
-        "core.workflows_services.rebuild_environment_document"
-    )
-    mock_trigger_update_version_webhooks = mocker.patch(
-        "core.workflows_services.trigger_update_version_webhooks"
+    mock_signal = mocker.patch(
+        "core.workflows_services.environment_feature_version_published"
     )
 
     # When
@@ -715,15 +712,8 @@ def test_change_request_commit__v2_versioning__publishes_environment_feature_ver
     assert environment_feature_version.published_by == admin_user
     assert environment_feature_version.live_from == now
 
-    mock_rebuild_environment_document_task.delay.assert_called_once_with(
-        kwargs={"environment_id": environment.id},
-        delay_until=environment_feature_version.live_from,
-    )
-    mock_trigger_update_version_webhooks.delay.assert_called_once_with(
-        kwargs={
-            "environment_feature_version_uuid": str(environment_feature_version.uuid)
-        },
-        delay_until=environment_feature_version.live_from,
+    mock_signal.send.assert_called_once_with(
+        EnvironmentFeatureVersion, instance=environment_feature_version
     )
 
 

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -381,7 +381,7 @@ Attributes:
 ### `workflows.change_request.committed`
 
 Logged at `info` from:
- - `api/core/workflows_services.py:39`
+ - `api/core/workflows_services.py:37`
 
 Attributes:
  - `environment.id`
@@ -391,7 +391,7 @@ Attributes:
 ### `workflows.missing_live_segment`
 
 Logged at `warning` from:
- - `api/core/workflows_services.py:114`
+ - `api/core/workflows_services.py:100`
 
 Attributes:
  - `draft_segment`
@@ -399,7 +399,7 @@ Attributes:
 ### `workflows.segment_revision_created`
 
 Logged at `info` from:
- - `api/core/workflows_services.py:119`
+ - `api/core/workflows_services.py:105`
 
 Attributes:
  - `revision_id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.

## Changes

Closes #7492 

Eliminates duplicate `Environment.write_environment_documents` calls
that occurred on every `EnvironmentFeatureVersion.publish()` across
all publish paths (standard, API, and Change Requests).

**Root cause**

Three paths were all independently scheduling the same document rebuild:

- **Path A** — `update_environment_document` receiver always called
  `rebuild_environment_document.delay()` including for immediate
  publishes already handled by the audit log path
- **Path B** — audit log `AFTER_CREATE` hook fired
  `process_environment_update` which writes the document and broadcasts
  SSE (this is the correct canonical path for immediate publishes)
- **Path C** — `ChangeRequestCommitService._publish_environment_feature_versions`
  manually called both `rebuild_environment_document.delay()` and
  `trigger_update_version_webhooks.delay()` before sending the signal,
  causing duplicates since the signal receivers handle both

**Changes**

- `api/features/versioning/receivers.py` — `update_environment_document`
  now returns early when `live_from` is `None` or in the past (immediate
  publish). Path B (audit log) handles immediate writes and SSE.
  Scheduled publishes (`live_from > now`) still go through Path A so
  the document is rebuilt at the correct time.
- `api/core/workflows_services.py` — removed manual
  `rebuild_environment_document.delay()` and
  `trigger_update_version_webhooks.delay()` calls from
  `_publish_environment_feature_versions`. The signal send that follows
  already triggers both via the registered receivers, making the manual
  calls redundant across all Change Request publish paths.
- `api/tests/unit/features/versioning/test_unit_versioning_receivers.py`
  — new test file covering both the immediate-publish skip and the
  scheduled-publish delay behaviour.
- `api/tests/unit/features/workflows/core/test_unit_workflows_models.py`
  — updated `test_change_request_commit__v2_versioning__publishes_environment_feature_versions`
  to assert on the signal send rather than the now-removed manual task
  calls.

## How did you test this code?

- Added two unit tests in
  `api/tests/unit/features/versioning/test_unit_versioning_receivers.py`:
  - `test_update_environment_document__immediate_publish__does_not_schedule_rebuild`
    — verifies `rebuild_environment_document.delay` is not called for
    immediate publishes
  - `test_update_environment_document__scheduled_publish__schedules_rebuild_at_live_from`
    — verifies the task is scheduled with the correct `delay_until` for
    future publishes
- Updated the existing Change Request v2 versioning test to verify the
  signal is sent rather than asserting on the removed manual task calls
- Ran the full unit test suite locally to confirm no regressions

```bash
cd api
python -m pytest tests/unit/features/versioning/test_unit_versioning_receivers.py -v
python -m pytest tests/unit/features/workflows/core/test_unit_workflows_models.py -v