### PR TITLE
feat: return experiment status counts along paginated list

### DIFF
--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -143,10 +143,7 @@ class ExperimentViewSet(
         response = super().list(request, *args, **kwargs)
         base_qs = super().get_queryset()
         counts = base_qs.aggregate(
-            **{
-                s.value: Count("id", filter=Q(status=s.value))
-                for s in ExperimentStatus
-            }
+            **{s.value: Count("id", filter=Q(status=s.value)) for s in ExperimentStatus}
         )
         response.data["status_counts"] = counts
         return response

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -142,6 +142,11 @@ class ExperimentViewSet(
     def list(self, request: Request, *args: object, **kwargs: object) -> Response:
         response = super().list(request, *args, **kwargs)
         base_qs = super().get_queryset()
+        q = request.query_params.get("q")
+        if q:
+            base_qs = base_qs.filter(
+                Q(name__icontains=q) | Q(feature__name__icontains=q)
+            )
         counts = base_qs.aggregate(
             **{
                 s.value: Count("id", filter=Q(status=s.value))

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from django.db.models import QuerySet
+from django.db.models import Count, Q, QuerySet
 from rest_framework import mixins, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
+from app.pagination import CustomPagination
 from environments.views import NestedEnvironmentViewSet
 from experimentation.models import (
     Experiment,
@@ -100,7 +101,7 @@ class ExperimentViewSet(
     mixins.DestroyModelMixin,
 ):
     serializer_class = ExperimentSerializer
-    pagination_class = None
+    pagination_class = CustomPagination
     permission_classes = [IsAuthenticated, ExperimentPermission]
     model_class = Experiment
     lookup_field = "id"
@@ -117,6 +118,18 @@ class ExperimentViewSet(
         if status_filter:
             qs = qs.filter(status=status_filter)
         return qs
+
+    def list(self, request: Request, *args: object, **kwargs: object) -> Response:
+        response = super().list(request, *args, **kwargs)
+        base_qs = super().get_queryset()
+        counts = base_qs.aggregate(
+            **{
+                s.value: Count("id", filter=Q(status=s.value))
+                for s in ExperimentStatus
+            }
+        )
+        response.data["status_counts"] = counts
+        return response
 
     def create(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = self.get_serializer(data=request.data)

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -483,6 +483,26 @@ def test_get_list__filtered__status_counts_reflect_all(
     assert data["status_counts"]["running"] == 0
 
 
+def test_get_list__searched__status_counts_reflect_search(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When
+    response = admin_client_new.get(_list_url(environment), {"q": "nonexistent"})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data["results"]) == 0
+    assert data["status_counts"]["created"] == 0
+    assert data["status_counts"]["running"] == 0
+
+
 def test_get_detail__exists__returns_200(
     admin_client_new: APIClient,
     environment: Environment,

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -472,7 +472,7 @@ def test_get_list__filtered__status_counts_reflect_all(
     # Given
     enable_features(EXPERIMENT_FLAG)
 
-    # When — filter to running (no results), but counts should still show all
+    # When
     response = admin_client_new.get(_list_url(environment), {"status": "running"})
 
     # Then

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -265,8 +265,9 @@ def test_get_list__with_experiments__returns_all(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json()[0]["id"] == experiment.id
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == experiment.id
 
 
 def test_get_list__empty__returns_200(
@@ -282,7 +283,7 @@ def test_get_list__empty__returns_200(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
+    assert response.json()["results"] == []
 
 
 @pytest.mark.parametrize(
@@ -310,7 +311,69 @@ def test_get_list__filter_by_status__returns_filtered(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == expected_count
+    assert len(response.json()["results"]) == expected_count
+
+
+def test_get_list__with_experiments__returns_status_counts(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    multivariate_feature: Feature,
+    enable_features: EnableFeaturesFixture,
+    project: Project,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    second_feature = Feature.objects.create(
+        project=project,
+        name="second_mv_feature",
+        type=MULTIVARIATE,
+        initial_value="control",
+    )
+    running_experiment = Experiment.objects.create(
+        environment=environment,
+        feature=second_feature,
+        name="Running experiment",
+        hypothesis="Test",
+        status=ExperimentStatus.RUNNING,
+    )
+
+    # When
+    response = admin_client_new.get(_list_url(environment))
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["status_counts"] == {
+        "created": 1,
+        "running": 1,
+        "paused": 0,
+        "completed": 0,
+    }
+    assert len(data["results"]) == 2
+
+    # Clean up
+    running_experiment.delete()
+
+
+def test_get_list__filtered__status_counts_reflect_all(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When — filter to running (no results), but counts should still show all
+    response = admin_client_new.get(_list_url(environment), {"status": "running"})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data["results"]) == 0
+    assert data["status_counts"]["created"] == 1
+    assert data["status_counts"]["running"] == 0
 
 
 def test_get_detail__exists__returns_200(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Added `status_counts` object to pass each status number of experiments:
```
{
  created: 3,
  running: 2,
  completed: 54
}
```

## How did you test this code?
- tests