### PR TITLE
fix(Runtime): Fix uv compatibility in local envs

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -7,7 +7,7 @@ COMPOSE_PROJECT_NAME ?= flagsmith
 
 DOTENV_OVERRIDE_FILE ?= .env
 
-UV_VERSION ?= $(shell python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["uv"]["required-version"].lstrip("="))')
+UV_VERSION ?= $(shell python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["uv"]["required-version"].lstrip("<=>"))')
 
 OPENAPI_FORMAT_VERSION ?= 1.23.0
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -158,7 +158,7 @@ flagsmith-private = { index = "flagsmith-pypi-production" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 
 [tool.uv]
-required-version = "0.11.18"  # Ensure this matches the version in .pre-commit-config.yaml
+required-version = ">=0.11.18"  # Ensure this matches the version in .pre-commit-config.yaml
 # Pin every resolved package to the exact version that api/poetry.lock used on
 # main before this migration, so the poetry -> uv switch is dependency-neutral.
 # Keep this list in sync with poetry.lock until the lockfile churn settles.


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Allow local environments to have newer uv than what's tracked in `main`, rather than force developers to downgrade/uvx-fu.

## How did you test this code?

Running stuff, and observing no changes to anything.