### PR TITLE
feat(MCP): Use native OpenAPI tool fields and consolidate private deps

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -45,8 +45,7 @@ jobs:
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--extra private --extra auth-controller --extra workflows"
-          make install-private-modules
+          make install-packages opts="--extra private --extra auth-controller"
           rm -rf ${HOME}/.git-credentials
 
       - name: Generate MCP schema

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -56,8 +56,7 @@ jobs:
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--extra dev --extra private --extra auth-controller --extra workflows"
-          make install-private-modules
+          make install-packages opts="--extra dev --extra private --extra auth-controller"
           make integrate-private-tests
           rm -rf ${HOME}/.git-credentials
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: flagsmith-lint-tests
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.8  # Ensure this matches the version in api/pyproject.toml
+    rev: 0.11.14  # Ensure this matches the version in api/pyproject.toml
     hooks:
       - id: uv-lock
         args: ["--project", "api", "--check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,10 +106,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # * build-python-private [build-python]
 FROM build-python AS build-python-private
 
-# Authenticate git with token, install private Python dependencies,
-# and integrate private modules
-ARG RBAC_REVISION
-ARG EXTRAS="--extra private --extra auth-controller --extra ldap --extra workflows --extra licensing"
+# Authenticate git with token and install private Python dependencies
+ARG EXTRAS="--extra private --extra auth-controller --extra ldap --extra licensing"
 RUN --mount=type=secret,id=github_private_cloud_token \
   --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
@@ -117,8 +115,7 @@ RUN --mount=type=secret,id=github_private_cloud_token \
   git config --global credential.helper store && \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD="$(cat /run/secrets/codeartifact_token)" \
-  make install-packages opts="--no-install-project ${EXTRAS}" && \
-  make install-private-modules
+  make install-packages opts="--no-install-project ${EXTRAS}"
 
 # * api-runtime
 FROM wolfi-base AS api-runtime
@@ -179,7 +176,7 @@ RUN --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD="$(cat /run/secrets/codeartifact_token)" \
-  make install-packages opts='--extra dev --extra private --extra auth-controller --extra ldap --extra workflows --extra licensing' && \
+  make install-packages opts='--extra dev --extra private --extra auth-controller --extra ldap --extra licensing' && \
   make integrate-private-tests && \
   git config --global --unset credential.helper && \
   rm -f ${HOME}/.git-credentials

--- a/api/Makefile
+++ b/api/Makefile
@@ -9,8 +9,6 @@ DOTENV_OVERRIDE_FILE ?= .env
 
 UV_VERSION ?= $(shell python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["uv"]["required-version"].lstrip("="))')
 
-RBAC_REVISION ?= v0.13.0
-
 OPENAPI_FORMAT_VERSION ?= 1.23.0
 
 -include .env-local
@@ -36,13 +34,6 @@ install-uv:
 .PHONY: install-packages
 install-packages:
 	uv sync --frozen $(opts)
-
-.PHONY: install-private-modules
-install-private-modules:
-	$(eval SITE_PACKAGES_DIR := $(shell uv run python -c 'import site; print(site.getsitepackages()[0])'))
-	rm -rf $(SITE_PACKAGES_DIR)/rbac
-	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && mv ./flagsmith-rbac/rbac $(SITE_PACKAGES_DIR)
-	rm -rf ./flagsmith-rbac
 
 .PHONY: install
 install: install-pip install-uv install-packages
@@ -160,13 +151,14 @@ generate-grafana-client-types:
 
 .PHONY: integrate-private-tests
 integrate-private-tests:
-	$(eval WORKFLOW_REVISION := $(shell uv run python -c 'import tomllib; d=tomllib.load(open("pyproject.toml","rb")); s=d.get("tool",{}).get("uv",{}).get("sources",{}).get("workflows-logic",{}); print(s.get("tag") or s.get("rev") or "")'))
+	$(eval FLAGSMITH_PRIVATE_REVISION := v$(shell uv run python -c 'import importlib.metadata; print(importlib.metadata.version("flagsmith-private"))'))
 	$(eval AUTH_CONTROLLER_REVISION := $(shell uv run python -c 'import tomllib; d=tomllib.load(open("pyproject.toml","rb")); s=d.get("tool",{}).get("uv",{}).get("sources",{}).get("auth-controller",{}); print(s.get("tag") or s.get("rev") or "")'))
 
-	git clone https://github.com/flagsmith/flagsmith-rbac --depth 1 --branch ${RBAC_REVISION} && mv ./flagsmith-rbac/tests tests/rbac_tests
-	git clone https://github.com/flagsmith/flagsmith-workflows --depth 1 --branch ${WORKFLOW_REVISION} && mv ./flagsmith-workflows/tests tests/workflow_tests
+	git clone https://github.com/Flagsmith/flagsmith-private --depth 1 --branch ${FLAGSMITH_PRIVATE_REVISION} \
+		&& mv ./flagsmith-private/integration_tests/rbac tests/rbac_tests \
+		&& mv ./flagsmith-private/integration_tests/workflows_logic tests/workflow_tests
 	git clone https://github.com/flagsmith/flagsmith-auth-controller --depth 1 --branch ${AUTH_CONTROLLER_REVISION} && mv ./flagsmith-auth-controller/tests tests/auth_controller_tests
-	rm -rf ./flagsmith-rbac ./flagsmith-workflows ./flagsmith-auth-controller
+	rm -rf ./flagsmith-private ./flagsmith-auth-controller
 
 .PHONY: generate-docs
 generate-docs: generate-flagsmith-sdk-openapi

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -80,12 +80,8 @@ logger = logging.getLogger(__name__)
                 type=int,
             )
         ],
-        extensions={
-            "x-gram": {
-                "name": "list_environments",
-                "description": "Lists all environments the user has access to",
-            },
-        },
+        operation_id="list_environments",
+        description="Lists all environments the user has access to",
     ),
 )
 class EnvironmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]

--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -27,12 +27,8 @@ from .serializers import FeatureExternalResourceSerializer
     name="list",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_feature_external_resources",
-                "description": "Retrieves external resources linked to the feature flag.",
-            },
-        },
+        operation_id="get_feature_external_resources",
+        description="Retrieves external resources linked to the feature flag.",
     ),
 )
 class FeatureExternalResourceViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]

--- a/api/features/feature_health/views.py
+++ b/api/features/feature_health/views.py
@@ -39,12 +39,8 @@ from users.models import FFAdminUser
     name="list",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_feature_health_events",
-                "description": "Retrieves feature health monitoring events and metrics for the project.",
-            },
-        },
+        operation_id="get_feature_health_events",
+        description="Retrieves feature health monitoring events and metrics for the project.",
     ),
 )
 class FeatureHealthEventViewSet(

--- a/api/features/feature_segments/views.py
+++ b/api/features/feature_segments/views.py
@@ -30,24 +30,16 @@ logger = logging.getLogger(__name__)
     decorator=extend_schema(
         tags=["mcp"],
         parameters=[FeatureSegmentQuerySerializer],
-        extensions={
-            "x-gram": {
-                "name": "list_feature_segments",
-                "description": "Lists segment overrides for a feature in an environment.",
-            },
-        },
+        operation_id="list_feature_segments",
+        description="Lists segment overrides for a feature in an environment.",
     ),
 )
 @method_decorator(
     name="destroy",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "delete_feature_segment",
-                "description": "Deletes a segment override. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
-            },
-        },
+        operation_id="delete_feature_segment",
+        description="Deletes a segment override. Applies to environments without v2 feature versioning (use_v2_feature_versioning: false).",
     ),
 )
 class FeatureSegmentViewSet(

--- a/api/features/multivariate/views.py
+++ b/api/features/multivariate/views.py
@@ -20,48 +20,32 @@ from .serializers import MultivariateFeatureOptionSerializer
     name="list",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "list_feature_multivariate_options",
-                "description": "Retrieves all multivariate options for a feature flag.",
-            },
-        },
+        operation_id="list_feature_multivariate_options",
+        description="Retrieves all multivariate options for a feature flag.",
     ),
 )
 @method_decorator(
     name="create",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_feature_multivariate_option",
-                "description": "Creates a new multivariate option for a feature flag.",
-            },
-        },
+        operation_id="create_feature_multivariate_option",
+        description="Creates a new multivariate option for a feature flag.",
     ),
 )
 @method_decorator(
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_feature_multivariate_option",
-                "description": "Updates an existing multivariate option.",
-            },
-        },
+        operation_id="update_feature_multivariate_option",
+        description="Updates an existing multivariate option.",
     ),
 )
 @method_decorator(
     name="destroy",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "delete_feature_multivariate_option",
-                "description": "Deletes a multivariate option.",
-            },
-        },
+        operation_id="delete_feature_multivariate_option",
+        description="Deletes a multivariate option.",
     ),
 )
 class MultivariateFeatureOptionViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]

--- a/api/features/versioning/views.py
+++ b/api/features/versioning/views.py
@@ -51,24 +51,16 @@ from users.models import FFAdminUser
     name="list",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_environment_feature_versions",
-                "description": "Retrieves version information for a feature flag in a specific environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
-            },
-        },
+        operation_id="get_environment_feature_versions",
+        description="Retrieves version information for a feature flag in a specific environment. Applies to environments with v2 feature versioning (use_v2_feature_versioning: true).",
     ),
 )
 @method_decorator(
     name="create",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_environment_feature_version",
-                "description": "Creates a new version for a feature flag in a specific environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
-            },
-        },
+        operation_id="create_environment_feature_version",
+        description="Creates a new version for a feature flag in a specific environment. Applies to environments with v2 feature versioning (use_v2_feature_versioning: true).",
     ),
 )
 class EnvironmentFeatureVersionViewSet(
@@ -160,12 +152,8 @@ class EnvironmentFeatureVersionViewSet(
 
     @extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "publish_environment_feature_version",
-                "description": "Publishes a feature version to make it live in the environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
-            },
-        },
+        operation_id="publish_environment_feature_version",
+        description="Publishes a feature version to make it live in the environment. Applies to environments with v2 feature versioning (use_v2_feature_versioning: true).",
     )
     @action(detail=True, methods=["POST"])
     def publish(self, request: Request, **kwargs) -> Response:  # type: ignore[no-untyped-def]
@@ -223,36 +211,24 @@ class EnvironmentFeatureVersionRetrieveAPIView(RetrieveAPIView):  # type: ignore
     name="list",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_environment_feature_version_states",
-                "description": "Retrieves feature state information for a specific version in an environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
-            },
-        },
+        operation_id="get_environment_feature_version_states",
+        description="Retrieves feature state information for a specific version in an environment. Applies to environments with v2 feature versioning (use_v2_feature_versioning: true).",
     ),
 )
 @method_decorator(
     name="create",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_environment_feature_version_state",
-                "description": "Creates a new feature state for a specific version in an environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
-            },
-        },
+        operation_id="create_environment_feature_version_state",
+        description="Creates a new feature state for a specific version in an environment. Applies to environments with v2 feature versioning (use_v2_feature_versioning: true).",
     ),
 )
 @method_decorator(
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_environment_feature_version_state",
-                "description": "Updates an existing feature state for a specific version in an environment. Use this tool for environments with v2 feature versioning (use_v2_feature_versioning: true).",
-            },
-        },
+        operation_id="update_environment_feature_version_state",
+        description="Updates an existing feature state for a specific version in an environment. Applies to environments with v2 feature versioning (use_v2_feature_versioning: true).",
     ),
 )
 class EnvironmentFeatureVersionFeatureStatesViewSet(

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -131,48 +131,32 @@ def get_feature_by_uuid(request, uuid):  # type: ignore[no-untyped-def]
     decorator=extend_schema(
         tags=["mcp"],
         parameters=[FeatureQuerySerializer],
-        extensions={
-            "x-gram": {
-                "name": "list_project_features",
-                "description": "Lists a project's feature flags (paginated). Pass `environment=<id>` to also get each feature's live state for that environment in `environment_feature_state`, along with override counts. Works for both v1 and v2 versioned environments.",
-            },
-        },
+        operation_id="list_project_features",
+        description="Lists a project's feature flags (paginated). Pass `environment=<id>` to also get each feature's live state for that environment in `environment_feature_state`, along with override counts. Works for both v1 and v2 versioned environments.",
     ),
 )
 @method_decorator(
     name="create",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_feature",
-                "description": "Creates a new feature flag in the specified project with default settings.",
-            },
-        },
+        operation_id="create_feature",
+        description="Creates a new feature flag in the specified project with default settings.",
     ),
 )
 @method_decorator(
     name="retrieve",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_feature_flag",
-                "description": "Retrieves detailed information about a specific feature flag.",
-            },
-        },
+        operation_id="get_feature_flag",
+        description="Retrieves detailed information about a specific feature flag.",
     ),
 )
 @method_decorator(
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_feature",
-                "description": "Updates feature flag properties such as name and description.",
-            },
-        },
+        operation_id="update_feature",
+        description="Updates feature flag properties such as name and description.",
     ),
 )
 class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
@@ -537,12 +521,8 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         tags=["mcp"],
         parameters=[GetUsageDataQuerySerializer],
         responses={200: FeatureEvaluationDataSerializer()},
-        extensions={
-            "x-gram": {
-                "name": "get_feature_evaluation_data",
-                "description": "Retrieves evaluation data and analytics for a specific feature flag.",
-            },
-        },
+        operation_id="get_feature_evaluation_data",
+        description="Retrieves evaluation data and analytics for a specific feature flag.",
     )
     @action(detail=True, methods=["GET"], url_path="evaluation-data")
     @throttle_classes([InfluxQueryThrottle])
@@ -827,12 +807,8 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_environment_feature_state",
-                "description": "Updates a feature state in an environment, including enabled status and value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
-            },
-        },
+        operation_id="update_environment_feature_state",
+        description="Updates a feature state in an environment, including enabled status and value. Applies to environments without v2 feature versioning (use_v2_feature_versioning: false).",
     ),
 )
 class EnvironmentFeatureStateViewSet(BaseFeatureStateViewSet):
@@ -925,12 +901,8 @@ class IdentityFeatureStateViewSet(BaseFeatureStateViewSet):
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_feature_state",
-                "description": "Updates a feature state, including its enabled status and value. Use this tool to update a segment override's value for environments without v2 feature versioning (use_v2_feature_versioning: false).",
-            },
-        },
+        operation_id="update_feature_state",
+        description="Updates a feature state, including its enabled status and value. Also updates a segment override's value for environments without v2 feature versioning (use_v2_feature_versioning: false).",
     ),
 )
 class SimpleFeatureStateViewSet(
@@ -1186,12 +1158,8 @@ def organisation_has_got_feature(request, organisation):  # type: ignore[no-unty
     tags=["mcp"],
     request=CustomCreateSegmentOverrideFeatureStateSerializer(),
     responses={201: CustomCreateSegmentOverrideFeatureStateSerializer()},
-    extensions={
-        "x-gram": {
-            "name": "create_segment_override",
-            "description": "Creates a segment override for a feature in an environment in a single call, setting both the segment binding and its value. Use this tool for environments without v2 feature versioning (use_v2_feature_versioning: false).",
-        },
-    },
+    operation_id="create_segment_override",
+    description="Creates a segment override for a feature in an environment in a single call, setting both the segment binding and its value. Applies to environments without v2 feature versioning (use_v2_feature_versioning: false).",
 )
 @api_view(["POST"])
 @permission_classes([CreateSegmentOverridePermissions])

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -111,21 +111,13 @@ class InviteLinkViewSet(
 @extend_schema_view(
     list=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "list_organization_invites",
-                "description": "Retrieves all pending invitations for the organization.",
-            },
-        },
+        operation_id="list_organization_invites",
+        description="Retrieves all pending invitations for the organisation.",
     ),
     create=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_organization_invite",
-                "description": "Send an invitation to join the organization with specified role and permissions.",
-            },
-        },
+        operation_id="create_organization_invite",
+        description="Send an invitation to join the organisation with specified role and permissions.",
     ),
 )
 class InviteViewSet(

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -67,12 +67,8 @@ logger = logging.getLogger(__name__)
 @extend_schema_view(
     list=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "list_organizations",
-                "description": "Lists all organizations accessible with the provided user API key.",
-            },
-        },
+        operation_id="list_organizations",
+        description="Lists all organisations accessible with the provided user API key.",
     ),
 )
 class OrganisationViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
@@ -147,12 +143,8 @@ class OrganisationViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
 
     @extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "list_projects_in_organization",
-                "description": "Retrieves all projects within a specified organization.",
-            },
-        },
+        operation_id="list_projects_in_organization",
+        description="Retrieves all projects within a specified organisation.",
     )
     @action(detail=True, permission_classes=[IsAuthenticated])
     def projects(self, request, pk):  # type: ignore[no-untyped-def]

--- a/api/projects/code_references/views.py
+++ b/api/projects/code_references/views.py
@@ -71,15 +71,6 @@ class FeatureFlagCodeReferencesScanCreateAPIView(
         )
 
 
-@extend_schema(
-    tags=["mcp"],
-    extensions={
-        "x-gram": {
-            "name": "get_feature_code_references",
-            "description": "Retrieves code references and usage information for the feature flag.",
-        },
-    },
-)
 class FeatureFlagCodeReferenceDetailAPIView(
     generics.RetrieveAPIView[FeatureFlagCodeReferencesRepositorySummary],  # type: ignore[type-var]
 ):
@@ -90,6 +81,11 @@ class FeatureFlagCodeReferenceDetailAPIView(
     serializer_class = FeatureFlagCodeReferencesRepositorySummarySerializer
     permission_classes = [ViewFeatureFlagCodeReferences]
 
+    @extend_schema(
+        tags=["mcp"],
+        operation_id="get_feature_code_references",
+        description="Retrieves code references and usage information for the feature flag.",
+    )
     def get(self, *args: Any, **kwargs: Any) -> response.Response:
         feature = get_object_or_404(
             Feature,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -55,24 +55,16 @@ from users.models import FFAdminUser
     name="retrieve",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_project",
-                "description": "Retrieves comprehensive information about a specific project including configuration and statistics.",
-            },
-        },
+        operation_id="get_project",
+        description="Retrieves comprehensive information about a specific project including configuration and statistics.",
     ),
 )
 @method_decorator(
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_project",
-                "description": "Updates project configuration settings such as the project name and feature visibility.",
-            },
-        },
+        operation_id="update_project",
+        description="Updates project configuration settings such as the project name and feature visibility.",
     ),
 )
 class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
@@ -132,12 +124,8 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
 
     @extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "list_project_environments",
-                "description": "Retrieves all environments configured for the specified project.",
-            },
-        },
+        operation_id="list_project_environments",
+        description="Retrieves all environments configured for the specified project.",
     )
     @action(detail=True)
     def environments(self, request, pk):  # type: ignore[no-untyped-def]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -99,14 +99,11 @@ auth-controller = [
     "django-multiselectfield>=1.0.1,<2",
 ]
 private = [
-    "flagsmith-private>=0.6.0,<1",
+    "flagsmith-private>=0.7.0,<1",
 ]
 ldap = [
     "flagsmith-ldap",
     "django-python3-ldap>=0.15.6,<1",
-]
-workflows = [
-    "workflows-logic",
 ]
 licensing = [
     "licensing",
@@ -179,13 +176,12 @@ explicit = true
 [tool.uv.sources]
 auth-controller = { git = "https://github.com/flagsmith/flagsmith-auth-controller", tag = "v0.2.0" }
 flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v0.1.2" }
-workflows-logic = { git = "https://github.com/flagsmith/flagsmith-workflows", tag = "v3.4.0" }
 licensing = { git = "https://github.com/flagsmith/licensing", tag = "v0.3.0" }
 flagsmith-private = { index = "flagsmith-pypi-production" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 
 [tool.uv]
-required-version = "0.11.8"  # Ensure this matches the version in .pre-commit-config.yaml
+required-version = "0.11.14"  # Ensure this matches the version in .pre-commit-config.yaml
 # Pin every resolved package to the exact version that api/poetry.lock used on
 # main before this migration, so the poetry -> uv switch is dependency-neutral.
 # Keep this list in sync with poetry.lock until the lockfile churn settles.
@@ -506,12 +502,14 @@ omit = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ['.']
 addopts = [
   '--ds=app.settings.test',
   '-vvvv',
   '-p',
   'no:warnings',
   '--dist=worksteal',
+  '--import-mode=importlib',
 ]
 console_output_style = 'count'
 log_level = 'INFO'

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -43,48 +43,32 @@ logger = logging.getLogger(__name__)
     decorator=extend_schema(
         tags=["mcp"],
         parameters=[SegmentListQuerySerializer],
-        extensions={
-            "x-gram": {
-                "name": "list_project_segments",
-                "description": "Retrieves all user segments defined for audience targeting within the project.",
-            },
-        },
+        operation_id="list_project_segments",
+        description="Retrieves all user segments defined for audience targeting within the project.",
     ),
 )
 @method_decorator(
     name="create",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "create_project_segment",
-                "description": "Creates a new user segment for audience targeting within the project.",
-            },
-        },
+        operation_id="create_project_segment",
+        description="Creates a new user segment for audience targeting within the project.",
     ),
 )
 @method_decorator(
     name="retrieve",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "get_project_segment",
-                "description": "Retrieves detailed information about a specific user segment.",
-            },
-        },
+        operation_id="get_project_segment",
+        description="Retrieves detailed information about a specific user segment.",
     ),
 )
 @method_decorator(
     name="update",
     decorator=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "update_project_segment",
-                "description": "Updates an existing user segment's properties and rules.",
-            },
-        },
+        operation_id="update_project_segment",
+        description="Updates an existing user segment's properties and rules.",
     ),
 )
 class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]

--- a/api/tests/unit/api/test_mcp_openapi.py
+++ b/api/tests/unit/api/test_mcp_openapi.py
@@ -84,16 +84,12 @@ def test_mcp_filter_paths__mixed_mcp_and_non_mcp_operations__includes_only_mcp()
     ]
 
 
-def test_mcp_transform_for_mcp__x_gram_extension_present__preserves_extension() -> None:
+def test_mcp_transform_for_mcp__friendly_operation_id__preserved() -> None:
     # Given
     operation: dict[str, Any] = {
-        "operationId": "organisations_list",
+        "operationId": "list_organizations",
         "tags": ["mcp"],
-        "description": "Original description",
-        "x-gram": {
-            "name": "list_organisations",
-            "description": "Gram-specific description",
-        },
+        "description": "Lists all organisations accessible with the provided user API key.",
     }
     generator = MCPSchemaGenerator()
 
@@ -101,12 +97,11 @@ def test_mcp_transform_for_mcp__x_gram_extension_present__preserves_extension() 
     transformed = generator._transform_for_mcp(operation)
 
     # Then
-    assert transformed["x-gram"] == {
-        "name": "list_organisations",
-        "description": "Gram-specific description",
-    }
-    assert transformed["operationId"] == "organisations_list"
-    assert transformed["description"] == "Original description"
+    assert transformed["operationId"] == "list_organizations"
+    assert (
+        transformed["description"]
+        == "Lists all organisations accessible with the provided user API key."
+    )
 
 
 def test_mcp_transform_for_mcp__no_extensions__preserves_original() -> None:
@@ -269,16 +264,20 @@ def test_mcp_schema__full_schema_generated__includes_expected_endpoints_only() -
     paths = schema["paths"]
 
     assert "/api/v1/organisations/" in paths
-    assert paths["/api/v1/organisations/"]["get"]["x-gram"] == {
-        "name": "list_organizations",
-        "description": "Lists all organizations accessible with the provided user API key.",
-    }
+    organisations_list = paths["/api/v1/organisations/"]["get"]
+    assert organisations_list["operationId"] == "list_organizations"
+    assert (
+        organisations_list["description"]
+        == "Lists all organisations accessible with the provided user API key."
+    )
 
     assert "/api/v1/organisations/{id}/projects/" in paths
-    assert paths["/api/v1/organisations/{id}/projects/"]["get"]["x-gram"] == {
-        "name": "list_projects_in_organization",
-        "description": "Retrieves all projects within a specified organization.",
-    }
+    projects_list = paths["/api/v1/organisations/{id}/projects/"]["get"]
+    assert projects_list["operationId"] == "list_projects_in_organization"
+    assert (
+        projects_list["description"]
+        == "Retrieves all projects within a specified organisation."
+    )
 
     assert "/api/v1/users/" not in paths
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -163,12 +163,8 @@ def password_reset_redirect(
 @extend_schema_view(
     list=extend_schema(
         tags=["mcp"],
-        extensions={
-            "x-gram": {
-                "name": "list_organization_groups",
-                "description": "Retrieves all permission groups within the organization.",
-            },
-        },
+        operation_id="list_organization_groups",
+        description="Retrieves all permission groups within the organisation.",
     ),
 )
 class UserPermissionGroupViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1529,9 +1529,6 @@ licensing = [
 private = [
     { name = "flagsmith-private" },
 ]
-workflows = [
-    { name = "workflows-logic" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -1589,7 +1586,7 @@ requires-dist = [
     { name = "flagsmith-common", extras = ["test-tools"], marker = "extra == 'dev'" },
     { name = "flagsmith-flag-engine", specifier = ">=10.1.0,<11.0.0" },
     { name = "flagsmith-ldap", marker = "extra == 'ldap'", git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2" },
-    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.6.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
+    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.7.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
     { name = "flagsmith-sql-flag-engine", specifier = ">=0.1.0,<0.2.0" },
     { name = "google-api-python-client", specifier = ">=1.12.5,<1.13.0" },
     { name = "google-re2", specifier = ">=1.0,<2.0.0" },
@@ -1652,9 +1649,8 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.20241016,<3.0.0" },
     { name = "tzdata", specifier = ">=2024.1,<2025.0.0" },
     { name = "whitenoise", specifier = ">=6.0.0,<6.1.0" },
-    { name = "workflows-logic", marker = "extra == 'workflows'", git = "https://github.com/flagsmith/flagsmith-workflows?tag=v3.4.0" },
 ]
-provides-extras = ["auth-controller", "private", "ldap", "workflows", "licensing", "dev"]
+provides-extras = ["auth-controller", "private", "ldap", "licensing", "dev"]
 
 [[package]]
 name = "flagsmith-common"
@@ -1729,16 +1725,16 @@ source = { git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2#2456465
 
 [[package]]
 name = "flagsmith-private"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" }
 dependencies = [
     { name = "django-scim2" },
     { name = "pysaml2" },
     { name = "scim2-filter-parser" },
 ]
-sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.6.0/flagsmith_private-0.6.0.tar.gz", hash = "sha256:5549704f4a23c98e465ba4bb05b82e5440bf84f8d12171d027ae41f265d78ea5" }
+sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.7.0/flagsmith_private-0.7.0.tar.gz", hash = "sha256:5fc8cab32e51cf0ff8fa6205124128c6182433731934f5df60f3889d98df7b71" }
 wheels = [
-    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.6.0/flagsmith_private-0.6.0-py3-none-any.whl", hash = "sha256:5016964c60dc75177a5ea0d290a50a23a6b2283a654ef95c27f8325c486f0cbe" },
+    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.7.0/flagsmith_private-0.7.0-py3-none-any.whl", hash = "sha256:370bebed2bc28f857acbaf4c1080fcd377b202ad8839ca5daceedce53948351a" },
 ]
 
 [[package]]
@@ -4163,17 +4159,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/d9/6625ead93412c5ce86db1f8b4f2a70b8043e0a7c1d30099ba3c6a81641ff/wmctrl-0.5.tar.gz", hash = "sha256:7839a36b6fe9e2d6fd22304e5dc372dbced2116ba41283ea938b2da57f53e962", size = 5202, upload-time = "2023-09-16T23:02:08.09Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/ca/723e3f8185738d7947f14ee7dc663b59415c6dee43bd71575f8c7f5cd6be/wmctrl-0.5-py2.py3-none-any.whl", hash = "sha256:ae695c1863a314c899e7cf113f07c0da02a394b968c4772e1936219d9234ddd7", size = 4268, upload-time = "2023-09-16T23:02:05.563Z" },
-]
-
-[[package]]
-name = "workflows-logic"
-version = "3.3.2"
-source = { git = "https://github.com/flagsmith/flagsmith-workflows?tag=v3.4.0#f9cedab3ec8dba7198277cb6bce84b059d4be188" }
-dependencies = [
-    { name = "djangorestframework" },
-    { name = "djangorestframework-recursive" },
-    { name = "flagsmith-common" },
-    { name = "flagsmith-flag-engine" },
 ]
 
 [[package]]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to Flagsmith/flagsmith-private#145 and the self-hosted MCP v3 epic (Flagsmith/flagsmith-private#127).

- Relocate the 36 MCP-tagged views' friendly names and descriptions from the non-standard `x-gram` extension to native `operation_id` and `description`. Gram falls back to `operationId`/`description` when `x-gram` is absent, so the existing Gram push keeps working unchanged; this also prepares for the self-hosted MCP v3 server (Flagsmith/flagsmith-private#146), which reads the same native fields from the live `/swagger`. Descriptions are phrased API-agnostically ("Applies to …" rather than "Use this tool …") since they now also feed the public API docs, and the organisation descriptions are Britishised. Tool names are unchanged.
- Consolidate the private apps: `rbac` and `workflows_logic` now ship inside `flagsmith-private` (>=0.7.0), so drop the separate `workflows-logic` dependency, the `flagsmith-rbac` clone in `install-private-modules`, and the `--extra workflows` installs. `integrate-private-tests` pulls those suites from `flagsmith-private` at the installed version's tag.
- Switch pytest to `--import-mode=importlib` (with `pythonpath = ["."]`) so the imported private test suites resolve without per-directory package markers, matching flagsmith-private's own pytest config. (`from tests.*` importers keep working via `pythonpath`.)
- Bump uv 0.11.8 -> 0.11.14.

The Gram schema generator and deploy push are deliberately left intact — Gram stays live until the v3 server lands.

## How did you test this code?

- Full core suite green locally under the new import mode: `3780 passed, 7 skipped`.
- `make typecheck` (1690 files) and `make lint` pass.
- Installed `flagsmith-private==0.7.0` from the index and ran `make generate-mcp-spec`: 43 `mcp`-tagged operations, no `x-gram`, every op with native `operationId` + `description`, including the private tools (org roles, release pipelines, change requests).
- Verified the imported `flagsmith-private` test suites (rbac, workflows) collect cleanly under importlib, including duplicate test-module basenames across `unit/` and `integration/`.