### PR TITLE
docs: Remove CI/CD overview link

### DIFF
--- a/docs/docs/third-party-integrations/ci-cd/index.md
+++ b/docs/docs/third-party-integrations/ci-cd/index.md
@@ -1,8 +1,0 @@
----
-title: CI/CD Overview
-sidebar_label: Overview
----
-
-Flagsmith can be integrated into your Continuous Integration and Continuous Deployment (CI/CD) pipelines to help you automate your feature flag management. By managing your flags as code, you can ensure that your feature flag configurations are version-controlled, repeatable, and aligned with your code deployments.
-
-This section covers the tools and providers that allow you to integrate Flagsmith into your CI/CD workflows. 

--- a/docs/docs/third-party-integrations/index.mdx
+++ b/docs/docs/third-party-integrations/index.mdx
@@ -81,7 +81,9 @@ Monitor flag performance and get alerts with APM tools to ensure proper operatio
 
 <Card>
     <h3>
-        <Link to="/third-party-integrations/observability-and-monitoring/grafana">Grafana & Prometheus Integration</Link>
+        <Link to="/third-party-integrations/observability-and-monitoring/grafana">
+            Grafana & Prometheus Integration
+        </Link>
     </h3>
     <p>Open-source monitoring and analytics</p>
 </Card>
@@ -157,13 +159,6 @@ deployments.
         <Link to="/third-party-integrations/ci-cd/terraform">Terraform Provider</Link>
     </h3>
     <p>Infrastructure as code automation</p>
-</Card>
-
-<Card>
-    <h3>
-        <Link to="/third-party-integrations/ci-cd">CI/CD Overview</Link>
-    </h3>
-    <p>Get started with continuous integration and deployment</p>
 </Card>
 
 </div>


### PR DESCRIPTION
## What changed

- Removed the redundant CI/CD Overview docs page so the CI/CD sidebar item behaves as an expandable category.
- Removed the Third-Party Integrations landing-page card that linked to the removed overview page.
- Left the CI/CD category metadata and Terraform child page in place.

## Why

The CI/CD section was the only Third-Party Integrations top-level category with a direct overview-page link, making it behave differently from the other integration categories.

Fixes #7454.

## Validation

- `make install-hooks`
- `npx prettier docs/third-party-integrations/index.mdx --write`
- `npx prettier docs/third-party-integrations/index.mdx --check`
- `npm run build`

Note: `make lint` currently stops on pre-existing Prettier drift across the docs tree before it reaches the build step. The direct Docusaurus build completed successfully; it still reports one unrelated existing broken anchor from `/deployment-self-hosting/core-configuration/running-flagsmith-on-flagsmith` to `/administration-and-security/access-control/oauth#github`.