### PR TITLE
deps: updated track event callsites with new interface

### DIFF
--- a/frontend/common/stores/config-store.js
+++ b/frontend/common/stores/config-store.js
@@ -41,6 +41,7 @@ flagsmith
     api: Project.flagsmithClientAPI,
     cacheFlags: true,
     enableAnalytics: window.E2E ? false : Project.flagsmithAnalytics,
+    enableEvents: window.E2E ? false : Project.flagsmithAnalytics,
     environmentID: Project.flagsmith,
     onChange: controller.loaded,
     realtime: window.E2E ? false : Project.flagsmithRealtime,

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -167,17 +167,15 @@ const controller = {
             createdFirstFeature = true
             flagsmith.setTrait('first_feature', 'true')
             API.trackEvent(Constants.events.CREATE_FIRST_FEATURE)
-            if (flagsmith.eventsEnabled) {
-              flagsmith.trackEvent('first_feature_created', {
-                metadata: {
-                  feature_type: featureType,
-                  project_id: projectId,
-                },
-                value: flag.name,
-              })
-            }
+            flagsmith.trackEvent('first_feature_created', {
+              metadata: {
+                feature_type: featureType,
+                project_id: projectId,
+              },
+              value: flag.name,
+            })
             window.lintrk?.('track', { conversion_id: 16798354 })
-          } else if (flagsmith.eventsEnabled) {
+          } else {
             flagsmith.trackEvent('feature_created', {
               metadata: {
                 feature_type: featureType,

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -167,16 +167,24 @@ const controller = {
             createdFirstFeature = true
             flagsmith.setTrait('first_feature', 'true')
             API.trackEvent(Constants.events.CREATE_FIRST_FEATURE)
-            flagsmith.trackEvent('first_feature_created', flag.name, {
-              feature_type: featureType,
-              project_id: projectId,
-            })
+            if (flagsmith.eventsEnabled) {
+              flagsmith.trackEvent('first_feature_created', {
+                metadata: {
+                  feature_type: featureType,
+                  project_id: projectId,
+                },
+                value: flag.name,
+              })
+            }
             window.lintrk?.('track', { conversion_id: 16798354 })
-          } else {
-            flagsmith.trackEvent('feature_created', flag.name, {
-              feature_type: featureType,
-              project_id: projectId,
-              total_feature_count: store.model?.features?.length ?? 0,
+          } else if (flagsmith.eventsEnabled) {
+            flagsmith.trackEvent('feature_created', {
+              metadata: {
+                feature_type: featureType,
+                project_id: projectId,
+                total_feature_count: store.model?.features?.length ?? 0,
+              },
+              value: flag.name,
             })
           }
         }),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@dnd-kit/abstract": "^0.3.2",
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
-        "@flagsmith/flagsmith": "11.0.0-internal.9",
+        "@flagsmith/flagsmith": "11.0.0-internal.10",
         "@ionic/react": "^7.5.3",
         "@react-oauth/google": "^0.2.8",
         "@reduxjs/toolkit": "1.9.1",
@@ -3233,9 +3233,9 @@
       }
     },
     "node_modules/@flagsmith/flagsmith": {
-      "version": "11.0.0-internal.9",
-      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-11.0.0-internal.9.tgz",
-      "integrity": "sha512-a4QodUy6uW+O+0Dr/6FTRwlFJ+qm2Y18M+CpPhDonIs7FK5Ecw5hLJ3BKl8hjab22SL3pJ2W8futQN2Ioup+WA==",
+      "version": "11.0.0-internal.10",
+      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-11.0.0-internal.10.tgz",
+      "integrity": "sha512-bt34SK4fCn6oC6DhVNDdwK3ubh5rWv+BmBfk6EKsD2c46amEgIFD60STu+FlgStPlhvesNOyRTgJRT06JHGWcg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@floating-ui/core": {
@@ -4851,9 +4851,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4871,9 +4868,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4891,9 +4885,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4911,9 +4902,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4931,9 +4919,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4951,9 +4936,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4971,9 +4953,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4991,9 +4970,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5229,9 +5205,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5246,9 +5219,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5263,9 +5233,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5280,9 +5247,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5297,9 +5261,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5314,9 +5275,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5331,9 +5289,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5348,9 +5303,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5541,9 +5493,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5563,9 +5512,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5587,9 +5533,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5609,9 +5552,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5633,9 +5573,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5655,9 +5592,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5908,9 +5842,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5923,9 +5854,6 @@
       "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5940,9 +5868,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5955,9 +5880,6 @@
       "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6042,9 +5964,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6057,9 +5976,6 @@
       "integrity": "sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6074,9 +5990,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6089,9 +6002,6 @@
       "integrity": "sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7310,9 +7220,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7330,9 +7237,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7350,9 +7254,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7370,9 +7271,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7390,9 +7288,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7410,9 +7305,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8638,9 +8530,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8655,9 +8544,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8672,9 +8558,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8689,9 +8572,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8706,9 +8586,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8723,9 +8600,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8740,9 +8614,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8757,9 +8628,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8774,9 +8642,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8791,9 +8656,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@dnd-kit/abstract": "^0.3.2",
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
-        "@flagsmith/flagsmith": "11.0.0-internal.10",
+        "@flagsmith/flagsmith": "11.0.0-internal.11",
         "@ionic/react": "^7.5.3",
         "@react-oauth/google": "^0.2.8",
         "@reduxjs/toolkit": "1.9.1",
@@ -3233,9 +3233,9 @@
       }
     },
     "node_modules/@flagsmith/flagsmith": {
-      "version": "11.0.0-internal.10",
-      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-11.0.0-internal.10.tgz",
-      "integrity": "sha512-bt34SK4fCn6oC6DhVNDdwK3ubh5rWv+BmBfk6EKsD2c46amEgIFD60STu+FlgStPlhvesNOyRTgJRT06JHGWcg==",
+      "version": "11.0.0-internal.11",
+      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-11.0.0-internal.11.tgz",
+      "integrity": "sha512-u2Mprn3GLz53TUEo1rpfK/18BMQbwf9Z5mKhs9jnUnRDjqh23Ud+83AwSPNjif5EjgXbrEg4p76gY8k/E/1RoA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@floating-ui/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "@dnd-kit/abstract": "^0.3.2",
     "@dnd-kit/helpers": "^0.3.2",
     "@dnd-kit/react": "^0.3.2",
-    "@flagsmith/flagsmith": "11.0.0-internal.10",
+    "@flagsmith/flagsmith": "11.0.0-internal.11",
     "@ionic/react": "^7.5.3",
     "@react-oauth/google": "^0.2.8",
     "@reduxjs/toolkit": "1.9.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "@dnd-kit/abstract": "^0.3.2",
     "@dnd-kit/helpers": "^0.3.2",
     "@dnd-kit/react": "^0.3.2",
-    "@flagsmith/flagsmith": "11.0.0-internal.9",
+    "@flagsmith/flagsmith": "11.0.0-internal.10",
     "@ionic/react": "^7.5.3",
     "@react-oauth/google": "^0.2.8",
     "@reduxjs/toolkit": "1.9.1",

--- a/frontend/web/components/experiments/ExperimentsFakeDoor/ExperimentsFakeDoor.tsx
+++ b/frontend/web/components/experiments/ExperimentsFakeDoor/ExperimentsFakeDoor.tsx
@@ -26,14 +26,12 @@ const ExperimentsFakeDoor: FC = () => {
         organisation: organisation?.name,
       },
     })
-    if (flagsmith.eventsEnabled) {
-      flagsmith.trackEvent('experiments_beta_signup', {
-        metadata: {
-          email: user?.email,
-          organisation: organisation?.name,
-        },
-      })
-    }
+    flagsmith.trackEvent('experiments_beta_signup', {
+      metadata: {
+        email: user?.email,
+        organisation: organisation?.name,
+      },
+    })
     flagsmith.setTrait(TRAIT_KEY, true).then(() => {
       setSignedUp(true)
     })

--- a/frontend/web/components/experiments/ExperimentsFakeDoor/ExperimentsFakeDoor.tsx
+++ b/frontend/web/components/experiments/ExperimentsFakeDoor/ExperimentsFakeDoor.tsx
@@ -16,15 +16,24 @@ const ExperimentsFakeDoor: FC = () => {
   const handleSignUp = useCallback(() => {
     const user = AccountStore.getUser()
     const organisation = AccountStore.getOrganisation()
+    const name = `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim()
     API.trackEvent({
       category: 'experiments',
       event: 'experiments_beta_signup',
       extra: {
         email: user?.email,
-        name: `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim(),
+        name,
         organisation: organisation?.name,
       },
     })
+    if (flagsmith.eventsEnabled) {
+      flagsmith.trackEvent('experiments_beta_signup', {
+        metadata: {
+          email: user?.email,
+          organisation: organisation?.name,
+        },
+      })
+    }
     flagsmith.setTrait(TRAIT_KEY, true).then(() => {
       setSignedUp(true)
     })

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
@@ -43,16 +43,14 @@ const FeatureCodeReferencesContainer: React.FC<
         (sum, repo) => sum + repo.code_references.length,
         0,
       )
-      if (flagsmith.eventsEnabled) {
-        flagsmith.trackEvent('code_references_view', {
-          metadata: {
-            feature_id: featureId,
-            project_id: projectId,
-            repos_count: data.length,
-            total_refs_count: totalRefs,
-          },
-        })
-      }
+      flagsmith.trackEvent('code_references_view', {
+        metadata: {
+          feature_id: featureId,
+          project_id: projectId,
+          repos_count: data.length,
+          total_refs_count: totalRefs,
+        },
+      })
     }
   }, [data, featureId, projectId])
 

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
@@ -43,12 +43,16 @@ const FeatureCodeReferencesContainer: React.FC<
         (sum, repo) => sum + repo.code_references.length,
         0,
       )
-      flagsmith.trackEvent('code_references_view', {
-        feature_id: featureId,
-        project_id: projectId,
-        repos_count: data.length,
-        total_refs_count: totalRefs,
-      })
+      if (flagsmith.eventsEnabled) {
+        flagsmith.trackEvent('code_references_view', {
+          metadata: {
+            feature_id: featureId,
+            project_id: projectId,
+            repos_count: data.length,
+            total_refs_count: totalRefs,
+          },
+        })
+      }
     }
   }, [data, featureId, projectId])
 

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/CodeReferenceItem.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/CodeReferenceItem.tsx
@@ -31,14 +31,12 @@ const CodeReferenceItem: React.FC<CodeReferenceItemProps> = ({
         target='_blank'
         rel='noreferrer'
         onClick={() => {
-          if (flagsmith.eventsEnabled) {
-            flagsmith.trackEvent('code_references_click_permalink', {
-              metadata: {
-                feature_id: featureId,
-                vcs_provider: vcsProvider,
-              },
-            })
-          }
+          flagsmith.trackEvent('code_references_click_permalink', {
+            metadata: {
+              feature_id: featureId,
+              vcs_provider: vcsProvider,
+            },
+          })
         }}
       >
         {codeReference.file_path}:{codeReference.line_number}

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/CodeReferenceItem.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/CodeReferenceItem.tsx
@@ -31,10 +31,14 @@ const CodeReferenceItem: React.FC<CodeReferenceItemProps> = ({
         target='_blank'
         rel='noreferrer'
         onClick={() => {
-          flagsmith.trackEvent('code_references_click_permalink', {
-            feature_id: featureId,
-            vcs_provider: vcsProvider,
-          })
+          if (flagsmith.eventsEnabled) {
+            flagsmith.trackEvent('code_references_click_permalink', {
+              metadata: {
+                feature_id: featureId,
+                vcs_provider: vcsProvider,
+              },
+            })
+          }
         }}
       >
         {codeReference.file_path}:{codeReference.line_number}

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/RepoCodeReferencesSection.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/RepoCodeReferencesSection.tsx
@@ -47,11 +47,15 @@ const RepoCodeReferencesSection: React.FC<RepoCodeReferencesSectionProps> = ({
           className='flex justify-content-between items-center cursor-pointer'
           onClick={() => {
             if (!isOpen) {
-              flagsmith.trackEvent('code_references_expand_repo', {
-                feature_id: featureId,
-                refs_count: repositoryScan?.code_references?.length,
-                vcs_provider: repositoryScan?.vcs_provider,
-              })
+              if (flagsmith.eventsEnabled) {
+                flagsmith.trackEvent('code_references_expand_repo', {
+                  metadata: {
+                    feature_id: featureId,
+                    refs_count: repositoryScan?.code_references?.length,
+                    vcs_provider: repositoryScan?.vcs_provider,
+                  },
+                })
+              }
             }
             setIsOpen(!isOpen)
           }}

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/RepoCodeReferencesSection.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/RepoCodeReferencesSection.tsx
@@ -47,15 +47,13 @@ const RepoCodeReferencesSection: React.FC<RepoCodeReferencesSectionProps> = ({
           className='flex justify-content-between items-center cursor-pointer'
           onClick={() => {
             if (!isOpen) {
-              if (flagsmith.eventsEnabled) {
-                flagsmith.trackEvent('code_references_expand_repo', {
-                  metadata: {
-                    feature_id: featureId,
-                    refs_count: repositoryScan?.code_references?.length,
-                    vcs_provider: repositoryScan?.vcs_provider,
-                  },
-                })
-              }
+              flagsmith.trackEvent('code_references_expand_repo', {
+                metadata: {
+                  feature_id: featureId,
+                  refs_count: repositoryScan?.code_references?.length,
+                  vcs_provider: repositoryScan?.vcs_provider,
+                },
+              })
             }
             setIsOpen(!isOpen)
           }}

--- a/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
@@ -47,13 +47,11 @@ const UsageTab: FC<UsageTabProps> = ({
             href='https://docs.flagsmith.com/managing-flags/code-references'
             rel='noreferrer'
             onClick={() => {
-              if (flagsmith.eventsEnabled) {
-                flagsmith.trackEvent('code_references_click_docs', {
-                  metadata: {
-                    feature_id: featureId,
-                  },
-                })
-              }
+              flagsmith.trackEvent('code_references_click_docs', {
+                metadata: {
+                  feature_id: featureId,
+                },
+              })
             }}
           >
             Learn more

--- a/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
@@ -47,9 +47,13 @@ const UsageTab: FC<UsageTabProps> = ({
             href='https://docs.flagsmith.com/managing-flags/code-references'
             rel='noreferrer'
             onClick={() => {
-              flagsmith.trackEvent('code_references_click_docs', {
-                feature_id: featureId,
-              })
+              if (flagsmith.eventsEnabled) {
+                flagsmith.trackEvent('code_references_click_docs', {
+                  metadata: {
+                    feature_id: featureId,
+                  },
+                })
+              }
             }}
           >
             Learn more

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseEventCodeHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseEventCodeHelp.tsx
@@ -43,8 +43,17 @@ System.out.println("Hello, Flagsmith Warehouse!");`,
   'JavaScript': {
     code: `import flagsmith from 'flagsmith';
 
-flagsmith.init({ environmentID: 'YOUR_ENVIRONMENT_KEY' });
-console.log('Hello, Flagsmith Warehouse!');`,
+await flagsmith.init({
+  environmentID: 'YOUR_ENVIRONMENT_KEY',
+  enableEvents: true,
+});
+
+flagsmith.trackEvent('purchase', {
+  identifier: 'user_42',
+  value: 99.5,
+  traits: { plan: 'premium' },
+  metadata: { source: 'web' },
+});`,
     enabled: true,
   },
   'Node JS': {
@@ -64,8 +73,18 @@ echo "Hello, Flagsmith Warehouse!";`,
   'Python': {
     code: `from flagsmith import Flagsmith
 
-flagsmith = Flagsmith(environment_key="YOUR_ENVIRONMENT_KEY")
-print("Hello, Flagsmith Ruby Warehouse!")`,
+flagsmith = Flagsmith(
+    environment_key="YOUR_ENVIRONMENT_KEY",
+    enable_events=True,
+)
+
+flagsmith.track_event(
+    "purchase",
+    identifier="user_42",
+    value=99.5,
+    traits={"plan": "premium"},
+    metadata={"source": "web"},
+)`,
     enabled: true,
   },
   'Ruby': {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Bumps @flagsmith/flagsmith to `11.0.0-internal.10`, whose events API changed: trackEvent is now `trackEvent(event, { value, metadata })`

- Enable events at `init` (config-store.js).
- Migrate the existing `trackEvent` calls to the new signature.
- Emit a new `experiments_beta_signup` custom event (metadata: email, organisation) alongside the existing Amplitude event when a user signs up for the Experiments beta.

## How did you test this code?
- Manually against staging ensuring events were processed