### PR TITLE
feat(experimentation): add unique event names from ClickHouse

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -787,6 +787,9 @@ REDIS_CLUSTER_READ_FROM_REPLICAS = env.bool(
 # Redis Cluster URL used to communicate with the event ingestion server.
 INGESTION_REDIS_URL = env.str("INGESTION_REDIS_URL", default="")
 
+# DSN for the ClickHouse instance holding ingested experimentation events.
+EXPERIMENTATION_CLICKHOUSE_URL = env.str("EXPERIMENTATION_CLICKHOUSE_URL", default=None)
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import typing
+from functools import lru_cache
 
+from clickhouse_driver import Client
+from django.conf import settings
 from django.utils import timezone
 
 from audit.models import AuditLog
@@ -29,6 +32,28 @@ def is_experiment_feature_enabled(organisation: Organisation) -> bool:
         default_value=False,
         evaluation_context=organisation.openfeature_evaluation_context,
     )
+
+
+@lru_cache(maxsize=1)
+def _get_clickhouse_client() -> Client:
+    """Build a clickhouse-driver client for the experimentation event store.
+
+    The database is taken from the DSN path, so queries can reference the
+    `events` table unqualified.
+    """
+    return Client.from_url(settings.EXPERIMENTATION_CLICKHOUSE_URL)
+
+
+def get_unique_event_names(environment_key: str) -> list[str]:
+    """Return the distinct event names recorded for `environment_key`,
+    ordered alphabetically."""
+    rows = _get_clickhouse_client().execute(
+        "SELECT DISTINCT event FROM events "
+        "WHERE environment_key = %(environment_key)s "
+        "ORDER BY event",
+        {"environment_key": environment_key},
+    )
+    return [row[0] for row in rows]
 
 
 def _resolve_audit_log_author(

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1,0 +1,68 @@
+from pytest_django.fixtures import SettingsWrapper
+from pytest_mock import MockerFixture
+
+from experimentation import services
+
+
+def test_get_clickhouse_client__configured_url__builds_client_from_url(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EXPERIMENTATION_CLICKHOUSE_URL = (
+        "clickhouse://user:pass@ch.example.com:9440/flagsmith_exp?secure=True"
+    )
+    mock_from_url = mocker.patch("experimentation.services.Client.from_url")
+    services._get_clickhouse_client.cache_clear()
+
+    # When
+    client = services._get_clickhouse_client()
+
+    # Then
+    mock_from_url.assert_called_once_with(
+        "clickhouse://user:pass@ch.example.com:9440/flagsmith_exp?secure=True",
+    )
+    assert client is mock_from_url.return_value
+    services._get_clickhouse_client.cache_clear()
+
+
+def test_get_unique_event_names__events_present__returns_ordered_names(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.execute.return_value = [("conversion",), ("page_view",)]
+    mocker.patch(
+        "experimentation.services._get_clickhouse_client",
+        return_value=mock_client,
+    )
+
+    # When
+    result = services.get_unique_event_names("env-key-123")
+
+    # Then
+    assert result == ["conversion", "page_view"]
+    mock_client.execute.assert_called_once_with(
+        "SELECT DISTINCT event FROM events "
+        "WHERE environment_key = %(environment_key)s "
+        "ORDER BY event",
+        {"environment_key": "env-key-123"},
+    )
+
+
+def test_get_unique_event_names__no_events__returns_empty_list(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.execute.return_value = []
+    mocker.patch(
+        "experimentation.services._get_clickhouse_client",
+        return_value=mock_client,
+    )
+
+    # When
+    result = services.get_unique_event_names("env-key-123")
+
+    # Then
+    assert result == []

--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -314,6 +314,10 @@
                 {
                     "name": "CLICKHOUSE_URL",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:clickhouse-url-kB2CK9"
+                },
+                {
+                    "name": "EXPERIMENTATION_CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:EXPERIMENTATION_CLICKHOUSE_URL::"
                 }
             ],
             "logConfiguration": {

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -303,6 +303,10 @@
                 {
                     "name": "CLICKHOUSE_URL",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:clickhouse-url-ns26gC"
+                },
+                {
+                    "name": "EXPERIMENTATION_CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:EXPERIMENTATION_CLICKHOUSE_URL::"
                 }
             ],
             "logConfiguration": {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds `experimentation.services.get_unique_event_names(environment_key)`, which returns the distinct event names recorded for an environment from the ingested events table in ClickHouse.

- Queries `SELECT DISTINCT event FROM events WHERE environment_key = … ORDER BY event` over **clickhouse-driver** (native protocol), reusing the driver already vendored for `segment_membership`.
- Connection is configured by a single `EXPERIMENTATION_CLICKHOUSE_URL` DSN setting and built with a cached `Client.from_url()` factory; the database comes from the DSN path so `events` is referenced unqualified.
- Wires `EXPERIMENTATION_CLICKHOUSE_URL` as a secret into the **admin-api** ECS task definitions for staging and production (the only consumer is a dashboard-side read), sourced from the existing `ECS-API-*` JSON secrets.

No new dependency or lockfile change — `clickhouse-driver` was already present.

> [!NOTE]
> The `EXPERIMENTATION_CLICKHOUSE_URL` key must exist in the `ECS-API-*` Secrets Manager secret in each account before the admin-api task rolls. ClickHouse Cloud uses the native secure port `9440` with `?secure=true`.

## How did you test this code?

- Added unit tests in `api/tests/unit/experimentation/test_services.py` (3 cases: client built from the DSN, events present → ordered list, no events → empty list), mocking the clickhouse-driver client. **3 passed.**
- `mypy` (strict) clean on the changed files; `ruff` check + format clean.
- ECS task definitions validated as JSON.