### PR TITLE
ci(renovate): Fix renovate config json, enable dependency dashboard & add config linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,11 @@ repos:
       - id: uv-lock
         args: ["--project", "api", "--check"]
 
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.205.2
+    hooks:
+      - id: renovate-config-validator
+
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,11 +54,6 @@ repos:
       - id: uv-lock
         args: ["--project", "api", "--check"]
 
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 43.205.2
-    hooks:
-      - id: renovate-config-validator
-
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,9 +54,16 @@ repos:
       - id: uv-lock
         args: ["--project", "api", "--check"]
 
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.205.2
+    hooks:
+      - id: renovate-config-validator
+        name: renovate-config-validator
+        stages: [pre-push]
+
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]
 
 ci:
-  skip: [generate-docs, python-typecheck]
+  skip: [generate-docs, python-typecheck, renovate-config-validator]
   autoupdate_commit_msg: "ci: pre-commit autoupdate"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [":disableDependencyDashboard", "security:only-security-updates", "semanticCommitType(deps)"],
+  "extends": ["security:only-security-updates", "semanticCommitType(deps)"],
   "packageRules": [
     {
       "matchManagers": ["uv"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["security:only-security-updates", "semanticCommitType(deps)"],
+  "extends": [
+    "security:only-security-updates",
+    ":semanticCommitType(deps)"
+  ],
   "packageRules": [
     {
       "matchManagers": ["uv"],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes the renovate.json file and enables Renovate's dependency dashboard (at least temporarily to verify the installation is working). 

Also adds pre-commit hook to validate configuration to avoid issues in the future. 

## How did you test this code?

N/a - needs testing once in main
