### PR TITLE
fix: handle DoesNotExist in delete_segment task to prevent race condition errors

### DIFF
--- a/api/segments/tasks.py
+++ b/api/segments/tasks.py
@@ -11,7 +11,10 @@ from segments.models import Segment
 
 @register_task_handler()
 def delete_segment(segment_id: int) -> None:
-    Segment.objects.get(pk=segment_id).delete()
+    try:
+        Segment.objects.get(pk=segment_id).delete()
+    except Segment.DoesNotExist:
+        return
 
 
 @register_task_handler()


### PR DESCRIPTION
## Description

Fixes #7354 - race condition in delete_segment task when the segment has already been deleted by another process.

**Root Cause:** When the delete_segment task runs and the segment has already been removed (e.g., deleted via the API before the async task executes), Segment.objects.get() raises Segment.DoesNotExist, causing a Sentry error.

**Fix:** Wrap the delete in a 	ry/except Segment.DoesNotExist block, gracefully returning when the segment no longer exists.