### PR TITLE
fix: Improve ButterBar text contrast on banners

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -145,15 +145,12 @@ const Utils = Object.assign({}, BaseUtils, {
     return res
   },
 
-  getContrastColour(backgroundColor: string): string {
-    if (!backgroundColor) {
-      return 'white'
-    }
+  getContrastColour(backgroundColor: string | null | undefined): string {
+    if (!backgroundColor) return 'white'
 
     try {
-      const parsed = Utils.colour(backgroundColor)
-      return parsed.luminosity() > 0.179 ? 'black' : 'white'
-    } catch (_error) {
+      return Color(backgroundColor).luminosity() > 0.179 ? 'black' : 'white'
+    } catch {
       return 'white'
     }
   },

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -145,6 +145,19 @@ const Utils = Object.assign({}, BaseUtils, {
     return res
   },
 
+  getContrastColour(backgroundColor: string): string {
+    if (!backgroundColor) {
+      return 'white'
+    }
+
+    try {
+      const parsed = Utils.colour(backgroundColor)
+      return parsed.luminosity() > 0.179 ? 'black' : 'white'
+    } catch (_error) {
+      return 'white'
+    }
+  },
+
   copyToClipboard: async (
     value: string,
     successMessage?: string,

--- a/frontend/web/components/ButterBar.tsx
+++ b/frontend/web/components/ButterBar.tsx
@@ -76,7 +76,7 @@ const ButterBar: React.FC<ButterBarProps> = ({ billingStatus, projectId }) => {
           className='butter-bar font-weight-medium'
           style={{
             backgroundColor: environmentDetail.banner_colour,
-            color:  Utils.getContrastColour(environmentDetail.banner_colour),
+            color: Utils.getContrastColour(environmentDetail.banner_colour),
           }}
         >
           {environmentDetail.banner_text}

--- a/frontend/web/components/ButterBar.tsx
+++ b/frontend/web/components/ButterBar.tsx
@@ -76,7 +76,7 @@ const ButterBar: React.FC<ButterBarProps> = ({ billingStatus, projectId }) => {
           className='butter-bar font-weight-medium'
           style={{
             backgroundColor: environmentDetail.banner_colour,
-            color: Utils.getContrastColour(environmentDetail.banner_colour ?? 'white'),
+            color:  Utils.getContrastColour(environmentDetail.banner_colour),
           }}
         >
           {environmentDetail.banner_text}

--- a/frontend/web/components/ButterBar.tsx
+++ b/frontend/web/components/ButterBar.tsx
@@ -76,7 +76,7 @@ const ButterBar: React.FC<ButterBarProps> = ({ billingStatus, projectId }) => {
           className='butter-bar font-weight-medium'
           style={{
             backgroundColor: environmentDetail.banner_colour,
-            color: 'white',
+            color: Utils.getContrastColour(environmentDetail.banner_colour ?? 'white'),
           }}
         >
           {environmentDetail.banner_text}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ x ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ x ] I have added information to `docs/` if required so people know about the feature.
- [ x ] I have filled in the "Changes" section below.
- [ x ] I have filled in the "How did you test this code" section below.


Contributes to #7604 

## Changes

- Added `Utils.getContrastColour(...)` to `frontend/common/utils/utils.tsx`
- Updated `frontend/web/components/ButterBar.tsx` to use `Utils.getContrastColour(...)` for environment banner text colour instead of hardcoding white

## How did you test this code?

- Ran the frontend locally
- Used an environment with a custom `banner_colour` and banner text
- Verified the banner text switched to black or white based on contrast