### PR TITLE
fix(experimentation): always insert new WarehouseConnection on create

### DIFF
--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -5,7 +5,6 @@ from rest_framework import serializers
 from environments.models import Environment
 from experimentation.models import (
     WarehouseConnection,
-    WarehouseConnectionStatus,
     WarehouseType,
 )
 from experimentation.types import SNOWFLAKE_DEFAULTS, SnowflakeConfig
@@ -50,23 +49,6 @@ class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignor
 
         if not validated_data.get("name"):
             validated_data["name"] = self._generate_name(warehouse_type, environment)
-
-        existing: WarehouseConnection | None = (
-            WarehouseConnection.objects.all_with_deleted()
-            .filter(
-                environment=environment,
-                warehouse_type=warehouse_type,
-                deleted_at__isnull=False,
-            )
-            .first()
-        )
-        if existing:
-            existing.deleted_at = None
-            existing.status = WarehouseConnectionStatus.CREATED
-            existing.name = validated_data["name"]
-            existing.config = validated_data.get("config")
-            existing.save()
-            return existing
 
         result: WarehouseConnection = super().create(validated_data)
         return result

--- a/api/tests/unit/experimentation/test_serializers.py
+++ b/api/tests/unit/experimentation/test_serializers.py
@@ -30,7 +30,7 @@ def test_create__no_existing__creates_new_connection(
     assert connection.name == f"Flagsmith Warehouse - {environment.name}"
 
 
-def test_create__soft_deleted_exists__resurrects_record(
+def test_create__soft_deleted_exists__creates_new_record(
     environment: Environment,
 ) -> None:
     # Given
@@ -51,7 +51,7 @@ def test_create__soft_deleted_exists__resurrects_record(
     connection = serializer.save(environment=environment)
 
     # Then
-    assert connection.pk == original_pk
+    assert connection.pk != original_pk
     assert connection.deleted_at is None
     assert connection.status == WarehouseConnectionStatus.CREATED
     assert connection.name == f"Flagsmith Warehouse - {environment.name}"

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -93,7 +93,7 @@ def test_post__different_type_already_exists__returns_409(
     )
 
 
-def test_post__soft_deleted_exists__resurrects_and_returns_201(
+def test_post__soft_deleted_exists__creates_new_record_and_returns_201(
     admin_client: APIClient,
     environment: Environment,
     enable_features: EnableFeaturesFixture,
@@ -114,7 +114,7 @@ def test_post__soft_deleted_exists__resurrects_and_returns_201(
 
     # Then
     assert response.status_code == status.HTTP_201_CREATED
-    assert response.json()["id"] == original_id
+    assert response.json()["id"] != original_id
     assert response.json()["status"] == "created"
 
 
@@ -487,7 +487,7 @@ def test_post__snowflake_no_name__auto_generates_name(
     assert response.json()["name"] == f"Snowflake Warehouse - {environment.name}"
 
 
-def test_post__snowflake_soft_deleted__resurrects_with_new_config(
+def test_post__snowflake_soft_deleted__creates_new_record_with_new_config(
     admin_client: APIClient,
     environment: Environment,
     enable_features: EnableFeaturesFixture,
@@ -516,7 +516,7 @@ def test_post__snowflake_soft_deleted__resurrects_with_new_config(
         warehouse_connection_url,
         data={
             "warehouse_type": "snowflake",
-            "name": "Resurrected",
+            "name": "Replacement",
             "config": {"account_identifier": "new.us-west-2"},
         },
         format="json",
@@ -525,9 +525,9 @@ def test_post__snowflake_soft_deleted__resurrects_with_new_config(
     # Then
     assert response.status_code == status.HTTP_201_CREATED
     data = response.json()
-    assert data["id"] == original_id
+    assert data["id"] != original_id
     assert data["status"] == "created"
-    assert data["name"] == "Resurrected"
+    assert data["name"] == "Replacement"
     assert data["config"]["account_identifier"] == "new.us-west-2"
 
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`WarehouseConnectionSerializer.create()` looked up a soft-deleted row for the same `(environment, warehouse_type)` and resurrected it by clearing `deleted_at` and calling `save()`. Because that path is an `UPDATE`, django-lifecycle's `@hook(AFTER_CREATE)` on `WarehouseConnection` never fired, and the environment key was never re-added to the ingestion Redis after a customer deleted and re-created a connection.

This PR drops the resurrect branch so create always performs an `INSERT`. The partial unique constraint `unique_active_warehouse_per_type_and_env` (conditioned on `deleted_at IS NULL`) already permits a fresh insert once the previous row is soft-deleted, and the "one active connection per environment" rule is still enforced by the 409 check in `WarehouseConnectionViewSet.create()`.

The two existing resurrect tests are rewritten to assert that a new PK is returned instead.

## How did you test this code?

- `pytest tests/unit/experimentation/` — all 46 tests pass.
- `mypy` clean on the touched files.