### PR TITLE
deps: Use uv supported by dependabot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: flagsmith-lint-tests
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.14  # Ensure this matches the version in api/pyproject.toml
+    rev: 0.11.8  # Ensure this matches the version in api/pyproject.toml
     hooks:
       - id: uv-lock
         args: ["--project", "api", "--check"]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -185,7 +185,7 @@ flagsmith-private = { index = "flagsmith-pypi-production" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 
 [tool.uv]
-required-version = "0.11.14"  # Ensure this matches the version in .pre-commit-config.yaml
+required-version = "0.11.8"  # Ensure this matches the version in .pre-commit-config.yaml
 # Pin every resolved package to the exact version that api/poetry.lock used on
 # main before this migration, so the poetry -> uv switch is dependency-neutral.
 # Keep this list in sync with poetry.lock until the lockfile churn settles.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Downgrade `uv` to `0.11.8` since this is the latest version supported by dependabot (for unknown, and baffling reasons). 

<img width="976" height="192" alt="image" src="https://github.com/user-attachments/assets/df871980-c1c3-4e95-b503-015b93ade237" />

## How did you test this code?

n/a
