### PR TITLE
feat(permissions): Add sorting feature for Users based on role

### DIFF
--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -22,7 +22,12 @@ import Switch from './Switch'
 import TabItem from './navigation/TabMenu/TabItem'
 import Tabs from './navigation/TabMenu/Tabs'
 import UserGroupList from './UserGroupList'
-import { PermissionLevel, Req, PermissionRoleType } from 'common/types/requests'
+import {
+  PermissionLevel,
+  Req,
+  PermissionRoleType,
+  SortOrder,
+} from 'common/types/requests'
 import { useGetAvailablePermissionsQuery } from 'common/services/useAvailablePermissions'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Icon from './icons/Icon'
@@ -1086,7 +1091,17 @@ const EditPermissions: FC<EditPermissionsType> = (props) => {
       >
         <TabItem tabLabel='Users'>
           <OrganisationProvider>
-            {({ isLoading, users }) => (
+            {({ isLoading, users }) => {
+              const usersWithRoleRank = users?.map((user) => ({
+                ...user,
+                _roleRank:
+                  user.role === 'ADMIN'
+                    ? 0
+                    : permissions?.find((p) => p.user.id === user.id)?.admin
+                    ? 1
+                    : 2,
+              }))
+              return (
               <div className='mt-4'>
                 {isLoading && !users?.length && (
                   <div className='centered-container'>
@@ -1101,7 +1116,14 @@ const EditPermissions: FC<EditPermissionsType> = (props) => {
                           id='org-members-list'
                           title='Users'
                           className='panel--transparent'
-                          items={users}
+                          items={usersWithRoleRank}
+                          sorting={[
+                            {
+                              label: 'Role',
+                              order: SortOrder.ASC,
+                              value: '_roleRank',
+                            },
+                          ]}
                           itemHeight={64}
                           header={
                             <Row className='table-header'>
@@ -1204,7 +1226,8 @@ const EditPermissions: FC<EditPermissionsType> = (props) => {
                   </div>
                 )}
               </div>
-            )}
+              )
+            }}
           </OrganisationProvider>
         </TabItem>
         <TabItem tabLabel='Groups'>

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -28,6 +28,13 @@ import {
   PermissionRoleType,
   SortOrder,
 } from 'common/types/requests'
+const USER_SORT_OPTIONS = [
+  {
+    label: 'Role',
+    order: SortOrder.ASC,
+    value: '_roleRank',
+  },
+]
 import { useGetAvailablePermissionsQuery } from 'common/services/useAvailablePermissions'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Icon from './icons/Icon'
@@ -1092,140 +1099,135 @@ const EditPermissions: FC<EditPermissionsType> = (props) => {
         <TabItem tabLabel='Users'>
           <OrganisationProvider>
             {({ isLoading, users }) => {
+              const adminUserIds = new Set(
+                permissions
+                  ?.filter((p) => p.admin && p.user?.id)
+                  .map((p) => p.user.id) || [],
+              )
               const usersWithRoleRank = users?.map((user) => ({
                 ...user,
                 _roleRank:
-                  user.role === 'ADMIN'
-                    ? 0
-                    : permissions?.find((p) => p.user.id === user.id)?.admin
-                    ? 1
-                    : 2,
+                  user.role === 'ADMIN' ? 0 : adminUserIds.has(user.id) ? 1 : 2,
               }))
               return (
-              <div className='mt-4'>
-                {isLoading && !users?.length && (
-                  <div className='centered-container'>
-                    <Loader />
-                  </div>
-                )}
-                {!!users?.length && (
-                  <div>
-                    <FormGroup className='panel no-pad pl-2 pr-2 panel--nested'>
-                      <div className={tabClassName}>
-                        <PanelSearch
-                          id='org-members-list'
-                          title='Users'
-                          className='panel--transparent'
-                          items={usersWithRoleRank}
-                          sorting={[
-                            {
-                              label: 'Role',
-                              order: SortOrder.ASC,
-                              value: '_roleRank',
-                            },
-                          ]}
-                          itemHeight={64}
-                          header={
-                            <Row className='table-header'>
-                              <Flex className='table-column px-3'>User</Flex>
-                              <Flex className='table-column'>Role</Flex>
-                              <div
-                                style={{ width: '80px' }}
-                                className='table-column text-center'
-                              >
-                                Action
-                              </div>
-                            </Row>
-                          }
-                          renderRow={(user) => {
-                            const { email, first_name, id, last_name, role } =
-                              user
-                            const onClick = () => {
-                              if (role !== 'ADMIN') {
-                                editUserPermissions(user)
-                              }
-                            }
-                            const matchingPermissions = permissions?.find(
-                              (v) => v.user.id === id,
-                            )
-
-                            return (
-                              <Row
-                                onClick={onClick}
-                                space
-                                className={`list-item${
-                                  role === 'ADMIN' ? '' : ' clickable'
-                                }`}
-                                key={id}
-                              >
-                                <Flex className='table-column px-3'>
-                                  <div className='mb-1 font-weight-medium'>
-                                    {`${first_name} ${last_name}`}{' '}
-                                    {String(id) ===
-                                      String(AccountStore.getUserId()) &&
-                                      '(You)'}
-                                  </div>
-                                  <div className='list-item-subtitle'>
-                                    {email}
-                                  </div>
-                                </Flex>
-                                {role === 'ADMIN' ? (
-                                  <Flex className='table-column fs-small lh-sm'>
-                                    <Tooltip
-                                      title={'Organisation Administrator'}
-                                    >
-                                      {
-                                        'Organisation administrators have all permissions enabled.<br/>To change the role of this user, visit Organisation Settings.'
-                                      }
-                                    </Tooltip>
-                                  </Flex>
-                                ) : (
-                                  <Flex
-                                    onClick={onClick}
-                                    className='table-column fs-small lh-sm'
-                                  >
-                                    {matchingPermissions &&
-                                    matchingPermissions.admin
-                                      ? `${Format.camelCase(
-                                          level,
-                                        )} Administrator`
-                                      : 'Regular User'}
-                                  </Flex>
-                                )}
+                <div className='mt-4'>
+                  {isLoading && !users?.length && (
+                    <div className='centered-container'>
+                      <Loader />
+                    </div>
+                  )}
+                  {!!users?.length && (
+                    <div>
+                      <FormGroup className='panel no-pad pl-2 pr-2 panel--nested'>
+                        <div className={tabClassName}>
+                          <PanelSearch
+                            id='org-members-list'
+                            title='Users'
+                            className='panel--transparent'
+                            items={usersWithRoleRank}
+                            sorting={USER_SORT_OPTIONS}
+                            itemHeight={64}
+                            header={
+                              <Row className='table-header'>
+                                <Flex className='table-column px-3'>User</Flex>
+                                <Flex className='table-column'>Role</Flex>
                                 <div
                                   style={{ width: '80px' }}
-                                  className='text-center'
+                                  className='table-column text-center'
                                 >
-                                  {role !== 'ADMIN' && (
-                                    <Icon
-                                      name='setting'
-                                      width={20}
-                                      fill='#656D7B'
-                                    />
-                                  )}
+                                  Action
                                 </div>
                               </Row>
-                            )
-                          }}
-                          renderNoResults={
-                            <div>You have no users in this organisation.</div>
-                          }
-                          filterRow={(item: User, search: string) => {
-                            const strToSearch = `${item.first_name} ${item.last_name} ${item.email}`
-                            return (
-                              strToSearch
-                                .toLowerCase()
-                                .indexOf(search.toLowerCase()) !== -1
-                            )
-                          }}
-                        />
-                      </div>
+                            }
+                            renderRow={(user) => {
+                              const { email, first_name, id, last_name, role } =
+                                user
+                              const onClick = () => {
+                                if (role !== 'ADMIN') {
+                                  editUserPermissions(user)
+                                }
+                              }
+                              const matchingPermissions = permissions?.find(
+                                (v) => v.user.id === id,
+                              )
 
-                      <div id='select-portal' />
-                    </FormGroup>
-                  </div>
-                )}
-              </div>
+                              return (
+                                <Row
+                                  onClick={onClick}
+                                  space
+                                  className={`list-item${
+                                    role === 'ADMIN' ? '' : ' clickable'
+                                  }`}
+                                  key={id}
+                                >
+                                  <Flex className='table-column px-3'>
+                                    <div className='mb-1 font-weight-medium'>
+                                      {`${first_name} ${last_name}`}{' '}
+                                      {String(id) ===
+                                        String(AccountStore.getUserId()) &&
+                                        '(You)'}
+                                    </div>
+                                    <div className='list-item-subtitle'>
+                                      {email}
+                                    </div>
+                                  </Flex>
+                                  {role === 'ADMIN' ? (
+                                    <Flex className='table-column fs-small lh-sm'>
+                                      <Tooltip
+                                        title={'Organisation Administrator'}
+                                      >
+                                        {
+                                          'Organisation administrators have all permissions enabled.<br/>To change the role of this user, visit Organisation Settings.'
+                                        }
+                                      </Tooltip>
+                                    </Flex>
+                                  ) : (
+                                    <Flex
+                                      onClick={onClick}
+                                      className='table-column fs-small lh-sm'
+                                    >
+                                      {matchingPermissions &&
+                                      matchingPermissions.admin
+                                        ? `${Format.camelCase(
+                                            level,
+                                          )} Administrator`
+                                        : 'Regular User'}
+                                    </Flex>
+                                  )}
+                                  <div
+                                    style={{ width: '80px' }}
+                                    className='text-center'
+                                  >
+                                    {role !== 'ADMIN' && (
+                                      <Icon
+                                        name='setting'
+                                        width={20}
+                                        fill='#656D7B'
+                                      />
+                                    )}
+                                  </div>
+                                </Row>
+                              )
+                            }}
+                            renderNoResults={
+                              <div>You have no users in this organisation.</div>
+                            }
+                            filterRow={(item: User, search: string) => {
+                              const strToSearch = `${item.first_name} ${item.last_name} ${item.email}`
+                              return (
+                                strToSearch
+                                  .toLowerCase()
+                                  .indexOf(search.toLowerCase()) !== -1
+                              )
+                            }}
+                          />
+                        </div>
+
+                        <div id='select-portal' />
+                      </FormGroup>
+                    </div>
+                  )}
+                </div>
               )
             }}
           </OrganisationProvider>

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/OrganisationUsersTable.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/OrganisationUsersTable.tsx
@@ -12,6 +12,13 @@ import OrganisationUsersTableHeader from './components/OrganisationUsersTableHea
 import OrganisationUsersTableRow from './components/OrganisationUsersTableRow'
 import getUserDisplayName from 'common/utils/getUserDisplayName'
 import { SortOrder } from 'common/types/requests'
+const ROLE_SORT_OPTIONS = [
+  {
+    label: 'Role',
+    order: SortOrder.ASC,
+    value: 'role',
+  },
+]
 interface OrganisationUsersTableProps {
   users: User[]
   organisation: Organisation
@@ -96,13 +103,7 @@ const OrganisationUsersTable: React.FC<OrganisationUsersTableProps> = ({
       header={<OrganisationUsersTableHeader widths={widths} />}
       items={users}
       itemHeight={65}
-      sorting={[
-        {
-          label: 'Role',
-          order: SortOrder.ASC,
-          value: 'role',
-        },
-      ]}
+      sorting={ROLE_SORT_OPTIONS}
       renderRow={(user) => {
         const { email, first_name, id, last_name } = user
 

--- a/frontend/web/components/users-permissions/OrganisationUsersTable/OrganisationUsersTable.tsx
+++ b/frontend/web/components/users-permissions/OrganisationUsersTable/OrganisationUsersTable.tsx
@@ -11,6 +11,7 @@ import Format from 'common/utils/format'
 import OrganisationUsersTableHeader from './components/OrganisationUsersTableHeader'
 import OrganisationUsersTableRow from './components/OrganisationUsersTableRow'
 import getUserDisplayName from 'common/utils/getUserDisplayName'
+import { SortOrder } from 'common/types/requests'
 interface OrganisationUsersTableProps {
   users: User[]
   organisation: Organisation
@@ -95,6 +96,13 @@ const OrganisationUsersTable: React.FC<OrganisationUsersTableProps> = ({
       header={<OrganisationUsersTableHeader widths={widths} />}
       items={users}
       itemHeight={65}
+      sorting={[
+        {
+          label: 'Role',
+          order: SortOrder.ASC,
+          value: 'role',
+        },
+      ]}
       renderRow={(user) => {
         const { email, first_name, id, last_name } = user
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✓] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [✓] I have added information to `docs/` if required so people know about the feature.
- [✓] I have filled in the "Changes" section below.
- [✓] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7613 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

Users in organisation, project, and environment permissions settings can now be sorted by role, making it easy to distinguish admisnitrators from standard users at a glance.

Each user is assigned a role rank for sorting:
- Organisation Administrator (rank 0)
- Project / Environment Administrator (rank 1)
- Standard User (rank 2)

Sorting ASC puts administrators at the top; toggling reverses the order.

## How did you test this code?

Tested manually on a local dev environment:

1. Navigated to Users & Permissions tab
2. Created users with different roles (Organisation Admin, Standard User)
4. Clicked the Role sort button - confirmed admins grouped at the top, standard users at the bottom; toggling reversed the order


https://github.com/user-attachments/assets/4352fcbf-f91a-4967-9456-ab35c5ec7b68










