### PR TITLE
fix: Password validation fires before disabled invites check

### DIFF
--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -79,6 +79,11 @@ class CustomUserCreateSerializer(UserCreateSerializer, InviteLinkValidationMixin
         }
 
     def validate(self, attrs):  # type: ignore[no-untyped-def]
+        email = attrs.get("email", "")
+        self._validate_registration_invite(
+            email=email, sign_up_type=attrs.get("sign_up_type")
+        )
+
         attrs = super().validate(attrs)
         email = attrs.get("email")
         if attrs.get("superuser"):
@@ -100,10 +105,6 @@ class CustomUserCreateSerializer(UserCreateSerializer, InviteLinkValidationMixin
             is_authentication_method_valid(
                 self.context.get("request"), email=email, raise_exception=True
             )
-
-        self._validate_registration_invite(
-            email=email, sign_up_type=attrs.get("sign_up_type")
-        )
 
         attrs["email"] = email.lower()
         return attrs

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -6,7 +6,6 @@ from djoser.serializers import UserCreateSerializer  # type: ignore[import-untyp
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.validators import UniqueValidator
 
 from organisations.invites.models import Invite, InviteLink
 from users.auth_type import AuthType
@@ -68,13 +67,7 @@ class CustomUserCreateSerializer(UserCreateSerializer, InviteLinkValidationMixin
         write_only_fields = ("sign_up_type",)
         extra_kwargs = {
             "email": {
-                "validators": [
-                    UniqueValidator(
-                        queryset=FFAdminUser.objects.all(),
-                        lookup="iexact",
-                        message="Email already exists. Please log in.",
-                    )
-                ]
+                "validators": list[object](),
             }
         }
 
@@ -83,6 +76,11 @@ class CustomUserCreateSerializer(UserCreateSerializer, InviteLinkValidationMixin
         self._validate_registration_invite(
             email=email, sign_up_type=attrs.get("sign_up_type")
         )
+
+        if FFAdminUser.objects.filter(email__iexact=email).exists():
+            raise serializers.ValidationError(
+                {"email": "Email already exists. Please log in."}
+            )
 
         attrs = super().validate(attrs)
         email = attrs.get("email")

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -123,6 +123,29 @@ def test_register__without_invite_when_disabled__returns_forbidden(
 
 
 @override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)  # type: ignore[misc]
+def test_register__existing_email_without_invite_when_disabled__returns_forbidden(
+    db: None,
+    api_client: APIClient,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    password = FFAdminUser.objects.make_random_password()
+    register_data = {
+        "email": admin_user.email,
+        "password": password,
+        "first_name": "test",
+        "last_name": "register",
+    }
+
+    # When
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+    response = api_client.post(url, data=register_data)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@override_settings(ALLOW_REGISTRATION_WITHOUT_INVITE=False)  # type: ignore[misc]
 def test_register__with_invite_when_registration_disabled__returns_created(
     db: None,
     api_client: APIClient,

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
@@ -132,6 +132,24 @@ def test_invite_link_validation__hash_not_provided__raises_permission_denied(
     assert exc_info.value.detail == USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
 
 
+def test_invite_link_validation__existing_email_without_invite__raises_permission_denied(
+    db: None,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.ALLOW_REGISTRATION_WITHOUT_INVITE = False
+    FFAdminUser.objects.create(email="testuser@mail.com")
+
+    serializer = CustomUserCreateSerializer(data=user_dict)
+
+    # When
+    with pytest.raises(PermissionDenied) as exc_info:
+        serializer.is_valid(raise_exception=True)
+
+    # Then
+    assert exc_info.value.detail == USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
+
+
 def test_invite_link_validation__invalid_hash__raises_permission_denied(
     invite_link: InviteLink,
     settings: SettingsWrapper,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [X] I have added information to `docs/` if required so people know about the feature.
- [X] I have filled in the "Changes" section below.
- [X] I have filled in the "How did you test this code" section below.

## Changes

Fixes #7695
Moved `_validate_registration_invite()` to execute before `super().validate()`
in `CustomUserCreateSerializer.validate()`.

Uninvited users should be rejected immediately with 403 before the server
performs any further validation. The previous ordering also had a minor
security implication — it leaked password rule feedback to users who were
not authorised to register at all.

## How did you test this code?

- `test_register__without_invite_when_disabled__returns_forbidden` — passes
  deterministically
- Full `custom_auth` unit + integration test suite — all passing
