### PR TITLE
feat: confirm CI can reach the private access token secret

### DIFF
--- a/.github/workflows/experiment-ci-secret-access.yml
+++ b/.github/workflows/experiment-ci-secret-access.yml
@@ -1,0 +1,42 @@
+# TEMPORARY EXPERIMENT — DO NOT MERGE INTO main.
+#
+# Purpose: confirm that the `GH_PRIVATE_ACCESS_TOKEN` repository secret is
+# reachable from a workflow run, by using it to open a GitHub issue.
+#
+# Scope and safety:
+#   - Triggers only on `push` to this experiment's own branch, so it never
+#     runs for arbitrary pull requests.
+#   - Secrets are deliberately NOT exposed by GitHub to runs originating from
+#     forks; this experiment relies on the branch living in this repository.
+#   - The whole experiment is this single file. Deleting the file removes the
+#     capability entirely.
+name: "Experiment: CI secret access"
+
+permissions:
+  contents: read # For actions/checkout
+
+on:
+  push:
+    branches:
+      - experiment/ci-secret-access
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    name: Create issue using GH_PRIVATE_ACCESS_TOKEN
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v5
+
+      - name: Open an issue with the private access token
+        env:
+          GH_TOKEN: ${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PRIVATE_ACCESS_TOKEN is empty — secret not reachable."
+            exit 1
+          fi
+          gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "CI secret access experiment — run ${GITHUB_RUN_ID}" \
+            --body "Opened by the temporary \`Experiment: CI secret access\` workflow to confirm that \`GH_PRIVATE_ACCESS_TOKEN\` is reachable from CI. Commit: ${GITHUB_SHA}. This issue and the workflow are safe to delete."


### PR DESCRIPTION
Temporary experiment to confirm that the \`GH_PRIVATE_ACCESS_TOKEN\` repository secret  can create an issue.

## Changes

- [x] Add a temporary workflow that opens an issue using the private access token.

> [!WARNING]
> Do not merge. This is a throwaway experiment. Close the PR and delete the branch once the secret access is confirmed.

Review effort: 1/5