### PR TITLE
feat(sdk): make evaluation result variant required and nullable

### DIFF
--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -28,9 +28,12 @@
                     "type": "string"
                 },
                 "variant": {
-                    "description": "A stable identifier of the selected multivariate variant. Omitted when no variant was selected, or when the selected variant has no key set.",
+                    "description": "A stable identifier of the multivariate variant the identity was bucketed into: the variant's key, \"control\" for the control bucket, or null when no multivariate split applied (a standard feature, an unkeyed variant, or evaluation without an identity).",
                     "title": "Variant",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "metadata": {
                     "existingJavaType": "java.util.Map<String,Object>",
@@ -43,7 +46,8 @@
                 "name",
                 "enabled",
                 "value",
-                "reason"
+                "reason",
+                "variant"
             ],
             "title": "FlagResult",
             "type": "object"


### PR DESCRIPTION
> Follow-up to #7704 (now merged). Aligns the schema with the always-present-nullable `variant` implemented in Flagsmith/flagsmith-engine#314 and Flagsmith/engine-test-data#56.

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature. _(SDK-facing docs land with the SDK slice.)_
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

#7704 added `variant` to `FlagResult` as an optional string. Since then we settled on the OpenFeature-faithful shape: `variant` is **always present, nullable** — matching `ResolutionDetails.variant` (`str | None`), which is always a field on the details object.

This makes the schema match the engine/corpus:

- `FlagResult.variant` becomes **required**.
- Its type becomes `["string", "null"]`.

Semantics: the variant's key when a named multivariate variant is selected, `"control"` when the identity falls in the control bucket, or `null` when no multivariate split applied (a standard feature, an unkeyed variant, or evaluation without an identity).

`FeatureValue.key` in the context schema (the input) stays optional — only the output `variant` is always-present.

## How did you test this code?

- File validates as JSON.
- `datamodel-code-generator` 0.33.0 against the updated schema emits `variant: Optional[str]` (a required, nullable key), which matches the hand-updated `flag_engine/result/types.py` in Flagsmith/flagsmith-engine#314.
- The engine PR + corpus (#56) exercise the behaviour end-to-end: 384 tests passing with `variant` on every flag result.