### PR TITLE
fix: support decimal multivariate variation weights

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -96,7 +96,7 @@ const Utils = Object.assign({}, BaseUtils, {
       }
       return null
     })
-    return 100 - total
+    return parseFloat((100 - total).toFixed(2))
   },
   calculateRemainingLimitsPercentage(
     total: number | undefined,

--- a/frontend/web/components/mv/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput.tsx
@@ -83,22 +83,21 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
       </div>
       <div className='ml-3' style={{ width: 160 }}>
         <InputGroup
-          type='text'
+          type='number'
           data-test={`featureVariationWeight${Utils.featureStateToValue(
             value,
           )}`}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const val = Utils.safeParseEventValue(e)
             onChange({
               ...value,
-              default_percentage_allocation: Utils.safeParseEventValue(e)
-                ? parseInt(Utils.safeParseEventValue(e))
-                : null,
+              default_percentage_allocation: val ? parseFloat(val) : null,
             })
           }}
           value={value.default_percentage_allocation}
           inputProps={{
-            maxLength: 3,
             readOnly: disabled,
+            step: 'any',
           }}
           title={weightTitle}
         />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to docs/ if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7671 

This PR enables support for decimal/fractional values in multivariate variation weights within the dashboard.

**Key updates:**
- Updated `VariationValueInput.tsx` to use a number input type with `step="any"`, allowing for decimal entry.
- Replaced `parseInt` with `parseFloat` in the variation weight change handler to ensure decimal values are preserved in the state.
- Updated the `calculateControl` utility in `utils.tsx` to round the calculated control remainder to 2 decimal places, preventing floating-point precision artifacts (e.g., `0.09999999999999432`) from appearing in the UI.

## How did you test this code?

- **Manual Verification:** Verified that decimal weights (e.g., 0.1 and 99.9) can now be entered and saved through the dashboard without being rounded to integers.
- **UI Logic Verification:** Confirmed that the "Control Value" percentage correctly calculates and displays as a clean decimal (e.g., 0.1%) when other variations total 99.9%.
- **Regression Testing:** Reviewed existing E2E test patterns to ensure that switching from `type="text"` to `type="number"` does not break existing automation that interacts with these fields.
