### PR TITLE
fix(frontend): prevent error when inputRef is undefined

### DIFF
--- a/frontend/web/components/pages/CreateOrganisationPage.tsx
+++ b/frontend/web/components/pages/CreateOrganisationPage.tsx
@@ -66,9 +66,7 @@ const CreateOrganisationPage: React.FC = () => {
   useEffect(() => {
     API.trackPage(Constants.pages.CREATE_ORGANISATION)
     focusTimeout.current = setTimeout(() => {
-      if (inputRef.current && typeof inputRef.current.focus === 'function') {
-        inputRef.current.focus()
-      }
+      inputRef.current?.focus?.()
       focusTimeout.current = null
     }, 500)
 

--- a/frontend/web/components/pages/CreateOrganisationPage.tsx
+++ b/frontend/web/components/pages/CreateOrganisationPage.tsx
@@ -66,7 +66,9 @@ const CreateOrganisationPage: React.FC = () => {
   useEffect(() => {
     API.trackPage(Constants.pages.CREATE_ORGANISATION)
     focusTimeout.current = setTimeout(() => {
-      inputRef.current?.focus()
+      if (inputRef.current && typeof inputRef.current.focus === 'function') {
+        inputRef.current.focus()
+      }
       focusTimeout.current = null
     }, 500)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✓] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [✓] I have added information to `docs/` if required so people know about the feature.
- [✓] I have filled in the "Changes" section below.
- [✓] I have filled in the "How did you test this code" section below.

## Changes

Closes to #7537 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

It's a problem that happens inside useEffect hook. This hook is used to help the page to focus the screen on a certain HTML element using useRef hook, which is assigned to inputRef.

We can see that the n.input is undefined when it's trying to execute method focus, so the inputRef has not been set.  To prevent this from happening, I propose an explicit check to verify that:

1. inputRef.current exists and isn't null
2. inputRef.current.focus is actually a function before attempting to call it

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. Run both the backend and frontend in my local
2. User will be prompted to create an account. Click next
3. User's cursor will be automatically focused on inputting Organization's Name

Video: 

[Screencast from 30-05-26 17:40:29.webm](https://github.com/user-attachments/assets/7a9fe7dc-29d0-4ef7-b83c-89c36a2fd402)



