### PR TITLE
deps: Bump uv to 0.11.18

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
       - id: flagsmith-lint-tests
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.14  # Ensure this matches the version in api/pyproject.toml
+    rev: 0.11.18  # Ensure this matches the version in api/pyproject.toml
     hooks:
       - id: uv-lock
         name: api-lockcheck

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -157,7 +157,7 @@ flagsmith-private = { index = "flagsmith-pypi-production" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 
 [tool.uv]
-required-version = "0.11.14"  # Ensure this matches the version in .pre-commit-config.yaml
+required-version = "0.11.18"  # Ensure this matches the version in .pre-commit-config.yaml
 # Pin every resolved package to the exact version that api/poetry.lock used on
 # main before this migration, so the poetry -> uv switch is dependency-neutral.
 # Keep this list in sync with poetry.lock until the lockfile churn settles.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

uv 0.11.14 → 0.11.18.

## How did you test this code?

`uv sync --frozen --extra dev` and pre-commit pass with uv 0.11.18.