### PR TITLE
fix(Web): Dark Mode isn't friendly to find

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -360,9 +360,13 @@ const controller = {
     } else if (!user) {
       store.ephemeral_token = null
       const darkMode = storageGet('dark_mode')
+      const themePreference = storageGet('theme_preference')
       AsyncStorage.clear()
       if (darkMode) {
         storageSet('dark_mode', darkMode)
+      }
+      if (themePreference) {
+        storageSet('theme_preference', themePreference)
       }
       if (!data.token) {
         return

--- a/frontend/web/components/DarkModeSwitch.tsx
+++ b/frontend/web/components/DarkModeSwitch.tsx
@@ -1,25 +1,179 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import classNames from 'classnames'
 import ConfigProvider from 'common/providers/ConfigProvider'
-import Setting from './Setting'
-import { getDarkMode, setDarkMode as persistDarkMode } from 'project/darkMode'
+import { calculateListPosition } from 'common/utils/calculateListPosition'
+import useOutsideClick from 'common/useOutsideClick'
+import InlinePillToggle from './base/forms/InlinePillToggle'
+import Icon, { type IconName } from './icons/Icon'
+import {
+  getResolvedDarkMode,
+  getThemePreference,
+  listenToThemePreference,
+  setThemePreference,
+  type ThemePreference,
+} from 'project/darkMode'
+import { createPortal } from 'react-dom'
 
-type DarkModeSwitchType = {}
+const themeOptions: {
+  icon: IconName
+  label: string
+  value: ThemePreference
+}[] = [
+  { icon: 'sun', label: 'Light', value: 'light' },
+  { icon: 'moon', label: 'Dark', value: 'dark' },
+  { icon: 'options-2', label: 'System', value: 'system' },
+]
 
-const DarkModeSwitch: FC<DarkModeSwitchType> = ({}) => {
-  const [darkModeLocal, setDarkModeLocal] = useState(getDarkMode())
+const getThemeOption = (preference: ThemePreference) =>
+  themeOptions.find((option) => option.value === preference) ?? themeOptions[0]
 
-  const toggleDarkMode = () => {
-    const newDarkMode = !getDarkMode()
-    setDarkModeLocal(newDarkMode)
-    persistDarkMode(newDarkMode)
+const getActiveThemeIcon = (
+  preference: ThemePreference,
+  resolvedDarkMode: boolean,
+) => {
+  if (preference === 'system') {
+    return resolvedDarkMode ? 'moon' : 'sun'
   }
+
+  return getThemeOption(preference).icon
+}
+
+const getThemeState = () => ({
+  preference: getThemePreference(),
+  resolvedDarkMode: getResolvedDarkMode(),
+})
+
+const useThemePreference = () => {
+  const [themeState, setThemeState] = useState(getThemeState)
+
+  useEffect(
+    () =>
+      listenToThemePreference(() => {
+        setThemeState(getThemeState())
+      }),
+    [],
+  )
+
+  return {
+    ...themeState,
+    setPreference: setThemePreference,
+  }
+}
+
+const DarkModeSwitch: FC = () => {
+  const { preference, setPreference } = useThemePreference()
+
   return (
-    <Setting
-      title='Dark Mode'
-      description='Adjust the theme you see when using Flagsmith.'
-      checked={darkModeLocal}
-      onChange={toggleDarkMode}
-    />
+    <>
+      <Row className='mb-2 align-items-center justify-content-between'>
+        <h5 className='mb-0'>Theme</h5>
+        <InlinePillToggle
+          data-test='theme-preference-setting'
+          options={themeOptions.map(({ label, value }) => ({ label, value }))}
+          size='small'
+          value={preference}
+          onChange={setPreference}
+        />
+      </Row>
+      <p className='fs-small lh-sm'>
+        Choose a light or dark theme, or follow your system setting.
+      </p>
+    </>
+  )
+}
+
+export const ThemeModeDropdown: FC = () => {
+  const { preference, resolvedDarkMode, setPreference } = useThemePreference()
+  const [isOpen, setIsOpen] = useState(false)
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const dropDownRef = useRef<HTMLDivElement>(null)
+  const activeOption = getThemeOption(preference)
+  const activeIcon = getActiveThemeIcon(preference, resolvedDarkMode)
+
+  useOutsideClick(dropDownRef as React.RefObject<HTMLElement>, () =>
+    setIsOpen(false),
+  )
+
+  useLayoutEffect(() => {
+    if (!isOpen || !dropDownRef.current || !btnRef.current) return
+    const listPosition = calculateListPosition(
+      btnRef.current,
+      dropDownRef.current,
+    )
+    dropDownRef.current.style.top = `${listPosition.top}px`
+    dropDownRef.current.style.left = `${listPosition.left}px`
+  }, [isOpen])
+
+  return (
+    <div className='feature-action' tabIndex={-1}>
+      <button
+        aria-expanded={isOpen}
+        aria-label='Theme'
+        className='account-dropdown-trigger d-flex ps-3 lh-1 align-items-center text-default'
+        data-test='theme-preference-trigger'
+        onClick={(e) => {
+          e.stopPropagation()
+          setIsOpen(!isOpen)
+        }}
+        ref={btnRef}
+        title='Theme'
+        type='button'
+      >
+        <span className='mr-1 icon-secondary'>
+          <Icon name={activeIcon} width={18} />
+        </span>
+        <span className='d-none d-lg-block'>{activeOption.label}</span>
+      </button>
+
+      {isOpen &&
+        createPortal(
+          <div ref={dropDownRef} className='feature-action__list'>
+            <div
+              className='feature-action__item feature-action__header'
+              style={{
+                color: '#656D7B',
+                cursor: 'default',
+                fontSize: '12px',
+                fontWeight: 600,
+                padding: '8px 16px',
+              }}
+            >
+              Theme
+            </div>
+            {themeOptions.map((option) => {
+              const isSelected = preference === option.value
+              return (
+                <button
+                  aria-pressed={isSelected}
+                  className={classNames('feature-action__item theme-option', {
+                    'feature-action__item--selected': isSelected,
+                  })}
+                  data-test={`theme-preference-${option.value}`}
+                  key={option.value}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setPreference(option.value)
+                    setIsOpen(false)
+                  }}
+                  type='button'
+                >
+                  <Icon name={option.icon} width={18} fill='#9DA4AE' />
+                  <span>{option.label}</span>
+                  {isSelected && (
+                    <Icon
+                      className='ms-auto'
+                      name='checkmark'
+                      width={16}
+                      fill='#6837FC'
+                    />
+                  )}
+                </button>
+              )
+            })}
+          </div>,
+          document.body,
+        )}
+    </div>
   )
 }
 

--- a/frontend/web/components/navigation/Nav.tsx
+++ b/frontend/web/components/navigation/Nav.tsx
@@ -3,15 +3,18 @@ import { useHistory, useLocation } from 'react-router-dom'
 import AccountStore from 'common/stores/account-store'
 import EnvironmentAside from './EnvironmentAside'
 import { Project as ProjectType } from 'common/types/responses'
+// @ts-ignore
 import { AsyncStorage } from 'polyfill-react-native'
 import ProjectNavbar from './navbars/ProjectNavbar'
 import OrganisationNavbar from './navbars/OrganisationNavbar'
 import TopNavbar from './navbars/TopNavbar'
 import { appLevelPaths } from './constants'
+import { ThemeModeDropdown } from 'components/DarkModeSwitch'
 
 type NavType = {
   environmentId: string | undefined
   projectId: number
+  children?: ReactNode
   header?: ReactNode
   activeProject: ProjectType | undefined
 }
@@ -73,10 +76,15 @@ const Nav: FC<NavType> = ({
           <div className='d-flex bg-faint pt-1 py-0'>
             <Flex className='flex-row px-2 '>
               {!!AccountStore.getUser() && (
-                <TopNavbar
-                  activeProject={activeProject}
-                  projectId={projectId}
-                />
+                <>
+                  <TopNavbar
+                    activeProject={activeProject}
+                    projectId={projectId}
+                  />
+                  <div className='d-flex d-sm-none justify-content-end full-width py-2'>
+                    <ThemeModeDropdown />
+                  </div>
+                </>
               )}
             </Flex>
           </div>

--- a/frontend/web/components/navigation/navbars/TopNavbar.tsx
+++ b/frontend/web/components/navigation/navbars/TopNavbar.tsx
@@ -7,6 +7,7 @@ import Icon from 'components/icons/Icon'
 import Headway from 'components/Headway'
 import { Project } from 'common/types/responses'
 import AccountDropdown from 'components/navigation/AccountDropdown'
+import { ThemeModeDropdown } from 'components/DarkModeSwitch'
 
 type TopNavType = {
   activeProject: Project | undefined
@@ -45,6 +46,7 @@ const TopNavbar: FC<TopNavType> = ({ activeProject, projectId }) => {
             <span className='d-none d-md-block'>Docs</span>
           </a>
           <Headway className='cursor-pointer ps-3' />
+          <ThemeModeDropdown />
 
           {Utils.getFlagsmithHasFeature('persona_based_views') ? (
             <AccountDropdown />

--- a/frontend/web/project/darkMode.test.ts
+++ b/frontend/web/project/darkMode.test.ts
@@ -1,0 +1,205 @@
+const listeners: Record<string, ((event: Event) => void)[]> = {}
+let systemDarkMode = false
+let systemListener: (() => void) | undefined
+
+const createClassList = () => {
+  const classes = new Set<string>()
+  return {
+    add: (className: string) => classes.add(className),
+    contains: (className: string) => classes.has(className),
+    remove: (className: string) => classes.delete(className),
+  }
+}
+
+const loadDarkMode = async () => {
+  jest.resetModules()
+  return import('./darkMode')
+}
+
+const dispatchStorageEvent = (key: string) => {
+  window.dispatchEvent({
+    key,
+    type: 'storage',
+  } as StorageEvent)
+}
+
+describe('darkMode', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>()
+    const documentElementAttributes = new Map<string, string>()
+    systemDarkMode = false
+    systemListener = undefined
+    Object.keys(listeners).forEach((key) => {
+      listeners[key] = []
+    })
+
+    Object.defineProperty(global, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: jest.fn((key: string) => storage.get(key) ?? null),
+        setItem: jest.fn((key: string, value: string) => {
+          storage.set(key, value)
+        }),
+      },
+    })
+
+    Object.defineProperty(global, 'document', {
+      configurable: true,
+      value: {
+        body: {
+          classList: createClassList(),
+        },
+        documentElement: {
+          getAttribute: jest.fn(
+            (name: string) => documentElementAttributes.get(name) ?? null,
+          ),
+          removeAttribute: jest.fn((name: string) => {
+            documentElementAttributes.delete(name)
+          }),
+          setAttribute: jest.fn((name: string, value: string) => {
+            documentElementAttributes.set(name, value)
+          }),
+        },
+      },
+    })
+
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        addEventListener: jest.fn(
+          (eventName: string, callback: (event: Event) => void) => {
+            listeners[eventName] = listeners[eventName] ?? []
+            listeners[eventName].push(callback)
+          },
+        ),
+        dispatchEvent: jest.fn((event: Event) => {
+          listeners[event.type]?.forEach((callback) => callback(event))
+          return true
+        }),
+        matchMedia: jest.fn(() => ({
+          addEventListener: jest.fn(
+            (_eventName: string, callback: () => void) => {
+              systemListener = callback
+            },
+          ),
+          addListener: jest.fn((callback: () => void) => {
+            systemListener = callback
+          }),
+          get matches() {
+            return systemDarkMode
+          },
+        })),
+        removeEventListener: jest.fn(
+          (eventName: string, callback: (event: Event) => void) => {
+            listeners[eventName] = (listeners[eventName] ?? []).filter(
+              (listener) => listener !== callback,
+            )
+          },
+        ),
+      },
+    })
+  })
+
+  it('uses the legacy dark mode value when no theme preference exists', async () => {
+    localStorage.setItem('dark_mode', 'true')
+
+    const { getDarkMode, getThemePreference } = await loadDarkMode()
+
+    expect(getThemePreference()).toBe('dark')
+    expect(getDarkMode()).toBe(true)
+    expect(document.body.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark')
+  })
+
+  it('stores explicit light and dark preferences', async () => {
+    const { getDarkMode, getThemePreference, setThemePreference } =
+      await loadDarkMode()
+
+    setThemePreference('dark')
+    expect(getThemePreference()).toBe('dark')
+    expect(getDarkMode()).toBe(true)
+    expect(localStorage.getItem('theme_preference')).toBe('dark')
+    expect(localStorage.getItem('dark_mode')).toBe('true')
+
+    setThemePreference('light')
+    expect(getThemePreference()).toBe('light')
+    expect(getDarkMode()).toBe(false)
+    expect(localStorage.getItem('dark_mode')).toBe('false')
+    expect(document.body.classList.contains('dark')).toBe(false)
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBeNull()
+  })
+
+  it('resolves the system preference from prefers-color-scheme', async () => {
+    systemDarkMode = true
+    const { getDarkMode, getThemePreference, setThemePreference } =
+      await loadDarkMode()
+
+    setThemePreference('system')
+
+    expect(getThemePreference()).toBe('system')
+    expect(getDarkMode()).toBe(true)
+    expect(localStorage.getItem('theme_preference')).toBe('system')
+    expect(localStorage.getItem('dark_mode')).toBe('true')
+  })
+
+  it('updates when another tab changes the preference', async () => {
+    const { getDarkMode, listenToThemePreference } = await loadDarkMode()
+    const callback = jest.fn()
+
+    listenToThemePreference(callback)
+    localStorage.setItem('theme_preference', 'dark')
+    dispatchStorageEvent('theme_preference')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(getDarkMode()).toBe(true)
+    expect(document.body.classList.contains('dark')).toBe(true)
+  })
+
+  it('ignores legacy storage events once a theme preference exists', async () => {
+    systemDarkMode = true
+    const { getDarkMode, listenToThemePreference } = await loadDarkMode()
+    const callback = jest.fn()
+
+    listenToThemePreference(callback)
+    localStorage.setItem('theme_preference', 'system')
+    dispatchStorageEvent('theme_preference')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(getDarkMode()).toBe(true)
+    expect(document.body.classList.contains('dark')).toBe(true)
+
+    localStorage.setItem('dark_mode', 'false')
+    dispatchStorageEvent('dark_mode')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(getDarkMode()).toBe(true)
+    expect(document.body.classList.contains('dark')).toBe(true)
+  })
+
+  it('still updates from legacy storage when no theme preference exists', async () => {
+    const { getDarkMode, listenToThemePreference } = await loadDarkMode()
+    const callback = jest.fn()
+
+    listenToThemePreference(callback)
+    localStorage.setItem('dark_mode', 'true')
+    dispatchStorageEvent('dark_mode')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(getDarkMode()).toBe(true)
+    expect(document.body.classList.contains('dark')).toBe(true)
+  })
+
+  it('reacts to system colour scheme changes while using the system preference', async () => {
+    systemDarkMode = false
+    const { getDarkMode, setThemePreference } = await loadDarkMode()
+
+    setThemePreference('system')
+    expect(getDarkMode()).toBe(false)
+
+    systemDarkMode = true
+    systemListener?.()
+
+    expect(getDarkMode()).toBe(true)
+    expect(document.body.classList.contains('dark')).toBe(true)
+  })
+})

--- a/frontend/web/project/darkMode.ts
+++ b/frontend/web/project/darkMode.ts
@@ -1,20 +1,139 @@
 import { storageGet, storageSet } from 'common/safeLocalStorage'
 
-export const getDarkMode = () => {
-  return storageGet('dark_mode') === 'true'
+const DARK_MODE_KEY = 'dark_mode'
+const THEME_PREFERENCE_KEY = 'theme_preference'
+const THEME_PREFERENCE_EVENT = 'flagsmith-theme-preference-change'
+
+export type ThemePreference = 'light' | 'dark' | 'system'
+
+const themePreferences: ThemePreference[] = ['light', 'dark', 'system']
+
+const isThemePreference = (value: string | null): value is ThemePreference =>
+  !!value && themePreferences.includes(value as ThemePreference)
+
+const getSystemDarkMode = () =>
+  typeof window !== 'undefined' &&
+  !!window.matchMedia?.('(prefers-color-scheme: dark)').matches
+
+const canUseDOM = () =>
+  typeof window !== 'undefined' && typeof document !== 'undefined'
+
+const dispatchThemePreferenceChange = () => {
+  if (!canUseDOM()) {
+    return
+  }
+
+  if (typeof CustomEvent === 'function') {
+    window.dispatchEvent(new CustomEvent(THEME_PREFERENCE_EVENT))
+  } else {
+    window.dispatchEvent(new Event(THEME_PREFERENCE_EVENT))
+  }
 }
-export const setDarkMode = (enabled: boolean) => {
+
+export const getThemePreference = (): ThemePreference => {
+  const storedPreference = storageGet(THEME_PREFERENCE_KEY)
+  if (isThemePreference(storedPreference)) {
+    return storedPreference
+  }
+
+  return storageGet(DARK_MODE_KEY) === 'true' ? 'dark' : 'light'
+}
+
+export const getResolvedDarkMode = (
+  preference: ThemePreference = getThemePreference(),
+) => {
+  if (preference === 'system') {
+    return getSystemDarkMode()
+  }
+
+  return preference === 'dark'
+}
+
+export const getDarkMode = () => {
+  return getResolvedDarkMode()
+}
+
+const applyDarkMode = (enabled: boolean) => {
+  if (!canUseDOM()) {
+    return
+  }
+
   if (enabled) {
-    storageSet('dark_mode', 'true')
     document.body.classList.add('dark')
     document.documentElement.setAttribute('data-bs-theme', 'dark')
   } else {
-    storageSet('dark_mode', 'false')
     document.body.classList.remove('dark')
     document.documentElement.removeAttribute('data-bs-theme')
   }
 }
 
-if (storageGet('dark_mode')) {
-  setDarkMode(getDarkMode())
+const applyThemePreference = (
+  preference = getThemePreference(),
+  { persistLegacy = false } = {},
+) => {
+  const enabled = getResolvedDarkMode(preference)
+  if (persistLegacy) {
+    storageSet(DARK_MODE_KEY, enabled ? 'true' : 'false')
+  }
+  applyDarkMode(enabled)
+}
+
+export const setThemePreference = (preference: ThemePreference) => {
+  storageSet(THEME_PREFERENCE_KEY, preference)
+  applyThemePreference(preference, { persistLegacy: true })
+  dispatchThemePreferenceChange()
+}
+
+export const setDarkMode = (enabled: boolean) => {
+  setThemePreference(enabled ? 'dark' : 'light')
+}
+
+export const listenToThemePreference = (callback: () => void) => {
+  if (!canUseDOM()) {
+    return () => {}
+  }
+
+  const handlePreferenceChange = () => {
+    applyThemePreference()
+    callback()
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (
+      event.key === THEME_PREFERENCE_KEY ||
+      (event.key === DARK_MODE_KEY &&
+        !isThemePreference(storageGet(THEME_PREFERENCE_KEY)))
+    ) {
+      handlePreferenceChange()
+    }
+  }
+
+  window.addEventListener(THEME_PREFERENCE_EVENT, handlePreferenceChange)
+  window.addEventListener('storage', handleStorage)
+
+  return () => {
+    window.removeEventListener(THEME_PREFERENCE_EVENT, handlePreferenceChange)
+    window.removeEventListener('storage', handleStorage)
+  }
+}
+
+const systemDarkMode = canUseDOM()
+  ? window.matchMedia?.('(prefers-color-scheme: dark)')
+  : undefined
+
+const handleSystemDarkModeChange = () => {
+  if (getThemePreference() === 'system') {
+    applyThemePreference('system')
+    dispatchThemePreferenceChange()
+  }
+}
+
+if (systemDarkMode?.addEventListener) {
+  systemDarkMode.addEventListener('change', handleSystemDarkModeChange)
+} else {
+  systemDarkMode?.addListener?.(handleSystemDarkModeChange)
+}
+
+if (storageGet(THEME_PREFERENCE_KEY) || storageGet(DARK_MODE_KEY)) {
+  applyThemePreference()
 }

--- a/frontend/web/styles/project/_FeaturesPage.scss
+++ b/frontend/web/styles/project/_FeaturesPage.scss
@@ -28,7 +28,6 @@
     &.placed-bottom {
       top: 100%;
     }
-
   }
 
   &__item {
@@ -57,6 +56,18 @@
       background: $bg-light200;
     }
   }
+
+  .theme-option {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    text-align: left;
+
+    &:focus-visible {
+      outline: none;
+      background: $bg-light200;
+    }
+  }
 }
 
 .dark {
@@ -69,6 +80,14 @@
     color: white !important;
 
     &:hover {
+      background: $primary;
+    }
+  }
+
+  .theme-option {
+    background: transparent;
+
+    &:focus-visible {
       background: $primary;
     }
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7702

Adds an always-available theme selector to the app header so users can switch theme without leaving their current page. The selector is shown in the existing desktop top nav and as a compact mobile header action.

- [x] Adds Light, Dark, and System theme choices without using an "auto" label.
- [x] Keeps the account settings appearance control in sync with the header selector.
- [x] Updates other open tabs immediately via local storage events while preserving the legacy `dark_mode` value for compatibility.

Review effort: 3/5

## How did you test this code?

- `npx eslint --fix web/project/darkMode.ts web/project/darkMode.test.ts web/components/DarkModeSwitch.tsx web/components/navigation/Nav.tsx web/components/navigation/navbars/TopNavbar.tsx common/stores/account-store.js`
- `npm run test:unit -- --runTestsByPath web/project/darkMode.test.ts`
- `npm run bundle`
- `git diff --check`

I also checked the touched files against `tsc`; the full repository typecheck currently reports existing errors outside this change.
