### PR TITLE
fix: feature pipeline status dark mode

### DIFF
--- a/frontend/web/components/release-pipelines/FeaturePipelineStatus.tsx
+++ b/frontend/web/components/release-pipelines/FeaturePipelineStatus.tsx
@@ -2,6 +2,7 @@ import {
   useGetReleasePipelineQuery,
   useGetReleasePipelinesQuery,
 } from 'common/services/useReleasePipelines'
+import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import AccordionCard from 'components/base/accordion/AccordionCard'
 import { useMemo } from 'react'
 
@@ -39,7 +40,7 @@ const FeaturePipelineStatus = ({
 
   const { data: releasePipeline } = useGetReleasePipelineQuery(
     {
-      pipelineId: matchingReleasePipeline?.id ?? NaN,
+      pipelineId: matchingReleasePipeline?.id ?? 0,
       projectId: Number(projectId),
     },
     {
@@ -49,6 +50,16 @@ const FeaturePipelineStatus = ({
 
   const stages = releasePipeline?.stages
   const totalStages = (stages?.length ?? 0) + 1
+
+  const { data: environments } = useGetEnvironmentsQuery(
+    { projectId: Number(projectId) },
+    { skip: !projectId || !stages?.length },
+  )
+  const envNameById = useMemo(() => {
+    const map = new Map<number, string>()
+    environments?.results?.forEach((env) => map.set(env.id, env.name))
+    return map
+  }, [environments])
 
   const stageHasFeature = useMemo(
     () =>
@@ -74,7 +85,7 @@ const FeaturePipelineStatus = ({
             key={stage.id}
             stageOrder={stage.order}
             stageName={stage.name}
-            stageEnvironment={stage.environment}
+            envName={envNameById.get(stage.environment)}
             stageActions={stage.actions}
             stageTrigger={stage.trigger}
             totalStages={totalStages}

--- a/frontend/web/components/release-pipelines/StageStatus.tsx
+++ b/frontend/web/components/release-pipelines/StageStatus.tsx
@@ -1,6 +1,4 @@
-import ProjectStore from 'common/stores/project-store'
 import {
-  Environment,
   Features,
   StageAction,
   StageTrigger,
@@ -18,16 +16,16 @@ interface StageStatusProps {
   totalStages: number
   stageActions?: StageAction[]
   stageTrigger?: StageTrigger
-  stageEnvironment?: number
+  envName?: string
   featureInStage?: Features[number]
   isCompleted?: boolean
 }
 
 const StageStatus = ({
+  envName,
   featureInStage,
   isCompleted,
   stageActions,
-  stageEnvironment,
   stageName,
   stageOrder,
   stageTrigger,
@@ -35,27 +33,19 @@ const StageStatus = ({
 }: StageStatusProps) => {
   const isFeatureInStage = !!featureInStage
   const showLine = totalStages > 1
-  const lastStage = stageOrder === totalStages - 1
+  const isLastStage = stageOrder === totalStages - 1
   const showLeftLine = showLine && stageOrder > 0
-  const showRightLine = showLine && stageOrder !== totalStages - 1
+  const showRightLine = showLine && !isLastStage
 
   const isWaiting =
     stageTrigger?.trigger_type === StageTriggerType.WAIT_FOR && isFeatureInStage
-  const isLastStage = stageOrder === totalStages - 1
-
-  const stageStyle = {
-    marginRight: lastStage ? '0px' : '24px',
-  }
-
-  const env = ProjectStore.getEnvironmentById(
-    stageEnvironment,
-  ) as unknown as Environment
-  const envName = env?.name
 
   return (
     <div
-      className='flex align-items-center gap-2 position-relative flex-1'
-      style={stageStyle}
+      className={classNames(
+        'flex align-items-center gap-2 position-relative flex-1',
+        isLastStage ? 'me-0' : 'me-4',
+      )}
     >
       {showLeftLine && (
         <div
@@ -81,15 +71,10 @@ const StageStatus = ({
             })}
           >
             {isWaiting ? (
-              <Icon name='timer' width={18} height={18} fill='#6837FC' />
+              <Icon name='timer' width={18} height={18} />
             ) : undefined}
             {isCompleted ? (
-              <Icon
-                name='checkmark-circle'
-                width={18}
-                height={18}
-                fill='#53af41'
-              />
+              <Icon name='checkmark-circle' width={18} height={18} />
             ) : undefined}
           </div>
         }
@@ -108,7 +93,7 @@ const StageStatus = ({
       <span>
         <b>{stageName}</b>
       </span>
-      {envName && <p className='text-muted'>{envName}</p>}
+      {envName && <span className='text-muted'>{envName}</span>}
     </div>
   )
 }

--- a/frontend/web/styles/components/_feature-pipeline-status.scss
+++ b/frontend/web/styles/components/_feature-pipeline-status.scss
@@ -14,10 +14,12 @@
 
       &.in-stage {
         border-color: var(--color-border-action);
+        color: var(--color-icon-action);
       }
 
       &.completed {
         border-color: var(--color-border-success);
+        color: var(--color-icon-success);
       }
 
   }

--- a/frontend/web/styles/components/_feature-pipeline-status.scss
+++ b/frontend/web/styles/components/_feature-pipeline-status.scss
@@ -1,7 +1,7 @@
   .circle-container {
-      background-color: white;
+      background-color: var(--color-surface-default);
       border: 4px solid;
-      border-color: #AAA;
+      border-color: var(--color-border-default);
       border-radius: 50%;
       height: 40px;
       width: 40px;
@@ -13,11 +13,11 @@
       justify-content: center;
 
       &.in-stage {
-        border-color: #6837fc;
+        border-color: var(--color-border-action);
       }
 
       &.completed {
-        border-color: #53af41;
+        border-color: var(--color-border-success);
       }
 
   }
@@ -27,7 +27,7 @@
   }
 
   .line-left {
-    background-color: #AAA;
+    background-color: var(--color-border-default);
     border: unset;
     height: 3px;
     left: 0%;
@@ -36,11 +36,11 @@
     z-index: 1;
 
     &.completed {
-      background-color: #53af41;
+      background-color: var(--color-border-success);
     }
   }
   .line-right {
-    background-color: #AAA;
+    background-color: var(--color-border-default);
     border: unset;
     height: 3px;
     left: 50%;
@@ -49,6 +49,6 @@
     z-index: 1;
 
     &.completed {
-      background-color: #53af41;
+      background-color: var(--color-border-success);
     }
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7018

The feature-pipeline status visualisation (circles + connector lines, rendered inside the Edit Feature modal when a feature is in a release pipeline) was broken in dark mode: white circles with grey `#AAA` borders and lines sat on the dark surface as stark, off-token shapes. Blocker #6904 (semantic colour tokens) landed via #6883 on 2026-04-07, which unblocked this.

### Dark mode fix (`_feature-pipeline-status.scss`)

Hardcoded colours swapped for semantic tokens. No `.dark { ... }` block needed — `_tokens.scss` publishes dark-mode overrides for every semantic token, so `var(--color-*)` adapts automatically.

| Old | New | Notes |
|---|---|---|
| `white` (circle bg) | `var(--color-surface-default)` | `--slate-0` light, `--slate-950` dark |
| `#AAA` (border / line) | `var(--color-border-default)` | Neutral border, opacity-based for dark |
| `#6837fc` (in-stage) | `var(--color-border-action)` | Identical in light (`--purple-600`); lighter in dark (`--purple-400`) for contrast |
| `#53af41` (completed) | `var(--color-border-success)` | Aligns to `--green-500` (`#27ab95`) — visual shift, intentional under #6606 |

`.in-stage` / `.completed` modifiers also set `color:` so the stage icons inside can inherit via `currentColor` (see component cleanup below).

### Component cleanup (`StageStatus.tsx`, `FeaturePipelineStatus.tsx`)

While we were here:

- **Decoupled from `ProjectStore` (legacy Flux).** `StageStatus` used `ProjectStore.getEnvironmentById()` to render the env name. Lifted the lookup into `FeaturePipelineStatus` via `useGetEnvironmentsQuery`, passes `envName` down as a prop. `StageStatus` is now pure / store-free / trivially testable.
- **Dropped hardcoded icon fills.** `<Icon fill='#6837FC' />` and `<Icon fill='#53af41' />` removed; icons default to `currentColor` and inherit from the `.circle-container` modifier classes set in SCSS. Same colour-by-state mapping, no duplicated hex.
- **Removed inline style.** `style={{ marginRight: lastStage ? '0px' : '24px' }}` → Bootstrap `me-0` / `me-4` classNames.
- **`<span>` instead of `<p>`** for the env-name label so it sits inline with the stage name instead of forcing a block break.
- **De-duplicated** `lastStage` / `isLastStage` (same expression, twice).
- **`?? NaN` → `?? 0`** sentinel on `pipelineId`. The `skip` guard means the value is never used, but `NaN` reads like leftover scaffolding.

### Deliberately not in scope

- **`renderToString(<StageSummaryData />)` workaround in `StageStatus`.** `Tooltip.tsx` types `children: string` and injects via `data-tooltip-html`, so JSX has to be serialised. Fixing it means changing the `Tooltip` API to accept `ReactNode` — wider change with cross-component impact. Worth a separate ticket.
- **Storybook stories.** Agreed they're worthwhile (Chromatic would have caught the original dark-mode bug), but writing them belongs in its own focused PR so the visual-regression baseline gets a clean commit.
- **`flex` className.** Verified it's a real project utility (`web/styles/flexbox/_index.scss:3`) that sets `flex-direction: column`. Layout depends on it.

## How did you test this code?

- Open the Edit Feature modal on a feature currently in a release pipeline (e.g. `sdk_usage_charts` in the "Internal testing" stage of the Quick rollout pipeline).
- Toggle light / dark theme and confirm the stage circles, in-stage purple ring, completed green ring, timer / checkmark icon colours, and the connector lines all read correctly against the surrounding modal surface.
- Verify the env name (e.g. "Production") still renders next to each stage name — confirms the new `useGetEnvironmentsQuery` lookup in `FeaturePipelineStatus` works end-to-end.
- `npx tsc --noEmit` — no new type errors in the touched files.
- `npx eslint` on the touched files — clean.