### PR TITLE
fix: code references count returns 0 after unchanged rescan

### DIFF
--- a/api/projects/code_references/services.py
+++ b/api/projects/code_references/services.py
@@ -146,7 +146,9 @@ def record_scan(
             for feature_name, references in references_by_feature.items()
             if (feature := features_by_name.get(feature_name)) is not None
         ],
-        ignore_conflicts=True,
+        update_conflicts=True,
+        unique_fields=["feature", "repository", "code_references_hash"],
+        update_fields=["created_at", "revision"],
     )
 
     return FeatureFlagCodeReferencesScan(

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
@@ -188,6 +188,7 @@ def test_create_code_reference__file_path_too_long__returns_400(
     assert not ScannedCodeReferences.objects.exists()
 
 
+@freezegun.freeze_time("2099-06-01T12:00:00+00:00")
 def test_create_code_reference__duplicate_payload__deduplicates_storage_and_references_remain_retrievable(
     admin_client_new: APIClient,
     project: Project,
@@ -220,10 +221,23 @@ def test_create_code_reference__duplicate_payload__deduplicates_storage_and_refe
         f"/api/v1/projects/{project.pk}/features/{feature.pk}/code-references/",
     )
     assert response.status_code == 200
-    data = response.json()
-    assert len(data) == 1
-    assert len(data[0]["code_references"]) == 1
-    assert data[0]["code_references"][0]["file_path"] == "path/to/file.py"
+    assert response.json() == [
+        {
+            "repository_url": "https://github.flagsmith.com/",
+            "vcs_provider": "github",
+            "revision": "rev-1",
+            "last_successful_repository_scanned_at": "2099-06-01T12:00:00+00:00",
+            "last_feature_found_at": "2099-06-01T12:00:00+00:00",
+            "code_references": [
+                {
+                    "feature_name": "feature-1",
+                    "file_path": "path/to/file.py",
+                    "line_number": 1,
+                    "permalink": "https://github.flagsmith.com/blob/rev-1/path/to/file.py#L1",
+                },
+            ],
+        },
+    ]
 
 
 def test_get_feature_code_references__multiple_scans_exist__returns_latest_per_repository(

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
@@ -188,12 +188,12 @@ def test_create_code_reference__file_path_too_long__returns_400(
     assert not ScannedCodeReferences.objects.exists()
 
 
-def test_create_code_reference__duplicate_payload__deduplicates_storage(
+def test_create_code_reference__duplicate_payload__deduplicates_storage_and_references_remain_retrievable(
     admin_client_new: APIClient,
     project: Project,
 ) -> None:
     # Given
-    Feature.objects.create(project=project, name="feature-1")
+    feature = Feature.objects.create(project=project, name="feature-1")
     payload = {
         "repository_url": "https://github.flagsmith.com/",
         "revision": "rev-1",
@@ -205,17 +205,25 @@ def test_create_code_reference__duplicate_payload__deduplicates_storage(
             },
         ],
     }
-
-    # When
     admin_client_new.post(
         f"/api/v1/projects/{project.pk}/code-references/", data=payload, format="json"
     )
+
+    # When
     admin_client_new.post(
         f"/api/v1/projects/{project.pk}/code-references/", data=payload, format="json"
     )
 
     # Then
     assert ScannedCodeReferences.objects.count() == 1
+    response = admin_client_new.get(
+        f"/api/v1/projects/{project.pk}/features/{feature.pk}/code-references/",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert len(data[0]["code_references"]) == 1
+    assert data[0]["code_references"][0]["file_path"] == "path/to/file.py"
 
 
 def test_get_feature_code_references__multiple_scans_exist__returns_latest_per_repository(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- `ignore_conflicts=True` was skipping creating a new code reference record when scanning an unchanged code reference
- We use a filter based on the last scanning `created_at=F("repository__last_scanned_at")` so while `last_scanned_at` advanced, there was no related `code_reference` on this date
- Switched to `update_conflicts=True` with unique_fields and `update_fields` being `created_at` and `revision` (only ones updated on conflict)

Impact appeared starting from second scanning.

## How did you test this code?
- Updated test to also check the payload is properly returned after conflicting update