### PR TITLE
feat: added pagination and deletion guard

### DIFF
--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing
 
-from django.db import transaction
 from django.utils import timezone
 
 from audit.models import AuditLog
@@ -98,7 +97,6 @@ def transition_experiment_status(
     elif target_status == ExperimentStatus.COMPLETED:
         experiment.ended_at = timezone.now()
 
-    with transaction.atomic():
-        experiment.save()
-        create_experiment_audit_log(experiment, user, action=target_status)
+    experiment.save()
+    create_experiment_audit_log(experiment, user, action=target_status)
     return experiment

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+from django.db import transaction
 from django.utils import timezone
 
 from audit.models import AuditLog
@@ -97,6 +98,7 @@ def transition_experiment_status(
     elif target_status == ExperimentStatus.COMPLETED:
         experiment.ended_at = timezone.now()
 
-    experiment.save()
-    create_experiment_audit_log(experiment, user, action=target_status)
+    with transaction.atomic():
+        experiment.save()
+        create_experiment_audit_log(experiment, user, action=target_status)
     return experiment

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
 from app.pagination import CustomPagination
-
 from environments.views import NestedEnvironmentViewSet
 from experimentation.models import (
     Experiment,

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -1,13 +1,16 @@
 import logging
 from typing import Any
 
+from django.db import IntegrityError
 from django.db.models import Q, QuerySet
-from rest_framework import mixins, status
+from rest_framework import mixins, serializers, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
+
+from app.pagination import CustomPagination
 
 from environments.views import NestedEnvironmentViewSet
 from experimentation.models import (
@@ -101,7 +104,7 @@ class ExperimentViewSet(
     mixins.DestroyModelMixin,
 ):
     serializer_class = ExperimentSerializer
-    pagination_class = None
+    pagination_class = CustomPagination
     permission_classes = [IsAuthenticated, ExperimentPermission]
     model_class = Experiment
     lookup_field = "id"
@@ -125,6 +128,10 @@ class ExperimentViewSet(
             )
         status_filter = self.request.query_params.get("status")
         if status_filter:
+            if status_filter not in ExperimentStatus.values:
+                raise serializers.ValidationError(
+                    {"status": f"Invalid status '{status_filter}'."}
+                )
             qs = qs.filter(status=status_filter)
 
         q = self.request.query_params.get("q")
@@ -152,7 +159,13 @@ class ExperimentViewSet(
                 status=status.HTTP_409_CONFLICT,
             )
 
-        self.perform_create(serializer)
+        try:
+            self.perform_create(serializer)
+        except IntegrityError:
+            return Response(
+                {"detail": "An active experiment already exists for this feature."},
+                status=status.HTTP_409_CONFLICT,
+            )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def perform_create(self, serializer: BaseSerializer[Experiment]) -> None:
@@ -162,12 +175,28 @@ class ExperimentViewSet(
         )
 
     def perform_update(self, serializer: BaseSerializer[Experiment]) -> None:
+        changed_fields = {
+            field
+            for field, value in serializer.validated_data.items()
+            if getattr(serializer.instance, field, None) != value
+        }
+        if not changed_fields:
+            return
         experiment: Experiment = serializer.save()
         create_experiment_audit_log(
             experiment, self._get_user(self.request), action="updated"
         )
 
     def perform_destroy(self, instance: Experiment) -> None:
+        if instance.status == ExperimentStatus.RUNNING:
+            raise serializers.ValidationError(
+                {
+                    "detail": (
+                        "Cannot delete a running experiment. "
+                        "Pause or complete it first."
+                    )
+                }
+            )
         create_experiment_audit_log(
             instance, self._get_user(self.request), action="deleted"
         )

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.db.models import QuerySet
 from rest_framework import mixins, serializers, status
 from rest_framework.decorators import action
@@ -159,28 +159,22 @@ class ExperimentViewSet(
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def perform_create(self, serializer: BaseSerializer[Experiment]) -> None:
-        with transaction.atomic():
-            experiment: Experiment = serializer.save(
-                environment=self._get_environment()
-            )
-            create_experiment_audit_log(
-                experiment, self._get_user(self.request), action="created"
-            )
+        experiment: Experiment = serializer.save(environment=self._get_environment())
+        create_experiment_audit_log(
+            experiment, self._get_user(self.request), action="created"
+        )
 
     def perform_update(self, serializer: BaseSerializer[Experiment]) -> None:
-        changed_fields = {
-            field
+        has_changes = any(
+            getattr(serializer.instance, field, None) != value
             for field, value in serializer.validated_data.items()
-            if getattr(serializer.instance, field, None) != value
-        }
-        if not changed_fields:
-            serializer.save()
+        )
+        if not has_changes:
             return
-        with transaction.atomic():
-            experiment: Experiment = serializer.save()
-            create_experiment_audit_log(
-                experiment, self._get_user(self.request), action="updated"
-            )
+        experiment: Experiment = serializer.save()
+        create_experiment_audit_log(
+            experiment, self._get_user(self.request), action="updated"
+        )
 
     def perform_destroy(self, instance: Experiment) -> None:
         if instance.status == ExperimentStatus.RUNNING:
@@ -192,11 +186,10 @@ class ExperimentViewSet(
                     )
                 }
             )
-        with transaction.atomic():
-            create_experiment_audit_log(
-                instance, self._get_user(self.request), action="deleted"
-            )
-            instance.delete()
+        create_experiment_audit_log(
+            instance, self._get_user(self.request), action="deleted"
+        )
+        instance.delete()
 
     @action(detail=True, methods=["post"])
     def start(self, request: Request, **kwargs: object) -> Response:

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -1,14 +1,17 @@
 import logging
 from typing import Any
 
+from django.db import IntegrityError, transaction
 from django.db.models import QuerySet
-from rest_framework import mixins, status
+from rest_framework import mixins, serializers, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
+from app.pagination import CustomPagination
+from environments.models import Environment
 from environments.views import NestedEnvironmentViewSet
 from experimentation.models import (
     Experiment,
@@ -100,11 +103,16 @@ class ExperimentViewSet(
     mixins.DestroyModelMixin,
 ):
     serializer_class = ExperimentSerializer
-    pagination_class = None
+    pagination_class = CustomPagination
     permission_classes = [IsAuthenticated, ExperimentPermission]
     model_class = Experiment
     lookup_field = "id"
     lookup_url_kwarg = "experiment_id"
+
+    def _get_environment(self) -> Environment:
+        if not hasattr(self, "_environment"):
+            self._environment = super()._get_environment()
+        return self._environment
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
@@ -114,9 +122,13 @@ class ExperimentViewSet(
     def get_queryset(self) -> "QuerySet[Experiment]":
         qs = super().get_queryset()
         status_filter = self.request.query_params.get("status")
-        if status_filter:
-            qs = qs.filter(status=status_filter)
-        return qs
+        if not status_filter:
+            return qs
+        if status_filter not in ExperimentStatus.values:
+            raise serializers.ValidationError(
+                {"status": f"'{status_filter}' is not a valid status."}
+            )
+        return qs.filter(status=status_filter)
 
     def create(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = self.get_serializer(data=request.data)
@@ -137,26 +149,54 @@ class ExperimentViewSet(
                 status=status.HTTP_409_CONFLICT,
             )
 
-        self.perform_create(serializer)
+        try:
+            self.perform_create(serializer)
+        except IntegrityError:
+            return Response(
+                {"detail": "An active experiment already exists for this feature."},
+                status=status.HTTP_409_CONFLICT,
+            )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def perform_create(self, serializer: BaseSerializer[Experiment]) -> None:
-        experiment: Experiment = serializer.save(environment=self._get_environment())
-        create_experiment_audit_log(
-            experiment, self._get_user(self.request), action="created"
-        )
+        with transaction.atomic():
+            experiment: Experiment = serializer.save(
+                environment=self._get_environment()
+            )
+            create_experiment_audit_log(
+                experiment, self._get_user(self.request), action="created"
+            )
 
     def perform_update(self, serializer: BaseSerializer[Experiment]) -> None:
-        experiment: Experiment = serializer.save()
-        create_experiment_audit_log(
-            experiment, self._get_user(self.request), action="updated"
-        )
+        changed_fields = {
+            field
+            for field, value in serializer.validated_data.items()
+            if getattr(serializer.instance, field, None) != value
+        }
+        if not changed_fields:
+            serializer.save()
+            return
+        with transaction.atomic():
+            experiment: Experiment = serializer.save()
+            create_experiment_audit_log(
+                experiment, self._get_user(self.request), action="updated"
+            )
 
     def perform_destroy(self, instance: Experiment) -> None:
-        create_experiment_audit_log(
-            instance, self._get_user(self.request), action="deleted"
-        )
-        instance.delete()
+        if instance.status == ExperimentStatus.RUNNING:
+            raise serializers.ValidationError(
+                {
+                    "detail": (
+                        "Cannot delete a running experiment. "
+                        "Pause or complete it first."
+                    )
+                }
+            )
+        with transaction.atomic():
+            create_experiment_audit_log(
+                instance, self._get_user(self.request), action="deleted"
+            )
+            instance.delete()
 
     @action(detail=True, methods=["post"])
     def start(self, request: Request, **kwargs: object) -> Response:

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from django.db import IntegrityError
 from django.urls import reverse
+from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -629,3 +631,32 @@ def test_patch__no_change__skips_audit_log(
         related_object_type=RelatedObjectType.EXPERIMENT.name
     ).count()
     assert audit_count_after == audit_count_before
+
+
+def test_post__concurrent_create_race__returns_409(
+    admin_client_new: APIClient,
+    environment: Environment,
+    multivariate_feature: Feature,
+    enable_features: EnableFeaturesFixture,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    mocker.patch(
+        "experimentation.views.ExperimentViewSet.perform_create",
+        side_effect=IntegrityError(),
+    )
+
+    # When
+    response = admin_client_new.post(
+        _list_url(environment),
+        data={
+            "feature": multivariate_feature.id,
+            "name": "Race",
+            "hypothesis": "Should 409",
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -287,9 +287,9 @@ def test_get_list__with_experiments__returns_nested_feature(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-    assert len(data) == 1
-    feature_data = data[0]["feature"]
+    results = response.json()["results"]
+    assert len(results) == 1
+    feature_data = results[0]["feature"]
     assert isinstance(feature_data, dict)
     assert feature_data["id"] == multivariate_feature.id
     assert feature_data["name"] == multivariate_feature.name
@@ -377,8 +377,9 @@ def test_get_list__search_by_experiment_name__returns_matching(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json()[0]["id"] == experiment.id
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == experiment.id
 
 
 def test_get_list__search_by_feature_name__returns_matching(
@@ -398,8 +399,9 @@ def test_get_list__search_by_feature_name__returns_matching(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json()[0]["id"] == experiment.id
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == experiment.id
 
 
 def test_get_list__search_no_match__returns_empty(
@@ -416,7 +418,7 @@ def test_get_list__search_no_match__returns_empty(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 0
+    assert len(response.json()["results"]) == 0
 
 
 def test_get_detail__exists__returns_200(

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -265,8 +265,9 @@ def test_get_list__with_experiments__returns_all(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json()[0]["id"] == experiment.id
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == experiment.id
 
 
 def test_get_list__empty__returns_200(
@@ -282,7 +283,7 @@ def test_get_list__empty__returns_200(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
+    assert response.json()["results"] == []
 
 
 @pytest.mark.parametrize(
@@ -310,7 +311,7 @@ def test_get_list__filter_by_status__returns_filtered(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == expected_count
+    assert len(response.json()["results"]) == expected_count
 
 
 def test_get_detail__exists__returns_200(
@@ -567,3 +568,64 @@ def test_delete__valid_delete__creates_audit_log(
     ).last()
     assert audit is not None
     assert "deleted" in audit.log
+
+
+def test_get_list__invalid_status__returns_400(
+    admin_client_new: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When
+    response = admin_client_new.get(_list_url(environment), {"status": "garbage"})
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_delete__running_experiment__returns_400(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    experiment.status = ExperimentStatus.RUNNING
+    experiment.save()
+
+    # When
+    response = admin_client_new.delete(_detail_url(environment, experiment))
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert Experiment.objects.filter(id=experiment.id).exists()
+
+
+def test_patch__no_change__skips_audit_log(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    audit_count_before = AuditLog.objects.filter(
+        related_object_type=RelatedObjectType.EXPERIMENT.name
+    ).count()
+
+    # When
+    response = admin_client_new.patch(
+        _detail_url(environment, experiment),
+        data={"name": experiment.name},
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    audit_count_after = AuditLog.objects.filter(
+        related_object_type=RelatedObjectType.EXPERIMENT.name
+    ).count()
+    assert audit_count_after == audit_count_before


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Wrap experiment mutations and status transitions in `transaction.atomic`, and return `409` (instead of 500) on concurrent-create
  races.
- Validate `?status=` against `ExperimentStatus`, block `DELETE` on running experiments, and skip the audit log on no-op `PATCH`.
- Paginate the list endpoint with `CustomPagination` and use `_get_environment()` per request.
- Prevent deleting a running experiment

## How did you test this code?
- new tests