### PR TITLE
ci: Use GH app authentication for release please workflow

### DIFF
--- a/.github/workflows/platform-release-please.yml
+++ b/.github/workflows/platform-release-please.yml
@@ -14,10 +14,17 @@ jobs:
     runs-on: depot-ubuntu-latest
 
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.FLAGSMITH_ENGINEERING_GH_APP_ID }}
+          private-key: ${{ secrets.FLAGSMITH_ENGINEERING_GH_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{secrets.RELEASE_PLEASE_GITHUB_TOKEN}}
+          token: ${{ steps.app-token.outputs.token }}
+
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       release_tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Replaces static GH PAT with app-based authentication (using Flagsmith Engineering app). 

## How did you test this code?

N/a - will need testing on merge. It should update the release please PR successfully. 
