### PR TITLE
feat(sdk): add variant key to evaluation schemas

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -82,6 +82,11 @@
         "FeatureValue": {
             "description": "Represents a multivariate value for a feature flag.",
             "properties": {
+                "key": {
+                    "description": "A stable, human-readable identifier for the variant. Omitted when the variant has no key set.",
+                    "title": "Key",
+                    "type": "string"
+                },
                 "value": {
                     "description": "The value of the feature.",
                     "title": "Value",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -27,6 +27,11 @@
                     "title": "Reason",
                     "type": "string"
                 },
+                "variant": {
+                    "description": "A stable identifier of the selected multivariate variant. Omitted when no variant was selected, or when the selected variant has no key set.",
+                    "title": "Variant",
+                    "type": "string"
+                },
                 "metadata": {
                     "existingJavaType": "java.util.Map<String,Object>",
                     "description": "Additional metadata associated with the feature.",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature. _(deferred — SDK-facing docs land with the SDK slice, once the variant key is consumable end-to-end.)_
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to the multivariate variant key work: #7698, #7699, and Flagsmith/flagsmith-engine#314 (which depends on this PR merging first — its generated type files reference these schemas).

Extends the canonical cross-SDK evaluation contract so engines can report which multivariate variant was selected:

- **`sdk/evaluation-context.json`** — `FeatureValue` gains an optional `key`: a stable, human-readable identifier for the variant, fed into evaluation from the environment document (see #7699).
- **`sdk/evaluation-result.json`** — `FlagResult` gains an optional `variant`: the selected variant's key. The name follows [OpenFeature's `ResolutionDetails.variant`](https://openfeature.dev/specification/types#resolution-details) ("a semantic identifier for a value"), so OpenFeature providers map it 1:1.

Both fields are **omitted when not applicable** (no variant selected, or the selected variant has no key), consistent with the existing optional fields (`metadata`, `variants`, `priority`) in these schemas. Purely additive — existing consumers are unaffected.

## How did you test this code?

- Both files validate as JSON.
- Ran `datamodel-code-generator` (0.33.0, as used by flagsmith-engine) against the updated schemas to confirm the emitted types are the expected `key: NotRequired[str]` / `variant: NotRequired[str]`.
- Flagsmith/flagsmith-engine#314 implements and tests the behaviour end-to-end against these schemas: TDD'd evaluator tests for keyed/unkeyed/no-variant cases, full suite of 378 passing with the shared engine-test-data corpus untouched (backwards compatibility).