### PR TITLE
fix(Segment membership): Read counts off segment.membership_counts

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -174,7 +174,7 @@ export type Segment = {
   project: string | number
   feature?: number
   metadata: Metadata[] | []
-  memberships?: SegmentMembership[]
+  membership_counts?: SegmentMembership[]
 }
 export type ProjectChangeRequest = Omit<
   ChangeRequest,

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -589,7 +589,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               <>
                 Identities
                 <SegmentMembershipTotalBadge
-                  memberships={segment.memberships}
+                  memberships={segment.membership_counts}
                 />
               </>
             }
@@ -606,7 +606,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 name={name}
                 searchInput={searchInput}
                 setSearchInput={setSearchInput}
-                memberships={segment.memberships}
+                memberships={segment.membership_counts}
               />
             </div>
           </TabItem>

--- a/frontend/web/components/segments/SegmentRow/SegmentRow.tsx
+++ b/frontend/web/components/segments/SegmentRow/SegmentRow.tsx
@@ -82,7 +82,7 @@ const SegmentRow: FC<SegmentRowProps> = ({ index, projectId, segment }) => {
           {feature && (
             <div className='chip chip--xs ml-2'>Feature-Specific</div>
           )}
-          <SegmentMembershipTotalBadge memberships={segment.memberships} />
+          <SegmentMembershipTotalBadge memberships={segment.membership_counts} />
         </Row>
         <div className='list-item-subtitle mt-1'>
           {description || 'No description'}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #5663.

The serializer ships per-segment counts as `membership_counts`; the chip was reading `segment.memberships`, which is always undefined, so no badge ever rendered on staging. Rename the optional field on the `Segment` response type to match and update the two call sites.

## How did you test this code?

`npx tsc --noEmit` clean. Verified the live staging segments response uses `membership_counts` for org 12804.