### PR TITLE
fix: rename SAML config "Name" field to "Organisation Name"

### DIFF
--- a/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
@@ -110,9 +110,9 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
     <div className='create-feature-tab px-3 mt-3'>
       <InputGroup
         className='mt-2'
-        title='Name*'
+        title='Organisation Name*'
         data-test='saml-name'
-        tooltip='An URL-friendly name for this configuration, used as the input when selecting "Single Sign-On" at login. It determines the Assertion Consumer Service (ACS) URL that your identity provider must post SAML responses to. This cannot be changed after the SAML configuration is created.'
+        tooltip='This is the value your users will type into the Organisation Name field on the Single Sign-On login page. It determines the Assertion Consumer Service (ACS) URL that your identity provider must post SAML responses to. This cannot be changed after the SAML configuration is created.'
         tooltipPlace='right'
         value={name}
         disabled={isEdit}


### PR DESCRIPTION
## Summary
- Renames the SAML configuration creation field label from `Name*` to `Organisation Name*` to match the value users are prompted for on the SSO login form.
- Updates the tooltip to make the connection explicit so admins know they're setting the value users will type at login.

Closes #7330.

## Test plan
- [ ] Open the SAML configuration creation modal under Organisation Settings → SSO → SAML and confirm the first field reads `Organisation Name*`.
- [ ] Hover the tooltip and confirm it references the Organisation Name field on the Single Sign-On login page.
- [ ] Confirm the SSO login form still shows `Organisation Name` and that a value set in the creation modal matches what users enter at login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)