### PR TITLE
ci: Run flagsmith-private test suites inline on 0.9.0

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--extra private --extra auth-controller"
+          make install-packages opts="--extra private"
           rm -rf ${HOME}/.git-credentials
 
       - name: Generate MCP schema

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--extra dev --extra private --extra auth-controller"
+          make install-packages opts="--extra dev --extra private"
           make integrate-private-tests
           rm -rf ${HOME}/.git-credentials
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM build-python AS build-python-private
 
 # Authenticate git with token and install private Python dependencies
-ARG EXTRAS="--extra private --extra auth-controller --extra ldap --extra licensing"
+ARG EXTRAS="--extra private --extra ldap --extra licensing"
 RUN --mount=type=secret,id=github_private_cloud_token \
   --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
@@ -176,7 +176,7 @@ RUN --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD="$(cat /run/secrets/codeartifact_token)" \
-  make install-packages opts='--extra dev --extra private --extra auth-controller --extra ldap --extra licensing' && \
+  make install-packages opts='--extra dev --extra private --extra ldap --extra licensing' && \
   make integrate-private-tests && \
   git config --global --unset credential.helper && \
   rm -f ${HOME}/.git-credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM build-python AS build-python-private
 
 # Authenticate git with token and install private Python dependencies
-ARG EXTRAS="--extra private --extra ldap --extra licensing"
+ARG EXTRAS="--extra private"
 RUN --mount=type=secret,id=github_private_cloud_token \
   --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
@@ -176,7 +176,7 @@ RUN --mount=type=secret,id=codeartifact_token \
   --mount=type=cache,target=/root/.cache/uv \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME=aws \
   UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD="$(cat /run/secrets/codeartifact_token)" \
-  make install-packages opts='--extra dev --extra private --extra ldap --extra licensing' && \
+  make install-packages opts='--extra dev --extra private' && \
   make integrate-private-tests && \
   git config --global --unset credential.helper && \
   rm -f ${HOME}/.git-credentials

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -9,5 +9,13 @@ static/*
 saml/
 features/workflows/logic/
 
+# flagsmith-private test suites integrated via `make integrate-private-tests`
+/flagsmith-private/
+/tests/rbac_tests/
+/tests/workflow_tests/
+/tests/auth_controller_tests/
+/tests/saml_integration_tests/
+/tests/saml_unit_tests/
+
 # Unit test coverage
 .coverage

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -15,6 +15,8 @@ features/workflows/logic/
 /tests/workflow_tests/
 /tests/auth_controller_tests/
 /tests/saml_integration_tests/
+/tests/licensing_integration_tests/
+/tests/ldap_integration_tests/
 /tests/saml_unit_tests/
 
 # Unit test coverage

--- a/api/Makefile
+++ b/api/Makefile
@@ -149,16 +149,22 @@ generate-grafana-client-types:
 		--wrap-string-literal \
 		--special-field-name-prefix=
 
+# scim and release_pipelines_logic are deliberately not pulled here: scim's
+# compliance tests need an SCIM_SERVICE_PROVIDER config that conflicts with Core
+# API's own scim tests (django-scim2 caches it globally), and release_pipelines
+# has an order-dependent assertion that only holds in isolation. Both run in
+# flagsmith-private's own CI.
+# TODO https://github.com/Flagsmith/flagsmith-private/issues/177
 .PHONY: integrate-private-tests
 integrate-private-tests:
 	$(eval FLAGSMITH_PRIVATE_REVISION := v$(shell uv run python -c 'import importlib.metadata; print(importlib.metadata.version("flagsmith-private"))'))
-	$(eval AUTH_CONTROLLER_REVISION := $(shell uv run python -c 'import tomllib; d=tomllib.load(open("pyproject.toml","rb")); s=d.get("tool",{}).get("uv",{}).get("sources",{}).get("auth-controller",{}); print(s.get("tag") or s.get("rev") or "")'))
-
-	git clone https://github.com/Flagsmith/flagsmith-private --depth 1 --branch ${FLAGSMITH_PRIVATE_REVISION} \
-		&& mv ./flagsmith-private/integration_tests/rbac tests/rbac_tests \
-		&& mv ./flagsmith-private/integration_tests/workflows_logic tests/workflow_tests
-	git clone https://github.com/flagsmith/flagsmith-auth-controller --depth 1 --branch ${AUTH_CONTROLLER_REVISION} && mv ./flagsmith-auth-controller/tests tests/auth_controller_tests
-	rm -rf ./flagsmith-private ./flagsmith-auth-controller
+	git clone https://github.com/Flagsmith/flagsmith-private --depth 1 --branch ${FLAGSMITH_PRIVATE_REVISION}
+	mv ./flagsmith-private/integration_tests/rbac tests/rbac_tests
+	mv ./flagsmith-private/integration_tests/workflows_logic tests/workflow_tests
+	mv ./flagsmith-private/integration_tests/auth_controller tests/auth_controller_tests
+	mv ./flagsmith-private/integration_tests/saml tests/saml_integration_tests
+	mv ./flagsmith-private/unit_tests/saml tests/saml_unit_tests
+	rm -rf ./flagsmith-private
 
 .PHONY: generate-docs
 generate-docs: generate-flagsmith-sdk-openapi

--- a/api/Makefile
+++ b/api/Makefile
@@ -149,6 +149,12 @@ generate-grafana-client-types:
 		--wrap-string-literal \
 		--special-field-name-prefix=
 
+PRIVATE_TEST_DIRS := tests/rbac_tests tests/workflow_tests tests/auth_controller_tests tests/saml_integration_tests tests/licensing_integration_tests tests/ldap_integration_tests tests/saml_unit_tests
+
+.PHONY: clean-private-tests
+clean-private-tests:
+	rm -rf $(PRIVATE_TEST_DIRS)
+
 # scim and release_pipelines_logic are deliberately not pulled here: scim's
 # compliance tests need an SCIM_SERVICE_PROVIDER config that conflicts with Core
 # API's own scim tests (django-scim2 caches it globally), and release_pipelines
@@ -157,6 +163,12 @@ generate-grafana-client-types:
 # TODO https://github.com/Flagsmith/flagsmith-private/issues/177
 .PHONY: integrate-private-tests
 integrate-private-tests:
+	@for dir in $(PRIVATE_TEST_DIRS); do \
+		if [ -d "$$dir" ]; then \
+			echo "Warning: $$dir already exists. Run 'make clean-private-tests' to remove all private test directories before re-running this command."; \
+			exit 1; \
+		fi; \
+	done
 	$(eval FLAGSMITH_PRIVATE_REVISION := v$(shell uv run python -c 'import importlib.metadata; print(importlib.metadata.version("flagsmith-private"))'))
 	git clone https://github.com/Flagsmith/flagsmith-private --depth 1 --branch ${FLAGSMITH_PRIVATE_REVISION}
 	mv ./flagsmith-private/integration_tests/rbac tests/rbac_tests

--- a/api/Makefile
+++ b/api/Makefile
@@ -163,6 +163,8 @@ integrate-private-tests:
 	mv ./flagsmith-private/integration_tests/workflows_logic tests/workflow_tests
 	mv ./flagsmith-private/integration_tests/auth_controller tests/auth_controller_tests
 	mv ./flagsmith-private/integration_tests/saml tests/saml_integration_tests
+	mv ./flagsmith-private/integration_tests/licensing tests/licensing_integration_tests
+	mv ./flagsmith-private/integration_tests/flagsmith_ldap tests/ldap_integration_tests
 	mv ./flagsmith-private/unit_tests/saml tests/saml_unit_tests
 	rm -rf ./flagsmith-private
 

--- a/api/app/settings/test.py
+++ b/api/app/settings/test.py
@@ -1,5 +1,9 @@
 from app.settings.common import *  # noqa
-from app.settings.common import REST_FRAMEWORK
+from app.settings.common import INSTALLED_APPS, LDAP_INSTALLED, REST_FRAMEWORK
+
+if LDAP_INSTALLED:
+    INSTALLED_APPS = INSTALLED_APPS + ["flagsmith_ldap"]
+    LDAP_DEFAULT_FLAGSMITH_ORGANISATION_ID = None
 
 # We dont want to track tests
 ENABLE_TELEMETRY = False

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -94,12 +94,8 @@ dependencies = [
 # without a PEP 517 `[build-system]` table, so setuptools fallback drops
 # them from the built wheel. We re-declare those transitive deps here so
 # the resolution matches what poetry produced on main.
-auth-controller = [
-    "auth-controller",
-    "django-multiselectfield>=1.0.1,<2",
-]
 private = [
-    "flagsmith-private>=0.7.0,<1",
+    "flagsmith-private>=0.8.0,<1",
 ]
 ldap = [
     "flagsmith-ldap",
@@ -174,7 +170,6 @@ url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazon
 explicit = true
 
 [tool.uv.sources]
-auth-controller = { git = "https://github.com/flagsmith/flagsmith-auth-controller", tag = "v0.2.0" }
 flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v0.1.2" }
 licensing = { git = "https://github.com/flagsmith/licensing", tag = "v0.3.0" }
 flagsmith-private = { index = "flagsmith-pypi-production" }

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -85,15 +85,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Optional groups historically pulled in as git deps from the original
-# poetry config. The dist names below match what each upstream project
-# actually publishes via its current build backend (setuptools fallback
-# for repos without [build-system], poetry-core where present).
-#
-# Several upstream repos declare deps via `[tool.poetry.dependencies]`
-# without a PEP 517 `[build-system]` table, so setuptools fallback drops
-# them from the built wheel. We re-declare those transitive deps here so
-# the resolution matches what poetry produced on main.
 private = [
     "flagsmith-private>=0.9.0,<1",
 ]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -95,15 +95,7 @@ dependencies = [
 # them from the built wheel. We re-declare those transitive deps here so
 # the resolution matches what poetry produced on main.
 private = [
-    "flagsmith-private>=0.8.0,<1",
-]
-ldap = [
-    "flagsmith-ldap",
-    "django-python3-ldap>=0.15.6,<1",
-]
-licensing = [
-    "licensing",
-    "cryptography>=44.0.1",
+    "flagsmith-private>=0.9.0,<1",
 ]
 dev = [
     "django-test-migrations>=1.2.0,<2.0.0",
@@ -170,8 +162,6 @@ url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazon
 explicit = true
 
 [tool.uv.sources]
-flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v0.1.2" }
-licensing = { git = "https://github.com/flagsmith/licensing", tag = "v0.3.0" }
 flagsmith-private = { index = "flagsmith-pypi-production" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -368,11 +368,6 @@ wheels = [
 ]
 
 [[package]]
-name = "auth-controller"
-version = "0.0.0"
-source = { git = "https://github.com/flagsmith/flagsmith-auth-controller?tag=v0.2.0#b7fa1f42c333b443763548ea1fe0054f07cdf641" }
-
-[[package]]
 name = "autopep8"
 version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1473,10 +1468,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-auth-controller = [
-    { name = "auth-controller" },
-    { name = "django-multiselectfield" },
-]
 dev = [
     { name = "autopep8" },
     { name = "boto3-stubs" },
@@ -1534,7 +1525,6 @@ private = [
 requires-dist = [
     { name = "appdirs", specifier = ">=1.4.4,<1.5.0" },
     { name = "asgiref", specifier = ">=3.8.1,<3.9.0" },
-    { name = "auth-controller", marker = "extra == 'auth-controller'", git = "https://github.com/flagsmith/flagsmith-auth-controller?tag=v0.2.0" },
     { name = "autopep8", marker = "extra == 'dev'", specifier = ">=2.0.1,<2.1.0" },
     { name = "backoff", specifier = ">=2.2.1,<2.3.0" },
     { name = "boto3", specifier = ">=1.35.95,<1.36.0" },
@@ -1558,7 +1548,6 @@ requires-dist = [
     { name = "django-filter", specifier = ">=2.4.0,<2.5.0" },
     { name = "django-health-check", specifier = ">=3.18.2,<3.19.0" },
     { name = "django-lifecycle", specifier = ">=1.2.4,<1.3.0" },
-    { name = "django-multiselectfield", marker = "extra == 'auth-controller'", specifier = ">=1.0.1,<2" },
     { name = "django-oauth-toolkit", specifier = ">=3.0.1,<4.0.0" },
     { name = "django-ordered-model", specifier = ">=3.4.1,<3.5.0" },
     { name = "django-python3-ldap", marker = "extra == 'ldap'", specifier = ">=0.15.6,<1" },
@@ -1586,7 +1575,7 @@ requires-dist = [
     { name = "flagsmith-common", extras = ["test-tools"], marker = "extra == 'dev'" },
     { name = "flagsmith-flag-engine", specifier = ">=10.1.0,<11.0.0" },
     { name = "flagsmith-ldap", marker = "extra == 'ldap'", git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2" },
-    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.7.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
+    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.8.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
     { name = "flagsmith-sql-flag-engine", specifier = ">=0.1.0,<0.2.0" },
     { name = "google-api-python-client", specifier = ">=1.12.5,<1.13.0" },
     { name = "google-re2", specifier = ">=1.0,<2.0.0" },
@@ -1650,7 +1639,7 @@ requires-dist = [
     { name = "tzdata", specifier = ">=2024.1,<2025.0.0" },
     { name = "whitenoise", specifier = ">=6.0.0,<6.1.0" },
 ]
-provides-extras = ["auth-controller", "private", "ldap", "licensing", "dev"]
+provides-extras = ["private", "ldap", "licensing", "dev"]
 
 [[package]]
 name = "flagsmith-common"
@@ -1725,16 +1714,17 @@ source = { git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2#2456465
 
 [[package]]
 name = "flagsmith-private"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" }
 dependencies = [
+    { name = "django-multiselectfield" },
     { name = "django-scim2" },
     { name = "pysaml2" },
     { name = "scim2-filter-parser" },
 ]
-sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.7.0/flagsmith_private-0.7.0.tar.gz", hash = "sha256:5fc8cab32e51cf0ff8fa6205124128c6182433731934f5df60f3889d98df7b71" }
+sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.8.0/flagsmith_private-0.8.0.tar.gz", hash = "sha256:9c9781f9db6a8e0e39cb8da791c67311898dfc605766031d4ab7d55a38703b34" }
 wheels = [
-    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.7.0/flagsmith_private-0.7.0-py3-none-any.whl", hash = "sha256:370bebed2bc28f857acbaf4c1080fcd377b202ad8839ca5daceedce53948351a" },
+    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.8.0/flagsmith_private-0.8.0-py3-none-any.whl", hash = "sha256:e7fc5ebec132a7ccfd176a5f8d94bb30fd657bdddef9f4e5751d56f8c7657ea7" },
 ]
 
 [[package]]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1509,14 +1509,6 @@ dev = [
     { name = "types-pytz" },
     { name = "types-requests" },
 ]
-ldap = [
-    { name = "django-python3-ldap" },
-    { name = "flagsmith-ldap" },
-]
-licensing = [
-    { name = "cryptography" },
-    { name = "licensing" },
-]
 private = [
     { name = "flagsmith-private" },
 ]
@@ -1532,7 +1524,6 @@ requires-dist = [
     { name = "chargebee", specifier = ">=3.10.0,<4.0.0" },
     { name = "clickhouse-driver", git = "https://github.com/Flagsmith/clickhouse-driver?branch=newjson" },
     { name = "coreapi", specifier = ">=2.3.3,<2.4.0" },
-    { name = "cryptography", marker = "extra == 'licensing'", specifier = ">=44.0.1" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.25,<0.26.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=10.1.0,<11.0.0" },
     { name = "dj-database-url", specifier = ">=3.0.1,<3.1.0" },
@@ -1550,7 +1541,6 @@ requires-dist = [
     { name = "django-lifecycle", specifier = ">=1.2.4,<1.3.0" },
     { name = "django-oauth-toolkit", specifier = ">=3.0.1,<4.0.0" },
     { name = "django-ordered-model", specifier = ">=3.4.1,<3.5.0" },
-    { name = "django-python3-ldap", marker = "extra == 'ldap'", specifier = ">=0.15.6,<1" },
     { name = "django-redis", specifier = ">=5.4.0,<6.0.0" },
     { name = "django-ses", specifier = ">=3.5.0,<3.6.0" },
     { name = "django-simple-history", specifier = ">=2.12.0,<2.13.0" },
@@ -1574,8 +1564,7 @@ requires-dist = [
     { name = "flagsmith-common", extras = ["common-core", "flagsmith-schemas", "task-processor"], specifier = ">=3.9.1,<4" },
     { name = "flagsmith-common", extras = ["test-tools"], marker = "extra == 'dev'" },
     { name = "flagsmith-flag-engine", specifier = ">=10.1.0,<11.0.0" },
-    { name = "flagsmith-ldap", marker = "extra == 'ldap'", git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2" },
-    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.8.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
+    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.9.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
     { name = "flagsmith-sql-flag-engine", specifier = ">=0.1.0,<0.2.0" },
     { name = "google-api-python-client", specifier = ">=1.12.5,<1.13.0" },
     { name = "google-re2", specifier = ">=1.0,<2.0.0" },
@@ -1583,7 +1572,6 @@ requires-dist = [
     { name = "hubspot-api-client", specifier = ">=12.0.0,<13.0.0" },
     { name = "influxdb-client", specifier = ">=1.50.0,<1.51.0" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=9.10.0,<10.0.0" },
-    { name = "licensing", marker = "extra == 'licensing'", git = "https://github.com/flagsmith/licensing?tag=v0.3.0" },
     { name = "moto", marker = "extra == 'dev'", specifier = ">=4.1.3,<4.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0,<2.0.0" },
     { name = "mypy-boto3-dynamodb", marker = "extra == 'dev'", specifier = ">=1.33.0,<2.0.0" },
@@ -1639,7 +1627,7 @@ requires-dist = [
     { name = "tzdata", specifier = ">=2024.1,<2025.0.0" },
     { name = "whitenoise", specifier = ">=6.0.0,<6.1.0" },
 ]
-provides-extras = ["private", "ldap", "licensing", "dev"]
+provides-extras = ["private", "dev"]
 
 [[package]]
 name = "flagsmith-common"
@@ -1708,23 +1696,20 @@ wheels = [
 ]
 
 [[package]]
-name = "flagsmith-ldap"
-version = "0.0.0"
-source = { git = "https://github.com/flagsmith/flagsmith-ldap?tag=v0.1.2#2456465164f39c8ec77c28a029f72119a93c6776" }
-
-[[package]]
 name = "flagsmith-private"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" }
 dependencies = [
+    { name = "cryptography" },
     { name = "django-multiselectfield" },
+    { name = "django-python3-ldap" },
     { name = "django-scim2" },
     { name = "pysaml2" },
     { name = "scim2-filter-parser" },
 ]
-sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.8.0/flagsmith_private-0.8.0.tar.gz", hash = "sha256:9c9781f9db6a8e0e39cb8da791c67311898dfc605766031d4ab7d55a38703b34" }
+sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.9.0/flagsmith_private-0.9.0.tar.gz", hash = "sha256:fc7b11ff24205f07e8eca8debbbf71807ec1da456a2572df4ec6815a4cce8ade" }
 wheels = [
-    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.8.0/flagsmith_private-0.8.0-py3-none-any.whl", hash = "sha256:e7fc5ebec132a7ccfd176a5f8d94bb30fd657bdddef9f4e5751d56f8c7657ea7" },
+    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.9.0/flagsmith_private-0.9.0-py3-none-any.whl", hash = "sha256:6e3fa41790af07cc3296cd45c498e73c35f5b8645a59679627e8287717dcdc95" },
 ]
 
 [[package]]
@@ -2219,11 +2204,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/43/ac/96bd5464e3edbc615
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/f6/71d6ec9f18da0b2201287ce9db6afb1a1f637dedb3f0703409558981c723/ldap3-2.9.1-py2.py3-none-any.whl", hash = "sha256:5869596fc4948797020d3f03b7939da938778a0f9e2009f7a072ccf92b8e8d70", size = 432192, upload-time = "2021-07-18T06:34:12.905Z" },
 ]
-
-[[package]]
-name = "licensing"
-version = "0.0.0"
-source = { git = "https://github.com/flagsmith/licensing?tag=v0.3.0#d38953cd93cb99eab7fd92a0467d8bfcccc4cf96" }
 
 [[package]]
 name = "markupsafe"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to Flagsmith/flagsmith-private#177, supersedes #7665.

Follows on from #7656, which consolidated `rbac` and `workflows_logic` into `flagsmith-private` and runs their suites inline via `make test`. This extends the same pattern to `flagsmith-private` 0.9.0, which also bundles `auth_controller`, `licensing` and `flagsmith-ldap` so the private suites run inline against Core API again.

- Bump `flagsmith-private` to `>=0.9.0`. It now ships `auth_controller`, `licensing` and `flagsmith-ldap` so drop the extras and git source references; `integrate-private-tests` no longer clones them separately.
- `integrate-private-tests` pulls each app's tests from `flagsmith-private` at the installed wheel's tag and drops them under `tests/` so they inherit Core API's `tests/conftest` and run inline with `make test`.
- `.gitignore` the cloned repo and the staged `tests/*_tests` directories.

`scim` and `release_pipelines_logic` are deliberately left out for now and continue to run in flagsmith-private's own CI:

- `scim`: its compliance tests require an `SCIM_SERVICE_PROVIDER` config (notably dropping the request-based `BASE_LOCATION_GETTER`) that directly conflicts with Core API's own `tests/integration/scim` tests, and django-scim2 reads that setting once at import — so both suites cannot share one pytest session.
- `release_pipelines_logic`: one test asserts a non-deterministic email ordering that only holds in isolation; it fails when collected alongside the full Core API suite.

Both gaps are tracked in Flagsmith/flagsmith-private#177.

## How did you test this code?

Locally, against the Compose Postgres, with `--extra dev --extra private` installed:

1. `make integrate-private-tests` to stage the suites.
2. Ran the staged suites under Core API's pytest config (`--ds=app.settings.test`, `--import-mode=importlib`):

   ```
   uv run pytest tests/rbac_tests tests/workflow_tests tests/auth_controller_tests \
     tests/saml_integration_tests tests/saml_unit_tests
   ```

   Result: 343 passed.
