### PR TITLE
feat: added search query to get experiment endpoints

### DIFF
--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from rest_framework import mixins, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -116,6 +116,11 @@ class ExperimentViewSet(
         status_filter = self.request.query_params.get("status")
         if status_filter:
             qs = qs.filter(status=status_filter)
+
+        q = self.request.query_params.get("q")
+        if q:
+            qs = qs.filter(Q(name__icontains=q) | Q(feature__name__icontains=q))
+
         return qs
 
     def create(self, request: Request, *args: object, **kwargs: object) -> Response:

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -323,7 +323,7 @@ def test_get_list__search_by_experiment_name__returns_matching(
     enable_features(EXPERIMENT_FLAG)
 
     # When
-    response = admin_client_new.get(_list_url(environment), {"q": "Test Exp"})
+    response = admin_client_new.get(_list_url(environment), {"q": experiment.name[:4]})
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -313,6 +313,62 @@ def test_get_list__filter_by_status__returns_filtered(
     assert len(response.json()) == expected_count
 
 
+def test_get_list__search_by_experiment_name__returns_matching(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When
+    response = admin_client_new.get(_list_url(environment), {"q": "Test Exp"})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 1
+    assert response.json()[0]["id"] == experiment.id
+
+
+def test_get_list__search_by_feature_name__returns_matching(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    multivariate_feature: Feature,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When
+    response = admin_client_new.get(
+        _list_url(environment), {"q": multivariate_feature.name}
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 1
+    assert response.json()[0]["id"] == experiment.id
+
+
+def test_get_list__search_no_match__returns_empty(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When
+    response = admin_client_new.get(_list_url(environment), {"q": "nonexistent"})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 0
+
+
 def test_get_detail__exists__returns_200(
     admin_client_new: APIClient,
     environment: Environment,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Given implementation of pagination, it is necessary that the backend handles experiment search
- Added a `q` query param search

## How did you test this code?
- tests