### PR TITLE
chore(API): Bump clickhouse-driver to b33d5e7

### DIFF
--- a/api/uv.lock
+++ b/api/uv.lock
@@ -616,7 +616,7 @@ wheels = [
 [[package]]
 name = "clickhouse-driver"
 version = "0.2.10"
-source = { git = "https://github.com/Flagsmith/clickhouse-driver?branch=newjson#11a9bee45efec2415c5987734778313ad318af4f" }
+source = { git = "https://github.com/Flagsmith/clickhouse-driver?branch=newjson#b33d5e74de2c320d02fa0793e45ed26b0b0d3911" }
 dependencies = [
     { name = "pytz" },
     { name = "tzlocal" },

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -195,6 +195,10 @@
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:DATABASE_URL::"
                 },
                 {
+                    "name": "CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:clickhouse-url-ns26gC"
+                },
+                {
                     "name": "DJANGO_SECRET_KEY",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:DJANGO_SECRET_KEY::"
                 },


### PR DESCRIPTION
## Changes

Bumps the pinned `clickhouse-driver` revision in `api/uv.lock` to the current tip of the `newjson` branch.

## How did you test this code?

- `uv lock --locked` passes (lockfile is consistent with `pyproject.toml`).
- `git ls-remote https://github.com/Flagsmith/clickhouse-driver newjson` confirms the SHA is the current branch tip.