### PR TITLE
docs: Update docs custom ssr to use new instance instead of singleton

### DIFF
--- a/docs/docs/integrating-with-flagsmith/sdks/client-side-sdks/nextjs-and-ssr.md
+++ b/docs/docs/integrating-with-flagsmith/sdks/client-side-sdks/nextjs-and-ssr.md
@@ -202,6 +202,11 @@ The same can be accomplished without using Next.js.
 Step 1: Initialising the SDK and passing the resulting state to the client.
 
 ```javascript
+import { createFlagsmithInstance } from "@flagsmith/flagsmith/isomorphic";
+
+// Create a fresh instance per request to prevent identity leaking across concurrent SSR requests
+const flagsmith = createFlagsmithInstance();
+
 await flagsmith.init({
  // fetches flags on the server
  environmentID: '<YOUR_ENVIRONMENT_KEY>',


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [X] I have added information to `docs/` if required so people know about the feature.
- [X] I have filled in the "Changes" section below.
- [X] I have filled in the "How did you test this code" section below.

## Changes

Updating the documentation for custom SSR as I think it is a bit misleading. 
I thought that the flagsmith init would be straight from flagsmith/isomorphic.
Which created issues in my SSR setup.

The documentation is showing to use createFlagsmithInstance which also reflects how the Next js is setup.

## How did you test this code?

Just documentation changes.