### PR TITLE
feat(multivariate): thread variant key into the environment document

### DIFF
--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -423,7 +423,11 @@ def identity_document(  # type: ignore[no-untyped-def]
         "multivariate_feature_state_values": [
             {
                 "percentage_allocation": 50,
-                "multivariate_feature_option": {"value": "50_percent", "id": 1},
+                "multivariate_feature_option": {
+                    "value": "50_percent",
+                    "id": 1,
+                    "key": None,
+                },
                 "mv_fs_value_uuid": "9438d56d-e06e-4f6b-bca5-f66755f063c0",
                 "id": 1,
             },
@@ -433,6 +437,7 @@ def identity_document(  # type: ignore[no-untyped-def]
                 "multivariate_feature_option": {
                     "value": "other_50_percent",
                     "id": None,
+                    "key": None,
                 },
                 "id": 2,
             },

--- a/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
@@ -661,6 +661,7 @@ def test_edge_identities_update_mv_featurestate__new_allocation__updates_documen
             "multivariate_feature_option": {
                 "id": mv_option_50_percent,
                 "value": mv_option_value,
+                "key": None,
             },
             "mv_fs_value_uuid": mock.ANY,
         }

--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -284,6 +284,69 @@ def test_map_feature_state_to_engine__feature_segment__return_expected(
     assert result == expected_result
 
 
+def test_map_mv_option_to_engine__option_with_key__includes_key(
+    multivariate_feature: "Feature",
+) -> None:
+    # Given
+    mv_option = multivariate_feature.multivariate_options.first()
+    assert mv_option is not None
+    mv_option.key = "control"
+    mv_option.save()
+
+    # When
+    result = engine.map_mv_option_to_engine(mv_option)
+
+    # Then
+    assert result.key == "control"
+    assert result == MultivariateFeatureOptionModel(
+        value=mv_option.value,
+        id=mv_option.id,
+        key="control",
+    )
+
+
+def test_map_feature_state_to_engine__mv_option_with_key__key_in_serialised_document(
+    segment_multivariate_feature_state: FeatureState,
+    multivariate_feature: "Feature",
+) -> None:
+    # Given
+    mv_option = multivariate_feature.multivariate_options.first()
+    assert mv_option is not None
+    mv_option.key = "control"
+    mv_option.save()
+    mv_fs_value = (
+        segment_multivariate_feature_state.multivariate_feature_state_values.get()
+    )
+
+    # When
+    result = engine.map_feature_state_to_engine(
+        segment_multivariate_feature_state,
+        mv_fs_values=[mv_fs_value],
+    )
+    document = result.model_dump()
+
+    # Then
+    assert (
+        document["multivariate_feature_state_values"][0]["multivariate_feature_option"][
+            "key"
+        ]
+        == "control"
+    )
+
+
+def test_multivariate_feature_option_model__document_without_key__defaults_to_none() -> (
+    None
+):
+    # Given - a document produced before `key` existed on the model
+    document = {"value": "control", "id": 1}
+
+    # When
+    model = MultivariateFeatureOptionModel.model_validate(document)
+
+    # Then
+    assert model.key is None
+
+
 def test_map_environment_to_engine__multiple_segments_and_versions__returns_expected_model(
     environment: Environment,
     feature: "Feature",

--- a/api/util/engine_models/features/models.py
+++ b/api/util/engine_models/features/models.py
@@ -19,6 +19,7 @@ class FeatureModel(BaseModel):
 class MultivariateFeatureOptionModel(BaseModel):
     value: typing.Any
     id: typing.Optional[int] = None
+    key: typing.Optional[str] = None
 
 
 class MultivariateFeatureStateValueModel(BaseModel):

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -185,7 +185,9 @@ def map_feature_to_engine(feature: "Feature") -> FeatureModel:
 def map_mv_option_to_engine(
     mv_option: "MultivariateFeatureOption",
 ) -> MultivariateFeatureOptionModel:
-    return MultivariateFeatureOptionModel(value=mv_option.value, id=mv_option.id)
+    return MultivariateFeatureOptionModel(
+        value=mv_option.value, id=mv_option.id, key=mv_option.key
+    )
 
 
 def map_environment_to_engine(


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature. _(deferred — the key isn't consumed by SDKs yet.)_
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes



Builds on #7698. Adds `key` to the engine `MultivariateFeatureOptionModel` and passes it through in `map_mv_option_to_engine`, so each variant's key is included in the environment document — both the SDK local-eval document and the DynamoDB/edge document `model_dump()` the same `EnvironmentModel`.

Variant selection is unchanged. Returning the key in SDK/identify responses is a later slice.

### Compatibility

- Old document (no `key`) → parses, `key` defaults to `None`.
- New document → older readers ignore the unknown field: these pydantic models use the default `extra='ignore'`, and `flagsmith-flag-engine` types are `TypedDict`s with no runtime validation.
- DynamoDB is schemaless — the new attribute is a no-op at the storage layer.

## How did you test this code?

New unit tests cover the mapper (`key` reaches the engine model), the serialised document (`key` present in `model_dump()` output), and parsing an older document without `key`. Edge API integration test snapshots of the DynamoDB identity document were updated to include the field.

Ran the mapper suite and the document consumers (`edge_api`, `environments`, `util`, feature serializers, import/export) locally — all green; `ruff`/`mypy` clean.