### PR TITLE
feat: added type filter on get feature endpoint

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -53,6 +53,7 @@ from .feature_segments.limits import (
 from .feature_segments.serializers import (
     CustomCreateSegmentOverrideFeatureSegmentSerializer,
 )
+from .feature_types import FEATURE_TYPE_CHOICES
 from .models import Feature, FeatureState
 from .multivariate.serializers import NestedMultivariateFeatureOptionSerializer
 
@@ -95,6 +96,11 @@ class FeatureQuerySerializer(serializers.Serializer):  # type: ignore[type-arg]
     )
 
     is_archived = serializers.BooleanField(required=False)
+    type = serializers.ChoiceField(
+        choices=FEATURE_TYPE_CHOICES,
+        required=False,
+        help_text="Feature type to filter on (STANDARD or MULTIVARIATE).",
+    )
     environment = serializers.IntegerField(
         required=False,
         help_text="Integer ID of the environment to view features in the context of.",

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -612,6 +612,9 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         if "is_archived" in query_serializer.initial_data:
             queryset = queryset.filter(is_archived=query_data["is_archived"])
 
+        if query_data.get("type"):
+            queryset = queryset.filter(type=query_data["type"])
+
         queryset = self.filter_owners_and_group_owners(queryset, query_data)
 
         return queryset

--- a/api/tests/integration/features/test_integration_features.py
+++ b/api/tests/integration/features/test_integration_features.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from django.urls import reverse
 from rest_framework import status
 
@@ -203,3 +204,39 @@ def test_list_features__filter_by_archived_status__returns_matching_features(  #
         list_features_is_archived_true_response.json()["results"][0]["id"]
         == archived_feature_id
     )
+
+
+@pytest.mark.parametrize(
+    "type_filter, expected_feature_name",
+    [
+        ("STANDARD", "standard_feature"),
+        ("MULTIVARIATE", "multivariate_feature"),
+    ],
+)
+def test_list_features__filter_by_type__returns_matching_features(  # type: ignore[no-untyped-def]
+    admin_client, project, type_filter, expected_feature_name
+):
+    # Given
+    features_url = reverse("api-v1:projects:project-features-list", args=[project])
+    admin_client.post(
+        features_url,
+        data={"name": "standard_feature", "project": project},
+    )
+    admin_client.post(
+        features_url,
+        data={
+            "name": "multivariate_feature",
+            "project": project,
+            "type": "MULTIVARIATE",
+            "initial_value": "control",
+        },
+    )
+
+    # When
+    response = admin_client.get(f"{features_url}?type={type_filter}")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    response_json = response.json()
+    assert response_json["count"] == 1
+    assert response_json["results"][0]["name"] == expected_feature_name


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Added a new query param `type` to allow filtering on `STANDARD` and `MULTIVARIATE` feature types
- Needed to get proper lists of multivariate features for experimentation

## How did you test this code?
- Added tests