### PR TITLE
fix: feature_segment missing in versioning

### DIFF
--- a/api/features/versioning/serializers.py
+++ b/api/features/versioning/serializers.py
@@ -161,7 +161,7 @@ class EnvironmentFeatureVersionCreateSerializer(EnvironmentFeatureVersionSeriali
         return [
             fs["feature_segment"]["segment"]
             for fs in self.initial_data.get("feature_states_to_create", [])
-            if fs["feature_segment"] is not None
+            if fs.get("feature_segment") is not None
         ]
 
     @transaction.atomic

--- a/api/tests/unit/features/versioning/test_unit_versioning_views.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_views.py
@@ -1001,6 +1001,46 @@ def test_create_version__non_segment_override_in_create_list__returns_bad_reques
     }
 
 
+def test_create_version__missing_feature_segment_key__returns_bad_request(
+    environment_v2_versioning: Environment,
+    feature: Feature,
+    admin_client_new: APIClient,
+) -> None:
+    # Given
+    # A payload where `feature_segment` key is omitted entirely
+    # (as opposed to being explicitly set to None).
+    # This previously caused a KeyError -> 500 Internal Server Error.
+    data = {
+        "feature_states_to_create": [
+            {
+                # `feature_segment` key is intentionally absent
+                "enabled": True,
+                "feature_state_value": {
+                    "type": "unicode",
+                    "string_value": "some new value",
+                },
+            }
+        ]
+    }
+
+    url = reverse(
+        "api-v1:versioning:environment-feature-versions-list",
+        args=[environment_v2_versioning.id, feature.id],
+    )
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    # Should return 400 Bad Request, not 500 Internal Server Error
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "message": "Cannot create FeatureState objects that are not segment overrides."
+    }
+
+
 def test_create_version__duplicate_segment_override__returns_bad_request(
     feature: Feature,
     admin_client_new: APIClient,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7587 

Fixes a 500 error that occurs when `feature_segment` is completely missing from `feature_states_to_create`. 

Swapped `fs["feature_segment"]` for `fs.get("feature_segment")` in `segment_ids_to_create_overrides` to safely handle missing keys and prevent `KeyError` crashes. The existing validation now correctly catches this and returns a 400.

## How did you test this code?

Added a test case verifying that a payload entirely missing the `feature_segment` key returns a 400 with the proper error message instead of a 500.