### PR TITLE
feat: label variant key UI

### DIFF
--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -396,6 +396,7 @@ const Constants = {
       'FEATURE_ID': 150,
       'SEGMENT_ID': 150,
       'TRAITS_ID': 150,
+      'VARIANT_KEY': 255,
     },
   },
 
@@ -651,6 +652,7 @@ const Constants = {
       'Features can have values as well as being simply on or off, e.g. a font size for a banner or an environment variable for a server.',
     REMOTE_CONFIG_DESCRIPTION_VARIATION:
       'Features can have values as well as being simply on or off, e.g. a font size for a banner or an environment variable for a server.<br/>Variation values are set per project, the environment weight is per environment.',
+    RESERVED_VARIANT_KEY: 'control',
     SEGMENT_OVERRIDES_DESCRIPTION:
       'Set different values for your feature based on what segments users are in. Identity overrides will take priority over any segment override.',
     TAGS_DESCRIPTION:

--- a/frontend/common/providers/FeatureListProvider.js
+++ b/frontend/common/providers/FeatureListProvider.js
@@ -79,7 +79,18 @@ const FeatureListProvider = class extends React.Component {
     environmentFlag,
     segmentOverrides,
   ) => {
-    AppActions.createFlag(projectId, environmentId, flag, segmentOverrides)
+    AppActions.createFlag(
+      projectId,
+      environmentId,
+      {
+        ...flag,
+        multivariate_options: flag.multivariate_options?.map((v, i) => ({
+          ...v,
+          key: v.key || Utils.getDefaultVariantKey(i),
+        })),
+      },
+      segmentOverrides,
+    )
   }
 
   editFeatureValue = (
@@ -94,7 +105,7 @@ const FeatureListProvider = class extends React.Component {
       Object.assign({}, projectFlag, {
         multivariate_options:
           flag.multivariate_options &&
-          flag.multivariate_options.map((v) => {
+          flag.multivariate_options.map((v, i) => {
             const matchingProjectVariate =
               (projectFlag.multivariate_options &&
                 projectFlag.multivariate_options.find((p) => p.id === v.id)) ||
@@ -103,6 +114,7 @@ const FeatureListProvider = class extends React.Component {
               ...v,
               default_percentage_allocation:
                 matchingProjectVariate.default_percentage_allocation,
+              key: v.key || Utils.getDefaultVariantKey(i),
             }
           }),
       }),
@@ -192,7 +204,7 @@ const FeatureListProvider = class extends React.Component {
       Object.assign({}, projectFlag, flag, {
         multivariate_options:
           flag.multivariate_options &&
-          flag.multivariate_options.map((v) => {
+          flag.multivariate_options.map((v, i) => {
             const matchingProjectVariate =
               (projectFlag.multivariate_options &&
                 projectFlag.multivariate_options.find((p) => p.id === v.id)) ||
@@ -201,6 +213,7 @@ const FeatureListProvider = class extends React.Component {
               ...v,
               default_percentage_allocation:
                 matchingProjectVariate.default_percentage_allocation,
+              key: v.key || Utils.getDefaultVariantKey(i),
             }
           }),
       }),

--- a/frontend/common/services/useMultivariateOption.ts
+++ b/frontend/common/services/useMultivariateOption.ts
@@ -1,0 +1,132 @@
+import { MultivariateOption, ProjectFlag, Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const multivariateOptionService = service.injectEndpoints({
+  endpoints: (builder) => ({
+    createMultivariateOption: builder.mutation<
+      Res['multivariateOption'],
+      Req['createMultivariateOption']
+    >({
+      query: (query) => ({
+        body: query.body,
+        method: 'POST',
+        url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/`,
+      }),
+    }),
+    saveMultivariateOptions: builder.mutation<
+      Res['saveMultivariateOptions'],
+      Req['saveMultivariateOptions']
+    >({
+      // No invalidatesTags: every save chain already ends with a broad
+      // invalidateTags(['ProjectFlag', 'FeatureList']) once the downstream
+      // feature-state save completes — invalidating here too would refetch
+      // every subscribed query twice per save.
+      queryFn: async (args, _, _2, baseQuery) => {
+        const featureUrl = `projects/${args.project_id}/features/${args.feature_id}/`
+        // Diff against the server's current options rather than any client
+        // cache, so stale state can never turn an update into a duplicate
+        // create.
+        const flagRes = await baseQuery({ method: 'GET', url: featureUrl })
+        if (flagRes.error) {
+          return { error: flagRes.error }
+        }
+        const serverOptions =
+          (flagRes.data as ProjectFlag)?.multivariate_options || []
+        const errors: Record<number, any> = {}
+        // Results are written back by input index — downstream feature
+        // state saves map weights to option ids positionally. Requests run
+        // sequentially so newly created options get ascending ids in input
+        // order, which is the order the UI displays.
+        const ordered: MultivariateOption[] = []
+        for (let i = 0; i < args.multivariate_options.length; i++) {
+          const v = args.multivariate_options[i]
+          let original
+          if (v.id) {
+            original = serverOptions.find((m) => m.id === v.id)
+          } else if (v.key) {
+            original = serverOptions.find((m) => !!m.key && m.key === v.key)
+          }
+          const body = {
+            ...v,
+            default_percentage_allocation: 0,
+            feature: args.feature_id,
+          }
+          const res = await baseQuery(
+            original
+              ? {
+                  body,
+                  method: 'PUT',
+                  url: `${featureUrl}mv-options/${original.id}/`,
+                }
+              : {
+                  body,
+                  method: 'POST',
+                  url: `${featureUrl}mv-options/`,
+                },
+          )
+          if (res.error) {
+            errors[i] = (res.error as { data?: any })?.data ?? null
+          } else {
+            ordered[i] = res.data as MultivariateOption
+          }
+        }
+        if (Object.keys(errors).length) {
+          return { data: { errors, multivariate_options: ordered } }
+        }
+        const deleted = serverOptions.filter(
+          (m) => !ordered.find((o) => o?.id === m.id),
+        )
+        const deleteResults = await Promise.all(
+          deleted.map((m) =>
+            baseQuery({
+              method: 'DELETE',
+              url: `${featureUrl}mv-options/${m.id}/`,
+            }),
+          ),
+        )
+        const failedDelete = deleteResults.find((r) => r.error)
+        if (failedDelete) {
+          return { error: failedDelete.error }
+        }
+        return { data: { errors: null, multivariate_options: ordered } }
+      },
+    }),
+    // END OF ENDPOINTS
+  }),
+})
+
+export async function createMultivariateOption(
+  store: any,
+  data: Req['createMultivariateOption'],
+  options?: Parameters<
+    typeof multivariateOptionService.endpoints.createMultivariateOption.initiate
+  >[1],
+) {
+  return store.dispatch(
+    multivariateOptionService.endpoints.createMultivariateOption.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function saveMultivariateOptions(
+  store: any,
+  data: Req['saveMultivariateOptions'],
+  options?: Parameters<
+    typeof multivariateOptionService.endpoints.saveMultivariateOptions.initiate
+  >[1],
+) {
+  return store.dispatch(
+    multivariateOptionService.endpoints.saveMultivariateOptions.initiate(
+      data,
+      options,
+    ),
+  )
+}
+
+export const {
+  useCreateMultivariateOptionMutation,
+  useSaveMultivariateOptionsMutation,
+  // END OF EXPORTS
+} = multivariateOptionService

--- a/frontend/common/services/useProjectFlag.ts
+++ b/frontend/common/services/useProjectFlag.ts
@@ -2,6 +2,7 @@ import { PagedResponse, ProjectFlag, Res } from 'common/types/responses'
 import { Req } from 'common/types/requests'
 import { service } from 'common/service'
 import Utils from 'common/utils/utils'
+import { sortMultivariateOptions } from 'common/utils/multivariate'
 
 /**
  * Number of features to display per page in the features list.
@@ -122,6 +123,12 @@ export const projectFlagService = service
             pageSize: arg.page_size || FEATURES_PAGE_SIZE,
             previous: response.previous,
           },
+          results: response.results.map((feature) => ({
+            ...feature,
+            multivariate_options: sortMultivariateOptions(
+              feature.multivariate_options,
+            ),
+          })),
         }),
       }),
 
@@ -129,6 +136,12 @@ export const projectFlagService = service
         providesTags: (res) => [{ id: res?.id, type: 'ProjectFlag' }],
         query: (query: Req['getProjectFlag']) => ({
           url: `projects/${query.project}/features/${query.id}/`,
+        }),
+        transformResponse: (res: Res['projectFlag']) => ({
+          ...res,
+          multivariate_options: sortMultivariateOptions(
+            res.multivariate_options,
+          ),
         }),
       }),
 

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -45,6 +45,10 @@ import { FEATURES_PAGE_SIZE } from 'common/services/useProjectFlag'
 import Dispatcher from 'common/dispatcher/dispatcher'
 import BaseStore from './base/_store'
 import data from 'common/data/base/_data'
+import {
+  createMultivariateOption,
+  saveMultivariateOptions,
+} from 'common/services/useMultivariateOption'
 import { createSegmentOverride } from 'common/services/useSegmentOverride'
 import { getStore } from 'common/store'
 let createdFirstFeature = false
@@ -122,13 +126,17 @@ const controller = {
         // Sequential so options get ascending ids in input order, which is
         // the order the UI displays.
         for (const v of flag.multivariate_options || []) {
-          await data.post(
-            `${Project.api}projects/${projectId}/features/${res.data.id}/mv-options/`,
-            {
+          const mvRes = await createMultivariateOption(getStore(), {
+            body: {
               ...v,
               feature: res.data.id,
             },
-          )
+            feature_id: res.data.id,
+            project_id: projectId,
+          })
+          if (mvRes.error) {
+            throw mvRes.error
+          }
         }
         return data.get(
           `${Project.api}projects/${projectId}/features/${res.data.id}/`,
@@ -242,90 +250,45 @@ const controller = {
       })
       return
     }
+    store.error = null
     const originalFlag =
       store.model && store.model.features
         ? store.model.features.find((v) => v.id === flag.id)
         : flag
-    store.error = null
-    Promise.all(
-      (flag.multivariate_options || []).map((v, i) => {
-        let originalMV = null
-        if (originalFlag?.multivariate_options) {
-          if (v.id) {
-            originalMV = originalFlag.multivariate_options.find(
-              (m: MultivariateOption) => m.id === v.id,
-            )
-          } else if (v.key) {
-            originalMV = originalFlag.multivariate_options.find(
-              (m: MultivariateOption) => !!m.key && m.key === v.key,
-            )
-          }
-        }
-        const url = `${Project.api}projects/${projectId}/features/${flag.id}/mv-options/`
-        const mvData = {
-          ...v,
-          default_percentage_allocation: 0,
-          feature: flag.id,
-        }
-        return (
-          originalMV
-            ? data.put(`${url}${originalMV.id}/`, mvData)
-            : data.post(url, mvData)
-        )
-          .then((res) => {
-            // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
-            flag.multivariate_options[i] = res
-            return {
-              ...v,
-              id: res.id,
-            }
-          })
-          .catch((e) => Promise.reject({ mvIndex: i, source: e }))
-      }),
-    )
-      .then(() => {
-        const deletedMv = (originalFlag?.multivariate_options || []).filter(
-          (v) => !flag.multivariate_options.find((x) => v.id === x.id),
-        )
-        return Promise.all(
-          deletedMv.map((v) =>
-            data.delete(
-              `${Project.api}projects/${projectId}/features/${flag.id}/mv-options/${v.id}/`,
-            ),
-          ),
-        )
-      })
-      .then(() => {
-        if (onComplete) {
-          onComplete(flag)
-        }
-      })
-      .catch((e) => {
-        if (typeof e?.mvIndex !== 'number') {
-          API.ajaxHandler(store, e)
-          return
-        }
-        // Attribute the failure to the option that caused it so the UI
-        // can surface it on the right variation.
-        const surface = (body: any) => {
-          store.error = { multivariate_options: { [e.mvIndex]: body } } as any
-          store.goneABitWest()
-        }
-        if (typeof e.source?.text === 'function') {
-          e.source
-            .text()
-            .then((text: string) => {
-              let body = text
-              try {
-                body = JSON.parse(text)
-              } catch {}
-              surface(body)
-            })
-            .catch(() => surface(null))
-        } else {
-          surface(e.source ?? null)
-        }
-      })
+    // Standard flags carry no multivariate data — skip the round-trip.
+    if (
+      !flag.multivariate_options?.length &&
+      !originalFlag?.multivariate_options?.length
+    ) {
+      if (onComplete) {
+        onComplete(flag)
+      }
+      return
+    }
+    saveMultivariateOptions(getStore(), {
+      feature_id: flag.id,
+      multivariate_options: flag.multivariate_options || [],
+      project_id: projectId,
+    }).then((res) => {
+      if (res.error) {
+        API.ajaxHandler(store, res.error)
+        return
+      }
+      if (res.data.errors) {
+        store.error = { multivariate_options: res.data.errors } as any
+        store.goneABitWest()
+        return
+      }
+      // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
+      res.data.multivariate_options.forEach(
+        (v: MultivariateOption, i: number) => {
+          flag.multivariate_options[i] = v
+        },
+      )
+      if (onComplete) {
+        onComplete(flag)
+      }
+    })
   },
   editFeatureState: async (
     projectId,

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -21,6 +21,7 @@ import {
   ChangeRequest,
   Environment,
   FeatureState,
+  MultivariateOption,
   PagedResponse,
   ProjectFlag,
   TypedFeatureState,
@@ -247,12 +248,21 @@ const controller = {
       store.model && store.model.features
         ? store.model.features.find((v) => v.id === flag.id)
         : flag
+    store.error = null
     Promise.all(
       (flag.multivariate_options || []).map((v, i) => {
-        const originalMV =
-          v.id && originalFlag?.multivariate_options
-            ? originalFlag.multivariate_options.find((m) => m.id === v.id)
-            : null
+        let originalMV = null
+        if (originalFlag?.multivariate_options) {
+          if (v.id) {
+            originalMV = originalFlag.multivariate_options.find(
+              (m: MultivariateOption) => m.id === v.id,
+            )
+          } else if (v.key) {
+            originalMV = originalFlag.multivariate_options.find(
+              (m: MultivariateOption) => !!m.key && m.key === v.key,
+            )
+          }
+        }
         const url = `${Project.api}projects/${projectId}/features/${flag.id}/mv-options/`
         const mvData = {
           ...v,
@@ -263,14 +273,16 @@ const controller = {
           originalMV
             ? data.put(`${url}${originalMV.id}/`, mvData)
             : data.post(url, mvData)
-        ).then((res) => {
-          // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
-          flag.multivariate_options[i] = res
-          return {
-            ...v,
-            id: res.id,
-          }
-        })
+        )
+          .then((res) => {
+            // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
+            flag.multivariate_options[i] = res
+            return {
+              ...v,
+              id: res.id,
+            }
+          })
+          .catch((e) => Promise.reject({ mvIndex: i, source: e }))
       }),
     )
       .then(() => {
@@ -288,6 +300,32 @@ const controller = {
       .then(() => {
         if (onComplete) {
           onComplete(flag)
+        }
+      })
+      .catch((e) => {
+        if (typeof e?.mvIndex !== 'number') {
+          API.ajaxHandler(store, e)
+          return
+        }
+        // Attribute the failure to the option that caused it so the UI
+        // can surface it on the right variation.
+        const surface = (body: any) => {
+          store.error = { multivariate_options: { [e.mvIndex]: body } } as any
+          store.goneABitWest()
+        }
+        if (typeof e.source?.text === 'function') {
+          e.source
+            .text()
+            .then((text: string) => {
+              let body = text
+              try {
+                body = JSON.parse(text)
+              } catch {}
+              surface(body)
+            })
+            .catch(() => surface(null))
+        } else {
+          surface(e.source ?? null)
         }
       })
   },
@@ -852,6 +890,11 @@ const controller = {
               projectId,
             }).then((version) => {
               if (version.error) {
+                // Multivariate options are saved separately at the project
+                // level, so an unchanged environment state is not a failure.
+                if (version.error.message === 'Feature contains no changes') {
+                  return
+                }
                 throw version.error
               }
               const featureState = version.data.feature_states[0].data

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -27,6 +27,7 @@ import {
   TypedFeatureState,
 } from 'common/types/responses'
 import Utils from 'common/utils/utils'
+import { sortMultivariateOptions } from 'common/utils/multivariate'
 import Actions from 'common/dispatcher/action-constants'
 import Project from 'common/project'
 import flagsmith from '@flagsmith/flagsmith'
@@ -114,26 +115,23 @@ const controller = {
       }),
       project_id: projectId,
     })
-      .then((res) => {
+      .then(async (res) => {
         if (res.error) {
           throw res.error?.error || res.error
         }
-        return Promise.all(
-          (flag.multivariate_options || []).map((v) =>
-            data
-              .post(
-                `${Project.api}projects/${projectId}/features/${res.data.id}/mv-options/`,
-                {
-                  ...v,
-                  feature: res.data.id,
-                },
-              )
-              .then(() => res.data),
-          ),
-        ).then(() =>
-          data.get(
-            `${Project.api}projects/${projectId}/features/${res.data.id}/`,
-          ),
+        // Sequential so options get ascending ids in input order, which is
+        // the order the UI displays.
+        for (const v of flag.multivariate_options || []) {
+          await data.post(
+            `${Project.api}projects/${projectId}/features/${res.data.id}/mv-options/`,
+            {
+              ...v,
+              feature: res.data.id,
+            },
+          )
+        }
+        return data.get(
+          `${Project.api}projects/${projectId}/features/${res.data.id}/`,
         )
       })
       .then(() =>
@@ -151,7 +149,7 @@ const controller = {
             feature: v.id,
           }))
           store.model = {
-            features: features.results,
+            features: features.results.map(controller.parseFlag),
             keyedEnvironmentFeatures:
               environmentFeatures && keyBy(environmentFeatures, 'feature'),
           }
@@ -1029,6 +1027,9 @@ const controller = {
           ...fs,
           segment: fs.segment.id,
         })),
+      multivariate_options:
+        flag.multivariate_options &&
+        sortMultivariateOptions(flag.multivariate_options),
     }
   },
   searchFeatures: throttle(

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -1039,5 +1039,15 @@ export type Req = {
     body: Req['createMetric']['body']
   }
   deleteMetric: { environmentId: string; metricId: number }
+  createMultivariateOption: {
+    project_id: string | number
+    feature_id: number
+    body: Partial<MultivariateOption> & { feature: number }
+  }
+  saveMultivariateOptions: {
+    project_id: string | number
+    feature_id: number
+    multivariate_options: Partial<MultivariateOption>[]
+  }
   // END OF TYPES
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1413,5 +1413,12 @@ export type Res = {
   experiment: Experiment
   metric: Metric
   metrics: PagedResponse<Metric>
+  multivariateOption: MultivariateOption
+  saveMultivariateOptions: {
+    multivariate_options: MultivariateOption[]
+    // Per-option API errors keyed by the input option's index; null when all
+    // requests succeeded.
+    errors: Record<number, any> | null
+  }
   // END OF TYPES
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -573,6 +573,9 @@ export type MultivariateOption = {
   string_value: string
   boolean_value?: boolean
   default_percentage_allocation: number
+  // A stable, human-readable identifier for the variant (the backend `key`).
+  // Surfaced in the UI as the variation "Label". Slug-constrained and nullable.
+  key?: string | null
 }
 
 export type FeatureType = 'STANDARD' | 'MULTIVARIATE'

--- a/frontend/common/utils/__tests__/multivariate.test.ts
+++ b/frontend/common/utils/__tests__/multivariate.test.ts
@@ -1,0 +1,54 @@
+import {
+  getDefaultVariantKey,
+  sortMultivariateOptions,
+} from 'common/utils/multivariate'
+
+describe('multivariate', () => {
+  describe('getDefaultVariantKey', () => {
+    it.each`
+      index | expected
+      ${0}  | ${'Variant_1'}
+      ${1}  | ${'Variant_2'}
+      ${9}  | ${'Variant_10'}
+    `(
+      'getDefaultVariantKey($index) returns $expected',
+      ({ expected, index }) => {
+        expect(getDefaultVariantKey(index)).toBe(expected)
+      },
+    )
+  })
+
+  describe('sortMultivariateOptions', () => {
+    it('sorts options by id ascending', () => {
+      const options = [{ id: 3 }, { id: 1 }, { id: 2 }]
+
+      expect(sortMultivariateOptions(options)).toEqual([
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+      ])
+    })
+
+    it('sorts unsaved options last, preserving their input order', () => {
+      const options = [
+        { id: undefined, value: 'new_a' },
+        { id: 2, value: 'saved' },
+        { id: null, value: 'new_b' },
+      ]
+
+      expect(sortMultivariateOptions(options)).toEqual([
+        { id: 2, value: 'saved' },
+        { id: undefined, value: 'new_a' },
+        { id: null, value: 'new_b' },
+      ])
+    })
+
+    it('does not mutate the input array', () => {
+      const options = [{ id: 2 }, { id: 1 }]
+
+      sortMultivariateOptions(options)
+
+      expect(options).toEqual([{ id: 2 }, { id: 1 }])
+    })
+  })
+})

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -4,3 +4,12 @@
 // pulling in Utils' store dependencies (Storybook stubs out Utils).
 export const getDefaultVariantKey = (index: number): string =>
   `Variant_${index + 1}`
+
+// Options not yet saved have no id and sort last, in input order.
+export const sortMultivariateOptions = <T extends { id?: number | null }>(
+  options: T[],
+): T[] =>
+  [...options].sort(
+    (a, b) =>
+      (a.id ?? Number.MAX_SAFE_INTEGER) - (b.id ?? Number.MAX_SAFE_INTEGER),
+  )

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -1,0 +1,6 @@
+// The label a variant displays (and is saved with) when the user never
+// sets one — keep display, validation and save payloads consistent.
+// Kept outside Utils so Storybook-rendered components can use it without
+// pulling in Utils' store dependencies (Storybook stubs out Utils).
+export const getDefaultVariantKey = (index: number): string =>
+  `Variant_${index + 1}`

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -92,7 +92,8 @@ const Utils = Object.assign({}, BaseUtils, {
       } else if (typeof v.default_percentage_allocation === 'number') {
         total += v.default_percentage_allocation
       } else {
-        total += (v as any).percentage_allocation
+        // A cleared weight input leaves the allocation null — treat as 0.
+        total += (v as any).percentage_allocation || 0
       }
       return null
     })

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -21,6 +21,7 @@ import find from 'lodash/find'
 import ErrorMessage from 'components/ErrorMessage'
 import WarningMessage from 'components/WarningMessage'
 import Constants from 'common/constants'
+import { getDefaultVariantKey } from './multivariate'
 import { defaultFlags } from 'common/stores/default-flags'
 import Color from 'color'
 import { selectBuildVersion } from 'common/services/useBuildVersion'
@@ -256,11 +257,7 @@ const Utils = Object.assign({}, BaseUtils, {
       OrganisationPermission.CREATE_PROJECT
     ]
   },
-  // The label a variant displays (and is saved with) when the user never
-  // sets one — keep display, validation and save payloads consistent.
-  getDefaultVariantKey(index: number) {
-    return `Variant_${index + 1}`
-  },
+  getDefaultVariantKey,
   getExistingWaitForTime: (
     waitFor: string | undefined,
   ):

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -256,6 +256,11 @@ const Utils = Object.assign({}, BaseUtils, {
       OrganisationPermission.CREATE_PROJECT
     ]
   },
+  // The label a variant displays (and is saved with) when the user never
+  // sets one — keep display, validation and save payloads consistent.
+  getDefaultVariantKey(index: number) {
+    return `Variant_${index + 1}`
+  },
   getExistingWaitForTime: (
     waitFor: string | undefined,
   ):

--- a/frontend/documentation/components/Input.stories.tsx
+++ b/frontend/documentation/components/Input.stories.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+
+import Input from 'components/base/forms/Input'
+
+const meta: Meta = {
+  parameters: { layout: 'centered' },
+  title: 'Components/Forms/Input',
+}
+export default meta
+
+type Story = StoryObj
+
+const Interactive = (props: Record<string, any>) => {
+  const [value, setValue] = useState(props.initialValue ?? '')
+  return (
+    <Input
+      {...props}
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        setValue(e.target.value)
+      }
+    />
+  )
+}
+
+export const Default: Story = {
+  render: () => <Interactive placeholder='Type here...' />,
+}
+
+export const Sizes: Story = {
+  render: () => (
+    <div className='d-flex flex-column gap-3'>
+      <Interactive size='large' placeholder='Large' />
+      <Interactive placeholder='Default' />
+      <Interactive size='small' placeholder='Small' />
+      <Interactive size='xSmall' placeholder='xSmall' />
+    </div>
+  ),
+}
+
+export const Search: Story = {
+  render: () => <Interactive search placeholder='Search...' />,
+}
+
+export const Password: Story = {
+  render: () => (
+    <Interactive type='password' initialValue='secret' placeholder='Password' />
+  ),
+}
+
+// Borderless input with a bottom underline only — used for inline edits
+// such as the variant label in the feature modal.
+export const Underline: Story = {
+  render: () => (
+    <Interactive
+      underline
+      size='small'
+      initialValue='my_variant'
+      placeholder='Variant_1'
+      style={{ width: 150 }}
+    />
+  ),
+}
+
+// Underline combined with centered, as used for the variant weight input.
+export const UnderlineCentered: Story = {
+  render: () => (
+    <div className='d-flex align-items-center gap-2'>
+      <div style={{ width: 64 }}>
+        <Interactive underline centered size='small' initialValue='50' />
+      </div>
+      <span className='text-muted'>%</span>
+    </div>
+  ),
+}

--- a/frontend/e2e/helpers/e2e-helpers.playwright.ts
+++ b/frontend/e2e/helpers/e2e-helpers.playwright.ts
@@ -626,6 +626,32 @@ export class E2EHelpers {
     await this.waitForElementNotExist('#create-feature-modal');
   }
 
+  // Edit a variant's label (the multivariate option key) and verify it persists
+  async editVariantLabel(featureName: string, index: number, label: string) {
+    await this.gotoFeatures();
+    const featureRow = this.page.locator('[data-test^="feature-item-"]').filter({
+      has: this.page.locator(`span:text-is("${featureName}")`)
+    }).first();
+    await featureRow.waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
+    await featureRow.dispatchEvent('click');
+    await this.waitForElementVisible(byId('update-feature-btn'));
+    await this.click(byId(`featureVariationKeyEdit${index}`));
+    await this.setText(byId(`featureVariationKeyInput${index}`), label);
+    await this.click(byId(`featureVariationKeySave${index}`));
+    await expect(this.page.locator(byId(`featureVariationKey${index}`))).toHaveText(label);
+    await this.waitForToastsToClear();
+    await this.click(byId('update-feature-btn'));
+    await this.waitForToast();
+    await this.closeModal();
+    await this.waitForElementNotExist('#create-feature-modal');
+    // Reopen the feature and verify the label was saved
+    await featureRow.dispatchEvent('click');
+    await this.waitForElementVisible(byId('update-feature-btn'));
+    await expect(this.page.locator(byId(`featureVariationKey${index}`))).toHaveText(label);
+    await this.closeModal();
+    await this.waitForElementNotExist('#create-feature-modal');
+  }
+
   // Create an environment
   async createEnvironment(name: string) {
     await this.page.waitForLoadState('networkidle');

--- a/frontend/e2e/tests/flag-tests.pw.ts
+++ b/frontend/e2e/tests/flag-tests.pw.ts
@@ -10,6 +10,7 @@ test.describe('Flag Tests', () => {
       createRemoteConfig,
       deleteFeature,
       editRemoteConfig,
+      editVariantLabel,
       gotoFeatures,
       gotoProject,
       login,
@@ -70,6 +71,9 @@ test.describe('Flag Tests', () => {
     const json = await tryItExpect('header_enabled', 'enabled', true)
     expect(json.header_size.value).toBe('big')
     expect(json.mv_flag.value).toBe('big')
+
+    log('Edit variant label')
+    await editVariantLabel('mv_flag', 0, 'variant_medium')
 
     log('Update feature')
     await editRemoteConfig('header_size', 12)

--- a/frontend/e2e/tests/mv-options-tests.pw.ts
+++ b/frontend/e2e/tests/mv-options-tests.pw.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../test-setup';
+import { byId, log, createHelpers, LONG_TIMEOUT } from '../helpers';
+import { E2E_USER, PASSWORD, E2E_TEST_PROJECT } from '../config';
+import type { Page } from '@playwright/test';
+
+// Regression tests for the multivariate option save flow: variants must
+// never duplicate on repeated saves and deletes must apply. The v2
+// feature versioning coverage lives in versioning-tests.pw.ts, which
+// owns the (irreversible) versioned environment setup.
+
+const openFeature = async (page: Page, name: string) => {
+  const featureRow = page.locator('[data-test^="feature-item-"]').filter({
+    has: page.locator(`span:text-is("${name}")`),
+  }).first();
+  await featureRow.waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
+  await featureRow.dispatchEvent('click');
+  await page.locator(byId('update-feature-btn')).first().waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
+};
+
+const variantCards = (page: Page) => page.locator('#create-feature-modal .variant-card');
+
+test.describe('Multivariate Options', () => {
+  test('Repeated saves keep the variant set stable @oss', async ({ page }) => {
+    const {
+      closeModal,
+      createRemoteConfig,
+      editRemoteConfig,
+      editVariantLabel,
+      gotoFeatures,
+      gotoProject,
+      login,
+      waitForElementNotExist,
+    } = createHelpers(page);
+
+    log('Login');
+    await login(E2E_USER, PASSWORD);
+    await gotoProject(E2E_TEST_PROJECT);
+
+    log('Create multivariate flag');
+    await createRemoteConfig({ name: 'mv_repeat_save', value: 'ctrl_value', mvs: [
+      { value: 'va', weight: 0 },
+      { value: 'vb', weight: 0 },
+    ]});
+
+    log('First save: label-only edit');
+    await editVariantLabel('mv_repeat_save', 0, 'first_variant');
+
+    log('Second save: value and weights, without structural changes');
+    await editRemoteConfig('mv_repeat_save', 'ctrl_value2', false, [
+      { value: 'va', weight: 30 },
+      { value: 'vb', weight: 20 },
+    ]);
+
+    log('Variant set is unchanged after both saves');
+    await gotoFeatures();
+    await openFeature(page, 'mv_repeat_save');
+    await expect(variantCards(page)).toHaveCount(2);
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('first_variant');
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+  });
+
+  test('Variants can be added and removed in a single save @oss', async ({ page }) => {
+    const {
+      click,
+      closeModal,
+      createRemoteConfig,
+      gotoFeatures,
+      gotoProject,
+      login,
+      setText,
+      waitForElementNotExist,
+      waitForToast,
+    } = createHelpers(page);
+
+    log('Login');
+    await login(E2E_USER, PASSWORD);
+    await gotoProject(E2E_TEST_PROJECT);
+
+    log('Create multivariate flag');
+    await createRemoteConfig({ name: 'mv_add_remove', value: 'root_val', mvs: [
+      { value: 'keep', weight: 0 },
+      { value: 'drop', weight: 0 },
+    ]});
+
+    log('Remove one variant and add another in the same edit');
+    await openFeature(page, 'mv_add_remove');
+    await page.locator('#create-feature-modal #delete-multivariate').nth(1).click();
+    await click('#confirm-btn-yes');
+    await expect(variantCards(page)).toHaveCount(1);
+    await click(byId('add-variation'));
+    await page.waitForTimeout(200);
+    await setText(byId('featureVariationValue1'), 'added');
+    await page.waitForTimeout(500);
+    await click(byId('update-feature-btn'));
+    await waitForToast();
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+
+    log('Saved set is exactly the kept and added variants');
+    await gotoFeatures();
+    await openFeature(page, 'mv_add_remove');
+    await expect(variantCards(page)).toHaveCount(2);
+    await expect(page.locator(byId('featureVariationWeightkeep'))).toBeVisible();
+    await expect(page.locator(byId('featureVariationWeightadded'))).toBeVisible();
+    await expect(page.locator(byId('featureVariationWeightdrop'))).toHaveCount(0);
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+  });
+});

--- a/frontend/e2e/tests/versioning-tests.pw.ts
+++ b/frontend/e2e/tests/versioning-tests.pw.ts
@@ -12,16 +12,22 @@ test('Versioning tests - Create, edit, and compare feature versions @oss', async
     const {
         assertNumberOfVersions,
         click,
+        closeModal,
         compareVersion,
         createFeature,
         createOrganisationAndProject,
         createRemoteConfig,
         editRemoteConfig,
+        gotoFeature,
+        gotoFeatures,
         login,
+        setText,
         toggleFeature,
         tryItExpect,
+        waitForElementNotExist,
         waitForElementVisible,
         waitForFeatureSwitch,
+        waitForToast,
         waitForToastsToClear,
     } = createHelpers(page)
     const flagsmith = await getFlagsmith()
@@ -78,6 +84,38 @@ test('Versioning tests - Create, edit, and compare feature versions @oss', async
     await compareVersion('a', 0, null, true, true, 'small', 'medium')
     await compareVersion('b', 0, null, true, true, 'small', 'small')
     await compareVersion('c', 0, null, false, true, null, null)
+
+    // ===================================================================================
+    // Test: Multivariate option edits in a versioned environment
+    // A label edit plus a structural change (new variant) in a single save must
+    // survive a reopen — the versioned save consumes option ids positionally
+    // from the multivariate save, so this pins that contract under v2.
+    // ===================================================================================
+    log('Edit variant label and add a variant in one save (versioned env)')
+    await gotoFeatures()
+    await gotoFeature('b')
+    await click(byId('featureVariationKeyEdit0'))
+    await setText(byId('featureVariationKeyInput0'), 'primary')
+    await click(byId('featureVariationKeySave0'))
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary')
+    await click(byId('add-variation'))
+    await page.waitForTimeout(200)
+    await setText(byId('featureVariationValue2'), 'huge')
+    await page.waitForTimeout(500)
+    await click(byId('update-feature-btn'))
+    await waitForToast()
+    await closeModal()
+    await waitForElementNotExist('#create-feature-modal')
+
+    log('Label and new variant survived the versioned save')
+    await gotoFeatures()
+    await gotoFeature('b')
+    await expect(page.locator('#create-feature-modal .variant-card')).toHaveCount(3)
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary')
+    await expect(page.locator(byId('featureVariationWeightbig'))).toHaveValue('100')
+    await expect(page.locator(byId('featureVariationWeighthuge'))).toBeVisible()
+    await closeModal()
+    await waitForElementNotExist('#create-feature-modal')
 
     // ===================================================================================
     // Test: Row toggle in versioned environment

--- a/frontend/web/components/base/forms/Input.js
+++ b/frontend/web/components/base/forms/Input.js
@@ -75,6 +75,7 @@ const Input = class extends React.Component {
 
   render() {
     const {
+      centered,
       disabled,
       inputClassName,
       isValid,
@@ -82,6 +83,7 @@ const Input = class extends React.Component {
       placeholderChar,
       showSuccess,
       size,
+      underline,
       ...rest
     } = this.props
 
@@ -91,6 +93,7 @@ const Input = class extends React.Component {
       {
         'focused': this.state.isFocused,
         'input-container': true,
+        'input-underline': underline,
         invalid,
         'password': this.props.type === 'password',
         'search': this.props.search,
@@ -101,7 +104,8 @@ const Input = class extends React.Component {
 
     const innerClassName = cn(
       {
-        input: true,
+        'input': true,
+        'text-center': centered,
       },
       inputClassName,
       sizeClassNames[size],
@@ -215,6 +219,7 @@ Input.defaultProps = {
 
 Input.propTypes = {
   autocomplete: propTypes.string,
+  centered: propTypes.bool,
   className: propTypes.any,
   inputClassName: OptionalString,
   isValid: propTypes.any,
@@ -226,6 +231,7 @@ Input.propTypes = {
   placeholderChar: OptionalString,
   search: propTypes.Boolean,
   size: OptionalString,
+  underline: propTypes.bool,
 }
 
 export default Input

--- a/frontend/web/components/base/forms/InputGroup.js
+++ b/frontend/web/components/base/forms/InputGroup.js
@@ -29,7 +29,10 @@ const InputGroup = class extends Component {
         {this.props.tooltip ? (
           <Tooltip
             title={
-              <label htmlFor={id} className='cols-sm-2 control-label'>
+              <label
+                htmlFor={id}
+                className='cols-sm-2 control-label cursor-pointer'
+              >
                 <div>
                   {props.title}{' '}
                   {!props.hideTooltipIcon && <Icon name='info-outlined' />}{' '}

--- a/frontend/web/components/base/grid/ContentCard/ContentCard.scss
+++ b/frontend/web/components/base/grid/ContentCard/ContentCard.scss
@@ -7,10 +7,21 @@
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-lg);
 
+  &__heading {
+    display: flex;
+    flex-direction: column;
+  }
+
   &__header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+  }
+
+  &__description {
+    font-size: var(--font-body-sm-size);
+    color: var(--color-text-secondary);
+    margin: 0;
   }
 
   .input-container {

--- a/frontend/web/components/base/grid/ContentCard/ContentCard.tsx
+++ b/frontend/web/components/base/grid/ContentCard/ContentCard.tsx
@@ -4,6 +4,7 @@ import './ContentCard.scss'
 
 type ContentCardProps = {
   title?: string
+  description?: ReactNode
   action?: ReactNode
   className?: string
   children: ReactNode
@@ -13,14 +14,22 @@ const ContentCard: FC<ContentCardProps> = ({
   action,
   children,
   className,
+  description,
   title,
 }) => {
   return (
     <div className={cn('content-card', className)}>
-      {(title || action) && (
-        <div className='content-card__header'>
-          {title && <h3 className='content-card__title'>{title}</h3>}
-          {action}
+      {(title || action || description) && (
+        <div className='content-card__heading'>
+          {(title || action) && (
+            <div className='content-card__header'>
+              {title && <h3 className='content-card__title'>{title}</h3>}
+              {action}
+            </div>
+          )}
+          {description && (
+            <p className='content-card__description'>{description}</p>
+          )}
         </div>
       )}
       {children}

--- a/frontend/web/components/experiments/VariationTable/VariationTable.scss
+++ b/frontend/web/components/experiments/VariationTable/VariationTable.scss
@@ -19,7 +19,6 @@
     letter-spacing: 0.02em;
 
     &--name,
-    &--desc,
     &--value {
       flex: 1;
     }
@@ -48,12 +47,6 @@
       white-space: nowrap;
     }
 
-    &--desc {
-      flex: 1;
-      min-width: 0;
-      word-break: break-word;
-    }
-
     &--value {
       flex: 1;
       min-width: 0;
@@ -73,12 +66,6 @@
     background: var(--color-surface-muted);
     padding: 2px 8px;
     border-radius: var(--radius-sm);
-  }
-
-  &__desc-text {
-    font-size: var(--font-body-sm-size);
-    color: var(--color-text-secondary);
-    line-height: 1.4;
   }
 
   &__value-badge {

--- a/frontend/web/components/experiments/VariationTable/VariationTable.tsx
+++ b/frontend/web/components/experiments/VariationTable/VariationTable.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { MultivariateOption } from 'common/types/responses'
 import ColorSwatch from 'components/ColorSwatch'
-import Utils from 'common/utils/utils'
+import { getDefaultVariantKey } from 'common/utils/multivariate'
 import { colorTextAction, colorTextSuccess } from 'common/theme/tokens'
 import './VariationTable.scss'
 
@@ -54,7 +54,7 @@ const VariationTable: FC<VariationTableProps> = ({
             <div className='variation-table__cell variation-table__cell--name'>
               <ColorSwatch color={colorTextAction} size='md' shape='circle' />
               <span className='variation-table__name-text'>
-                {mv.key || Utils.getDefaultVariantKey(index)}
+                {mv.key || getDefaultVariantKey(index)}
               </span>
             </div>
             <div className='variation-table__cell variation-table__cell--value'>

--- a/frontend/web/components/experiments/VariationTable/VariationTable.tsx
+++ b/frontend/web/components/experiments/VariationTable/VariationTable.tsx
@@ -1,22 +1,13 @@
 import { FC } from 'react'
 import { MultivariateOption } from 'common/types/responses'
 import ColorSwatch from 'components/ColorSwatch'
+import Utils from 'common/utils/utils'
 import { colorTextAction, colorTextSuccess } from 'common/theme/tokens'
 import './VariationTable.scss'
 
 type VariationTableProps = {
   controlValue: string
   variations: MultivariateOption[]
-}
-
-const getVariantLetter = (index: number): string => {
-  let result = ''
-  let n = index
-  do {
-    result = String.fromCharCode(65 + (n % 26)) + result
-    n = Math.floor(n / 26) - 1
-  } while (n >= 0)
-  return result
 }
 
 const getVariationValue = (mv: MultivariateOption) => {
@@ -58,13 +49,12 @@ const VariationTable: FC<VariationTableProps> = ({
 
       {variations.map((mv, index) => {
         const value = getVariationValue(mv)
-        const letter = getVariantLetter(index)
         return (
           <div key={mv.id} className='variation-table__row'>
             <div className='variation-table__cell variation-table__cell--name'>
               <ColorSwatch color={colorTextAction} size='md' shape='circle' />
               <span className='variation-table__name-text'>
-                {mv.key || `Variant ${letter}`}
+                {mv.key || Utils.getDefaultVariantKey(index)}
               </span>
             </div>
             <div className='variation-table__cell variation-table__cell--value'>

--- a/frontend/web/components/experiments/VariationTable/VariationTable.tsx
+++ b/frontend/web/components/experiments/VariationTable/VariationTable.tsx
@@ -36,9 +36,6 @@ const VariationTable: FC<VariationTableProps> = ({
         <span className='variation-table__th variation-table__th--name'>
           Name
         </span>
-        <span className='variation-table__th variation-table__th--desc'>
-          Description
-        </span>
         <span className='variation-table__th variation-table__th--value'>
           Value
         </span>
@@ -49,11 +46,6 @@ const VariationTable: FC<VariationTableProps> = ({
           <ColorSwatch color={colorTextSuccess} size='md' shape='circle' />
           <span className='variation-table__name-text'>Control</span>
           <span className='variation-table__control-tag'>control</span>
-        </div>
-        <div className='variation-table__cell variation-table__cell--desc'>
-          <span className='variation-table__desc-text'>
-            Flag&apos;s base value
-          </span>
         </div>
         <div className='variation-table__cell variation-table__cell--value'>
           {controlValue ? (
@@ -72,11 +64,8 @@ const VariationTable: FC<VariationTableProps> = ({
             <div className='variation-table__cell variation-table__cell--name'>
               <ColorSwatch color={colorTextAction} size='md' shape='circle' />
               <span className='variation-table__name-text'>
-                {`Variant ${letter}`}
+                {mv.key || `Variant ${letter}`}
               </span>
-            </div>
-            <div className='variation-table__cell variation-table__cell--desc'>
-              <span className='variation-table__desc-text' />
             </div>
             <div className='variation-table__cell variation-table__cell--value'>
               {value ? (

--- a/frontend/web/components/experiments/steps/SetupStep.tsx
+++ b/frontend/web/components/experiments/steps/SetupStep.tsx
@@ -51,12 +51,10 @@ const SetupStep: FC<SetupStepProps> = ({
 
   return (
     <div className='d-flex flex-column gap-4'>
-      <ContentCard title='Experiment details'>
-        <p className='text-muted fs-small mb-0'>
-          Name the experiment and capture what you&apos;re trying to learn
-          before picking a flag.
-        </p>
-
+      <ContentCard
+        title='Experiment details'
+        description="Name the experiment and capture what you're trying to learn before picking a flag."
+      >
         <InputGroup
           title='Experiment Name *'
           value={name}
@@ -86,12 +84,10 @@ const SetupStep: FC<SetupStepProps> = ({
         </div>
       </ContentCard>
 
-      <ContentCard title='Feature flag'>
-        <p className='text-muted fs-small mb-0'>
-          The flag you&apos;re experimenting on. Variations are read-only,
-          defined on the flag itself.
-        </p>
-
+      <ContentCard
+        title='Feature flag'
+        description="The flag you're experimenting on. Variations are read-only, defined on the flag itself."
+      >
         <div className='wizard-field'>
           <label className='wizard-field__label'>Feature Flag</label>
           <Select

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import cloneDeep from 'lodash/cloneDeep'
 import moment from 'moment'
 import { useProjectEnvironments } from 'common/hooks/useProjectEnvironments'
@@ -68,6 +75,21 @@ type InjectedSegmentOverrideProps = {
   updateSegments: (segments: SegmentOverrideValue[]) => void
   removeMultivariateOption: (id: number) => void
 }
+
+// Replaces each option's default weight with its environment allocation.
+const mergeEnvironmentWeights = (options: any[], variations: any[]): any[] =>
+  options.map((v: any) => {
+    const matchingVariation = variations.find(
+      (e: any) => e.multivariate_feature_option === v.id,
+    )
+    return {
+      ...v,
+      default_percentage_allocation:
+        (matchingVariation && matchingVariation.percentage_allocation) ||
+        v.default_percentage_allocation ||
+        0,
+    }
+  })
 
 const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
   const {
@@ -232,22 +254,33 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
     if (!identity && environmentVariations?.length) {
       setProjectFlag((prev: any) => ({
         ...prev,
-        multivariate_options: prev.multivariate_options?.map((v: any) => {
-          const matchingVariation = (
-            props.multivariate_options || environmentVariations
-          ).find((e: any) => e.multivariate_feature_option === v.id)
-          return {
-            ...v,
-            default_percentage_allocation:
-              (matchingVariation && matchingVariation.percentage_allocation) ||
-              v.default_percentage_allocation ||
-              0,
-          }
-        }),
+        multivariate_options:
+          prev.multivariate_options &&
+          mergeEnvironmentWeights(
+            prev.multivariate_options,
+            props.multivariate_options || environmentVariations,
+          ),
       }))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environmentVariations])
+
+  // The persisted variants with the same environment weights merged in,
+  // so the modal's edited copy only differs after a user change.
+  const originalMultivariateOptions = useMemo(() => {
+    const options = props.projectFlag?.multivariate_options
+    if (!options) {
+      return undefined
+    }
+    if (identity || !environmentVariations?.length) {
+      return options
+    }
+    return mergeEnvironmentWeights(
+      options,
+      props.multivariate_options || environmentVariations,
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.projectFlag?.multivariate_options, environmentVariations])
 
   const cleanInputValue = (value: any) => {
     if (value && typeof value === 'string') {
@@ -596,6 +629,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       isVersioned={isVersioned}
                       isSaving={isSaving}
                       existingChangeRequest={!!existingChangeRequest}
+                      originalMultivariateOptions={originalMultivariateOptions}
                       onSaveFeatureValue={saveFeatureValue}
                       onEnvironmentFlagChange={(changes: any) => {
                         setEnvironmentFlag((prev: any) => ({

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -635,7 +635,15 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                 <Tabs
                   urlParam='tab'
                   history={props.history}
-                  onChange={() => setTabKey((k) => k + 1)}
+                  onChange={() => {
+                    setTabKey((k) => k + 1)
+                    // A save error belongs to the tab it occurred on — the
+                    // other tabs cannot render its shape meaningfully.
+                    if (FeatureListStore.error) {
+                      FeatureListStore.error = null
+                      FeatureListStore.trigger('change')
+                    }
+                  }}
                   overflowX
                 >
                   <TabItem

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -245,6 +245,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
   useEffect(() => {
     if (props.projectFlag) {
       setProjectFlag(cloneDeep(props.projectFlag))
+      setSavedMultivariateOptions(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.projectFlag?.id])
@@ -266,8 +267,16 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
   }, [environmentVariations])
 
   // The persisted variants with the same environment weights merged in,
-  // so the modal's edited copy only differs after a user change.
+  // so the modal's edited copy only differs after a user change. Refreshed
+  // from the edited copy after each successful value save.
+  const [savedMultivariateOptions, setSavedMultivariateOptions] = useState<
+    any[] | null
+  >(null)
+  const mvBaselineRefreshRef = useRef(false)
   const originalMultivariateOptions = useMemo(() => {
+    if (savedMultivariateOptions) {
+      return savedMultivariateOptions
+    }
     const options = props.projectFlag?.multivariate_options
     if (!options) {
       return undefined
@@ -280,7 +289,11 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
       props.multivariate_options || environmentVariations,
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.projectFlag?.multivariate_options, environmentVariations])
+  }, [
+    props.projectFlag?.multivariate_options,
+    environmentVariations,
+    savedMultivariateOptions,
+  ])
 
   const cleanInputValue = (value: any) => {
     if (value && typeof value === 'string') {
@@ -440,9 +453,22 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
 
   return (
     <Provider
+      onError={() => {
+        if (mvBaselineRefreshRef.current) {
+          // The value save failed — keep the unsaved indicators accurate.
+          mvBaselineRefreshRef.current = false
+          setValueChanged(true)
+        }
+      }}
       onSave={() => {
         if (identity) {
           close()
+        }
+        if (mvBaselineRefreshRef.current) {
+          mvBaselineRefreshRef.current = false
+          setSavedMultivariateOptions(
+            cloneDeep(projectFlag.multivariate_options || []),
+          )
         }
         AppActions.refreshFeatures(projectId, environmentId)
 
@@ -571,6 +597,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
               )
             } else {
               setValueChanged(false)
+              mvBaselineRefreshRef.current = true
               save(editFeatureValue, isSaving)
             }
           },

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -98,18 +98,18 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   const addVariation = () => {
     // Default the label to the first free Variant_n so new variants are
     // saved with a key even if the user never edits it. Variants with no
-    // key display as Variant_{index + 1}, so avoid those names too.
+    // key display (and persist) their fallback, so avoid those names too.
     const existingNames = multivariate_options.map(
-      (option, index) => option.key || `Variant_${index + 1}`,
+      (option, index) => option.key || Utils.getDefaultVariantKey(index),
     )
-    let variantNumber = multivariate_options.length + 1
-    while (existingNames.includes(`Variant_${variantNumber}`)) {
-      variantNumber += 1
+    let nextIndex = multivariate_options.length
+    while (existingNames.includes(Utils.getDefaultVariantKey(nextIndex))) {
+      nextIndex += 1
     }
     const newVariation = {
       ...Utils.valueToFeatureState(''),
       default_percentage_allocation: 0,
-      key: `Variant_${variantNumber}`,
+      key: Utils.getDefaultVariantKey(nextIndex),
     }
     onProjectFlagChange({
       multivariate_options: [...multivariate_options, newVariation],

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -5,6 +5,7 @@ import Constants from 'common/constants'
 import { VariationOptions } from 'components/mv/VariationOptions'
 import { AddVariationButton } from 'components/mv/AddVariationButton'
 import ErrorMessage from 'components/ErrorMessage'
+import InfoMessage from 'components/InfoMessage'
 import WarningMessage from 'components/WarningMessage'
 import Tooltip from 'components/Tooltip'
 import Icon from 'components/icons/Icon'
@@ -12,7 +13,11 @@ import Switch from 'components/Switch'
 import JSONReference from 'components/JSONReference'
 import { FlagValueFooter } from 'components/modals/FlagValueFooter'
 import Utils from 'common/utils/utils'
-import { FeatureState, ProjectFlag } from 'common/types/responses'
+import {
+  FeatureState,
+  MultivariateOption,
+  ProjectFlag,
+} from 'common/types/responses'
 import { useHasPermission } from 'common/providers/Permission'
 import { ProjectPermission } from 'common/types/permissions.types'
 
@@ -42,6 +47,8 @@ type FeatureValueTabProps = {
   isSaving?: boolean
   existingChangeRequest?: boolean
   onSaveFeatureValue?: (schedule?: boolean) => void
+  // The persisted variants, used to tag edited ones as not saved.
+  originalMultivariateOptions?: MultivariateOption[]
   onEnvironmentFlagChange: (changes: Partial<FeatureState>) => void
   onProjectFlagChange: (changes: Partial<ProjectFlag>) => void
   onRemoveMultivariateOption?: (id: number) => void
@@ -63,6 +70,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   onProjectFlagChange,
   onRemoveMultivariateOption,
   onSaveFeatureValue,
+  originalMultivariateOptions,
   projectFlag,
   projectId,
 }) => {
@@ -88,9 +96,17 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
     controlPercentage < 0
 
   const addVariation = () => {
+    // Default the label to the first free Variant_n so new variants are
+    // saved with a key even if the user never edits it.
+    const existingKeys = multivariate_options.map((option) => option.key)
+    let variantNumber = multivariate_options.length + 1
+    while (existingKeys.includes(`Variant_${variantNumber}`)) {
+      variantNumber += 1
+    }
     const newVariation = {
       ...Utils.valueToFeatureState(''),
       default_percentage_allocation: 0,
+      key: `Variant_${variantNumber}`,
     }
     onProjectFlagChange({
       multivariate_options: [...multivariate_options, newVariation],
@@ -155,13 +171,60 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
 
   const enabledString = isEdit ? 'Enabled' : 'Enabled by default'
 
-  const getValueString = () => {
-    if (multivariate_options && multivariate_options.length) {
-      return `Control Value - ${controlPercentage}%`
+  const hasVariations = !!multivariate_options && !!multivariate_options.length
+
+  // Fields the user can change on a variant from this tab.
+  const variantFields: (keyof MultivariateOption)[] = [
+    'key',
+    'type',
+    'string_value',
+    'integer_value',
+    'boolean_value',
+    'default_percentage_allocation',
+  ]
+  const unsavedVariations = multivariate_options.map((option) => {
+    if (!originalMultivariateOptions) {
+      return false
     }
-    return 'Value'
-  }
-  const valueString = getValueString()
+    if (!option.id) {
+      return true
+    }
+    const original = originalMultivariateOptions.find((o) => o.id === option.id)
+    if (!original) {
+      return true
+    }
+    return variantFields.some((field) => option[field] !== original[field])
+  })
+  const valueTitle = hasVariations ? (
+    <span className='d-inline-flex align-items-center'>
+      Control Value
+      <span className='ml-1'>
+        <Icon name='info-outlined' />
+      </span>
+      <span className='chip chip--xs ml-2'>{controlPercentage}%</span>
+    </span>
+  ) : (
+    'Value'
+  )
+
+  const variationsInfo = hasVariations && (
+    <p className='mb-4'>
+      <InfoMessage collapseId={'variation-value'}>
+        Changing a Variation Value will affect <strong>all environments</strong>
+        , their weights are specific to this environment. Existing users will
+        see the new variation value if it is changed. These values will only
+        apply when you identify via the SDK.
+        <a
+          target='_blank'
+          href='https://docs.flagsmith.com/basic-features/managing-features#multi-variate-flags'
+          rel='noreferrer'
+        >
+          Check the Docs for more details
+        </a>
+        .
+      </InfoMessage>
+    </p>
+  )
 
   const showValue = !(
     !!identity &&
@@ -203,7 +266,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
               <ValueEditor
                 data-test='featureValue'
                 name='featureValue'
-                className='full-width'
+                className={`full-width${hasVariations ? ' code-medium' : ''}`}
                 value={`${
                   typeof initial_value === 'undefined' || initial_value === null
                     ? ''
@@ -224,7 +287,8 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
                 ? '<br/>Setting this when creating a feature will set the value for all environments. You can edit this individually for each environment once the feature is created.'
                 : ''
             }`}
-            title={`${valueString}`}
+            title={valueTitle}
+            hideTooltipIcon={hasVariations}
           />
         </FormGroup>
       )}
@@ -255,6 +319,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
       {!!identity && (
         <div>
           <FormGroup className='mb-4'>
+            {variationsInfo}
             <VariationOptions
               canCreateFeature={false}
               disabled
@@ -284,6 +349,34 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
 
       {!identity && (
         <div>
+          {variationsInfo}
+          {hasVariations && (
+            <Row className='justify-content-between align-items-center mb-2'>
+              {Utils.getFlagsmithHasFeature('experimental_flags') ? (
+                <Tooltip
+                  title={
+                    <label className='mb-0 cursor-pointer'>
+                      Variants <Icon name='info-outlined' />
+                    </label>
+                  }
+                >
+                  To use this flag in an experiment, all the variants must have
+                  a label.
+                </Tooltip>
+              ) : (
+                <label className='mb-0'>Variants</label>
+              )}
+              {Utils.renderWithPermission(
+                createFeature,
+                Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
+                <AddVariationButton
+                  multivariateOptions={multivariate_options}
+                  disabled={!createFeature || noPermissions}
+                  onClick={addVariation}
+                />,
+              )}
+            </Row>
+          )}
           <FormGroup className='mb-0'>
             {(!!environmentVariations || !isEdit) && (
               <VariationOptions
@@ -300,6 +393,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
                     multivariate_feature_state_values: variations as any,
                   })
                 }
+                unsavedVariations={unsavedVariations}
                 updateVariation={handleUpdateVariation}
                 weightTitle={
                   isEdit ? 'Environment Weight %' : 'Default Weight %'
@@ -309,14 +403,18 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
               />
             )}
           </FormGroup>
-          {Utils.renderWithPermission(
-            createFeature,
-            Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
-            <AddVariationButton
-              multivariateOptions={multivariate_options}
-              disabled={!createFeature || noPermissions}
-              onClick={addVariation}
-            />,
+          {!hasVariations && (
+            <div className='text-end'>
+              {Utils.renderWithPermission(
+                createFeature,
+                Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
+                <AddVariationButton
+                  multivariateOptions={multivariate_options}
+                  disabled={!createFeature || noPermissions}
+                  onClick={addVariation}
+                />,
+              )}
+            </div>
           )}
         </div>
       )}

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -97,10 +97,13 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
 
   const addVariation = () => {
     // Default the label to the first free Variant_n so new variants are
-    // saved with a key even if the user never edits it.
-    const existingKeys = multivariate_options.map((option) => option.key)
+    // saved with a key even if the user never edits it. Variants with no
+    // key display as Variant_{index + 1}, so avoid those names too.
+    const existingNames = multivariate_options.map(
+      (option, index) => option.key || `Variant_${index + 1}`,
+    )
     let variantNumber = multivariate_options.length + 1
-    while (existingKeys.includes(`Variant_${variantNumber}`)) {
+    while (existingNames.includes(`Variant_${variantNumber}`)) {
       variantNumber += 1
     }
     const newVariation = {
@@ -193,7 +196,11 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
     if (!original) {
       return true
     }
-    return variantFields.some((field) => option[field] !== original[field])
+    return variantFields.some((field) => {
+      const edited = option[field] ?? null
+      const persisted = original[field] ?? null
+      return edited !== persisted
+    })
   })
   const valueTitle = hasVariations ? (
     <span className='d-inline-flex align-items-center'>

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -189,18 +189,31 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
     if (!originalMultivariateOptions) {
       return false
     }
-    if (!option.id) {
-      return true
+    // A just-saved variant may not have its id reflected in local state
+    // yet, so id-less options are matched against id-less baseline entries.
+    const savedMvs = originalMultivariateOptions.filter((o) =>
+      option.id ? o.id === option.id : !o.id,
+    )
+    return !savedMvs.some((savedMv) =>
+      variantFields.every(
+        (field) => (option[field] ?? null) === (savedMv[field] ?? null),
+      ),
+    )
+  })
+
+  const variationApiErrors = multivariate_options.map((_, i) => {
+    const variationError = error?.multivariate_options?.[i]
+    if (!variationError) {
+      return null
     }
-    const original = originalMultivariateOptions.find((o) => o.id === option.id)
-    if (!original) {
-      return true
+    if (typeof variationError === 'string') {
+      return variationError
     }
-    return variantFields.some((field) => {
-      const edited = option[field] ?? null
-      const persisted = original[field] ?? null
-      return edited !== persisted
-    })
+    const firstField = Object.values(variationError)[0]
+    return (
+      (Array.isArray(firstField) ? firstField[0] : firstField) ||
+      'Failed to save this variation.'
+    )
   })
   const valueTitle = hasVariations ? (
     <span className='d-inline-flex align-items-center'>
@@ -400,6 +413,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
                     multivariate_feature_state_values: variations as any,
                   })
                 }
+                apiErrors={variationApiErrors}
                 unsavedVariations={unsavedVariations}
                 updateVariation={handleUpdateVariation}
                 weightTitle={

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -221,7 +221,9 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
       <span className='ml-1'>
         <Icon name='info-outlined' />
       </span>
-      <span className='chip chip--xs ml-2'>{controlPercentage}%</span>
+      <span className='chip chip--xs ml-2'>
+        {Math.max(0, controlPercentage)}%
+      </span>
     </span>
   ) : (
     'Value'

--- a/frontend/web/components/mv/AddVariationButton.tsx
+++ b/frontend/web/components/mv/AddVariationButton.tsx
@@ -1,4 +1,5 @@
 import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
 import React from 'react'
 
 interface AddVariationButtonProps {
@@ -13,16 +14,16 @@ export const AddVariationButton: React.FC<AddVariationButtonProps> = ({
   onClick,
 }) => {
   return (
-    <div className='text-end'>
-      <Button
-        disabled={disabled}
-        data-test='add-variation'
-        type='button'
-        onClick={onClick}
-        theme='outline'
-      >
-        {multivariateOptions?.length ? 'Add Variation' : 'Create A/B/n Test'}
-      </Button>
-    </div>
+    <Button
+      disabled={disabled}
+      data-test='add-variation'
+      type='button'
+      size='xSmall'
+      theme={multivariateOptions?.length ? 'primary' : 'outline'}
+      onClick={onClick}
+    >
+      <Icon name='plus' width={16} />
+      {multivariateOptions?.length ? 'Add variant' : 'Create A/B/n Test'}
+    </Button>
   )
 }

--- a/frontend/web/components/mv/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel.tsx
@@ -35,22 +35,23 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   // Display-only placeholder when no label is set; the persisted key stays null.
   const displayName = value || `Variant_${index + 1}`
 
+  // Validates the raw input — trimming here would hide a trailing
+  // space from the user until their next keystroke.
   const validate = (next: string): string | null => {
-    const trimmed = next.trim()
-    if (!trimmed) {
+    if (!next) {
       // Empty clears the label (key persists as null).
       return null
     }
-    if (trimmed.length > Constants.forms.maxLength.VARIANT_KEY) {
+    if (next.length > Constants.forms.maxLength.VARIANT_KEY) {
       return `Label must be ${Constants.forms.maxLength.VARIANT_KEY} characters or fewer.`
     }
-    if (!VARIANT_KEY_REGEX.test(trimmed)) {
+    if (!VARIANT_KEY_REGEX.test(next)) {
       return 'Label can only contain letters, numbers, hyphens and underscores.'
     }
-    if (trimmed === Constants.strings.RESERVED_VARIANT_KEY) {
+    if (next === Constants.strings.RESERVED_VARIANT_KEY) {
       return `"${Constants.strings.RESERVED_VARIANT_KEY}" is a reserved label.`
     }
-    if (siblingKeys.some((key) => key === trimmed)) {
+    if (siblingKeys.some((key) => key === next)) {
       return 'This label is already used by another variation.'
     }
     return null
@@ -69,24 +70,26 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   }
 
   const commit = () => {
-    const trimmed = draft.trim()
-    const validationError = validate(trimmed)
+    const validationError = validate(draft)
     if (validationError) {
       setError(validationError)
       return
     }
-    onChange(trimmed || null)
+    onChange(draft || null)
     setError(null)
     setIsEditing(false)
   }
 
   if (isEditing && canEdit) {
     return (
-      <div className='mb-2'>
-        <Row className='align-items-center gap-4'>
+      <div>
+        <Row className='align-items-center gap-3'>
           <Input
             autoFocus
             size='small'
+            underline
+            data-test={`featureVariationKeyInput${index}`}
+            style={{ width: 150 }}
             value={draft}
             isValid={!error}
             maxLength={Constants.forms.maxLength.VARIANT_KEY}
@@ -107,23 +110,18 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
               }
             }}
           />
-          <div className='d-flex align-items-center gap-2'>
-            <button
-              type='button'
-              className='btn btn-with-icon'
+          <div className='d-flex align-items-center gap-1'>
+            <Button
+              theme='text'
               onClick={commit}
+              data-test={`featureVariationKeySave${index}`}
               aria-label='Save label'
             >
               <Icon name='checkmark-circle' width={20} fill='#6837FC' />
-            </button>
-            <button
-              type='button'
-              className='btn btn-with-icon'
-              onClick={cancel}
-              aria-label='Cancel'
-            >
+            </Button>
+            <Button theme='text' onClick={cancel} aria-label='Cancel'>
               <Icon name='close-circle' width={20} fill='#656D7B' />
-            </button>
+            </Button>
           </div>
         </Row>
         {!!error && <span className='text-danger text-small'>{error}</span>}
@@ -132,13 +130,19 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   }
 
   return (
-    <Row className='align-items-center mb-2'>
-      <span className='h5 mb-0'>{displayName}</span>
+    <Row className='align-items-center'>
+      <span
+        className='h6 mb-0 font-weight-semibold'
+        data-test={`featureVariationKey${index}`}
+      >
+        {displayName}
+      </span>
       {canEdit && (
         <Button
           theme='text'
           className='text-primary ml-2'
           onClick={startEditing}
+          data-test={`featureVariationKeyEdit${index}`}
           aria-label='Edit label'
         >
           <Icon name='edit' width={16} />

--- a/frontend/web/components/mv/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel.tsx
@@ -1,0 +1,149 @@
+import React, { FC, useState } from 'react'
+import Constants from 'common/constants'
+import Button from 'components/base/forms/Button'
+import Icon from 'components/icons/Icon'
+import Input from 'components/base/forms/Input'
+import Utils from 'common/utils/utils'
+
+interface VariationKeyLabelProps {
+  // The variant's `key`, surfaced in the UI as its "Label".
+  value?: string | null
+  index: number
+  disabled?: boolean
+  readOnly?: boolean
+  // Keys of the other variations, used to enforce per-feature uniqueness.
+  siblingKeys: (string | null | undefined)[]
+  onChange: (key: string | null) => void
+}
+
+// Mirrors the backend `validate_slug` rule for the multivariate option key.
+const VARIANT_KEY_REGEX = /^[a-zA-Z0-9_-]+$/
+
+export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
+  disabled,
+  index,
+  onChange,
+  readOnly,
+  siblingKeys,
+  value,
+}) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(value ?? '')
+  const [error, setError] = useState<string | null>(null)
+
+  const canEdit = !readOnly && !disabled
+  // Display-only placeholder when no label is set; the persisted key stays null.
+  const displayName = value || `Variant_${index + 1}`
+
+  const validate = (next: string): string | null => {
+    const trimmed = next.trim()
+    if (!trimmed) {
+      // Empty clears the label (key persists as null).
+      return null
+    }
+    if (trimmed.length > Constants.forms.maxLength.VARIANT_KEY) {
+      return `Label must be ${Constants.forms.maxLength.VARIANT_KEY} characters or fewer.`
+    }
+    if (!VARIANT_KEY_REGEX.test(trimmed)) {
+      return 'Label can only contain letters, numbers, hyphens and underscores.'
+    }
+    if (trimmed === Constants.strings.RESERVED_VARIANT_KEY) {
+      return `"${Constants.strings.RESERVED_VARIANT_KEY}" is a reserved label.`
+    }
+    if (siblingKeys.some((key) => key === trimmed)) {
+      return 'This label is already used by another variation.'
+    }
+    return null
+  }
+
+  const startEditing = () => {
+    setDraft(value ?? '')
+    setError(null)
+    setIsEditing(true)
+  }
+
+  const cancel = () => {
+    setDraft(value ?? '')
+    setError(null)
+    setIsEditing(false)
+  }
+
+  const commit = () => {
+    const trimmed = draft.trim()
+    const validationError = validate(trimmed)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    onChange(trimmed || null)
+    setError(null)
+    setIsEditing(false)
+  }
+
+  if (isEditing && canEdit) {
+    return (
+      <div className='mb-2'>
+        <Row className='align-items-center gap-4'>
+          <Input
+            autoFocus
+            size='small'
+            value={draft}
+            isValid={!error}
+            maxLength={Constants.forms.maxLength.VARIANT_KEY}
+            placeholder={`Variant_${index + 1}`}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const next = Utils.safeParseEventValue(e)
+              setDraft(next)
+              setError(validate(next))
+            }}
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                commit()
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault()
+                cancel()
+              }
+            }}
+          />
+          <div className='d-flex align-items-center gap-2'>
+            <button
+              type='button'
+              className='btn btn-with-icon'
+              onClick={commit}
+              aria-label='Save label'
+            >
+              <Icon name='checkmark-circle' width={20} fill='#6837FC' />
+            </button>
+            <button
+              type='button'
+              className='btn btn-with-icon'
+              onClick={cancel}
+              aria-label='Cancel'
+            >
+              <Icon name='close-circle' width={20} fill='#656D7B' />
+            </button>
+          </div>
+        </Row>
+        {!!error && <span className='text-danger text-small'>{error}</span>}
+      </div>
+    )
+  }
+
+  return (
+    <Row className='align-items-center mb-2'>
+      <span className='h5 mb-0'>{displayName}</span>
+      {canEdit && (
+        <Button
+          theme='text'
+          className='text-primary ml-2'
+          onClick={startEditing}
+          aria-label='Edit label'
+        >
+          <Icon name='edit' width={16} />
+        </Button>
+      )}
+    </Row>
+  )
+}

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.scss
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.scss
@@ -1,0 +1,5 @@
+.variation-key-label {
+  &__input {
+    width: 150px;
+  }
+}

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
@@ -72,11 +72,6 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   }
 
   const commit = () => {
-    const validationError = validate(draft)
-    if (validationError) {
-      setError(validationError)
-      return
-    }
     onChange(draft || null)
     setError(null)
     setIsEditing(false)
@@ -97,18 +92,23 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
             maxLength={Constants.forms.maxLength.VARIANT_KEY}
             placeholder={`Variant_${index + 1}`}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              const next = Utils.safeParseEventValue(e)
+              const next = Utils.safeParseEventValue(e).replace(/ /g, '_')
               setDraft(next)
               setError(validate(next))
             }}
+            onBlur={commit}
             onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
                 commit()
               }
               if (e.key === 'Escape') {
-                e.preventDefault()
-                cancel()
+                // The input blurs (and commits) on Escape before this
+                // handler runs — revert to the original value.
+                onChange(value ?? null)
+                setDraft(value ?? '')
+                setError(null)
+                setIsEditing(false)
               }
             }}
           />
@@ -116,12 +116,18 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
             <Button
               theme='text'
               onClick={commit}
+              onMouseDown={(e) => e.preventDefault()}
               data-test={`featureVariationKeySave${index}`}
               aria-label='Save label'
             >
               <Icon name='checkmark-circle' width={20} fill={colorIconAction} />
             </Button>
-            <Button theme='text' onClick={cancel} aria-label='Cancel'>
+            <Button
+              theme='text'
+              onClick={cancel}
+              onMouseDown={(e) => e.preventDefault()}
+              aria-label='Cancel'
+            >
               <Icon name='close-circle' width={20} fill={colorIconSecondary} />
             </Button>
           </div>

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
@@ -34,8 +34,8 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   const [error, setError] = useState<string | null>(null)
 
   const canEdit = !readOnly && !disabled
-  // Display-only placeholder when no label is set; the persisted key stays null.
-  const displayName = value || `Variant_${index + 1}`
+  // Fallback label when none is set — persisted on save by the provider.
+  const displayName = value || Utils.getDefaultVariantKey(index)
 
   // Validates the raw input — trimming here would hide a trailing
   // space from the user until their next keystroke.
@@ -72,6 +72,9 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   }
 
   const commit = () => {
+    if (error) {
+      return
+    }
     onChange(draft || null)
     setError(null)
     setIsEditing(false)
@@ -90,13 +93,19 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
             value={draft}
             isValid={!error}
             maxLength={Constants.forms.maxLength.VARIANT_KEY}
-            placeholder={`Variant_${index + 1}`}
+            placeholder={Utils.getDefaultVariantKey(index)}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               const next = Utils.safeParseEventValue(e).replace(/ /g, '_')
               setDraft(next)
               setError(validate(next))
             }}
-            onBlur={commit}
+            // An invalid draft must not be committed — keep the row in edit
+            // mode with the error visible instead.
+            onBlur={() => {
+              if (!error) {
+                commit()
+              }
+            }}
             onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
@@ -115,12 +124,17 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
           <div className='d-flex align-items-center gap-1'>
             <Button
               theme='text'
+              disabled={!!error}
               onClick={commit}
               onMouseDown={(e) => e.preventDefault()}
               data-test={`featureVariationKeySave${index}`}
               aria-label='Save label'
             >
-              <Icon name='checkmark-circle' width={20} fill={colorIconAction} />
+              <Icon
+                name='checkmark-circle'
+                width={20}
+                fill={error ? colorIconSecondary : colorIconAction}
+              />
             </Button>
             <Button
               theme='text'

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
@@ -4,6 +4,8 @@ import Button from 'components/base/forms/Button'
 import Icon from 'components/icons/Icon'
 import Input from 'components/base/forms/Input'
 import Utils from 'common/utils/utils'
+import { colorIconAction, colorIconSecondary } from 'common/theme/tokens'
+import './VariationKeyLabel.scss'
 
 interface VariationKeyLabelProps {
   // The variant's `key`, surfaced in the UI as its "Label".
@@ -88,8 +90,8 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
             autoFocus
             size='small'
             underline
+            className='variation-key-label__input'
             data-test={`featureVariationKeyInput${index}`}
-            style={{ width: 150 }}
             value={draft}
             isValid={!error}
             maxLength={Constants.forms.maxLength.VARIANT_KEY}
@@ -117,10 +119,10 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
               data-test={`featureVariationKeySave${index}`}
               aria-label='Save label'
             >
-              <Icon name='checkmark-circle' width={20} fill='#6837FC' />
+              <Icon name='checkmark-circle' width={20} fill={colorIconAction} />
             </Button>
             <Button theme='text' onClick={cancel} aria-label='Cancel'>
-              <Icon name='close-circle' width={20} fill='#656D7B' />
+              <Icon name='close-circle' width={20} fill={colorIconSecondary} />
             </Button>
           </div>
         </Row>

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
@@ -106,18 +106,11 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
                 commit()
               }
             }}
+            // Escape is left to bubble up and close the modal.
             onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
                 commit()
-              }
-              if (e.key === 'Escape') {
-                // The input blurs (and commits) on Escape before this
-                // handler runs — revert to the original value.
-                onChange(value ?? null)
-                setDraft(value ?? '')
-                setError(null)
-                setIsEditing(false)
               }
             }}
           />

--- a/frontend/web/components/mv/VariationKeyLabel/index.ts
+++ b/frontend/web/components/mv/VariationKeyLabel/index.ts
@@ -1,0 +1,1 @@
+export { VariationKeyLabel } from './VariationKeyLabel'

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -153,9 +153,14 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
             readOnly={readOnly ?? false}
             unsaved={unsavedVariations?.[i]}
             value={theValue}
+            // Effective keys: unset labels persist as their Variant_n
+            // fallback, so they count for uniqueness too.
             siblingKeys={multivariateOptions
-              .filter((_, index) => index !== i)
-              .map((option) => option.key)}
+              .map(
+                (option, index) =>
+                  option.key || Utils.getDefaultVariantKey(index),
+              )
+              .filter((_, index) => index !== i)}
             onChange={(e) => {
               updateVariation(i, e, variationOverrides)
             }}

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -13,6 +13,7 @@ type VariationOverride = {
 }
 
 interface VariationOptionsProps {
+  apiErrors?: (string | null)[]
   canCreateFeature: boolean
   controlPercentage: number
   controlValue: FlagsmithValue
@@ -34,6 +35,7 @@ interface VariationOptionsProps {
 }
 
 export const VariationOptions: React.FC<VariationOptionsProps> = ({
+  apiErrors,
   canCreateFeature,
   controlPercentage,
   controlValue,
@@ -146,6 +148,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
           <VariationValueInput
             key={i}
             index={i}
+            apiError={apiErrors?.[i]}
             canCreateFeature={canCreateFeature}
             readOnly={readOnly ?? false}
             unsaved={unsavedVariations?.[i]}

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ValueEditor from 'components/ValueEditor'
-import InfoMessage from 'components/InfoMessage'
 import ErrorMessage from 'components/ErrorMessage'
 import { VariationValueInput } from './VariationValueInput'
 import Utils from 'common/utils/utils'
@@ -24,6 +23,7 @@ interface VariationOptionsProps {
   select?: boolean
   setValue: (value: FlagsmithValue) => void
   setVariations: (variations: VariationOverride[]) => void
+  unsavedVariations?: boolean[]
   updateVariation: (
     index: number,
     value: MultivariateOption,
@@ -44,6 +44,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
   select,
   setValue,
   setVariations,
+  unsavedVariations,
   updateVariation,
   variationOverrides,
   weightTitle,
@@ -63,26 +64,6 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
           error='Your variation percentage splits total to over 100%'
         />
       )}
-      {!readOnly && (
-        <p className='mb-4'>
-          <InfoMessage collapseId={'variation-value'}>
-            Changing a Variation Value will affect{' '}
-            <strong>all environments</strong>, their weights are specific to
-            this environment. Existing users will see the new variation value if
-            it is changed. These values will only apply when you identify via
-            the SDK.
-            <a
-              target='_blank'
-              href='https://docs.flagsmith.com/basic-features/managing-features#multi-variate-flags'
-              rel='noreferrer'
-            >
-              Check the Docs for more details
-            </a>
-            .
-          </InfoMessage>
-        </p>
-      )}
-
       {select && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
@@ -167,6 +148,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
             index={i}
             canCreateFeature={canCreateFeature}
             readOnly={readOnly ?? false}
+            unsaved={unsavedVariations?.[i]}
             value={theValue}
             siblingKeys={multivariateOptions
               .filter((_, index) => index !== i)

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -168,6 +168,9 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
             canCreateFeature={canCreateFeature}
             readOnly={readOnly ?? false}
             value={theValue}
+            siblingKeys={multivariateOptions
+              .filter((_, index) => index !== i)
+              .map((option) => option.key)}
             onChange={(e) => {
               updateVariation(i, e, variationOverrides)
             }}

--- a/frontend/web/components/mv/VariationValueInput.scss
+++ b/frontend/web/components/mv/VariationValueInput.scss
@@ -1,0 +1,7 @@
+.variant-card {
+  // The InputGroup label is internal to the component, so its weight
+  // can only be reduced from here.
+  label {
+    font-weight: 400;
+  }
+}

--- a/frontend/web/components/mv/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 import ValueEditor from 'components/ValueEditor'
 import Constants from 'common/constants'
 import Icon from 'components/icons/Icon'
+import Input from 'components/base/forms/Input'
 import InputGroup from 'components/base/forms/InputGroup'
+import Button from 'components/base/forms/Button'
 import Utils from 'common/utils/utils'
 import shallowEqual from 'fbjs/lib/shallowEqual'
 import { ProjectPermission } from 'common/types/permissions.types'
 import { VariationKeyLabel } from './VariationKeyLabel'
+import './VariationValueInput.scss'
 
 interface VariationValueProps {
   canCreateFeature: boolean
@@ -16,6 +19,7 @@ interface VariationValueProps {
   onRemove?: () => void
   readOnly: boolean
   siblingKeys: (string | null | undefined)[]
+  unsaved?: boolean
   value: any
   weightTitle: string
 }
@@ -28,106 +32,110 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
   onRemove,
   readOnly,
   siblingKeys,
+  unsaved,
   value,
   weightTitle,
 }) => {
   return (
-    <div className='mb-2'>
-      <VariationKeyLabel
-        value={value.key}
-        index={index}
-        disabled={disabled || !canCreateFeature}
-        readOnly={readOnly}
-        siblingKeys={siblingKeys}
-        onChange={(key) => onChange({ ...value, key })}
-      />
-      <Row className='align-items-start'>
-        <div className='flex flex-1 overflow-hidden'>
-          <InputGroup
-            noMargin
-            component={
-              <>
-                {Utils.renderWithPermission(
-                  canCreateFeature,
-                  readOnly
-                    ? 'Variation values are defined at the feature level and cannot be changed per segment.'
-                    : Constants.projectPermissions(
-                        ProjectPermission.CREATE_FEATURE,
-                      ),
-                  <ValueEditor
-                    data-test={`featureVariationValue${
-                      Utils.featureStateToValue(value) || index
-                    }`}
-                    name='featureValue'
-                    className='full-width code-medium'
-                    value={Utils.getTypedValue(
-                      Utils.featureStateToValue(value),
-                    )}
-                    disabled={!canCreateFeature || disabled || readOnly}
-                    onBlur={() => {
-                      const newValue = {
-                        ...value,
-                        // Trim spaces and do conversion on blur
-                        ...Utils.valueToFeatureState(
-                          Utils.featureStateToValue(value),
-                        ),
-                      }
-                      if (!shallowEqual(newValue, value)) {
-                        //occurs if we converted a trimmed value
-                        onChange(newValue)
-                      }
-                    }}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      onChange({
-                        ...value,
-                        ...Utils.valueToFeatureState(
-                          Utils.safeParseEventValue(e),
-                          false,
-                        ),
-                      })
-                    }}
-                    placeholder="e.g. 'big' "
-                  />,
-                )}
-              </>
-            }
-            tooltip={Constants.strings.REMOTE_CONFIG_DESCRIPTION_VARIATION}
-            title='Variation Value'
-          />
-        </div>
-        <div className='ml-3' style={{ width: 160 }}>
-          <InputGroup
-            type='number'
-            data-test={`featureVariationWeight${Utils.featureStateToValue(
-              value,
-            )}`}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              const val = Utils.safeParseEventValue(e)
-              onChange({
-                ...value,
-                default_percentage_allocation: val ? parseFloat(val) : null,
-              })
-            }}
-            value={value.default_percentage_allocation}
-            inputProps={{
-              readOnly: disabled,
-              step: 'any',
-            }}
-            title={weightTitle}
-          />
-        </div>
-        {!!onRemove && !readOnly && (
-          <div style={{ top: '27px' }} className='ml-2 position-relative'>
-            <button
+    <div className='variant-card rounded border-1 shadow-sm p-3 mb-3'>
+      <Row className='justify-content-between align-items-start mb-3'>
+        <VariationKeyLabel
+          value={value.key}
+          index={index}
+          disabled={disabled || !canCreateFeature}
+          readOnly={readOnly}
+          siblingKeys={siblingKeys}
+          onChange={(key) => onChange({ ...value, key })}
+        />
+        <div className='d-flex align-items-center gap-3'>
+          {!!unsaved && <span className='chip chip--xs'>Not saved</span>}
+          {!!onRemove && !readOnly && (
+            <Button
+              theme='text'
               onClick={onRemove}
               id='delete-multivariate'
-              type='button'
-              className='btn btn-with-icon'
+              aria-label='Remove variant'
             >
-              <Icon name='trash-2' width={20} fill={'#656D7B'} />
-            </button>
+              <Icon name='trash-2' width={20} fill='#656D7B' />
+            </Button>
+          )}
+        </div>
+      </Row>
+      <InputGroup
+        noMargin
+        component={
+          <>
+            {Utils.renderWithPermission(
+              canCreateFeature,
+              readOnly
+                ? 'Variation values are defined at the feature level and cannot be changed per segment.'
+                : Constants.projectPermissions(
+                    ProjectPermission.CREATE_FEATURE,
+                  ),
+              <ValueEditor
+                data-test={`featureVariationValue${
+                  Utils.featureStateToValue(value) || index
+                }`}
+                name='featureValue'
+                className='full-width code-medium'
+                value={Utils.getTypedValue(Utils.featureStateToValue(value))}
+                disabled={!canCreateFeature || disabled || readOnly}
+                onBlur={() => {
+                  const newValue = {
+                    ...value,
+                    // Trim spaces and do conversion on blur
+                    ...Utils.valueToFeatureState(
+                      Utils.featureStateToValue(value),
+                    ),
+                  }
+                  if (!shallowEqual(newValue, value)) {
+                    //occurs if we converted a trimmed value
+                    onChange(newValue)
+                  }
+                }}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  onChange({
+                    ...value,
+                    ...Utils.valueToFeatureState(
+                      Utils.safeParseEventValue(e),
+                      false,
+                    ),
+                  })
+                }}
+                placeholder="e.g. 'big' "
+              />,
+            )}
+          </>
+        }
+        tooltip={Constants.strings.REMOTE_CONFIG_DESCRIPTION_VARIATION}
+        title='Variation Value'
+      />
+      <Row className='justify-content-between align-items-center mt-2'>
+        <label className='mb-0'>{weightTitle}</label>
+        <div className='d-flex align-items-center gap-2'>
+          <div style={{ width: 64 }}>
+            <Input
+              type='number'
+              size='small'
+              underline
+              centered
+              data-test={`featureVariationWeight${Utils.featureStateToValue(
+                value,
+              )}`}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const val = Utils.safeParseEventValue(e)
+                onChange({
+                  ...value,
+                  default_percentage_allocation: val ? parseFloat(val) : null,
+                })
+              }}
+              value={value.default_percentage_allocation}
+              readOnly={disabled}
+              step='any'
+            />
           </div>
-        )}
+          <span className='text-muted'>%</span>
+        </div>
       </Row>
     </div>
   )

--- a/frontend/web/components/mv/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput.tsx
@@ -6,6 +6,7 @@ import InputGroup from 'components/base/forms/InputGroup'
 import Utils from 'common/utils/utils'
 import shallowEqual from 'fbjs/lib/shallowEqual'
 import { ProjectPermission } from 'common/types/permissions.types'
+import { VariationKeyLabel } from './VariationKeyLabel'
 
 interface VariationValueProps {
   canCreateFeature: boolean
@@ -14,6 +15,7 @@ interface VariationValueProps {
   onChange: (value: any) => void
   onRemove?: () => void
   readOnly: boolean
+  siblingKeys: (string | null | undefined)[]
   value: any
   weightTitle: string
 }
@@ -25,95 +27,108 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
   onChange,
   onRemove,
   readOnly,
+  siblingKeys,
   value,
   weightTitle,
 }) => {
   return (
-    <Row className='align-items-start mb-2'>
-      <div className='flex flex-1 overflow-hidden'>
-        <InputGroup
-          noMargin
-          component={
-            <>
-              {Utils.renderWithPermission(
-                canCreateFeature,
-                readOnly
-                  ? 'Variation values are defined at the feature level and cannot be changed per segment.'
-                  : Constants.projectPermissions(
-                      ProjectPermission.CREATE_FEATURE,
-                    ),
-                <ValueEditor
-                  data-test={`featureVariationValue${
-                    Utils.featureStateToValue(value) || index
-                  }`}
-                  name='featureValue'
-                  className='full-width code-medium'
-                  value={Utils.getTypedValue(Utils.featureStateToValue(value))}
-                  disabled={!canCreateFeature || disabled || readOnly}
-                  onBlur={() => {
-                    const newValue = {
-                      ...value,
-                      // Trim spaces and do conversion on blur
-                      ...Utils.valueToFeatureState(
-                        Utils.featureStateToValue(value),
+    <div className='mb-2'>
+      <VariationKeyLabel
+        value={value.key}
+        index={index}
+        disabled={disabled || !canCreateFeature}
+        readOnly={readOnly}
+        siblingKeys={siblingKeys}
+        onChange={(key) => onChange({ ...value, key })}
+      />
+      <Row className='align-items-start'>
+        <div className='flex flex-1 overflow-hidden'>
+          <InputGroup
+            noMargin
+            component={
+              <>
+                {Utils.renderWithPermission(
+                  canCreateFeature,
+                  readOnly
+                    ? 'Variation values are defined at the feature level and cannot be changed per segment.'
+                    : Constants.projectPermissions(
+                        ProjectPermission.CREATE_FEATURE,
                       ),
-                    }
-                    if (!shallowEqual(newValue, value)) {
-                      //occurs if we converted a trimmed value
-                      onChange(newValue)
-                    }
-                  }}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    onChange({
-                      ...value,
-                      ...Utils.valueToFeatureState(
-                        Utils.safeParseEventValue(e),
-                        false,
-                      ),
-                    })
-                  }}
-                  placeholder="e.g. 'big' "
-                />,
-              )}
-            </>
-          }
-          tooltip={Constants.strings.REMOTE_CONFIG_DESCRIPTION_VARIATION}
-          title='Variation Value'
-        />
-      </div>
-      <div className='ml-3' style={{ width: 160 }}>
-        <InputGroup
-          type='number'
-          data-test={`featureVariationWeight${Utils.featureStateToValue(
-            value,
-          )}`}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            const val = Utils.safeParseEventValue(e)
-            onChange({
-              ...value,
-              default_percentage_allocation: val ? parseFloat(val) : null,
-            })
-          }}
-          value={value.default_percentage_allocation}
-          inputProps={{
-            readOnly: disabled,
-            step: 'any',
-          }}
-          title={weightTitle}
-        />
-      </div>
-      {!!onRemove && !readOnly && (
-        <div style={{ top: '27px' }} className='ml-2 position-relative'>
-          <button
-            onClick={onRemove}
-            id='delete-multivariate'
-            type='button'
-            className='btn btn-with-icon'
-          >
-            <Icon name='trash-2' width={20} fill={'#656D7B'} />
-          </button>
+                  <ValueEditor
+                    data-test={`featureVariationValue${
+                      Utils.featureStateToValue(value) || index
+                    }`}
+                    name='featureValue'
+                    className='full-width code-medium'
+                    value={Utils.getTypedValue(
+                      Utils.featureStateToValue(value),
+                    )}
+                    disabled={!canCreateFeature || disabled || readOnly}
+                    onBlur={() => {
+                      const newValue = {
+                        ...value,
+                        // Trim spaces and do conversion on blur
+                        ...Utils.valueToFeatureState(
+                          Utils.featureStateToValue(value),
+                        ),
+                      }
+                      if (!shallowEqual(newValue, value)) {
+                        //occurs if we converted a trimmed value
+                        onChange(newValue)
+                      }
+                    }}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      onChange({
+                        ...value,
+                        ...Utils.valueToFeatureState(
+                          Utils.safeParseEventValue(e),
+                          false,
+                        ),
+                      })
+                    }}
+                    placeholder="e.g. 'big' "
+                  />,
+                )}
+              </>
+            }
+            tooltip={Constants.strings.REMOTE_CONFIG_DESCRIPTION_VARIATION}
+            title='Variation Value'
+          />
         </div>
-      )}
-    </Row>
+        <div className='ml-3' style={{ width: 160 }}>
+          <InputGroup
+            type='number'
+            data-test={`featureVariationWeight${Utils.featureStateToValue(
+              value,
+            )}`}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const val = Utils.safeParseEventValue(e)
+              onChange({
+                ...value,
+                default_percentage_allocation: val ? parseFloat(val) : null,
+              })
+            }}
+            value={value.default_percentage_allocation}
+            inputProps={{
+              readOnly: disabled,
+              step: 'any',
+            }}
+            title={weightTitle}
+          />
+        </div>
+        {!!onRemove && !readOnly && (
+          <div style={{ top: '27px' }} className='ml-2 position-relative'>
+            <button
+              onClick={onRemove}
+              id='delete-multivariate'
+              type='button'
+              className='btn btn-with-icon'
+            >
+              <Icon name='trash-2' width={20} fill={'#656D7B'} />
+            </button>
+          </div>
+        )}
+      </Row>
+    </div>
   )
 }

--- a/frontend/web/components/mv/VariationValueInput/VariationValueInput.scss
+++ b/frontend/web/components/mv/VariationValueInput/VariationValueInput.scss
@@ -2,6 +2,10 @@
   // The InputGroup label is internal to the component, so its weight
   // can only be reduced from here.
   label {
-    font-weight: 400;
+    font-weight: var(--font-weight-regular);
+  }
+
+  &__weight {
+    width: 64px;
   }
 }

--- a/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
@@ -130,7 +130,7 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
                   default_percentage_allocation: val ? parseFloat(val) : null,
                 })
               }}
-              value={value.default_percentage_allocation}
+              value={value.default_percentage_allocation ?? ''}
               readOnly={disabled}
               step='any'
             />

--- a/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ValueEditor from 'components/ValueEditor'
+import ErrorMessage from 'components/ErrorMessage'
 import Constants from 'common/constants'
 import Icon from 'components/icons/Icon'
 import Input from 'components/base/forms/Input'
@@ -13,6 +14,7 @@ import { VariationKeyLabel } from 'components/mv/VariationKeyLabel'
 import './VariationValueInput.scss'
 
 interface VariationValueProps {
+  apiError?: string | null
   canCreateFeature: boolean
   disabled: boolean
   index: number
@@ -26,6 +28,7 @@ interface VariationValueProps {
 }
 
 export const VariationValueInput: React.FC<VariationValueProps> = ({
+  apiError,
   canCreateFeature,
   disabled,
   index,
@@ -138,6 +141,11 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
           <span className='text-muted'>%</span>
         </div>
       </Row>
+      {!!apiError && (
+        <div className='mt-2'>
+          <ErrorMessage error={apiError} />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
@@ -8,7 +8,8 @@ import Button from 'components/base/forms/Button'
 import Utils from 'common/utils/utils'
 import shallowEqual from 'fbjs/lib/shallowEqual'
 import { ProjectPermission } from 'common/types/permissions.types'
-import { VariationKeyLabel } from './VariationKeyLabel'
+import { colorIconSecondary } from 'common/theme/tokens'
+import { VariationKeyLabel } from 'components/mv/VariationKeyLabel'
 import './VariationValueInput.scss'
 
 interface VariationValueProps {
@@ -56,7 +57,7 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
               id='delete-multivariate'
               aria-label='Remove variant'
             >
-              <Icon name='trash-2' width={20} fill='#656D7B' />
+              <Icon name='trash-2' width={20} fill={colorIconSecondary} />
             </Button>
           )}
         </div>
@@ -113,7 +114,7 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
       <Row className='justify-content-between align-items-center mt-2'>
         <label className='mb-0'>{weightTitle}</label>
         <div className='d-flex align-items-center gap-2'>
-          <div style={{ width: 64 }}>
+          <div className='variant-card__weight'>
             <Input
               type='number'
               size='small'

--- a/frontend/web/components/mv/VariationValueInput/index.ts
+++ b/frontend/web/components/mv/VariationValueInput/index.ts
@@ -1,0 +1,1 @@
+export { VariationValueInput } from './VariationValueInput'

--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -20,7 +20,12 @@
   }
   &.code-medium {
     .hljs {
-      padding: $input-padding;
+      // Align the single-line editor height with adjacent inputs ($input-height).
+      // Reduced vertical padding so border + line-height + padding == $input-height,
+      // while min-height keeps the empty/placeholder state aligned too. The editor
+      // still grows for multi-line values.
+      padding: 9px 12px 9px 16px;
+      min-height: $input-height;
     }
   }
   textarea {

--- a/frontend/web/styles/components/_input.scss
+++ b/frontend/web/styles/components/_input.scss
@@ -28,6 +28,37 @@ textarea {
 
 @import '~react-datepicker/dist/react-datepicker.css';
 
+// Borderless input with a bottom underline only; the underline turns
+// primary while focused. Used for inline edits (variant label, weight).
+.input-container.input-underline {
+  input.input {
+    border: none;
+    border-bottom: 1px solid $input-border-color;
+    border-radius: 0;
+    background-color: transparent;
+    padding-left: 8px;
+    padding-right: 8px;
+    // _forms.scss re-applies a full border shorthand on hover/focus.
+    &:hover {
+      border: none;
+      border-bottom: 1px solid $basic-alpha-48;
+    }
+    &:focus {
+      border: none;
+      border-bottom: 1px solid $primary;
+    }
+  }
+  input[type='number'].input {
+    -moz-appearance: textfield;
+    appearance: textfield;
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+  }
+}
+
 .input-container,
 .react-datepicker-wrapper .react-datepicker__input-container {
   font-family: $font-family;

--- a/frontend/web/styles/components/_input.scss
+++ b/frontend/web/styles/components/_input.scss
@@ -59,6 +59,25 @@ textarea {
   }
 }
 
+// _forms.scss (.dark .input-container input.input) re-applies the full
+// border and a solid background at equal specificity, so the underline
+// variant needs its own dark overrides.
+.dark .input-container.input-underline {
+  input.input {
+    border: none;
+    border-bottom: 1px solid $white-alpha-16;
+    background-color: transparent;
+    &:hover {
+      border: none;
+      border-bottom: 1px solid $white-alpha-48;
+    }
+    &:focus {
+      border: none;
+      border-bottom: 1px solid $primary;
+    }
+  }
+}
+
 .input-container,
 .react-datepicker-wrapper .react-datepicker__input-container {
   font-family: $font-family;

--- a/frontend/web/styles/project/_type.scss
+++ b/frontend/web/styles/project/_type.scss
@@ -60,7 +60,7 @@ a {
 }
 
 .font-weight-semibold {
-  font-weight: 600 !important;
+  font-weight: var(--font-weight-semibold) !important;
 }
 
 .text-primary {

--- a/frontend/web/styles/project/_type.scss
+++ b/frontend/web/styles/project/_type.scss
@@ -59,6 +59,10 @@ a {
   font-weight: 500  !important;
 }
 
+.font-weight-semibold {
+  font-weight: 600 !important;
+}
+
 .text-primary {
   color: $primary;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds UI to set a **label** on multivariate variants (maps to the backend `key` field) and revamps the variants section of the feature modal's Value tab.

**Variant labels**

- Each variant shows an inline-editable label (slug characters only, max 255, `control` reserved, unique per feature).
- New variants get a default label (`Variant_n`, first free number) that is persisted on save; existing variants with no key fall back to a display-only placeholder.
- No save-flow changes — the key persists through the existing writable `/mv-options/` endpoint.

**Improvements**
- Added error management at the MV option level (returning invalid key or duplicated one)
- Error message appears in card
- Success response from MV options update only are also showing a success toast and updating the edition colorswatch

**Variants UI revamp**

- Each variant renders in a bordered, shadowed card: label header with a "Not saved" chip + delete icon.
- "Variants" section header with a primary "+ Add variant" button (outline "Create A/B/n Test" when none exist), and a tooltip explaining labels are required for experiments (behind `experimental_flags`).
- Control Value title shows the control percentage as a chip.
- `Input` gains reusable `underline` and `centered` props; aligned the value editor height with adjacent inputs.

**Experiment setup page**

- The variations table shows the variant label/key as the name and drops the unused Description column; `ContentCard` gains a `description` prop used by the setup step.

## How did you test this code?

- Extended the E2E flag test: `editVariantLabel` edits a variant's label via the new UI, saves, reopens the modal, and asserts persistence. Audited existing selectors (`add-variation`, `featureVariationValue*`, `featureVariationWeight*`, `delete-multivariate`) for compatibility with the new layout.
- Added Storybook stories for the new `Input` variants (`Underline`, `UnderlineCentered`).
- Manually, against a local API:
  1. Create a multivariate feature; add variants — they default to `Variant_1`, `Variant_2`…
  2. Rename a label; verify validation (spaces, `control`, duplicates rejected with inline errors) and the "Not saved" chip appearing only on edited variants.
  3. Save, reopen — labels persist; clear a label — it saves as `null` and the placeholder returns.

<img width="697" height="575" alt="image" src="https://github.com/user-attachments/assets/e2856608-9356-4699-adab-06876a0dde7b" />
<img width="689" height="235" alt="image" src="https://github.com/user-attachments/assets/64c179ae-7346-4b1e-a70e-ebae5022b5a7" />
