### PR TITLE
chore(sentry): Reduce admin API trace sample rates to control costs

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -227,7 +227,11 @@
                 },
                 {
                     "name": "DASHBOARD_ENDPOINTS_SENTRY_TRACE_SAMPLE_RATE",
-                    "value": "0.5"
+                    "value": "0.02"
+                },
+                {
+                    "name": "SENTRY_TRACE_SAMPLE_RATE",
+                    "value": "0"
                 },
                 {
                     "name": "INGESTION_REDIS_URL",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Reduces Sentry performance tracing sample rates on the admin API ECS task definition to bring usage within quota.

- `DASHBOARD_ENDPOINTS_SENTRY_TRACE_SAMPLE_RATE`: `0.5` → `0.02` (2%)
- `SENTRY_TRACE_SAMPLE_RATE`: added explicitly as `0` (was defaulting to `1.0` in Django settings)

The admin API was receiving ~60K requests/hour. At 50% sampling that generated ~720K traces/day, exhausting the 2M monthly plan quota in under 4 days and triggering on-demand overage charges. At 2% the expected volume is ~1M traces/month, well within quota.

## How did you test this code?

Configuration-only change to the ECS task definition. Verified by reviewing the sampler logic in `api/integrations/sentry/samplers.py` and the Django settings defaults in `api/app/settings/common.py` to confirm the env var names and that the fallback default for `SENTRY_TRACE_SAMPLE_RATE` is `1.0` when unset.