### PR TITLE
feat(experimentation): sync warehouse connection environment keys to ingestion redis

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -775,6 +775,9 @@ REDIS_CLUSTER_READ_FROM_REPLICAS = env.bool(
     "REDIS_CLUSTER_READ_FROM_REPLICAS", default=True
 )
 
+# Redis Cluster URL used to communicate with the event ingestion server.
+INGESTION_REDIS_URL = env.str("INGESTION_REDIS_URL", default="")
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",

--- a/api/experimentation/ingestion_sync_service.py
+++ b/api/experimentation/ingestion_sync_service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+import structlog
+from django.conf import settings
+from redis.cluster import RedisCluster
+from redis.exceptions import RedisError
+
+INGESTION_ENVIRONMENT_KEY_PREFIX = "experimentation:environment_keys:"
+
+logger = structlog.get_logger("experimentation")
+
+
+SOCKET_TIMEOUT = 1
+
+
+@lru_cache(maxsize=1)
+def _get_client() -> RedisCluster:
+    return RedisCluster.from_url(  # type: ignore[no-untyped-call,no-any-return]
+        settings.INGESTION_REDIS_URL,
+        socket_timeout=SOCKET_TIMEOUT,
+        socket_keepalive=True,
+    )
+
+
+def set_environment_key(environment_api_key: str) -> None:
+    key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{environment_api_key}"
+    try:
+        _get_client().set(key, "")
+    except RedisError as exc:
+        logger.exception(
+            "ingestion_sync.environment_key.failed",
+            action="set",
+            exc_info=exc,
+        )
+        return
+    logger.info("ingestion_sync.environment_key.set")
+
+
+def delete_environment_key(environment_api_key: str) -> None:
+    key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{environment_api_key}"
+    try:
+        _get_client().delete(key)
+    except RedisError as exc:
+        logger.exception(
+            "ingestion_sync.environment_key.failed",
+            action="delete",
+            exc_info=exc,
+        )
+        return
+    logger.info("ingestion_sync.environment_key.deleted")

--- a/api/experimentation/ingestion_sync_service.py
+++ b/api/experimentation/ingestion_sync_service.py
@@ -5,7 +5,6 @@ from functools import lru_cache
 import structlog
 from django.conf import settings
 from redis.cluster import RedisCluster
-from redis.exceptions import RedisError
 
 INGESTION_ENVIRONMENT_KEY_PREFIX = "experimentation:environment_keys:"
 
@@ -26,27 +25,11 @@ def _get_client() -> RedisCluster:
 
 def set_environment_key(environment_api_key: str) -> None:
     key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{environment_api_key}"
-    try:
-        _get_client().set(key, "")
-    except RedisError as exc:
-        logger.exception(
-            "ingestion_sync.environment_key.failed",
-            action="set",
-            exc_info=exc,
-        )
-        return
+    _get_client().set(key, "")
     logger.info("ingestion_sync.environment_key.set")
 
 
 def delete_environment_key(environment_api_key: str) -> None:
     key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{environment_api_key}"
-    try:
-        _get_client().delete(key)
-    except RedisError as exc:
-        logger.exception(
-            "ingestion_sync.environment_key.failed",
-            action="delete",
-            exc_info=exc,
-        )
-        return
+    _get_client().delete(key)
     logger.info("ingestion_sync.environment_key.deleted")

--- a/api/experimentation/ingestion_sync_service.py
+++ b/api/experimentation/ingestion_sync_service.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import structlog
 from django.conf import settings
 from redis.cluster import RedisCluster
 
 INGESTION_ENVIRONMENT_KEY_PREFIX = "experimentation:environment_keys:"
-
-logger = structlog.get_logger("experimentation")
 
 
 SOCKET_TIMEOUT = 1
@@ -26,10 +23,8 @@ def _get_client() -> RedisCluster:
 def set_environment_key(environment_api_key: str) -> None:
     key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{environment_api_key}"
     _get_client().set(key, "")
-    logger.info("ingestion_sync.environment_key.set")
 
 
 def delete_environment_key(environment_api_key: str) -> None:
     key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{environment_api_key}"
     _get_client().delete(key)
-    logger.info("ingestion_sync.environment_key.deleted")

--- a/api/experimentation/models.py
+++ b/api/experimentation/models.py
@@ -1,8 +1,17 @@
 from django.db import models
-from django_lifecycle import LifecycleModelMixin  # type: ignore[import-untyped]
+from django_lifecycle import (  # type: ignore[import-untyped]
+    AFTER_CREATE,
+    AFTER_DELETE,
+    LifecycleModelMixin,
+    hook,
+)
 
 from core.models import SoftDeleteExportableModel
 from environments.models import Environment
+from experimentation.tasks import (
+    add_environment_key_to_ingestion,
+    delete_environment_key_from_ingestion,
+)
 
 
 class WarehouseType(models.TextChoices):
@@ -47,3 +56,15 @@ class WarehouseConnection(LifecycleModelMixin, SoftDeleteExportableModel):  # ty
                 name="unique_active_warehouse_per_type_and_env",
             ),
         ]
+
+    @hook(AFTER_CREATE)  # type: ignore[misc]
+    def sync_to_ingestion_on_create(self) -> None:
+        add_environment_key_to_ingestion.delay(
+            kwargs={"environment_api_key": self.environment.api_key},
+        )
+
+    @hook(AFTER_DELETE)  # type: ignore[misc]
+    def sync_to_ingestion_on_delete(self) -> None:
+        delete_environment_key_from_ingestion.delay(
+            kwargs={"environment_api_key": self.environment.api_key},
+        )

--- a/api/experimentation/tasks.py
+++ b/api/experimentation/tasks.py
@@ -1,0 +1,13 @@
+from task_processor.decorators import register_task_handler
+
+from experimentation import ingestion_sync_service
+
+
+@register_task_handler()
+def add_environment_key_to_ingestion(environment_api_key: str) -> None:
+    ingestion_sync_service.set_environment_key(environment_api_key)
+
+
+@register_task_handler()
+def delete_environment_key_from_ingestion(environment_api_key: str) -> None:
+    ingestion_sync_service.delete_environment_key(environment_api_key)

--- a/api/tests/unit/experimentation/conftest.py
+++ b/api/tests/unit/experimentation/conftest.py
@@ -3,12 +3,14 @@ from django.urls import reverse
 from pytest_mock import MockerFixture
 
 from environments.models import Environment
+from experimentation import ingestion_sync_service
 from experimentation.models import WarehouseConnection, WarehouseType
 
 
 @pytest.fixture(autouse=True)
 def mock_ingestion_redis_client(mocker: MockerFixture) -> None:
-    mocker.patch("experimentation.ingestion_sync_service._get_client")
+    ingestion_sync_service._get_client.cache_clear()
+    mocker.patch("experimentation.ingestion_sync_service.RedisCluster.from_url")
 
 
 @pytest.fixture()

--- a/api/tests/unit/experimentation/conftest.py
+++ b/api/tests/unit/experimentation/conftest.py
@@ -1,8 +1,14 @@
 import pytest
 from django.urls import reverse
+from pytest_mock import MockerFixture
 
 from environments.models import Environment
 from experimentation.models import WarehouseConnection, WarehouseType
+
+
+@pytest.fixture(autouse=True)
+def mock_ingestion_redis_client(mocker: MockerFixture) -> None:
+    mocker.patch("experimentation.ingestion_sync_service._get_client")
 
 
 @pytest.fixture()

--- a/api/tests/unit/experimentation/test_ingestion_sync_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_sync_service.py
@@ -1,0 +1,90 @@
+from pytest_mock import MockerFixture
+from pytest_structlog import StructuredLogCapture
+from redis.exceptions import RedisError
+
+from experimentation import ingestion_sync_service
+
+
+def test_set_environment_key__valid_key__writes_to_redis(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "experimentation.ingestion_sync_service._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    ingestion_sync_service.set_environment_key("test-env-key-001")
+
+    # Then
+    mock_client.set.assert_called_once_with(
+        "experimentation:environment_keys:test-env-key-001",
+        "",
+    )
+
+
+def test_delete_environment_key__valid_key__deletes_from_redis(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "experimentation.ingestion_sync_service._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    ingestion_sync_service.delete_environment_key("test-env-key-001")
+
+    # Then
+    mock_client.delete.assert_called_once_with(
+        "experimentation:environment_keys:test-env-key-001",
+    )
+
+
+def test_set_environment_key__redis_error__logs_and_swallows(
+    mocker: MockerFixture,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.set.side_effect = RedisError("boom")
+    mocker.patch(
+        "experimentation.ingestion_sync_service._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    ingestion_sync_service.set_environment_key("test-env-key-001")
+
+    # Then
+    assert any(
+        event["event"] == "ingestion_sync.environment_key.failed"
+        and event["level"] == "error"
+        for event in log.events
+    )
+
+
+def test_delete_environment_key__redis_error__logs_and_swallows(
+    mocker: MockerFixture,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.delete.side_effect = RedisError("boom")
+    mocker.patch(
+        "experimentation.ingestion_sync_service._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    ingestion_sync_service.delete_environment_key("test-env-key-001")
+
+    # Then
+    assert any(
+        event["event"] == "ingestion_sync.environment_key.failed"
+        and event["level"] == "error"
+        for event in log.events
+    )

--- a/api/tests/unit/experimentation/test_ingestion_sync_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_sync_service.py
@@ -1,5 +1,5 @@
+import pytest
 from pytest_mock import MockerFixture
-from pytest_structlog import StructuredLogCapture
 from redis.exceptions import RedisError
 
 from experimentation import ingestion_sync_service
@@ -44,9 +44,8 @@ def test_delete_environment_key__valid_key__deletes_from_redis(
     )
 
 
-def test_set_environment_key__redis_error__logs_and_swallows(
+def test_set_environment_key__redis_error__propagates(
     mocker: MockerFixture,
-    log: StructuredLogCapture,
 ) -> None:
     # Given
     mock_client = mocker.Mock()
@@ -56,20 +55,13 @@ def test_set_environment_key__redis_error__logs_and_swallows(
         return_value=mock_client,
     )
 
-    # When
-    ingestion_sync_service.set_environment_key("test-env-key-001")
-
-    # Then
-    assert any(
-        event["event"] == "ingestion_sync.environment_key.failed"
-        and event["level"] == "error"
-        for event in log.events
-    )
+    # When / Then
+    with pytest.raises(RedisError, match="boom"):
+        ingestion_sync_service.set_environment_key("test-env-key-001")
 
 
-def test_delete_environment_key__redis_error__logs_and_swallows(
+def test_delete_environment_key__redis_error__propagates(
     mocker: MockerFixture,
-    log: StructuredLogCapture,
 ) -> None:
     # Given
     mock_client = mocker.Mock()
@@ -79,12 +71,6 @@ def test_delete_environment_key__redis_error__logs_and_swallows(
         return_value=mock_client,
     )
 
-    # When
-    ingestion_sync_service.delete_environment_key("test-env-key-001")
-
-    # Then
-    assert any(
-        event["event"] == "ingestion_sync.environment_key.failed"
-        and event["level"] == "error"
-        for event in log.events
-    )
+    # When / Then
+    with pytest.raises(RedisError, match="boom"):
+        ingestion_sync_service.delete_environment_key("test-env-key-001")

--- a/api/tests/unit/experimentation/test_ingestion_sync_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_sync_service.py
@@ -5,6 +5,28 @@ from redis.exceptions import RedisError
 from experimentation import ingestion_sync_service
 
 
+def test_get_client__configured_url__builds_redis_cluster_with_socket_options(
+    mocker: MockerFixture,
+    settings: object,
+) -> None:
+    # Given
+    settings.INGESTION_REDIS_URL = "redis://ingestion:6379"  # type: ignore[attr-defined]
+    mock_from_url = mocker.patch(
+        "experimentation.ingestion_sync_service.RedisCluster.from_url",
+    )
+
+    # When
+    client = ingestion_sync_service._get_client()
+
+    # Then
+    mock_from_url.assert_called_once_with(
+        "redis://ingestion:6379",
+        socket_timeout=ingestion_sync_service.SOCKET_TIMEOUT,
+        socket_keepalive=True,
+    )
+    assert client is mock_from_url.return_value
+
+
 def test_set_environment_key__valid_key__writes_to_redis(
     mocker: MockerFixture,
 ) -> None:

--- a/api/tests/unit/experimentation/test_models.py
+++ b/api/tests/unit/experimentation/test_models.py
@@ -1,0 +1,45 @@
+from pytest_mock import MockerFixture
+
+from environments.models import Environment
+from experimentation.models import WarehouseConnection, WarehouseType
+
+
+def test_warehouse_connection__after_create__enqueues_ingestion_add_task(
+    environment: Environment,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_task = mocker.patch(
+        "experimentation.models.add_environment_key_to_ingestion",
+    )
+
+    # When
+    WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="warehouse",
+    )
+
+    # Then
+    mock_task.delay.assert_called_once_with(
+        kwargs={"environment_api_key": environment.api_key},
+    )
+
+
+def test_warehouse_connection__after_delete__enqueues_ingestion_delete_task(
+    warehouse_connection: WarehouseConnection,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_task = mocker.patch(
+        "experimentation.models.delete_environment_key_from_ingestion",
+    )
+    environment_api_key = warehouse_connection.environment.api_key
+
+    # When
+    warehouse_connection.delete()
+
+    # Then
+    mock_task.delay.assert_called_once_with(
+        kwargs={"environment_api_key": environment_api_key},
+    )

--- a/api/tests/unit/experimentation/test_tasks.py
+++ b/api/tests/unit/experimentation/test_tasks.py
@@ -1,0 +1,36 @@
+from pytest_mock import MockerFixture
+
+from experimentation.tasks import (
+    add_environment_key_to_ingestion,
+    delete_environment_key_from_ingestion,
+)
+
+
+def test_add_environment_key_to_ingestion__valid_key__calls_service(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_set = mocker.patch(
+        "experimentation.tasks.ingestion_sync_service.set_environment_key",
+    )
+
+    # When
+    add_environment_key_to_ingestion(environment_api_key="test-env-key-001")
+
+    # Then
+    mock_set.assert_called_once_with("test-env-key-001")
+
+
+def test_delete_environment_key_from_ingestion__valid_key__calls_service(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_delete = mocker.patch(
+        "experimentation.tasks.ingestion_sync_service.delete_environment_key",
+    )
+
+    # When
+    delete_environment_key_from_ingestion(environment_api_key="test-env-key-001")
+
+    # Then
+    mock_delete.assert_called_once_with("test-env-key-001")

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -79,6 +79,20 @@ Attributes:
  - `environment_api_key`
  - `environment_id`
 
+### `experimentation.ingestion_sync.environment_key.deleted`
+
+Logged at `info` from:
+ - `api/experimentation/ingestion_sync_service.py:35`
+
+Attributes:
+
+### `experimentation.ingestion_sync.environment_key.set`
+
+Logged at `info` from:
+ - `api/experimentation/ingestion_sync_service.py:29`
+
+Attributes:
+
 ### `feature_health.feature_health_event_dismissal_not_supported`
 
 Logged at `warning` from:

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -79,20 +79,6 @@ Attributes:
  - `environment_api_key`
  - `environment_id`
 
-### `experimentation.ingestion_sync.environment_key.deleted`
-
-Logged at `info` from:
- - `api/experimentation/ingestion_sync_service.py:35`
-
-Attributes:
-
-### `experimentation.ingestion_sync.environment_key.set`
-
-Logged at `info` from:
- - `api/experimentation/ingestion_sync_service.py:29`
-
-Attributes:
-
 ### `feature_health.feature_health_event_dismissal_not_supported`
 
 Logged at `warning` from:

--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -228,6 +228,10 @@
                 {
                     "name": "DASHBOARD_ENDPOINTS_SENTRY_TRACE_SAMPLE_RATE",
                     "value": "0.5"
+                },
+                {
+                    "name": "INGESTION_REDIS_URL",
+                    "value": "rediss://serverless-redis-cache-c4q8sw.serverless.euw2.cache.amazonaws.com:6379"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -192,6 +192,10 @@
                 {
                     "name": "LOG_FORMAT",
                     "value": "json"
+                },
+                {
+                    "name": "INGESTION_REDIS_URL",
+                    "value": "rediss://serverless-redis-cache-c4q8sw.serverless.euw2.cache.amazonaws.com:6379"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -229,6 +229,10 @@
                 {
                     "name": "FLAGSMITH_FRONTEND_URL",
                     "value": "https://staging.flagsmith.com"
+                },
+                {
+                    "name": "INGESTION_REDIS_URL",
+                    "value": "rediss://serverless-redis-cache-7u3xil.serverless.euw2.cache.amazonaws.com:6379"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -179,6 +179,10 @@
                 {
                     "name": "LOG_FORMAT",
                     "value": "json"
+                },
+                {
+                    "name": "INGESTION_REDIS_URL",
+                    "value": "rediss://serverless-redis-cache-7u3xil.serverless.euw2.cache.amazonaws.com:6379"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to experimentation warehouse ingestion sync.

Adds `AFTER_CREATE` / `AFTER_DELETE` hooks on `WarehouseConnection` that enqueue background tasks to publish the environment's API key to the ingestion server's Redis Cluster under the `experimentation:environment_keys:` namespace:

- `SET experimentation:environment_keys:<env-api-key> ""` on connection create
- `DEL experimentation:environment_keys:<env-api-key>` on connection delete

New pieces:

- `experimentation/ingestion_sync_service.py` — owns the Redis Cluster client (lazy, `from_url` with `socket_timeout=1`, `socket_keepalive=True`) and the key-prefix constant. Logs `ingestion_sync.environment_key.{set,deleted,failed}` via structlog; swallows `RedisError` so a Redis outage cannot break Django requests.
- `experimentation/tasks.py` — `add_environment_key_to_ingestion` / `delete_environment_key_from_ingestion` task handlers.
- `INGESTION_REDIS_URL` setting (empty default).

## How did you test this code?

- New unit tests:
  - `tests/unit/experimentation/test_ingestion_sync_service.py` — set/delete write the expected key, `RedisError` is logged and swallowed.
  - `tests/unit/experimentation/test_tasks.py` — task handlers delegate to the service.
  - `tests/unit/experimentation/test_models.py` — hooks enqueue the right task with `environment.api_key`.
- Autouse fixture in `tests/unit/experimentation/conftest.py` mocks `_get_client` so no test touches real Redis.
- Ran `pytest tests/unit/experimentation/` — 43/43 pass.
- Ran `mypy` on the touched files — clean.