### PR TITLE
fix(Segment membership): Zero out (segment, env) pairs that stopped matching

### DIFF
--- a/api/segment_membership/tasks.py
+++ b/api/segment_membership/tasks.py
@@ -168,8 +168,11 @@ def refresh_project_segment_counts(project_id: int) -> None:
         # so the stale count would linger. Append explicit zeros for those
         # missing pairs so the next refresh writes them down to zero.
         new_pairs = {(m.segment_id, m.environment_id) for m in membership_counts}
+        # `count__gt=0` keeps steady-state refreshes off rows that are already
+        # zeroed -- writing zero over zero on every run is just churn.
         existing_pairs = SegmentMembershipCount.objects.filter(
             segment__project=project,
+            count__gt=0,
         ).values_list("segment_id", "environment_id")
         zeroed_counts = [
             SegmentMembershipCount(

--- a/api/segment_membership/tasks.py
+++ b/api/segment_membership/tasks.py
@@ -162,8 +162,6 @@ def refresh_project_segment_counts(project_id: int) -> None:
         for m in membership_counts:
             m.last_synced_at = now
 
-        # Drop pairs that stopped matching this run so the next refresh
-        # doesn't carry stale counts forward.
         new_pairs = {(m.segment_id, m.environment_id) for m in membership_counts}
         stale_ids = [
             pk
@@ -174,11 +172,9 @@ def refresh_project_segment_counts(project_id: int) -> None:
             )
             if (segment_id, environment_id) not in new_pairs
         ]
-        stale_deleted, _ = (
-            SegmentMembershipCount.objects.filter(id__in=stale_ids).delete()
-            if stale_ids
-            else (0, {})
-        )
+        stale_deleted, _ = SegmentMembershipCount.objects.filter(
+            id__in=stale_ids,
+        ).delete()
 
         SegmentMembershipCount.objects.bulk_create(
             membership_counts,

--- a/api/segment_membership/tasks.py
+++ b/api/segment_membership/tasks.py
@@ -162,31 +162,26 @@ def refresh_project_segment_counts(project_id: int) -> None:
         for m in membership_counts:
             m.last_synced_at = now
 
-        # Pairs that previously matched but no longer do (rule edited, traits
-        # drifted, identities deleted) won't appear in `membership_counts`.
-        # `bulk_create(update_conflicts=True)` only touches rows it's handed,
-        # so the stale count would linger. Append explicit zeros for those
-        # missing pairs so the next refresh writes them down to zero.
+        # Drop pairs that stopped matching this run so the next refresh
+        # doesn't carry stale counts forward.
         new_pairs = {(m.segment_id, m.environment_id) for m in membership_counts}
-        # `count__gt=0` keeps steady-state refreshes off rows that are already
-        # zeroed -- writing zero over zero on every run is just churn.
-        existing_pairs = SegmentMembershipCount.objects.filter(
-            segment__project=project,
-            count__gt=0,
-        ).values_list("segment_id", "environment_id")
-        zeroed_counts = [
-            SegmentMembershipCount(
-                segment_id=segment_id,
-                environment_id=environment_id,
-                count=0,
-                last_synced_at=now,
+        stale_ids = [
+            pk
+            for pk, segment_id, environment_id in (
+                SegmentMembershipCount.objects.filter(
+                    segment__project=project
+                ).values_list("id", "segment_id", "environment_id")
             )
-            for segment_id, environment_id in existing_pairs
             if (segment_id, environment_id) not in new_pairs
         ]
+        stale_deleted, _ = (
+            SegmentMembershipCount.objects.filter(id__in=stale_ids).delete()
+            if stale_ids
+            else (0, {})
+        )
 
         SegmentMembershipCount.objects.bulk_create(
-            membership_counts + zeroed_counts,
+            membership_counts,
             update_conflicts=True,
             unique_fields=["segment", "environment"],
             update_fields=["count", "last_synced_at"],
@@ -195,5 +190,5 @@ def refresh_project_segment_counts(project_id: int) -> None:
             "refresh.project.completed",
             project__id=project_id,
             membership_counts__count=len(membership_counts),
-            zeroed_counts__count=len(zeroed_counts),
+            stale_counts__count=stale_deleted,
         )

--- a/api/segment_membership/tasks.py
+++ b/api/segment_membership/tasks.py
@@ -161,8 +161,29 @@ def refresh_project_segment_counts(project_id: int) -> None:
         now = timezone.now()
         for m in membership_counts:
             m.last_synced_at = now
+
+        # Pairs that previously matched but no longer do (rule edited, traits
+        # drifted, identities deleted) won't appear in `membership_counts`.
+        # `bulk_create(update_conflicts=True)` only touches rows it's handed,
+        # so the stale count would linger. Append explicit zeros for those
+        # missing pairs so the next refresh writes them down to zero.
+        new_pairs = {(m.segment_id, m.environment_id) for m in membership_counts}
+        existing_pairs = SegmentMembershipCount.objects.filter(
+            segment__project=project,
+        ).values_list("segment_id", "environment_id")
+        zeroed_counts = [
+            SegmentMembershipCount(
+                segment_id=segment_id,
+                environment_id=environment_id,
+                count=0,
+                last_synced_at=now,
+            )
+            for segment_id, environment_id in existing_pairs
+            if (segment_id, environment_id) not in new_pairs
+        ]
+
         SegmentMembershipCount.objects.bulk_create(
-            membership_counts,
+            membership_counts + zeroed_counts,
             update_conflicts=True,
             unique_fields=["segment", "environment"],
             update_fields=["count", "last_synced_at"],
@@ -171,4 +192,5 @@ def refresh_project_segment_counts(project_id: int) -> None:
             "refresh.project.completed",
             project__id=project_id,
             membership_counts__count=len(membership_counts),
+            zeroed_counts__count=len(zeroed_counts),
         )

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 from pytest_structlog import StructuredLogCapture
@@ -295,3 +296,64 @@ def test_refresh_project_segment_counts__counts_returned__upserts_per_env_rows(
             f":project_{project.id}"
         )
     )
+
+
+def test_refresh_project_segment_counts__previously_matching_pair_drops_to_zero__row_zeroed(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    project: Project,
+    environment: Environment,
+    segment: Segment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given a prior refresh that landed a non-zero count for (segment, env)
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    SegmentMembershipCount.objects.create(
+        segment=segment,
+        environment=environment,
+        count=15,
+        last_synced_at=timezone.now(),
+    )
+    cursor = MagicMock()
+    open_cursor = mocker.patch.object(tasks, "open_clickhouse_cursor")
+    open_cursor.return_value.__enter__.return_value = cursor
+    # ... and a new compute that returns no matches for the same pair (the
+    # rule was edited, the identity set drifted, etc.).
+    mocker.patch.object(tasks, "compute_segment_counts_for_project", return_value=[])
+
+    # When
+    refresh_project_segment_counts(project.id)
+
+    # Then the stale row is reset to zero rather than left at 15.
+    membership = SegmentMembershipCount.objects.get(
+        segment=segment, environment=environment
+    )
+    assert membership.count == 0
+    assert membership.last_synced_at is not None
+
+
+def test_refresh_project_segment_counts__never_matched_pair__no_row_written(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    project: Project,
+    environment: Environment,
+    segment: Segment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given a project with no prior membership rows
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    cursor = MagicMock()
+    open_cursor = mocker.patch.object(tasks, "open_clickhouse_cursor")
+    open_cursor.return_value.__enter__.return_value = cursor
+    mocker.patch.object(tasks, "compute_segment_counts_for_project", return_value=[])
+
+    # When
+    refresh_project_segment_counts(project.id)
+
+    # Then no row is written: the zero-fill only resets previously-matching
+    # pairs, it doesn't pre-populate every (segment, env) combination.
+    assert not SegmentMembershipCount.objects.filter(
+        segment=segment, environment=environment
+    ).exists()

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from django.utils import timezone
@@ -331,6 +332,40 @@ def test_refresh_project_segment_counts__previously_matching_pair_drops_to_zero_
     )
     assert membership.count == 0
     assert membership.last_synced_at is not None
+
+
+def test_refresh_project_segment_counts__already_zeroed_pair__not_rewritten(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    project: Project,
+    environment: Environment,
+    segment: Segment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given a row that's already at zero from a previous refresh
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    zeroed_at = timezone.now() - timedelta(hours=1)
+    SegmentMembershipCount.objects.create(
+        segment=segment,
+        environment=environment,
+        count=0,
+        last_synced_at=zeroed_at,
+    )
+    cursor = MagicMock()
+    open_cursor = mocker.patch.object(tasks, "open_clickhouse_cursor")
+    open_cursor.return_value.__enter__.return_value = cursor
+    mocker.patch.object(tasks, "compute_segment_counts_for_project", return_value=[])
+
+    # When a refresh runs that still produces zero matches
+    refresh_project_segment_counts(project.id)
+
+    # Then the row is left alone -- zeroing zero again is just write churn.
+    membership = SegmentMembershipCount.objects.get(
+        segment=segment, environment=environment
+    )
+    assert membership.count == 0
+    assert membership.last_synced_at == zeroed_at
 
 
 def test_refresh_project_segment_counts__never_matched_pair__no_row_written(

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from unittest.mock import MagicMock
 
 from django.utils import timezone
@@ -299,7 +298,7 @@ def test_refresh_project_segment_counts__counts_returned__upserts_per_env_rows(
     )
 
 
-def test_refresh_project_segment_counts__previously_matching_pair_drops_to_zero__row_zeroed(
+def test_refresh_project_segment_counts__previously_matching_pair_drops_to_zero__row_deleted(
     mocker: MockerFixture,
     settings: SettingsWrapper,
     project: Project,
@@ -326,46 +325,11 @@ def test_refresh_project_segment_counts__previously_matching_pair_drops_to_zero_
     # When
     refresh_project_segment_counts(project.id)
 
-    # Then the stale row is reset to zero rather than left at 15.
-    membership = SegmentMembershipCount.objects.get(
+    # Then the stale row is gone -- pairs that no longer match drop out of
+    # the table entirely rather than lingering at the previous count.
+    assert not SegmentMembershipCount.objects.filter(
         segment=segment, environment=environment
-    )
-    assert membership.count == 0
-    assert membership.last_synced_at is not None
-
-
-def test_refresh_project_segment_counts__already_zeroed_pair__not_rewritten(
-    mocker: MockerFixture,
-    settings: SettingsWrapper,
-    project: Project,
-    environment: Environment,
-    segment: Segment,
-    enable_features: EnableFeaturesFixture,
-) -> None:
-    # Given a row that's already at zero from a previous refresh
-    enable_features("segment_membership_inspection")
-    settings.CLICKHOUSE_ENABLED = True
-    zeroed_at = timezone.now() - timedelta(hours=1)
-    SegmentMembershipCount.objects.create(
-        segment=segment,
-        environment=environment,
-        count=0,
-        last_synced_at=zeroed_at,
-    )
-    cursor = MagicMock()
-    open_cursor = mocker.patch.object(tasks, "open_clickhouse_cursor")
-    open_cursor.return_value.__enter__.return_value = cursor
-    mocker.patch.object(tasks, "compute_segment_counts_for_project", return_value=[])
-
-    # When a refresh runs that still produces zero matches
-    refresh_project_segment_counts(project.id)
-
-    # Then the row is left alone -- zeroing zero again is just write churn.
-    membership = SegmentMembershipCount.objects.get(
-        segment=segment, environment=environment
-    )
-    assert membership.count == 0
-    assert membership.last_synced_at == zeroed_at
+    ).exists()
 
 
 def test_refresh_project_segment_counts__never_matched_pair__no_row_written(
@@ -387,8 +351,8 @@ def test_refresh_project_segment_counts__never_matched_pair__no_row_written(
     # When
     refresh_project_segment_counts(project.id)
 
-    # Then no row is written: the zero-fill only resets previously-matching
-    # pairs, it doesn't pre-populate every (segment, env) combination.
+    # Then no row is written: refresh upserts matches, drops misses, and
+    # leaves never-matched pairs untouched.
     assert not SegmentMembershipCount.objects.filter(
         segment=segment, environment=environment
     ).exists()

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -368,12 +368,12 @@ Attributes:
 ### `segment_membership.refresh.project.completed`
 
 Logged at `info` from:
- - `api/segment_membership/tasks.py:194`
+ - `api/segment_membership/tasks.py:189`
 
 Attributes:
  - `membership_counts.count`
  - `project.id`
- - `zeroed_counts.count`
+ - `stale_counts.count`
 
 ### `segment_membership.refresh.project.failed`
 

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -368,7 +368,7 @@ Attributes:
 ### `segment_membership.refresh.project.completed`
 
 Logged at `info` from:
- - `api/segment_membership/tasks.py:189`
+ - `api/segment_membership/tasks.py:185`
 
 Attributes:
  - `membership_counts.count`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -368,7 +368,7 @@ Attributes:
 ### `segment_membership.refresh.project.completed`
 
 Logged at `info` from:
- - `api/segment_membership/tasks.py:191`
+ - `api/segment_membership/tasks.py:194`
 
 Attributes:
  - `membership_counts.count`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -368,11 +368,12 @@ Attributes:
 ### `segment_membership.refresh.project.completed`
 
 Logged at `info` from:
- - `api/segment_membership/tasks.py:170`
+ - `api/segment_membership/tasks.py:191`
 
 Attributes:
  - `membership_counts.count`
  - `project.id`
+ - `zeroed_counts.count`
 
 ### `segment_membership.refresh.project.failed`
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #5663.

`refresh_project_segment_counts` only upserts pairs returned by compute (count > 0), so a pair that previously matched but no longer does keeps its stale non-zero count forever. Append explicit zero rows for every `(segment, env)` pair already in the table that didn't appear in this run; pairs that have never matched stay absent.

## How did you test this code?

Added `test_refresh_project_segment_counts__previously_matching_pair_drops_to_zero__row_zeroed` and `test_refresh_project_segment_counts__never_matched_pair__no_row_written`.