### PR TITLE
feat(experimentation): one warehouse connection per environment

### DIFF
--- a/api/experimentation/migrations/0003_unique_connection_per_environment.py
+++ b/api/experimentation/migrations/0003_unique_connection_per_environment.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("experimentation", "0002_add_config_and_created_status"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="warehouseconnection",
+            name="unique_active_warehouse_per_type_and_env",
+        ),
+        migrations.AddConstraint(
+            model_name="warehouseconnection",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("deleted_at__isnull", True)),
+                fields=("environment",),
+                name="unique_active_warehouse_per_env",
+            ),
+        ),
+    ]

--- a/api/experimentation/models.py
+++ b/api/experimentation/models.py
@@ -42,8 +42,8 @@ class WarehouseConnection(LifecycleModelMixin, SoftDeleteExportableModel):  # ty
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["warehouse_type", "environment"],
+                fields=["environment"],
                 condition=models.Q(deleted_at__isnull=True),
-                name="unique_active_warehouse_per_type_and_env",
+                name="unique_active_warehouse_per_env",
             ),
         ]

--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -55,14 +55,13 @@ class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignor
             WarehouseConnection.objects.all_with_deleted()
             .filter(
                 environment=environment,
+                warehouse_type=warehouse_type,
                 deleted_at__isnull=False,
             )
-            .order_by("-deleted_at")
             .first()
         )
         if existing:
             existing.deleted_at = None
-            existing.warehouse_type = warehouse_type
             existing.status = WarehouseConnectionStatus.CREATED
             existing.name = validated_data["name"]
             existing.config = validated_data.get("config")

--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -55,13 +55,14 @@ class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignor
             WarehouseConnection.objects.all_with_deleted()
             .filter(
                 environment=environment,
-                warehouse_type=warehouse_type,
                 deleted_at__isnull=False,
             )
+            .order_by("-deleted_at")
             .first()
         )
         if existing:
             existing.deleted_at = None
+            existing.warehouse_type = warehouse_type
             existing.status = WarehouseConnectionStatus.CREATED
             existing.name = validated_data["name"]
             existing.config = validated_data.get("config")

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -52,13 +52,13 @@ class WarehouseConnectionViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        warehouse_type = serializer.validated_data["warehouse_type"]
         if WarehouseConnection.objects.filter(
             environment=environment,
-            warehouse_type=warehouse_type,
         ).exists():
             return Response(
-                {"detail": "Warehouse connection already exists."},
+                {
+                    "detail": "This environment already has an active warehouse connection."
+                },
                 status=409,
             )
 

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -531,6 +531,44 @@ def test_post__snowflake_soft_deleted__resurrects_with_new_config(
     assert data["config"]["account_identifier"] == "new.us-west-2"
 
 
+def test_post__different_type_soft_deleted__creates_new_record(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection_url: str,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    create_response = admin_client.post(
+        warehouse_connection_url,
+        data={
+            "warehouse_type": "snowflake",
+            "name": "Old Snowflake",
+            "config": {"account_identifier": "xy12345.us-east-1"},
+        },
+        format="json",
+    )
+    original_id = create_response.json()["id"]
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-detail",
+        args=[environment.api_key, original_id],
+    )
+    admin_client.delete(url)
+
+    # When
+    response = admin_client.post(
+        warehouse_connection_url,
+        data={"warehouse_type": "flagsmith"},
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["id"] != original_id
+    assert data["warehouse_type"] == "flagsmith"
+
+
 def test_patch__snowflake_update_config__returns_200(
     admin_client: APIClient,
     environment: Environment,

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -58,7 +58,39 @@ def test_post__already_exists__returns_409(
 
     # Then
     assert response.status_code == status.HTTP_409_CONFLICT
-    assert response.json()["detail"] == "Warehouse connection already exists."
+    assert (
+        response.json()["detail"]
+        == "This environment already has an active warehouse connection."
+    )
+
+
+def test_post__different_type_already_exists__returns_409(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection: WarehouseConnection,
+    warehouse_connection_url: str,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+
+    # When
+    response = admin_client.post(
+        warehouse_connection_url,
+        data={
+            "warehouse_type": "snowflake",
+            "name": "My Snowflake",
+            "config": {"account_identifier": "xy12345.us-east-1"},
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert (
+        response.json()["detail"]
+        == "This environment already has an active warehouse connection."
+    )
 
 
 def test_post__soft_deleted_exists__resurrects_and_returns_201(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Enforce a single active warehouse connection per environment, regardless of warehouse type:

- **Model:** Replace `unique_active_warehouse_per_type_and_env` constraint (scoped to `warehouse_type + environment`) with `unique_active_warehouse_per_env` (scoped to `environment` only)
- **View:** The 409 check on create now rejects any new connection if the environment already has one, not just same-type duplicates
- **Serializer:** Soft-delete resurrection reuses any deleted connection in the environment (updating its `warehouse_type`) rather than matching by type
- **Migration:** `0003_unique_connection_per_environment` removes the old constraint and adds the new one
- **Test:** Added `test_post__different_type_already_exists__returns_409` to verify cross-type uniqueness

## How did you test this code?

Updated tests.