### PR TITLE
feat(experiment): use backend type filter for multivariate features

### DIFF
--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -26,6 +26,7 @@ import {
   ChangeRequest,
   FlagsmithValue,
   TagStrategy,
+  FeatureType,
 } from './responses'
 import { UtmsType } from './utms'
 
@@ -897,6 +898,7 @@ export type Req = {
     sort_field?: string
     sort_direction?: 'ASC' | 'DESC'
     identity?: string
+    type?: FeatureType
   }
   updateFeatureState: {
     environmentId: string

--- a/frontend/documentation/components/ContentCard.stories.tsx
+++ b/frontend/documentation/components/ContentCard.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { Meta, StoryObj } from 'storybook'
 
 import ContentCard from 'components/base/grid/ContentCard'
+import Button from 'components/base/forms/Button'
 
 const meta: Meta<typeof ContentCard> = {
   component: ContentCard,
@@ -43,7 +44,11 @@ export const WithAction: Story = {
   render: () => (
     <ContentCard
       title='Feature flag'
-      action={<button className='btn btn-sm btn-primary'>Edit</button>}
+      action={
+        <Button theme='primary' size='small'>
+          Edit
+        </Button>
+      }
     >
       <p className='text-muted fs-small mb-0'>
         The flag you&apos;re experimenting on. Variations are read-only, defined

--- a/frontend/documentation/components/ContentCard.stories.tsx
+++ b/frontend/documentation/components/ContentCard.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+
+import ContentCard from 'components/base/grid/ContentCard'
+
+const meta: Meta<typeof ContentCard> = {
+  component: ContentCard,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A surface card with an optional title and action slot. Used as a section container in wizards and detail pages.',
+      },
+    },
+    layout: 'padded',
+  },
+  title: 'Components/Grid/ContentCard',
+}
+export default meta
+
+type Story = StoryObj<typeof ContentCard>
+
+export const Default: Story = {
+  render: () => (
+    <ContentCard title='Experiment details'>
+      <p className='text-muted fs-small mb-0'>
+        Name the experiment and capture what you&apos;re trying to learn before
+        picking a flag.
+      </p>
+    </ContentCard>
+  ),
+}
+
+export const WithAction: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass an `action` node to render a button or link in the card header.',
+      },
+    },
+  },
+  render: () => (
+    <ContentCard
+      title='Feature flag'
+      action={<button className='btn btn-sm btn-primary'>Edit</button>}
+    >
+      <p className='text-muted fs-small mb-0'>
+        The flag you&apos;re experimenting on. Variations are read-only, defined
+        on the flag itself.
+      </p>
+    </ContentCard>
+  ),
+}
+
+export const NoTitle: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Without a title, the card renders as a plain content surface.',
+      },
+    },
+  },
+  render: () => (
+    <ContentCard>
+      <p className='mb-0'>
+        This card has no header — just content inside a bordered surface.
+      </p>
+    </ContentCard>
+  ),
+}

--- a/frontend/documentation/components/VariationTable.stories.tsx
+++ b/frontend/documentation/components/VariationTable.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from 'storybook'
+
+import VariationTable from 'components/experiments/VariationTable'
+import { MultivariateOption } from 'common/types/responses'
+
+const TWO_VARIATIONS: MultivariateOption[] = [
+  {
+    boolean_value: false,
+    default_percentage_allocation: 50,
+    id: 1,
+    string_value: 'variant-a',
+    type: 'unicode',
+    uuid: 'a1',
+  },
+  {
+    boolean_value: false,
+    default_percentage_allocation: 50,
+    id: 2,
+    string_value: 'variant-b',
+    type: 'unicode',
+    uuid: 'b2',
+  },
+]
+
+const MANY_VARIATIONS: MultivariateOption[] = [
+  {
+    boolean_value: false,
+    default_percentage_allocation: 25,
+    id: 1,
+    string_value: 'small-hero',
+    type: 'unicode',
+    uuid: 'v1',
+  },
+  {
+    boolean_value: false,
+    default_percentage_allocation: 25,
+    id: 2,
+    integer_value: 42,
+    string_value: '',
+    type: 'int',
+    uuid: 'v2',
+  },
+  {
+    boolean_value: true,
+    default_percentage_allocation: 25,
+    id: 3,
+    string_value: '',
+    type: 'bool',
+    uuid: 'v3',
+  },
+  {
+    boolean_value: false,
+    default_percentage_allocation: 15,
+    id: 4,
+    string_value: 'large-hero',
+    type: 'unicode',
+    uuid: 'v4',
+  },
+  {
+    boolean_value: false,
+    default_percentage_allocation: 10,
+    id: 5,
+    string_value: 'extra-large-hero',
+    type: 'unicode',
+    uuid: 'v5',
+  },
+]
+
+const meta: Meta<typeof VariationTable> = {
+  component: VariationTable,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Displays a feature flag's control value and multivariate options in a read-only table. Used in the experiment wizard to preview variations.",
+      },
+    },
+    layout: 'padded',
+  },
+  title: 'Components/Experiments/VariationTable',
+}
+export default meta
+
+type Story = StoryObj<typeof VariationTable>
+
+export const Default: Story = {
+  args: {
+    controlValue: 'default-button',
+    variations: TWO_VARIATIONS,
+  },
+}
+
+export const ManyVariations: Story = {
+  args: {
+    controlValue: 'control-value',
+    variations: MANY_VARIATIONS,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A table with multiple variation types (unicode, int, bool) showing how different value types render.',
+      },
+    },
+  },
+}

--- a/frontend/web/components/experiments/VariationTable/VariationTable.scss
+++ b/frontend/web/components/experiments/VariationTable/VariationTable.scss
@@ -24,7 +24,7 @@
     }
 
     &--value {
-      width: 100px;
+      min-width: 120px;
     }
   }
 
@@ -57,8 +57,9 @@
     }
 
     &--value {
-      width: 120px;
+      min-width: 120px;
       flex-shrink: 0;
+      word-break: break-word;
     }
   }
 

--- a/frontend/web/components/experiments/steps/SetupStep.tsx
+++ b/frontend/web/components/experiments/steps/SetupStep.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useMemo } from 'react'
+import { ChangeEvent, FC } from 'react'
 import { ProjectFlag } from 'common/types/responses'
 import { useGetFeatureListQuery } from 'common/services/useProjectFlag'
 import { useProjectEnvironments } from 'common/hooks/useProjectEnvironments'
@@ -42,14 +42,12 @@ const SetupStep: FC<SetupStepProps> = ({
         page_size: 50,
         projectId,
         search: search || undefined,
+        type: 'MULTIVARIATE',
       },
       { skip: !numericEnvId },
     )
 
-  const multivariateFeatures = useMemo(() => {
-    if (!featureList?.results) return []
-    return featureList.results.filter((f) => f.type === 'MULTIVARIATE')
-  }, [featureList])
+  const multivariateFeatures = featureList?.results ?? []
 
   return (
     <div className='d-flex flex-column gap-4'>
@@ -106,18 +104,21 @@ const SetupStep: FC<SetupStepProps> = ({
                 : null
             }
             options={multivariateFeatures.map((f) => ({
+              feature: f,
               label: f.name,
               value: f.id,
             }))}
             onInputChange={(val: string) => setSearchInput(val)}
-            onChange={(option: { label: string; value: number } | null) => {
-              if (option) {
-                const feature = multivariateFeatures.find(
-                  (f) => f.id === option.value,
-                )
-                if (feature) onFeatureSelect(feature)
-              }
+            onChange={(
+              option: {
+                feature: ProjectFlag
+                label: string
+                value: number
+              } | null,
+            ) => {
+              if (option) onFeatureSelect(option.feature)
             }}
+            filterOption={(options: unknown[]) => options}
             isLoading={isFeaturesLoading}
             placeholder='Search for a multivariate feature...'
             isClearable={false}

--- a/frontend/web/components/experiments/steps/SetupStep.tsx
+++ b/frontend/web/components/experiments/steps/SetupStep.tsx
@@ -118,7 +118,6 @@ const SetupStep: FC<SetupStepProps> = ({
             ) => {
               if (option) onFeatureSelect(option.feature)
             }}
-            filterOption={(options: unknown[]) => options}
             isLoading={isFeaturesLoading}
             placeholder='Search for a multivariate feature...'
             isClearable={false}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7596

- Use backend `type=MULTIVARIATE` query param instead of client-side filtering in the experiment wizard feature select — fixes pagination issues where multivariate flags on later pages were invisible
- Attach full `ProjectFlag` object to Select options, removing the `.find()` lookup that could hit race conditions during search
- Disable react-select client-side filtering since results are already server-filtered
- Add Storybook stories for `VariationTable` and `ContentCard` components

## How did you test this code?

- Open experiment creation wizard, confirm feature select only shows multivariate flags
- Type in the select — verify server-side search works (debounced)
- Select a feature — verify variation table renders correctly
- Run Storybook and check VariationTable and ContentCard stories render