### PR TITLE
fix: pass django-settings-modules as make argument to override env local

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -51,10 +51,9 @@ jobs:
 
       - name: Generate MCP schema
         env:
-          DJANGO_SETTINGS_MODULE: app.settings.production
           FLAGSMITH_API_URL: 'https://api.flagsmith.com'
           FLAGSMITH_FRONTEND_URL: 'https://app.flagsmith.com'
-        run: make generate-mcp-spec
+        run: make generate-mcp-spec DJANGO_SETTINGS_MODULE=app.settings.production
 
       - name: Install Gram CLI
         run: curl -fsSL https://go.getgram.ai/cli.sh | bash


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Makefile's `.EXPORT_ALL_VARIABLES` + `-include .env-local` causes `DJANGO_SETTINGS_MODULE=app.settings.local` to override the step-level env var, loading `debug_toolbar` which isn't installed in CI.

Fix: 
- Pass `DJANGO_SETTINGS_MODULE` as a Make argument instead, which has the highest precedence and can't  be overridden by included env files.

## How did you test this code?
- Locally, resetting the modules until resolution