### PR TITLE
test: Isolate router tests from Django apps registry

### DIFF
--- a/api/tests/unit/app/test_unit_app_routers.py
+++ b/api/tests/unit/app/test_unit_app_routers.py
@@ -1,10 +1,30 @@
-from unittest import mock
+from collections.abc import Iterator
 
 import pytest
+from django.apps import apps
 from django.db import models
-from django.db.models.options import Options
 
 from app import routers
+
+
+@pytest.fixture(autouse=True)
+def isolate_apps_registry() -> Iterator[None]:
+    # Ad-hoc model subclasses defined in these tests register themselves
+    # in `apps.all_models` and would otherwise leak into later tests
+    # (e.g. makemigrations would propose phantom migrations for them).
+    snapshot = {
+        app_label: dict(app_models) for app_label, app_models in apps.all_models.items()
+    }
+    try:
+        yield
+    finally:
+        # Inner dicts must be restored in place: `AppConfig.models` is set to
+        # `apps.all_models[label]` by reference at import time, so swapping the
+        # outer entry leaves the app config pointing at the polluted dict.
+        for app_label, app_models in apps.all_models.items():
+            app_models.clear()
+            app_models.update(snapshot.get(app_label, {}))
+        apps.clear_cache()
 
 
 @pytest.mark.parametrize(
@@ -19,13 +39,14 @@ def test_analytics_router_db_for_read__given_app_label__returns_expected_db(
     expected_db: str | None,
 ) -> None:
     # Given
-    mock_model = mock.MagicMock(spec=models.Model)
-    mock_model._meta = mock.MagicMock(spec=Options)
-    mock_model._meta.app_label = given_app_label
+    class AnalyticsModel(models.Model):
+        class Meta:
+            app_label = given_app_label
+
     router = routers.AnalyticsRouter()
 
     # When
-    db = router.db_for_read(mock_model)
+    db = router.db_for_read(AnalyticsModel)
 
     # Then
     assert db == expected_db
@@ -43,13 +64,14 @@ def test_analytics_router_db_for_write__given_app_label__returns_expected_db(
     expected_db: str | None,
 ) -> None:
     # Given
-    mock_model = mock.MagicMock(spec=models.Model)
-    mock_model._meta = mock.MagicMock(spec=Options)
-    mock_model._meta.app_label = model_app_label
+    class AnalyticsModel(models.Model):
+        class Meta:
+            app_label = model_app_label
+
     router = routers.AnalyticsRouter()
 
     # When
-    db = router.db_for_write(mock_model)
+    db = router.db_for_write(AnalyticsModel)
 
     # Then
     assert db == expected_db
@@ -68,16 +90,18 @@ def test_analytics_router_allow_relation__given_app_labels__returns_expected(
     expected: bool | None,
 ) -> None:
     # Given
-    mock_instance1 = mock.MagicMock(spec=models.Model)
-    mock_instance1._meta = mock.MagicMock(spec=Options)
-    mock_instance1._meta.app_label = model1_app_label
-    mock_instance2 = mock.MagicMock(spec=models.Model)
-    mock_instance2._meta = mock.MagicMock(spec=Options)
-    mock_instance2._meta.app_label = model2_app_label
+    class AnalyticsModel1(models.Model):
+        class Meta:
+            app_label = model1_app_label
+
+    class AnalyticsModel2(models.Model):
+        class Meta:
+            app_label = model2_app_label
+
     router = routers.AnalyticsRouter()
 
     # When
-    result = router.allow_relation(mock_instance1, mock_instance2)
+    result = router.allow_relation(AnalyticsModel1(), AnalyticsModel2())
 
     # Then
     assert result == expected
@@ -144,14 +168,14 @@ def test_clickhouse_router_db_for_write__given_app_label__returns_expected_db(
     expected_db: str | None,
 ) -> None:
     # Given
-    class MyModel(models.Model):
+    class ClickHouseModel(models.Model):
         class Meta:
             app_label = model_app_label
 
     router = routers.ClickHouseRouter()
 
     # When
-    db = router.db_for_write(MyModel)
+    db = router.db_for_write(ClickHouseModel)
 
     # Then
     assert db == expected_db
@@ -172,18 +196,18 @@ def test_clickhouse_router_allow_relation__given_app_labels__returns_expected(
     expected: bool | None,
 ) -> None:
     # Given
-    class MyModel1(models.Model):
+    class ClickHouseModel1(models.Model):
         class Meta:
             app_label = model1_app_label
 
-    class MyModel2(models.Model):
+    class ClickHouseModel2(models.Model):
         class Meta:
             app_label = model2_app_label
 
     router = routers.ClickHouseRouter()
 
     # When
-    result = router.allow_relation(MyModel1(), MyModel2())
+    result = router.allow_relation(ClickHouseModel1(), ClickHouseModel2())
 
     # Then
     assert result is expected


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The router unit tests in `api/tests/unit/app/test_unit_app_routers.py` define ad-hoc `models.Model` subclasses with `app_label = "clickhouse"` (and other labels) to exercise the routers. Each subclass permanently registers itself in `django.apps.apps.all_models`, so once any router test runs, the apps registry stays polluted for the rest of the worker process.

When pytest-xdist scheduled both a polluting router test and `test_makemigrations__with_check_changes` onto the same worker (`gw14` on Python 3.11 in [run #26286987922](https://github.com/Flagsmith/flagsmith/actions/runs/26286987922/job/77376989353)), `makemigrations --check` found "phantom" models in the `clickhouse` app and exited 1. The 3.12 and 3.13 jobs passed only because xdist sent those tests to different workers.

- Add an autouse `isolate_apps_registry` fixture that snapshots `apps.all_models` around each test and refills the per-app inner dicts in place. `AppConfig.models` is bound to `apps.all_models[label]` by reference at import time, so the inner dicts must be restored in place rather than swapped — otherwise `app_config.models` still points at the polluted dict.
- Port the analytics router tests away from `MagicMock` so all parametrised cases use real model subclasses, now safely cleaned up by the same fixture.

Django's own `django.test.utils.isolate_apps` is unsuitable here: it calls `Apps.populate()` on its args, so every label must be a real installed app — `another_app` and `yet_another_app` are not.

## How did you test this code?

- `make test opts='-n0 tests/unit/app/test_unit_app_routers.py tests/unit/core/management/test_unit_core_management_makemigrations.py'` — 26 passed.
- Standalone repro outside pytest: register a `Leaker(models.Model)` with `app_label = "clickhouse"`, run the fixture's cleanup, then call `makemigrations --check` — exits cleanly. The same repro against the shallow-snapshot and per-label-`dict()` variants still leaks via `AppConfig.models`, confirming the in-place restore is necessary.