### PR TITLE
fix(Segments): Fix N+1 on get_segment retrieve

### DIFF
--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -104,7 +104,7 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         project = self.get_project()
         queryset = Segment.live_objects.filter(project=project, is_system_segment=False)
 
-        if self.action == "list":
+        if self.action in ("list", "retrieve"):
             # TODO: at the moment, the UI only shows the name and description of the segment in the list view.
             #  we shouldn't return all of the rules and conditions in the list view.
             queryset = queryset.prefetch_related(
@@ -115,6 +115,9 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
                 "rules__rules__rules",
                 "metadata",
             )
+
+        if self.action == "retrieve":
+            queryset = queryset.select_related("project__organisation")
 
         query_serializer = SegmentListQuerySerializer(data=self.request.query_params)
         query_serializer.is_valid(raise_exception=True)

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -626,6 +626,51 @@ def test_list_segments__without_rbac__expected_num_queries(
     assert response_json["count"] == num_segments
 
 
+@pytest.mark.skipif(
+    settings.IS_RBAC_INSTALLED is True,
+    reason="Skip this test if RBAC is installed",
+)
+@pytest.mark.parametrize(
+    "client, expected_num_queries",
+    [
+        (lazy_fixture("admin_master_api_key_client"), 12),
+        (lazy_fixture("admin_client"), 14),
+    ],
+)
+def test_retrieve_segment__without_rbac__expected_num_queries(
+    django_assert_num_queries: DjangoAssertNumQueries,
+    project: Project,
+    client: APIClient,
+    required_a_segment_metadata_field: MetadataModelField,
+    expected_num_queries: int,
+) -> None:
+    # Given
+    # A segment with metadata and multiple rules and conditions to expose any N+1 issues.
+    segment = Segment.objects.create(project=project, name="test segment")
+    Metadata.objects.create(
+        object_id=segment.id,
+        content_type=ContentType.objects.get_for_model(segment),
+        model_field=required_a_segment_metadata_field,
+        field_value="test",
+    )
+    all_rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    for _ in range(3):
+        any_rule = SegmentRule.objects.create(rule=all_rule, type=SegmentRule.ANY_RULE)
+        Condition.objects.create(property="foo", value="bar", rule=any_rule)
+
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project.id, segment.id],
+    )
+
+    # When
+    with django_assert_num_queries(expected_num_queries):
+        response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+
 def test_list_segments__system_segment_exists__excludes_system_segment(
     project: Project,
     admin_client: APIClient,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/7557

The `retrieve` action on `SegmentViewSet` was missing the `prefetch_related` applied to `list`, causing a separate `SELECT` query for conditions for every rule on the segment (N+1). Additionally, `has_object_permission` was lazily loading `segment.project` and `project.organisation` on every retrieve request.

- Extends `prefetch_related` to cover `retrieve` as well as `list`
- Adds `select_related("project__organisation")` for `retrieve` to avoid the redundant lazy-loads triggered by `has_object_permission`
- Adds a query-count regression test (`test_retrieve_segment__without_rbac__expected_num_queries`)

## How did you test this code?

Added a `django_assert_num_queries` test that creates a segment with 3 nested rules and conditions and asserts the total query count is fixed regardless of the number of rules, covering both `admin_client` and `admin_master_api_key_client` auth types.