### PR TITLE
docs: document CR scope, notifications and non-notification events

### DIFF
--- a/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
+++ b/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
@@ -4,8 +4,6 @@ sidebar_label: Change Requests
 sidebar_position: 10
 ---
 
-You can use Change Requests to add workflow control to the changing of flag values. Change Requests allow a user to propose a change to a flag value, and then require that change is approved by a number of other team members.
-
 You can use Change Requests to ensure that, for example, a change to a flag in Production has to be approved by another team member. They work in a similar way to Pull Requests in git. This guide explains how to use Change Requests to add workflow control to changing flag values. You will learn how to set up, create, approve, and publish Change Requests.
 
 ## Prerequisites
@@ -79,6 +77,10 @@ Request lifecycle:
 | A Change Request is assigned to an individual | The assignee receives an email informing them that their approval is pending |
 | A Change Request is approved | The CR author receives an email confirming the approval |
 | A Change Request is assigned to a group | All members of the group receive a notification via background task |
+
+:::note
+**Self-hosting?** To ensure these email notifications are delivered correctly, you must configure the [self-hosted email setup](https://docs.flagsmith.com/deployment-self-hosting/core-configuration/email-setup).
+:::
 
 **What does not trigger a notification:**
 

--- a/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
+++ b/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 You can use Change Requests to add workflow control to the changing of flag values. Change Requests allow a user to propose a change to a flag value, and then require that change is approved by a number of other team members.
 
-You can use Change Requests to ensure that, for example, a change to a flag in Production has to be approved by another team member. They work in a similar way to Pull Requests in git. This guide explains how to use Change Requests to add workflow control to changing flag values. You will learn how to set up, create, approve, and publish Change Requests. 
+You can use Change Requests to ensure that, for example, a change to a flag in Production has to be approved by another team member. They work in a similar way to Pull Requests in git. This guide explains how to use Change Requests to add workflow control to changing flag values. You will learn how to set up, create, approve, and publish Change Requests.
 
 ## Prerequisites
 
@@ -20,15 +20,40 @@ Change Requests are configured at the environment level. To enable and set up Ch
 2.  Enable the **Change Request** setting.
 3.  Select the required number of approvals for each Change Request to be applied.
 
+## Scope of Change Requests
+
+Change Requests apply to **environment-level** and **segment-level** flag changes only. The workflow does not apply to identity-level overrides.
+
+| Feature state type  | Scoped to                       | Requires a Change Request? |
+| ------------------- | ------------------------------- | -------------------------- |
+| Environment default | All users in an environment     | ✅ Yes                     |
+| Segment override    | Users matching a segment        | ✅ Yes                     |
+| Identity override   | A single specific identity      | ❌ No — live immediately   |
+
+**Identity overrides are intentionally excluded.** They do not participate in
+Flagsmith's versioning system, which is what the CR workflow is built on.
+Changes to an identity override take effect the moment they are saved, with
+no approval step.
+
+:::tip
+If your team requires approval gates on all flag changes, prefer
+**segment-based targeting** (e.g. a `qa-team` segment) over individual
+identity overrides. Segment overrides are subject to the full Change Request
+workflow.
+:::
+
 ## Create a Change Request
 
-Once an environment is configured with Change Requests enabled, attempting to change a flag value will prompt you to create a new Change Request.
+Once an environment is configured with Change Requests enabled, attempting to
+change an environment default or segment override will prompt you to create a
+new Change Request.
 
 When creating a Change Request, you will need to provide the following:
 
 * The **title** of the Change Request.
 * An **optional description** of the reason for the Change Request.
-* Any number of **assignees**. These individuals will receive an email notification about the Change Request.
+* Any number of **assignees**. These individuals will receive an email
+  notification about the Change Request.
 
 ## Approve a Change Request
 
@@ -40,14 +65,41 @@ Change Requests awaiting approval are listed in the **Change Request** area.
 
 ## Publish a Change Request
 
-When the required number of approvals have been made, you will be able to publish the Change Request. The Change Request will immediately come into effect once the **Publish Change** button is clicked.
+When the required number of approvals have been made, you will be able to
+publish the Change Request. The Change Request will immediately come into
+effect once the **Publish Change** button is clicked.
+
+## Notifications
+
+Flagsmith sends email notifications at the following points in the Change
+Request lifecycle:
+
+| Event | Who is notified |
+| ----- | --------------- |
+| A Change Request is assigned to an individual | The assignee receives an email informing them that their approval is pending |
+| A Change Request is approved | The CR author receives an email confirming the approval |
+| A Change Request is assigned to a group | All members of the group receive a notification via background task |
+
+**What does not trigger a notification:**
+
+- **Committing a Change Request** — no email is sent when a CR is published.
+  Only audit log entries are created for the affected feature states.
+- **Rejecting a Change Request** — there is no first-class rejection flow.
+  Closing a CR means deleting it, and no email is sent on deletion.
+- **Webhook events** — there are no webhook events for CR lifecycle changes.
+  The organisation webhook receives audit log events only.
 
 ## Permissions
 
-| Action                  | Required permission      |
-| ----------------------- | ------------------------ |
-| Create a Change Request | Create change request    |
-| Approve a Change Request| Approve change request   |
-| Publish a Change Request| Update feature state     |
+| Action                   | Required permission       |
+| ------------------------ | ------------------------- |
+| Create a Change Request  | Create change request     |
+| Approve a Change Request | Approve change request    |
+| Publish a Change Request | Update feature state      |
 
-These permissions can be configured at both the project level and the environment level. For example, you might allow all developers to create change requests in Production, but only senior engineers to approve and publish them. See [Role-based access control](/administration-and-security/access-control/rbac) for details on configuring permissions.
+These permissions can be configured at both the project level and the
+environment level. For example, you might allow all developers to create
+change requests in Production, but only senior engineers to approve and
+publish them. See
+[Role-based access control](/administration-and-security/access-control/rbac)
+for details on configuring permissions.


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7505 
The Change Requests docs page had two gaps that were causing avoidable
support conversations:

1. **Scope was not documented** — the page said "attempting to change a flag
   value will prompt you to create a new Change Request" without clarifying
   that identity-level overrides are intentionally excluded from the workflow
   and go live immediately.

2. **Notifications were not documented** — the page mentioned assignee emails
   only once in passing. The full set of emails that fire (pending-approval to
   assignee, approval-granted to author, group assignment notification) was
   not described anywhere. Equally important, what does _not_ trigger a
   notification (commit, deletion, webhooks) was also undocumented, leading
   customers to expect behaviour that does not exist.

**Changes made **

- Added a **Scope of Change Requests** section with a table showing which
  feature state types require a CR and which do not, with an explanation of
  why identity overrides are excluded (they do not participate in the
  versioning system the CR workflow is built on)
- Added a tip recommending segment-based targeting for teams that need
  approval gates on all changes
- Added a **Notifications** section with a table of all email notifications
  that fire during the CR lifecycle, and an explicit list of events that do
  not trigger notifications (commit, deletion, webhooks)
- Updated the "Create a Change Request" section to clarify that the prompt
  applies to environment defaults and segment overrides, not all flag changes

Both additions are verified against the actual implementation in
`api/features/workflows/core/models.py`.

## How did you test this code?

This is a documentation-only change — no code was modified.

Verified the described behaviour against the source code:

- **Scope** — confirmed via `FeatureState.type` property and `is_live`
  property in `api/features/models.py` that identity overrides bypass
  versioning and are live immediately
- **Notifications** — confirmed via `send_email_notification_to_assignee`,
  `send_email_notification_to_author`, and
  `notify_group_of_change_request_assignment` hooks in
  `api/features/workflows/core/models.py` that the documented emails are the
  complete set
- **Non-notifications** — confirmed no email fires on commit, no rejection
  flow exists, and no CR lifecycle webhook events are present in the codebase