### PR TITLE
docs: Consolidate PR collaboration guide to Flagsmith/AGENTS.md

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,1 @@
+Follow https://github.com/Flagsmith/AGENTS.md/blob/main/PR_COLLABORATION.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ If you are prepared to contribute but are uncertain as to how, consider narrowin
 ## Submit a PR
 
 1. The target branch should always be set to `main`, unless otherwise asked in the respective issue.
-1. Feel free to open a draft pull request. If you open a regular PR, a reviewer will be assigned immediately and your PR will be considered ready for review, unless you specify otherwise in a PR comment. You're welcome to use a PR to run checks against unfinished code.
-1. Once you have addressed the review feedback, preferably in new commits, reply to review comments, ensure the checks are passing and re-request a review. It is okay to not address the nitpicks and notes.
 1. An approved PR is eventually merged into `main`. Documentation changes will get deployed immediately afterwards. Your frontend changes will get deployed to SaaS, and you can expect both backend and frontend changes to be included in the next release.
+
+For how we write PR titles and descriptions, structure reviews, and address feedback, see [PR_COLLABORATION.md](https://github.com/Flagsmith/AGENTS.md/blob/main/PR_COLLABORATION.md). It's the guide our team and review agents follow, and you're welcome to follow it too.
 
 ## Setup local development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you are prepared to contribute but are uncertain as to how, consider narrowin
 1. The target branch should always be set to `main`, unless otherwise asked in the respective issue.
 1. An approved PR is eventually merged into `main`. Documentation changes will get deployed immediately afterwards. Your frontend changes will get deployed to SaaS, and you can expect both backend and frontend changes to be included in the next release.
 
-For how we write PR titles and descriptions, structure reviews, and address feedback, see [PR_COLLABORATION.md](https://github.com/Flagsmith/AGENTS.md/blob/main/PR_COLLABORATION.md). It's the guide our team and review agents follow, and you're welcome to follow it too.
+To learn how we write PR titles and descriptions, structure reviews, and address feedback, see [PR_COLLABORATION.md](https://github.com/Flagsmith/AGENTS.md/blob/main/PR_COLLABORATION.md). It's the guide our team and review agents follow, and we encourage you to follow it as well.
 
 ## Setup local development
 


### PR DESCRIPTION
Our pull-request playbook now lives at https://github.com/Flagsmith/AGENTS.md so it can be shared across repositories and consumed by review agents from a single source. This PR consolidates Flagsmith's own references against that new home.

## Changes

- [x] `CONTRIBUTING.md` points contributors at the consolidated playbook in `Flagsmith/AGENTS.md` and drops the steps now covered there (draft PRs, addressing feedback).
- [x] `.gemini/styleguide.md` directs Gemini Code Assist at the same playbook. The styleguide is only consulted once `.gemini/config.yaml` is in place — should land in #7577.

> [!NOTE]
> I'm not sure if Gemini will follow the link, or only read inline instructions. We'll see. IMO guidelines aren't much relevant to Gemini reviews anyway.

Closes Flagsmith/AGENTS.md#1

Review effort: 1/5