### PR TITLE
chore(Segment membership): Add CLICKHOUSE_URL to prod task defs

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -306,6 +306,10 @@
                 {
                     "name": "PYLON_IDENTITY_VERIFICATION_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:PYLON_IDENTITY_VERIFICATION_SECRET::"
+                },
+                {
+                    "name": "CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:clickhouse-url-kB2CK9"
                 }
             ],
             "logConfiguration": {

--- a/infrastructure/aws/production/ecs-task-definition-migration.json
+++ b/infrastructure/aws/production/ecs-task-definition-migration.json
@@ -51,6 +51,10 @@
                 {
                     "name": "DATABASE_URL",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:DATABASE_URL::"
+                },
+                {
+                    "name": "CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:clickhouse-url-kB2CK9"
                 }
             ],
             "logConfiguration": {

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -258,6 +258,10 @@
                 {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_KEY",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:FLAGSMITH_ON_FLAGSMITH_SERVER_KEY::"
+                },
+                {
+                    "name": "CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:clickhouse-url-kB2CK9"
                 }
             ],
             "logConfiguration": {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #5663.

Wire the prod `CLICKHOUSE_URL` secret into the three production task definitions that need a ClickHouse connection:

- `task-processor` — runs the segment-membership backfill + refresh recurring tasks.
- `admin-api` — serves the segments endpoints that read the counts.
- `migration` — so `clickhouse/0001_create_identities` actually applies on deploy instead of being silently skipped (`CLICKHOUSE_ENABLED` is `False` without the URL).

`sdk-api` is left untouched — it never touches the table. Mirrors the staging task defs.

## How did you test this code?

Validated all three files parse and expose `CLICKHOUSE_URL` pointing at `clickhouse-url-kB2CK9`. Same change shape that's already live on staging.