### PR TITLE
fix: return 400 instead of 500 when request user is invalid (closes #6809)

### DIFF
--- a/api/core/dataclasses.py
+++ b/api/core/dataclasses.py
@@ -16,10 +16,11 @@ class AuthorData:
     @classmethod
     def from_request(cls, request: "Request") -> "AuthorData":
         from users.models import FFAdminUser
+        from rest_framework.exceptions import ValidationError
 
         if type(request.user) is FFAdminUser:
             return cls(user=request.user)
         elif hasattr(request.user, "key"):
             return cls(api_key=request.user.key)
         else:
-            raise ValueError("Request user must be FFAdminUser or have an API key")
+            raise ValidationError("Request user must be FFAdminUser or have an API key")

--- a/api/core/dataclasses.py
+++ b/api/core/dataclasses.py
@@ -15,8 +15,9 @@ class AuthorData:
 
     @classmethod
     def from_request(cls, request: "Request") -> "AuthorData":
-        from users.models import FFAdminUser
         from rest_framework.exceptions import ValidationError
+
+        from users.models import FFAdminUser
 
         if type(request.user) is FFAdminUser:
             return cls(user=request.user)


### PR DESCRIPTION
## What
When a request has an unexpected user type (e.g., anonymous, or a user model that is neither FFAdminUser nor an API key), `AuthorData.from_request` raises a bare `ValueError`. This propagates to database operations where unvalidated input (like a string 'PROJECT_ID' for an integer field) causes a similar `ValueError`, resulting in a 500 Internal Server Error.

## Fix
Replaced the generic `ValueError` with Django REST Framework's `ValidationError`, which automatically results in an HTTP 400 Bad Request response. This aligns with the project's goal of validating input early and returning proper error responses.

Closes #6809