### PR TITLE
docs(api): Add python venv as a pre-requisite for API local dev

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,6 +6,7 @@ The project assumes the following tools installed:
 - [Python](https://www.python.org/downloads/). Any version allowed by `requires-python` in `pyproject.toml` is supported.
 - [GNU Make](https://www.gnu.org/software/make/).
 - Docker or a compatible tool like [Podman](https://podman.io/). We recommend [OrbStack](https://orbstack.dev/) for macOS.
+- A Python [virtual environment](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments) is created and activated.
 
 To install dev dependencies, run `make install`. Only Flagsmith maintainers can run `uv lock` due to private dependencies.
 


### PR DESCRIPTION
setup

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [ ] I have filled in the "Changes" section below.
- [ ] I have filled in the "How did you test this code" section below.

## Changes

Contributes to <!-- insert issue # or URL -->

Mention that a user needs to have a virtual environment created and activated. Most new distro releases uphelds PEP 668 and prevents users from globally installing python packages by default.  

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._

## How did you test this code?

On Ubuntu Noble:
```
sudo apt install python3.12-venv
git clone https://github.com/Flagsmith/flagsmith.git
cd flagsmith
python3 -m venv .venv
source .venv/bin/activate
make install
```
<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
