### PR TITLE
feat: verify warehouse connection api and events received

### DIFF
--- a/api/experimentation/dataclasses.py
+++ b/api/experimentation/dataclasses.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WarehouseEventStats:
+    total_events_received: int
+    unique_events_count: int

--- a/api/experimentation/models.py
+++ b/api/experimentation/models.py
@@ -1,3 +1,5 @@
+import typing
+
 from django.db import models
 from django.db.models import Q
 from django_lifecycle import (  # type: ignore[import-untyped]
@@ -13,6 +15,9 @@ from experimentation.tasks import (
     add_environment_key_to_ingestion,
     delete_environment_key_from_ingestion,
 )
+
+if typing.TYPE_CHECKING:
+    from experimentation.dataclasses import WarehouseEventStats
 
 
 class WarehouseType(models.TextChoices):
@@ -48,6 +53,10 @@ class WarehouseConnection(LifecycleModelMixin, SoftDeleteExportableModel):  # ty
         models.JSONField(null=True, blank=True)
     )
     created_at = models.DateTimeField(auto_now_add=True)
+
+    # Populated at serialization time for flagsmith connections from ClickHouse;
+    # never persisted to the database.
+    event_stats: "WarehouseEventStats | None" = None
 
     class Meta:
         constraints = [

--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework import serializers
 
 from environments.models import Environment
+from experimentation.dataclasses import WarehouseEventStats
 from experimentation.models import (
     Experiment,
     WarehouseConnection,
@@ -17,10 +18,21 @@ from features.multivariate.serializers import NestedMultivariateFeatureOptionSer
 class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     name = serializers.CharField(max_length=255, required=False)
     config = serializers.JSONField(default=None, required=False, allow_null=True)
+    total_events_received = serializers.SerializerMethodField()
+    unique_events_count = serializers.SerializerMethodField()
 
     class Meta:
         model = WarehouseConnection
-        fields = ("id", "warehouse_type", "status", "name", "config", "created_at")
+        fields = (
+            "id",
+            "warehouse_type",
+            "status",
+            "name",
+            "config",
+            "created_at",
+            "total_events_received",
+            "unique_events_count",
+        )
         read_only_fields = ("id", "status", "created_at")
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
@@ -56,6 +68,14 @@ class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignor
 
         result: WarehouseConnection = super().create(validated_data)
         return result
+
+    def get_total_events_received(self, obj: WarehouseConnection) -> int | None:
+        stats: WarehouseEventStats | None = obj.event_stats
+        return stats.total_events_received if stats else None
+
+    def get_unique_events_count(self, obj: WarehouseConnection) -> int | None:
+        stats: WarehouseEventStats | None = obj.event_stats
+        return stats.unique_events_count if stats else None
 
     @staticmethod
     def _generate_name(warehouse_type: str, environment: Environment) -> str:

--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -69,13 +69,13 @@ class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignor
         result: WarehouseConnection = super().create(validated_data)
         return result
 
-    def get_total_events_received(self, obj: WarehouseConnection) -> int | None:
+    def get_total_events_received(self, obj: WarehouseConnection) -> int:
         stats: WarehouseEventStats | None = obj.event_stats
-        return stats.total_events_received if stats else None
+        return stats.total_events_received if stats else 0
 
-    def get_unique_events_count(self, obj: WarehouseConnection) -> int | None:
+    def get_unique_events_count(self, obj: WarehouseConnection) -> int:
         stats: WarehouseEventStats | None = obj.event_stats
-        return stats.unique_events_count if stats else None
+        return stats.unique_events_count if stats else 0
 
     @staticmethod
     def _generate_name(warehouse_type: str, environment: Environment) -> str:

--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -69,13 +69,13 @@ class WarehouseConnectionSerializer(serializers.ModelSerializer):  # type: ignor
         result: WarehouseConnection = super().create(validated_data)
         return result
 
-    def get_total_events_received(self, obj: WarehouseConnection) -> int:
+    def get_total_events_received(self, obj: WarehouseConnection) -> int | None:
         stats: WarehouseEventStats | None = obj.event_stats
-        return stats.total_events_received if stats else 0
+        return stats.total_events_received if stats else None
 
-    def get_unique_events_count(self, obj: WarehouseConnection) -> int:
+    def get_unique_events_count(self, obj: WarehouseConnection) -> int | None:
         stats: WarehouseEventStats | None = obj.event_stats
-        return stats.unique_events_count if stats else 0
+        return stats.unique_events_count if stats else None
 
     @staticmethod
     def _generate_name(warehouse_type: str, environment: Environment) -> str:

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 
 import structlog
 from clickhouse_driver import Client
+from clickhouse_driver.util.helpers import parse_url
 from django.conf import settings
 from django.utils import timezone
 
@@ -26,6 +27,9 @@ if typing.TYPE_CHECKING:
     from users.models import FFAdminUser
 
 logger = structlog.get_logger("warehouse")
+
+CLICKHOUSE_CONNECT_TIMEOUT_SECONDS = 5
+CLICKHOUSE_QUERY_TIMEOUT_SECONDS = 30
 
 
 def is_warehouse_feature_enabled(organisation: Organisation) -> bool:
@@ -49,9 +53,13 @@ def _get_clickhouse_client() -> Client:
     """Build a clickhouse-driver client for the experimentation event store.
 
     The database is taken from the DSN path, so queries can reference the
-    `events` table unqualified.
+    `events` table unqualified. Connect and query timeouts are bounded unless the
+    DSN overrides them.
     """
-    return Client.from_url(settings.EXPERIMENTATION_CLICKHOUSE_URL)
+    host, kwargs = parse_url(settings.EXPERIMENTATION_CLICKHOUSE_URL)
+    kwargs.setdefault("connect_timeout", CLICKHOUSE_CONNECT_TIMEOUT_SECONDS)
+    kwargs.setdefault("send_receive_timeout", CLICKHOUSE_QUERY_TIMEOUT_SECONDS)
+    return Client(host, **kwargs)
 
 
 def get_unique_event_names(environment_key: str) -> list[str]:
@@ -158,7 +166,7 @@ def mark_warehouse_pending_connection(
         return connection
 
     connection.status = WarehouseConnectionStatus.PENDING_CONNECTION
-    connection.save()
+    connection.save(update_fields=["status"])
     logger.info(
         "connection.test_event_sent",
         environment__id=connection.environment_id,
@@ -178,7 +186,7 @@ def refresh_warehouse_connection_status(
         and stats.total_events_received > 0
     ):
         connection.status = WarehouseConnectionStatus.CONNECTED
-        connection.save()
+        connection.save(update_fields=["status"])
         logger.info(
             "connection.connected",
             environment__id=connection.environment_id,
@@ -191,21 +199,15 @@ def annotate_warehouse_event_stats(
     connection: WarehouseConnection,
     environment_key: str,
 ) -> None:
-    """Attach warehouse event stats to a flagsmith connection and update its
-    status to match. No-op for non-flagsmith connections or when no warehouse
-    is configured; leaves the connection unchanged if the warehouse errors."""
+    """Attach live warehouse event stats to a flagsmith connection. No-op for
+    non-flagsmith connections or when no warehouse is configured; leaves stats
+    unset when the warehouse is unreachable. Read-only: never changes status."""
     if (
         connection.warehouse_type != WarehouseType.FLAGSMITH
         or not settings.EXPERIMENTATION_CLICKHOUSE_URL
     ):
         return
     try:
-        stats = get_warehouse_event_stats(environment_key)
+        connection.event_stats = get_warehouse_event_stats(environment_key)
     except Exception:
-        logger.exception(
-            "connection.event_stats_unavailable",
-            environment__id=connection.environment_id,
-        )
         return
-    connection.event_stats = stats
-    refresh_warehouse_connection_status(connection, stats)

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing
 from functools import lru_cache
 
+import structlog
 from clickhouse_driver import Client
 from django.conf import settings
 from django.utils import timezone
@@ -10,12 +11,21 @@ from django.utils import timezone
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from experimentation.constants import EXPERIMENT_FLAG, WAREHOUSE_CONNECTION_FLAG
+from experimentation.dataclasses import WarehouseEventStats
+from experimentation.models import (
+    VALID_STATUS_TRANSITIONS,
+    ExperimentStatus,
+    WarehouseConnectionStatus,
+    WarehouseType,
+)
 from integrations.flagsmith.client import get_openfeature_client
 
 if typing.TYPE_CHECKING:
     from experimentation.models import Experiment, WarehouseConnection
     from organisations.models import Organisation
     from users.models import FFAdminUser
+
+logger = structlog.get_logger("warehouse")
 
 
 def is_warehouse_feature_enabled(organisation: Organisation) -> bool:
@@ -54,6 +64,20 @@ def get_unique_event_names(environment_key: str) -> list[str]:
         {"environment_key": environment_key},
     )
     return [row[0] for row in rows]
+
+
+def get_warehouse_event_stats(environment_key: str) -> WarehouseEventStats:
+    """Return event counts recorded for `environment_key` in the warehouse."""
+    rows = _get_clickhouse_client().execute(
+        "SELECT count() AS total, uniqExact(event) AS unique "
+        "FROM events WHERE environment_key = %(environment_key)s",
+        {"environment_key": environment_key},
+    )
+    total, unique = rows[0] if rows else (0, 0)
+    return WarehouseEventStats(
+        total_events_received=int(total),
+        unique_events_count=int(unique),
+    )
 
 
 def _resolve_audit_log_author(
@@ -107,8 +131,6 @@ def transition_experiment_status(
     target_status: str,
     user: FFAdminUser,
 ) -> Experiment:
-    from experimentation.models import VALID_STATUS_TRANSITIONS, ExperimentStatus
-
     valid_targets = VALID_STATUS_TRANSITIONS.get(experiment.status, set())
     if target_status not in valid_targets:
         raise ValueError(
@@ -125,3 +147,65 @@ def transition_experiment_status(
     experiment.save()
     create_experiment_audit_log(experiment, user, action=target_status)
     return experiment
+
+
+def mark_warehouse_pending_connection(
+    connection: WarehouseConnection,
+) -> WarehouseConnection:
+    """Move a connection from created to pending_connection. No-op for any
+    other status."""
+    if connection.status != WarehouseConnectionStatus.CREATED:
+        return connection
+
+    connection.status = WarehouseConnectionStatus.PENDING_CONNECTION
+    connection.save()
+    logger.info(
+        "connection.test_event_sent",
+        environment__id=connection.environment_id,
+        organisation__id=connection.environment.project.organisation_id,
+    )
+    return connection
+
+
+def refresh_warehouse_connection_status(
+    connection: WarehouseConnection,
+    stats: WarehouseEventStats,
+) -> WarehouseConnection:
+    """Set a pending connection to connected when the warehouse has received at
+    least one event. No-op otherwise."""
+    if (
+        connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
+        and stats.total_events_received > 0
+    ):
+        connection.status = WarehouseConnectionStatus.CONNECTED
+        connection.save()
+        logger.info(
+            "connection.connected",
+            environment__id=connection.environment_id,
+            organisation__id=connection.environment.project.organisation_id,
+        )
+    return connection
+
+
+def annotate_warehouse_event_stats(
+    connection: WarehouseConnection,
+    environment_key: str,
+) -> None:
+    """Attach warehouse event stats to a flagsmith connection and update its
+    status to match. No-op for non-flagsmith connections or when no warehouse
+    is configured; leaves the connection unchanged if the warehouse errors."""
+    if (
+        connection.warehouse_type != WarehouseType.FLAGSMITH
+        or not settings.EXPERIMENTATION_CLICKHOUSE_URL
+    ):
+        return
+    try:
+        stats = get_warehouse_event_stats(environment_key)
+    except Exception:
+        logger.exception(
+            "connection.event_stats_unavailable",
+            environment__id=connection.environment_id,
+        )
+        return
+    connection.event_stats = stats
+    refresh_warehouse_connection_status(connection, stats)

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -84,16 +84,12 @@ class WarehouseConnectionViewSet(
 
     def retrieve(self, request: Request, *args: object, **kwargs: object) -> Response:
         connection = self.get_object()
-        annotate_warehouse_event_stats(
-            connection, self.kwargs["environment_api_key"]
-        )
+        annotate_warehouse_event_stats(connection, self.kwargs["environment_api_key"])
         serializer = self.get_serializer(connection)
         return Response(serializer.data)
 
     @action(detail=True, methods=["post"], url_path="test-warehouse-connection")
-    def test_warehouse_connection(
-        self, request: Request, **kwargs: object
-    ) -> Response:
+    def test_warehouse_connection(self, request: Request, **kwargs: object) -> Response:
         connection: WarehouseConnection = self.get_object()
         if connection.warehouse_type != WarehouseType.FLAGSMITH:
             return Response(

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -16,6 +16,7 @@ from experimentation.models import (
     Experiment,
     ExperimentStatus,
     WarehouseConnection,
+    WarehouseType,
 )
 from experimentation.permissions import (
     ExperimentPermission,
@@ -27,8 +28,10 @@ from experimentation.serializers import (
     WarehouseConnectionSerializer,
 )
 from experimentation.services import (
+    annotate_warehouse_event_stats,
     create_experiment_audit_log,
     create_warehouse_audit_log,
+    mark_warehouse_pending_connection,
     transition_experiment_status,
 )
 from users.models import FFAdminUser
@@ -70,6 +73,36 @@ class WarehouseConnectionViewSet(
             instance, self._get_user(self.request), action="deleted"
         )
         instance.delete()
+
+    def list(self, request: Request, *args: object, **kwargs: object) -> Response:
+        environment_api_key: str = self.kwargs["environment_api_key"]
+        connections = list(self.filter_queryset(self.get_queryset()))
+        for connection in connections:
+            annotate_warehouse_event_stats(connection, environment_api_key)
+        serializer = self.get_serializer(connections, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request: Request, *args: object, **kwargs: object) -> Response:
+        connection = self.get_object()
+        annotate_warehouse_event_stats(
+            connection, self.kwargs["environment_api_key"]
+        )
+        serializer = self.get_serializer(connection)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], url_path="test-warehouse-connection")
+    def test_warehouse_connection(
+        self, request: Request, **kwargs: object
+    ) -> Response:
+        connection: WarehouseConnection = self.get_object()
+        if connection.warehouse_type != WarehouseType.FLAGSMITH:
+            return Response(
+                {"detail": "Test events are only supported for Flagsmith warehouses."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        mark_warehouse_pending_connection(connection)
+        serializer = self.get_serializer(connection)
+        return Response(serializer.data)
 
     def create(self, request: Request, *args: object, **kwargs: object) -> Response:
         environment = self._get_environment()

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -32,6 +32,7 @@ from experimentation.services import (
     create_experiment_audit_log,
     create_warehouse_audit_log,
     mark_warehouse_pending_connection,
+    refresh_warehouse_connection_status,
     transition_experiment_status,
 )
 from users.models import FFAdminUser
@@ -97,6 +98,9 @@ class WarehouseConnectionViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         mark_warehouse_pending_connection(connection)
+        annotate_warehouse_event_stats(connection, self.kwargs["environment_api_key"])
+        if connection.event_stats is not None:
+            refresh_warehouse_connection_status(connection, connection.event_stats)
         serializer = self.get_serializer(connection)
         return Response(serializer.data)
 

--- a/api/tests/unit/experimentation/test_serializers.py
+++ b/api/tests/unit/experimentation/test_serializers.py
@@ -151,19 +151,3 @@ def test_warehouse_serializer__event_stats_attached__serializes_counts() -> None
     # Then
     assert data["total_events_received"] == 7
     assert data["unique_events_count"] == 2
-
-
-def test_warehouse_serializer__no_event_stats__serializes_nulls() -> None:
-    # Given
-    connection = WarehouseConnection(
-        warehouse_type=WarehouseType.SNOWFLAKE,
-        name="Snowflake Warehouse",
-        status=WarehouseConnectionStatus.CREATED,
-    )
-
-    # When
-    data = WarehouseConnectionSerializer(connection).data
-
-    # Then
-    assert data["total_events_received"] is None
-    assert data["unique_events_count"] is None

--- a/api/tests/unit/experimentation/test_serializers.py
+++ b/api/tests/unit/experimentation/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from environments.models import Environment
+from experimentation.dataclasses import WarehouseEventStats
 from experimentation.models import (
     WarehouseConnection,
     WarehouseConnectionStatus,
@@ -130,3 +131,39 @@ def test_create__flagsmith_with_config__raises_validation_error(
     # When / Then
     assert not serializer.is_valid()
     assert "config" in serializer.errors
+
+
+def test_warehouse_serializer__event_stats_attached__serializes_counts() -> None:
+    # Given
+    connection = WarehouseConnection(
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.CONNECTED,
+    )
+    connection.event_stats = WarehouseEventStats(
+        total_events_received=7,
+        unique_events_count=2,
+    )
+
+    # When
+    data = WarehouseConnectionSerializer(connection).data
+
+    # Then
+    assert data["total_events_received"] == 7
+    assert data["unique_events_count"] == 2
+
+
+def test_warehouse_serializer__no_event_stats__serializes_nulls() -> None:
+    # Given
+    connection = WarehouseConnection(
+        warehouse_type=WarehouseType.SNOWFLAKE,
+        name="Snowflake Warehouse",
+        status=WarehouseConnectionStatus.CREATED,
+    )
+
+    # When
+    data = WarehouseConnectionSerializer(connection).data
+
+    # Then
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1,7 +1,16 @@
+import pytest
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
+from pytest_structlog import StructuredLogCapture
 
+from environments.models import Environment
 from experimentation import services
+from experimentation.dataclasses import WarehouseEventStats
+from experimentation.models import (
+    WarehouseConnection,
+    WarehouseConnectionStatus,
+    WarehouseType,
+)
 
 
 def test_get_clickhouse_client__configured_url__builds_client_from_url(
@@ -66,3 +75,192 @@ def test_get_unique_event_names__no_events__returns_empty_list(
 
     # Then
     assert result == []
+
+
+def test_get_warehouse_event_stats__events_present__returns_counts(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.execute.return_value = [(42, 3)]
+    mocker.patch(
+        "experimentation.services._get_clickhouse_client",
+        return_value=mock_client,
+    )
+
+    # When
+    result = services.get_warehouse_event_stats("env-key-123")
+
+    # Then
+    assert result.total_events_received == 42
+    assert result.unique_events_count == 3
+    mock_client.execute.assert_called_once_with(
+        "SELECT count() AS total, uniqExact(event) AS unique "
+        "FROM events WHERE environment_key = %(environment_key)s",
+        {"environment_key": "env-key-123"},
+    )
+
+
+def test_get_warehouse_event_stats__non_int_clickhouse_values__casts_to_int(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.execute.return_value = [("42", "3")]
+    mocker.patch(
+        "experimentation.services._get_clickhouse_client",
+        return_value=mock_client,
+    )
+
+    # When
+    result = services.get_warehouse_event_stats("env-key-123")
+
+    # Then
+    assert result.total_events_received == 42
+    assert result.unique_events_count == 3
+    assert isinstance(result.total_events_received, int)
+    assert isinstance(result.unique_events_count, int)
+
+
+def test_get_warehouse_event_stats__empty_result_set__returns_zeroes(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mock_client.execute.return_value = []
+    mocker.patch(
+        "experimentation.services._get_clickhouse_client",
+        return_value=mock_client,
+    )
+
+    # When
+    result = services.get_warehouse_event_stats("env-key-123")
+
+    # Then
+    assert result.total_events_received == 0
+    assert result.unique_events_count == 0
+
+
+@pytest.mark.django_db
+def test_mark_warehouse_pending_connection__created__transitions_to_pending(
+    environment: Environment,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+    )
+
+    # When
+    result = services.mark_warehouse_pending_connection(connection)
+
+    # Then
+    assert result.status == WarehouseConnectionStatus.PENDING_CONNECTION
+    connection.refresh_from_db()
+    assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "connection.test_event_sent",
+            "environment__id": environment.id,
+            "organisation__id": environment.project.organisation_id,
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_mark_warehouse_pending_connection__already_pending__is_noop(
+    environment: Environment,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+
+    # When
+    result = services.mark_warehouse_pending_connection(connection)
+
+    # Then
+    assert result.status == WarehouseConnectionStatus.PENDING_CONNECTION
+    assert log.events == []
+
+
+@pytest.mark.django_db
+def test_refresh_warehouse_connection_status__events_exist__transitions_to_connected(
+    environment: Environment,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    stats = WarehouseEventStats(total_events_received=5, unique_events_count=1)
+
+    # When
+    result = services.refresh_warehouse_connection_status(connection, stats)
+
+    # Then
+    assert result.status == WarehouseConnectionStatus.CONNECTED
+    connection.refresh_from_db()
+    assert connection.status == WarehouseConnectionStatus.CONNECTED
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "connection.connected",
+            "environment__id": environment.id,
+            "organisation__id": environment.project.organisation_id,
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_refresh_warehouse_connection_status__no_events__stays_pending(
+    environment: Environment,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    stats = WarehouseEventStats(total_events_received=0, unique_events_count=0)
+
+    # When
+    result = services.refresh_warehouse_connection_status(connection, stats)
+
+    # Then
+    assert result.status == WarehouseConnectionStatus.PENDING_CONNECTION
+    assert log.events == []
+
+
+@pytest.mark.django_db
+def test_refresh_warehouse_connection_status__already_connected__is_noop(
+    environment: Environment,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.CONNECTED,
+    )
+    stats = WarehouseEventStats(total_events_received=99, unique_events_count=4)
+
+    # When
+    result = services.refresh_warehouse_connection_status(connection, stats)
+
+    # Then
+    assert result.status == WarehouseConnectionStatus.CONNECTED
+    assert log.events == []

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -13,7 +13,7 @@ from experimentation.models import (
 )
 
 
-def test_get_clickhouse_client__configured_url__builds_client_from_url(
+def test_get_clickhouse_client__configured_url__builds_client_with_timeouts(
     mocker: MockerFixture,
     settings: SettingsWrapper,
 ) -> None:
@@ -21,17 +21,49 @@ def test_get_clickhouse_client__configured_url__builds_client_from_url(
     settings.EXPERIMENTATION_CLICKHOUSE_URL = (
         "clickhouse://user:pass@ch.example.com:9440/flagsmith_exp?secure=True"
     )
-    mock_from_url = mocker.patch("experimentation.services.Client.from_url")
+    mock_client_cls = mocker.patch("experimentation.services.Client")
     services._get_clickhouse_client.cache_clear()
 
     # When
     client = services._get_clickhouse_client()
 
     # Then
-    mock_from_url.assert_called_once_with(
-        "clickhouse://user:pass@ch.example.com:9440/flagsmith_exp?secure=True",
+    mock_client_cls.assert_called_once_with(
+        "ch.example.com",
+        port=9440,
+        database="flagsmith_exp",
+        user="user",
+        password="pass",
+        secure=True,
+        connect_timeout=services.CLICKHOUSE_CONNECT_TIMEOUT_SECONDS,
+        send_receive_timeout=services.CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
     )
-    assert client is mock_from_url.return_value
+    assert client is mock_client_cls.return_value
+    services._get_clickhouse_client.cache_clear()
+
+
+def test_get_clickhouse_client__dsn_timeouts__are_preserved(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.EXPERIMENTATION_CLICKHOUSE_URL = (
+        "clickhouse://ch.example.com:9000/db?connect_timeout=1&send_receive_timeout=2"
+    )
+    mock_client_cls = mocker.patch("experimentation.services.Client")
+    services._get_clickhouse_client.cache_clear()
+
+    # When
+    services._get_clickhouse_client()
+
+    # Then
+    mock_client_cls.assert_called_once_with(
+        "ch.example.com",
+        port=9000,
+        database="db",
+        connect_timeout=1,
+        send_receive_timeout=2,
+    )
     services._get_clickhouse_client.cache_clear()
 
 

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -77,12 +77,23 @@ def test_get_unique_event_names__no_events__returns_empty_list(
     assert result == []
 
 
-def test_get_warehouse_event_stats__events_present__returns_counts(
+@pytest.mark.parametrize(
+    "rows, expected_total, expected_unique",
+    [
+        ([(42, 3)], 42, 3),
+        ([], 0, 0),
+    ],
+    ids=["events_present", "empty_result_set"],
+)
+def test_get_warehouse_event_stats__rows__returns_counts(
     mocker: MockerFixture,
+    rows: list[tuple[int, int]],
+    expected_total: int,
+    expected_unique: int,
 ) -> None:
     # Given
     mock_client = mocker.Mock()
-    mock_client.execute.return_value = [(42, 3)]
+    mock_client.execute.return_value = rows
     mocker.patch(
         "experimentation.services._get_clickhouse_client",
         return_value=mock_client,
@@ -92,53 +103,13 @@ def test_get_warehouse_event_stats__events_present__returns_counts(
     result = services.get_warehouse_event_stats("env-key-123")
 
     # Then
-    assert result.total_events_received == 42
-    assert result.unique_events_count == 3
+    assert result.total_events_received == expected_total
+    assert result.unique_events_count == expected_unique
     mock_client.execute.assert_called_once_with(
         "SELECT count() AS total, uniqExact(event) AS unique "
         "FROM events WHERE environment_key = %(environment_key)s",
         {"environment_key": "env-key-123"},
     )
-
-
-def test_get_warehouse_event_stats__non_int_clickhouse_values__casts_to_int(
-    mocker: MockerFixture,
-) -> None:
-    # Given
-    mock_client = mocker.Mock()
-    mock_client.execute.return_value = [("42", "3")]
-    mocker.patch(
-        "experimentation.services._get_clickhouse_client",
-        return_value=mock_client,
-    )
-
-    # When
-    result = services.get_warehouse_event_stats("env-key-123")
-
-    # Then
-    assert result.total_events_received == 42
-    assert result.unique_events_count == 3
-    assert isinstance(result.total_events_received, int)
-    assert isinstance(result.unique_events_count, int)
-
-
-def test_get_warehouse_event_stats__empty_result_set__returns_zeroes(
-    mocker: MockerFixture,
-) -> None:
-    # Given
-    mock_client = mocker.Mock()
-    mock_client.execute.return_value = []
-    mocker.patch(
-        "experimentation.services._get_clickhouse_client",
-        return_value=mock_client,
-    )
-
-    # When
-    result = services.get_warehouse_event_stats("env-key-123")
-
-    # Then
-    assert result.total_events_received == 0
-    assert result.unique_events_count == 0
 
 
 @pytest.mark.django_db

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -1,15 +1,42 @@
 import pytest
 from django.urls import reverse
+from pytest_django.fixtures import SettingsWrapper
+from pytest_mock import MockerFixture
+from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from environments.models import Environment
-from experimentation.models import WarehouseConnection
+from experimentation import services
+from experimentation.dataclasses import WarehouseEventStats
+from experimentation.models import (
+    WarehouseConnection,
+    WarehouseConnectionStatus,
+    WarehouseType,
+)
 from tests.types import EnableFeaturesFixture
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def mock_clickhouse_stats(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+) -> object:
+    """Default every view test to a configured, empty warehouse. Tests that need
+    events re-patch experimentation.services.get_warehouse_event_stats; tests for the
+    unconfigured/erroring paths override the setting / raise."""
+    settings.EXPERIMENTATION_CLICKHOUSE_URL = "clickhouse://localhost:9000/test"
+    services._get_clickhouse_client.cache_clear()
+    mock_client = mocker.Mock()
+    mock_client.execute.return_value = [(0, 0)]
+    return mocker.patch(
+        "experimentation.services._get_clickhouse_client",
+        return_value=mock_client,
+    )
 
 
 def test_post__valid_data__returns_201_and_creates_connection(
@@ -745,3 +772,297 @@ def test_patch__exists__creates_audit_log(
         related_object_type=RelatedObjectType.WAREHOUSE_CONNECTION.name,
     )
     assert "updated" in audit_log.log
+
+
+def test_get__flagsmith_connection__includes_event_stats(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection: WarehouseConnection,
+    warehouse_connection_url: str,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+        return_value=WarehouseEventStats(
+            total_events_received=12,
+            unique_events_count=3,
+        ),
+    )
+
+    # When
+    response = admin_client.get(warehouse_connection_url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()[0]
+    assert data["total_events_received"] == 12
+    assert data["unique_events_count"] == 3
+
+
+def test_get__pending_connection_with_events__flips_to_connected(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection_url: str,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+        return_value=WarehouseEventStats(
+            total_events_received=1,
+            unique_events_count=1,
+        ),
+    )
+
+    # When
+    response = admin_client.get(warehouse_connection_url)
+
+    # Then
+    assert response.json()[0]["status"] == "connected"
+    connection.refresh_from_db()
+    assert connection.status == WarehouseConnectionStatus.CONNECTED
+
+
+def test_get__pending_connection_no_events__stays_pending(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection_url: str,
+) -> None:
+    # Given (autouse mock returns 0 events)
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+
+    # When
+    response = admin_client.get(warehouse_connection_url)
+
+    # Then
+    assert response.json()[0]["status"] == "pending_connection"
+    connection.refresh_from_db()
+    assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
+
+
+def test_get__snowflake_connection__skips_clickhouse_and_nulls_stats(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection_url: str,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.SNOWFLAKE,
+        name="Snowflake Warehouse",
+        config={"account_identifier": "xy12345.us-east-1"},
+        status=WarehouseConnectionStatus.CREATED,
+    )
+    stats_spy = mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+    )
+
+    # When
+    response = admin_client.get(warehouse_connection_url)
+
+    # Then
+    data = response.json()[0]
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None
+    stats_spy.assert_not_called()
+
+
+def test_get_detail__flagsmith_connection__includes_event_stats(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection: WarehouseConnection,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+        return_value=WarehouseEventStats(
+            total_events_received=8,
+            unique_events_count=2,
+        ),
+    )
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-detail",
+        args=[environment.api_key, warehouse_connection.id],
+    )
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.json()["total_events_received"] == 8
+    assert response.json()["unique_events_count"] == 2
+
+
+def _test_warehouse_connection_url(environment: Environment, connection_id: int) -> str:
+    return reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, connection_id],
+    )
+
+
+def test_test_warehouse_connection__created_flagsmith__returns_200_and_pending(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection: WarehouseConnection,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    url = _test_warehouse_connection_url(environment, warehouse_connection.id)
+
+    # When
+    response = admin_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "pending_connection"
+    warehouse_connection.refresh_from_db()
+    assert warehouse_connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
+
+
+def test_test_warehouse_connection__snowflake__returns_400(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.SNOWFLAKE,
+        name="Snowflake Warehouse",
+        config={"account_identifier": "xy12345.us-east-1"},
+    )
+    url = _test_warehouse_connection_url(environment, connection.id)
+
+    # When
+    response = admin_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_test_warehouse_connection__already_connected__is_noop(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.CONNECTED,
+    )
+    url = _test_warehouse_connection_url(environment, connection.id)
+
+    # When
+    response = admin_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "connected"
+
+
+def test_test_warehouse_connection__non_admin__returns_403(
+    staff_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection: WarehouseConnection,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    url = _test_warehouse_connection_url(environment, warehouse_connection.id)
+
+    # When
+    response = staff_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get__clickhouse_unconfigured__returns_200_without_stats(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection: WarehouseConnection,
+    warehouse_connection_url: str,
+    settings: SettingsWrapper,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    settings.EXPERIMENTATION_CLICKHOUSE_URL = None
+    stats_spy = mocker.patch("experimentation.services.get_warehouse_event_stats")
+
+    # When
+    response = admin_client.get(warehouse_connection_url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()[0]
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None
+    stats_spy.assert_not_called()
+
+
+def test_get__clickhouse_errors__returns_200_without_stats_and_logs(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    warehouse_connection_url: str,
+    mocker: MockerFixture,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+        side_effect=OSError("clickhouse unreachable"),
+    )
+
+    # When
+    response = admin_client.get(warehouse_connection_url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()[0]
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None
+    # connection stays pending (no flip on error)
+    assert data["status"] == "pending_connection"
+    # an actionable event was logged
+    assert any(
+        e["event"] == "connection.event_stats_unavailable" for e in log.events
+    )

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -774,16 +774,38 @@ def test_patch__exists__creates_audit_log(
     assert "updated" in audit_log.log
 
 
-def test_get__flagsmith_connection__includes_event_stats(
+@pytest.mark.parametrize(
+    "warehouse_type, config, expected_total, expected_unique",
+    [
+        (WarehouseType.FLAGSMITH, None, 12, 3),
+        (
+            WarehouseType.SNOWFLAKE,
+            {"account_identifier": "xy12345.us-east-1"},
+            0,
+            0,
+        ),
+    ],
+    ids=["flagsmith", "snowflake"],
+)
+def test_get__warehouse_type__returns_expected_event_stats(
     admin_client: APIClient,
     environment: Environment,
     enable_features: EnableFeaturesFixture,
-    warehouse_connection: WarehouseConnection,
     warehouse_connection_url: str,
     mocker: MockerFixture,
+    warehouse_type: str,
+    config: dict[str, str] | None,
+    expected_total: int,
+    expected_unique: int,
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
+    WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=warehouse_type,
+        name="Warehouse",
+        config=config,
+    )
     mocker.patch(
         "experimentation.services.get_warehouse_event_stats",
         return_value=WarehouseEventStats(
@@ -798,8 +820,8 @@ def test_get__flagsmith_connection__includes_event_stats(
     # Then
     assert response.status_code == status.HTTP_200_OK
     data = response.json()[0]
-    assert data["total_events_received"] == 12
-    assert data["unique_events_count"] == 3
+    assert data["total_events_received"] == expected_total
+    assert data["unique_events_count"] == expected_unique
 
 
 def test_get__pending_connection_with_events__flips_to_connected(
@@ -858,112 +880,48 @@ def test_get__pending_connection_no_events__stays_pending(
     assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
 
 
-def test_get__snowflake_connection__skips_clickhouse_and_nulls_stats(
-    admin_client: APIClient,
-    environment: Environment,
-    enable_features: EnableFeaturesFixture,
-    warehouse_connection_url: str,
-    mocker: MockerFixture,
-) -> None:
-    # Given
-    enable_features("experimentation_warehouse_connection")
-    WarehouseConnection.objects.create(
-        environment=environment,
-        warehouse_type=WarehouseType.SNOWFLAKE,
-        name="Snowflake Warehouse",
-        config={"account_identifier": "xy12345.us-east-1"},
-        status=WarehouseConnectionStatus.CREATED,
-    )
-    stats_spy = mocker.patch(
-        "experimentation.services.get_warehouse_event_stats",
-    )
-
-    # When
-    response = admin_client.get(warehouse_connection_url)
-
-    # Then
-    data = response.json()[0]
-    assert data["total_events_received"] is None
-    assert data["unique_events_count"] is None
-    stats_spy.assert_not_called()
-
-
-def test_get_detail__flagsmith_connection__includes_event_stats(
-    admin_client: APIClient,
-    environment: Environment,
-    enable_features: EnableFeaturesFixture,
-    warehouse_connection: WarehouseConnection,
-    mocker: MockerFixture,
-) -> None:
-    # Given
-    enable_features("experimentation_warehouse_connection")
-    mocker.patch(
-        "experimentation.services.get_warehouse_event_stats",
-        return_value=WarehouseEventStats(
-            total_events_received=8,
-            unique_events_count=2,
+@pytest.mark.parametrize(
+    "warehouse_type, config, expected_status",
+    [
+        (WarehouseType.FLAGSMITH, None, status.HTTP_200_OK),
+        (
+            WarehouseType.SNOWFLAKE,
+            {"account_identifier": "xy12345.us-east-1"},
+            status.HTTP_400_BAD_REQUEST,
         ),
-    )
-    url = reverse(
-        "api-v1:environments:experimentation:warehouse-connections-detail",
-        args=[environment.api_key, warehouse_connection.id],
-    )
-
-    # When
-    response = admin_client.get(url)
-
-    # Then
-    assert response.json()["total_events_received"] == 8
-    assert response.json()["unique_events_count"] == 2
-
-
-def _test_warehouse_connection_url(environment: Environment, connection_id: int) -> str:
-    return reverse(
-        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
-        args=[environment.api_key, connection_id],
-    )
-
-
-def test_test_warehouse_connection__created_flagsmith__returns_200_and_pending(
+    ],
+    ids=["flagsmith", "snowflake"],
+)
+def test_test_warehouse_connection__warehouse_type__expected_status(
     admin_client: APIClient,
     environment: Environment,
     enable_features: EnableFeaturesFixture,
-    warehouse_connection: WarehouseConnection,
-) -> None:
-    # Given
-    enable_features("experimentation_warehouse_connection")
-    url = _test_warehouse_connection_url(environment, warehouse_connection.id)
-
-    # When
-    response = admin_client.post(url, format="json")
-
-    # Then
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["status"] == "pending_connection"
-    warehouse_connection.refresh_from_db()
-    assert warehouse_connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
-
-
-def test_test_warehouse_connection__snowflake__returns_400(
-    admin_client: APIClient,
-    environment: Environment,
-    enable_features: EnableFeaturesFixture,
+    warehouse_type: str,
+    config: dict[str, str] | None,
+    expected_status: int,
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
     connection = WarehouseConnection.objects.create(
         environment=environment,
-        warehouse_type=WarehouseType.SNOWFLAKE,
-        name="Snowflake Warehouse",
-        config={"account_identifier": "xy12345.us-east-1"},
+        warehouse_type=warehouse_type,
+        name="Warehouse",
+        config=config,
     )
-    url = _test_warehouse_connection_url(environment, connection.id)
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, connection.id],
+    )
 
     # When
     response = admin_client.post(url, format="json")
 
     # Then
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == expected_status
+    if expected_status == status.HTTP_200_OK:
+        assert response.json()["status"] == "pending_connection"
+        connection.refresh_from_db()
+        assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
 
 
 def test_test_warehouse_connection__already_connected__is_noop(
@@ -979,7 +937,10 @@ def test_test_warehouse_connection__already_connected__is_noop(
         name="Flagsmith Warehouse",
         status=WarehouseConnectionStatus.CONNECTED,
     )
-    url = _test_warehouse_connection_url(environment, connection.id)
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, connection.id],
+    )
 
     # When
     response = admin_client.post(url, format="json")
@@ -997,7 +958,10 @@ def test_test_warehouse_connection__non_admin__returns_403(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    url = _test_warehouse_connection_url(environment, warehouse_connection.id)
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, warehouse_connection.id],
+    )
 
     # When
     response = staff_client.post(url, format="json")
@@ -1026,8 +990,8 @@ def test_get__clickhouse_unconfigured__returns_200_without_stats(
     # Then
     assert response.status_code == status.HTTP_200_OK
     data = response.json()[0]
-    assert data["total_events_received"] is None
-    assert data["unique_events_count"] is None
+    assert data["total_events_received"] == 0
+    assert data["unique_events_count"] == 0
     stats_spy.assert_not_called()
 
 
@@ -1058,11 +1022,9 @@ def test_get__clickhouse_errors__returns_200_without_stats_and_logs(
     # Then
     assert response.status_code == status.HTTP_200_OK
     data = response.json()[0]
-    assert data["total_events_received"] is None
-    assert data["unique_events_count"] is None
+    assert data["total_events_received"] == 0
+    assert data["unique_events_count"] == 0
     # connection stays pending (no flip on error)
     assert data["status"] == "pending_connection"
     # an actionable event was logged
-    assert any(
-        e["event"] == "connection.event_stats_unavailable" for e in log.events
-    )
+    assert any(e["event"] == "connection.event_stats_unavailable" for e in log.events)

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -2,7 +2,6 @@ import pytest
 from django.urls import reverse
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
-from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -781,8 +780,8 @@ def test_patch__exists__creates_audit_log(
         (
             WarehouseType.SNOWFLAKE,
             {"account_identifier": "xy12345.us-east-1"},
-            0,
-            0,
+            None,
+            None,
         ),
     ],
     ids=["flagsmith", "snowflake"],
@@ -795,8 +794,8 @@ def test_get__warehouse_type__returns_expected_event_stats(
     mocker: MockerFixture,
     warehouse_type: str,
     config: dict[str, str] | None,
-    expected_total: int,
-    expected_unique: int,
+    expected_total: int | None,
+    expected_unique: int | None,
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
@@ -824,7 +823,7 @@ def test_get__warehouse_type__returns_expected_event_stats(
     assert data["unique_events_count"] == expected_unique
 
 
-def test_get__pending_connection_with_events__flips_to_connected(
+def test_get__pending_connection_with_events__shows_stats_but_does_not_flip(
     admin_client: APIClient,
     environment: Environment,
     enable_features: EnableFeaturesFixture,
@@ -851,31 +850,11 @@ def test_get__pending_connection_with_events__flips_to_connected(
     response = admin_client.get(warehouse_connection_url)
 
     # Then
-    assert response.json()[0]["status"] == "connected"
-    connection.refresh_from_db()
-    assert connection.status == WarehouseConnectionStatus.CONNECTED
-
-
-def test_get__pending_connection_no_events__stays_pending(
-    admin_client: APIClient,
-    environment: Environment,
-    enable_features: EnableFeaturesFixture,
-    warehouse_connection_url: str,
-) -> None:
-    # Given (autouse mock returns 0 events)
-    enable_features("experimentation_warehouse_connection")
-    connection = WarehouseConnection.objects.create(
-        environment=environment,
-        warehouse_type=WarehouseType.FLAGSMITH,
-        name="Flagsmith Warehouse",
-        status=WarehouseConnectionStatus.PENDING_CONNECTION,
-    )
-
-    # When
-    response = admin_client.get(warehouse_connection_url)
-
-    # Then
-    assert response.json()[0]["status"] == "pending_connection"
+    data = response.json()[0]
+    assert data["total_events_received"] == 1
+    assert data["unique_events_count"] == 1
+    # GET is read-only: the flip happens on the POST endpoint, not here.
+    assert data["status"] == "pending_connection"
     connection.refresh_from_db()
     assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
 
@@ -922,6 +901,104 @@ def test_test_warehouse_connection__warehouse_type__expected_status(
         assert response.json()["status"] == "pending_connection"
         connection.refresh_from_db()
         assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
+
+
+def test_test_warehouse_connection__pending_with_events__flips_to_connected(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+        return_value=WarehouseEventStats(
+            total_events_received=1,
+            unique_events_count=1,
+        ),
+    )
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, connection.id],
+    )
+
+    # When
+    response = admin_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "connected"
+    connection.refresh_from_db()
+    assert connection.status == WarehouseConnectionStatus.CONNECTED
+
+
+def test_test_warehouse_connection__pending_no_events__stays_pending(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given (autouse mock returns 0 events)
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, connection.id],
+    )
+
+    # When
+    response = admin_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "pending_connection"
+    connection.refresh_from_db()
+    assert connection.status == WarehouseConnectionStatus.PENDING_CONNECTION
+
+
+def test_test_warehouse_connection__clickhouse_unreachable__stays_pending(
+    admin_client: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    enable_features("experimentation_warehouse_connection")
+    connection = WarehouseConnection.objects.create(
+        environment=environment,
+        warehouse_type=WarehouseType.FLAGSMITH,
+        name="Flagsmith Warehouse",
+        status=WarehouseConnectionStatus.PENDING_CONNECTION,
+    )
+    mocker.patch(
+        "experimentation.services.get_warehouse_event_stats",
+        side_effect=OSError("clickhouse unreachable"),
+    )
+    url = reverse(
+        "api-v1:environments:experimentation:warehouse-connections-test-warehouse-connection",
+        args=[environment.api_key, connection.id],
+    )
+
+    # When
+    response = admin_client.post(url, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["status"] == "pending_connection"
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None
 
 
 def test_test_warehouse_connection__already_connected__is_noop(
@@ -990,18 +1067,17 @@ def test_get__clickhouse_unconfigured__returns_200_without_stats(
     # Then
     assert response.status_code == status.HTTP_200_OK
     data = response.json()[0]
-    assert data["total_events_received"] == 0
-    assert data["unique_events_count"] == 0
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None
     stats_spy.assert_not_called()
 
 
-def test_get__clickhouse_errors__returns_200_without_stats_and_logs(
+def test_get__clickhouse_errors__returns_200_without_stats(
     admin_client: APIClient,
     environment: Environment,
     enable_features: EnableFeaturesFixture,
     warehouse_connection_url: str,
     mocker: MockerFixture,
-    log: StructuredLogCapture,
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
@@ -1022,9 +1098,7 @@ def test_get__clickhouse_errors__returns_200_without_stats_and_logs(
     # Then
     assert response.status_code == status.HTTP_200_OK
     data = response.json()[0]
-    assert data["total_events_received"] == 0
-    assert data["unique_events_count"] == 0
-    # connection stays pending (no flip on error)
+    assert data["total_events_received"] is None
+    assert data["unique_events_count"] is None
+    # connection stays pending (GET never writes)
     assert data["status"] == "pending_connection"
-    # an actionable event was logged
-    assert any(e["event"] == "connection.event_stats_unavailable" for e in log.events)

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -442,6 +442,24 @@ Attributes:
  - `feature_name`
  - `sentry_action`
 
+### `warehouse.connection.connected`
+
+Logged at `info` from:
+ - `api/experimentation/services.py:186`
+
+Attributes:
+ - `environment.id`
+ - `organisation.id`
+
+### `warehouse.connection.test_event_sent`
+
+Logged at `info` from:
+ - `api/experimentation/services.py:164`
+
+Attributes:
+ - `environment.id`
+ - `organisation.id`
+
 ### `workflows.change_request.committed`
 
 Logged at `info` from:

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -445,24 +445,16 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:182`
+ - `api/experimentation/services.py:190`
 
 Attributes:
  - `environment.id`
  - `organisation.id`
 
-### `warehouse.connection.event_stats_unavailable`
-
-Logged at `exception` from:
- - `api/experimentation/services.py:205`
-
-Attributes:
- - `environment.id`
-
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:162`
+ - `api/experimentation/services.py:170`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -445,16 +445,24 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:186`
+ - `api/experimentation/services.py:182`
 
 Attributes:
  - `environment.id`
  - `organisation.id`
 
+### `warehouse.connection.event_stats_unavailable`
+
+Logged at `exception` from:
+ - `api/experimentation/services.py:205`
+
+Attributes:
+ - `environment.id`
+
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:164`
+ - `api/experimentation/services.py:162`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Backend support for verifying a Flagsmith-managed warehouse connection:

- `POST .../warehouse-connections/{id}/test-warehouse-connection/` moves a connection `created → pending_connection` (Flagsmith only; 400 otherwise).
- The connections `GET` returns ClickHouse event counts (`total_events_received`, `unique_events_count`) and lazily flips `pending_connection → connected` once an event lands. 
- Adds `connection.test_event_sent` / `connection.connected` structured events.

## How did you test this code?
- New tests
- E2E using staging warehouse