### PR TITLE
feat(multivariate): reserve "control" as a variant key

### DIFF
--- a/api/features/constants.py
+++ b/api/features/constants.py
@@ -9,6 +9,7 @@ DRAFT = "DRAFT"
 
 # Multivariate variant reported when an identity falls through to the control value
 CONTROL_VARIANT_KEY = "control"
+RESERVED_VARIANT_KEY_MESSAGE = f'"{CONTROL_VARIANT_KEY}" is a reserved variant key.'
 
 # Tag filtering strategy
 UNION = "UNION"

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -5,6 +5,7 @@ from django.db.models import Sum
 from rest_framework import serializers
 
 from core.constants import BOOLEAN, INTEGER
+from features.constants import CONTROL_VARIANT_KEY, RESERVED_VARIANT_KEY_MESSAGE
 from features.models import Feature, FeatureState
 from features.multivariate.models import MultivariateFeatureOption
 
@@ -70,6 +71,11 @@ class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSeriali
         # ourselves in `validate()`, with the database constraint as the final
         # guard, so drop it.
         return []
+
+    def validate_key(self, value: str | None) -> str | None:
+        if value == CONTROL_VARIANT_KEY:
+            raise serializers.ValidationError(RESERVED_VARIANT_KEY_MESSAGE)
+        return value
 
     def validate(self, attrs):  # type: ignore[no-untyped-def]
         attrs = super().validate(attrs)

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -6,6 +6,7 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from features.constants import RESERVED_VARIANT_KEY_MESSAGE
 from features.models import Feature
 from organisations.models import Organisation
 from projects.models import Project
@@ -57,7 +58,7 @@ def test_create_mv_option__with_key__returns_created_with_key(
         "feature": feature,
         "string_value": "bigger",
         "default_percentage_allocation": 50,
-        "key": "control",
+        "key": "variant-a",
     }
     # When
     response = admin_client_new.post(
@@ -67,7 +68,35 @@ def test_create_mv_option__with_key__returns_created_with_key(
     )
     # Then
     assert response.status_code == status.HTTP_201_CREATED
-    assert response.json()["key"] == "control"
+    assert response.json()["key"] == "variant-a"
+
+
+def test_create_mv_option__reserved_control_key__returns_bad_request(
+    admin_client_new: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given - "control" is reserved for the variant an identity falls through to
+    url = reverse(
+        "api-v1:projects:feature-mv-options-list",
+        args=[project, feature],
+    )
+    data = {
+        "type": "unicode",
+        "feature": feature,
+        "string_value": "bigger",
+        "default_percentage_allocation": 50,
+        "key": "control",
+    }
+    # When
+    response = admin_client_new.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["key"] == [RESERVED_VARIANT_KEY_MESSAGE]
 
 
 def test_create_mv_option__duplicate_key_for_same_feature__returns_bad_request(
@@ -85,7 +114,7 @@ def test_create_mv_option__duplicate_key_for_same_feature__returns_bad_request(
         "feature": feature,
         "string_value": "bigger",
         "default_percentage_allocation": 50,
-        "key": "control",
+        "key": "variant-a",
     }
     assert (
         admin_client_new.post(
@@ -100,7 +129,7 @@ def test_create_mv_option__duplicate_key_for_same_feature__returns_bad_request(
         "feature": feature,
         "string_value": "biggest",
         "default_percentage_allocation": 50,
-        "key": "control",
+        "key": "variant-a",
     }
     # When
     response = admin_client_new.post(
@@ -192,7 +221,7 @@ def test_update_mv_option__unchanged_key__returns_ok(
         "feature": feature,
         "string_value": "bigger",
         "default_percentage_allocation": 50,
-        "key": "control",
+        "key": "variant-a",
     }
     option_id = admin_client_new.post(
         create_url,
@@ -213,7 +242,7 @@ def test_update_mv_option__unchanged_key__returns_ok(
 
     # Then - the option does not collide with itself
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["key"] == "control"
+    assert response.json()["key"] == "variant-a"
 
 
 def test_update_mv_option__duplicate_sibling_key__returns_bad_request(
@@ -231,7 +260,7 @@ def test_update_mv_option__duplicate_sibling_key__returns_bad_request(
         "feature": feature,
         "string_value": "bigger",
         "default_percentage_allocation": 50,
-        "key": "control",
+        "key": "variant-a",
     }
     unkeyed_option_data = {
         "type": "unicode",
@@ -261,7 +290,7 @@ def test_update_mv_option__duplicate_sibling_key__returns_bad_request(
     response = admin_client_new.put(
         update_url,
         data=json.dumps(
-            {**unkeyed_option_data, "id": unkeyed_option_id, "key": "control"}
+            {**unkeyed_option_data, "id": unkeyed_option_id, "key": "variant-a"}
         ),
         content_type="application/json",
     )


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature. _(deferred — see #7723.)_
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes


`"control"` is the variant the SDK reports when an identity falls through to the base value (see #7723), so it must not also be usable as an explicit multivariate option key — otherwise a real variant and the control group would be indistinguishable in experimentation data.

This rejects `"control"` at the multivariate-options endpoint:
- `MultivariateFeatureOptionSerializer.validate_key` raises a `400` when the key equals `CONTROL_VARIANT_KEY`.
- The message is defined as a reusable constant `RESERVED_VARIANT_KEY_MESSAGE` in `features/constants.py` (matching the codebase's `*_MESSAGE` convention).
- No whitespace handling is needed: the `key` field's `validate_slug` validator already rejects any whitespace/non-slug input before `validate_key` runs, so only a clean `"control"` can reach the check. The check is exact-match (case-sensitive) — `"Control"` is a distinct slug and doesn't collide with the lowercase fall-through value.

Scoped to the writable path only: `key` is read-only on the nested serializer (feature-creation path), so the dedicated mv-options endpoint is the only place a key can be set.

## How did you test this code?

- **Integration** (`tests/integration/features/multivariate/`): creating an mv option with `key="control"` returns `400` with the reserved-key message; non-reserved keys (e.g. `"variant-a"`) still succeed. Existing key tests that incidentally used `"control"` were updated to a non-reserved key.
- Verified model-level creation and the read-only nested feature-creation path are unaffected (no regression).

Local verification:
- `tests/unit/features/multivariate/` + `tests/integration/features/multivariate/`: 60 passed.
- `ruff check` and `mypy` (strict): clean.