### PR TITLE
ci: self-hosted renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -30,11 +30,10 @@ jobs:
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v46.1.14
+        run: npx --yes renovate@46
         env:
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME }}
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD }}
-        with:
-          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,8 +24,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.RENOVATE_APP_ID }}
-          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.FLAGSMITH_ENGINEERING_GH_APP_ID }}
+          private-key: ${{ secrets.FLAGSMITH_ENGINEERING_GH_APP_PRIVATE_KEY }}
 
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.14

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Authenticate with CodeArtifact
+        id: codeartifact
         uses: ./.github/actions/codeartifact-login
 
       - name: Generate GitHub App token
@@ -38,5 +39,5 @@ jobs:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
-          UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME }}
-          UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD }}
+          RENOVATE_HOST_RULES: >-
+            [{"matchHost":"flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com","username":"aws","password":"${{ steps.codeartifact.outputs.token }}"}]

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/codeartifact-login
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v40
+        uses: renovatebot/github-action@v46.1.14
         env:
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME }}
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,17 +3,11 @@ name: Renovate
 on:
   schedule:
     - cron: '0 3 * * *'
-  push:
-    branches:
-      - ci/self-hosted-renovate
   workflow_dispatch: {}
 
 permissions:
   contents: read
   id-token: write # For CodeArtifact OIDC
-
-env:
-  LOG_LEVEL: DEBUG
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - name: Run Renovate
-        run: npx --yes renovate@46
+        uses: renovatebot/github-action@v46.1.14
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-16
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.14
         env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME }}
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD }}
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   id-token: write # For CodeArtifact OIDC
 
+env:
+  LOG_LEVEL: DEBUG
+
 jobs:
   renovate:
     runs-on: depot-ubuntu-latest-16

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Authenticate with CodeArtifact
         uses: ./.github/actions/codeartifact-login
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.14
         env:
@@ -30,4 +37,4 @@ jobs:
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME }}
           UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD }}
         with:
-          token: ${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  push:
+    branches:
+      - ci/self-hosted-renovate
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write # For CodeArtifact OIDC
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Authenticate with CodeArtifact
+        uses: ./.github/actions/codeartifact-login
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40
+        env:
+          UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_USERNAME }}
+          UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD: ${{ env.UV_INDEX_FLAGSMITH_PYPI_PRODUCTION_PASSWORD }}
+        with:
+          token: ${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "security:only-security-updates",
     ":semanticCommitTypeAll(deps)"
   ],
+  "recreateClosed": true,
   "packageRules": [
     {
       "matchManagers": ["uv"],

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":semanticCommitTypeAll(deps)"
   ],
   "recreateClosed": true,
+  "rebaseWhen": "always",
   "packageRules": [
     {
       "matchManagers": ["uv"],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds a workflow to run a renovate docker container in GH actions directly in order to authenticate with CodeArtifact and generate `uv.lock` correctly. 

Some pre-requisites: 

 - [x] Create a Github App for authentication

... and updates to complete after merge:

 - [ ] Disable Cloud Renovate from Flagsmith/flagsmith

## How did you test this code?

With much much pain. [Here](https://github.com/Flagsmith/flagsmith/actions/workflows/renovate.yml) is the evidence. 

Result: a successfully generated PR by Renovate to update `pytest` dependency [here](https://github.com/Flagsmith/flagsmith/pull/7689).
