### PR TITLE
feat(MCP): Push MCP usage via OTel

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -367,6 +367,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
+    "telemetry.middleware.MCPUsageLoggerMiddleware",  # Must come last!
 ]
 
 ADD_NEVER_CACHE_HEADERS = env.bool("ADD_NEVER_CACHE_HEADERS", True)

--- a/api/permissions/permission_service.py
+++ b/api/permissions/permission_service.py
@@ -6,6 +6,7 @@ from django.db.models import Q, QuerySet
 from environments.models import Environment
 from organisations.models import Organisation, OrganisationRole
 from projects.models import Project
+from telemetry.spans import set_span_attribute
 
 from .rbac_wrapper import (  # type: ignore[attr-defined]
     get_permitted_environments_for_master_api_key_using_roles,
@@ -25,6 +26,7 @@ def is_user_organisation_admin(
 ) -> bool:
     user_organisation = user.get_user_organisation(organisation)
     if user_organisation is not None:
+        set_span_attribute("organisation.id", user_organisation.organisation_id)
         return user_organisation.role == OrganisationRole.ADMIN.name
     return False
 

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -3,7 +3,7 @@ set -e
 
 # common environment variables
 ACCESS_LOG_FORMAT=${ACCESS_LOG_FORMAT:-'%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({origin}i)s %({access-control-allow-origin}o)s'}
-APPLICATION_LOGGERS=${APPLICATION_LOGGERS:-"app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,oauth2_metadata,organisations,projects,segments,task_processor,users,webhooks,workflows"}
+APPLICATION_LOGGERS=${APPLICATION_LOGGERS:-"app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,mcp,oauth2_metadata,organisations,projects,segments,task_processor,users,webhooks,workflows"}
 
 waitfordb() {
   if [ -z "${SKIP_WAIT_FOR_DB}" ]; then

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -33,12 +33,11 @@ class MCPUsageLoggerMiddleware:
             # - flagsmith.mcp.client.name
             # - flagsmith.mcp.client.version
             "status": "error" if response.status_code >= 400 else "success",
-            "organisation__id": (org_id := self._get_organisation_id(request)),
         }
-        if org_id is not None:
-            logger.info("tool.called", **event)
+        if (org_id := self._get_organisation_id(request)) is not None:
+            logger.info("tool.called", organisation__id=org_id, **event)
         else:
-            logger.warning("tool.called", **event)
+            logger.warning("tool.called", organisation__id=None, **event)
 
         return response
 

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -8,10 +8,6 @@ from opentelemetry import baggage
 from telemetry.spans import get_span_attribute
 
 
-class UndefinedOrganisationError(Exception):
-    """The organisation can't be probed from context."""
-
-
 class MCPUsageLoggerMiddleware:
     """Emit telemetry events for MCP usage"""
 
@@ -37,16 +33,16 @@ class MCPUsageLoggerMiddleware:
             # - flagsmith.mcp.client.name
             # - flagsmith.mcp.client.version
             "status": "error" if response.status_code >= 400 else "success",
+            "organisation__id": (org_id := self._get_organisation_id(request)),
         }
-        try:
-            org_id = self._get_organisation_id(request)
-            logger.info("tool.called", organisation__id=org_id, **event)
-        except UndefinedOrganisationError:
-            logger.warning("tool.called", organisation__id=None, **event)
+        if org_id is not None:
+            logger.info("tool.called", **event)
+        else:
+            logger.warning("tool.called", **event)
 
         return response
 
-    def _get_organisation_id(self, request: HttpRequest) -> int:
+    def _get_organisation_id(self, request: HttpRequest) -> int | None:
         """Obtain the organisation ID from the request context."""
         from organisations.models import Organisation
 
@@ -59,6 +55,6 @@ class MCPUsageLoggerMiddleware:
             return request.user.organisations.get().id
         except (
             Organisation.DoesNotExist,
-            Organisation.MultipleObjectsReturned,
-        ) as error:
-            raise UndefinedOrganisationError from error
+            Organisation.MultipleObjectsReturned,  # Don't guess
+        ):
+            return None

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -1,0 +1,94 @@
+from collections.abc import Callable
+
+import structlog
+from django.http.request import HttpRequest
+from django.http.response import HttpResponse
+from opentelemetry import baggage
+
+
+class UndefinedOrganisationError(Exception):
+    """The organisation can't be probed from context."""
+
+
+class MCPUsageLoggerMiddleware:
+    """Emit telemetry events for MCP usage"""
+
+    _url_param_to_organisation_lookup = {
+        "organisation_pk": "pk",
+        "project_pk": "projects__pk",
+        "environment_pk": "projects__environments__pk",
+        "environment_api_key": "projects__environments__api_key",
+    }
+
+    _pk_url_name_to_organisation_lookup = {
+        "organisation-projects": "pk",
+        "project-detail": "projects__pk",
+        "project-environments": "projects__pk",
+        "featurestates-detail": "projects__features__feature_states__pk",
+        "feature-segment-detail": "projects__features__feature_segments__pk",
+    }
+
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse],
+    ) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+
+        if not request.user.is_authenticated:
+            return response
+
+        if baggage.get_baggage("flagsmith.client.name") != "flagsmith-mcp":
+            return response
+
+        logger = structlog.get_logger("mcp")
+        event = {
+            # NOTE: The following W3C Baggage items are added by downstream processor
+            # - gen_ai.tool.name
+            # - flagsmith.mcp.client.name
+            # - flagsmith.mcp.client.version
+            "status": "error" if response.status_code >= 400 else "success",
+        }
+        try:
+            org_id = self._get_organisation_id(request)
+        except UndefinedOrganisationError:
+            logger.warning("tool.called", organisation__id=None, **event)
+        else:
+            logger.info("tool.called", organisation__id=org_id, **event)
+
+        return response
+
+    def _get_organisation_id(self, request: HttpRequest) -> int:
+        """Obtain the organisation ID from the request context."""
+        from organisations.models import Organisation
+
+        assert request.user.is_authenticated  # NOTE: protected upstream
+        user_orgs = request.user.organisations.all()
+        try:  # Most of the time, the user belongs to one organisation
+            return user_orgs.get().id
+        except Organisation.MultipleObjectsReturned:
+            pass
+
+        # Known URL parameter names
+        assert request.resolver_match
+        kwargs = request.resolver_match.kwargs
+        for url_param, value in kwargs.items():
+            if lookup := self._url_param_to_organisation_lookup.get(url_param):
+                try:
+                    return user_orgs.filter(**{lookup: value}).get().id
+                except Organisation.DoesNotExist as error:
+                    raise UndefinedOrganisationError from error
+
+        # Known URLs using `pk`
+        assert (url_name := request.resolver_match.url_name)
+        if (lookup := self._pk_url_name_to_organisation_lookup.get(url_name)) and (
+            pk := kwargs["pk"]
+        ):
+            try:
+                return user_orgs.filter(**{lookup: pk}).get().id
+            except Organisation.DoesNotExist as error:
+                raise UndefinedOrganisationError from error
+
+        raise UndefinedOrganisationError

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -20,10 +20,10 @@ class MCPUsageLoggerMiddleware:
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
 
-        if not request.user or not request.user.is_authenticated:
+        if baggage.get_baggage("flagsmith.client.name") != "flagsmith-mcp":
             return response
 
-        if baggage.get_baggage("flagsmith.client.name") != "flagsmith-mcp":
+        if not request.user or not request.user.is_authenticated:
             return response
 
         logger = structlog.get_logger("mcp")

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -5,6 +5,8 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from opentelemetry import baggage
 
+from telemetry.spans import get_span_attribute
+
 
 class UndefinedOrganisationError(Exception):
     """The organisation can't be probed from context."""
@@ -12,21 +14,6 @@ class UndefinedOrganisationError(Exception):
 
 class MCPUsageLoggerMiddleware:
     """Emit telemetry events for MCP usage"""
-
-    _url_param_to_organisation_lookup = {
-        "organisation_pk": "pk",
-        "project_pk": "projects__pk",
-        "environment_pk": "projects__environments__pk",
-        "environment_api_key": "projects__environments__api_key",
-    }
-
-    _pk_url_name_to_organisation_lookup = {
-        "organisation-projects": "pk",
-        "project-detail": "projects__pk",
-        "project-environments": "projects__pk",
-        "featurestates-detail": "projects__features__feature_states__pk",
-        "feature-segment-detail": "projects__features__feature_segments__pk",
-    }
 
     def __init__(
         self,
@@ -63,33 +50,15 @@ class MCPUsageLoggerMiddleware:
         """Obtain the organisation ID from the request context."""
         from organisations.models import Organisation
 
+        # Set by the permission layer for organisations the user belongs to
+        if isinstance(organisation_id := get_span_attribute("organisation.id"), int):
+            return organisation_id
+
         assert request.user.is_authenticated  # NOTE: protected upstream
-        user_orgs = request.user.organisations.all()
         try:  # Most of the time, the user belongs to one organisation
-            return user_orgs.get().id
-        except Organisation.MultipleObjectsReturned:
-            pass
-        except Organisation.DoesNotExist as error:
+            return request.user.organisations.get().id
+        except (
+            Organisation.DoesNotExist,
+            Organisation.MultipleObjectsReturned,
+        ) as error:
             raise UndefinedOrganisationError from error
-
-        # Known URL parameter names
-        assert request.resolver_match
-        kwargs = request.resolver_match.kwargs
-        for url_param, value in kwargs.items():
-            if lookup := self._url_param_to_organisation_lookup.get(url_param):
-                try:
-                    return user_orgs.filter(**{lookup: value}).get().id
-                except Organisation.DoesNotExist as error:
-                    raise UndefinedOrganisationError from error
-
-        # Known URLs using `pk`
-        assert (url_name := request.resolver_match.url_name)
-        if (lookup := self._pk_url_name_to_organisation_lookup.get(url_name)) and (
-            pk := kwargs["pk"]
-        ):
-            try:
-                return user_orgs.filter(**{lookup: pk}).get().id
-            except Organisation.DoesNotExist as error:
-                raise UndefinedOrganisationError from error
-
-        raise UndefinedOrganisationError

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -53,10 +53,9 @@ class MCPUsageLoggerMiddleware:
         }
         try:
             org_id = self._get_organisation_id(request)
+            logger.info("tool.called", organisation__id=org_id, **event)
         except UndefinedOrganisationError:
             logger.warning("tool.called", organisation__id=None, **event)
-        else:
-            logger.info("tool.called", organisation__id=org_id, **event)
 
         return response
 

--- a/api/telemetry/middleware.py
+++ b/api/telemetry/middleware.py
@@ -37,7 +37,7 @@ class MCPUsageLoggerMiddleware:
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
 
-        if not request.user.is_authenticated:
+        if not request.user or not request.user.is_authenticated:
             return response
 
         if baggage.get_baggage("flagsmith.client.name") != "flagsmith-mcp":
@@ -69,6 +69,8 @@ class MCPUsageLoggerMiddleware:
             return user_orgs.get().id
         except Organisation.MultipleObjectsReturned:
             pass
+        except Organisation.DoesNotExist as error:
+            raise UndefinedOrganisationError from error
 
         # Known URL parameter names
         assert request.resolver_match

--- a/api/telemetry/spans.py
+++ b/api/telemetry/spans.py
@@ -1,0 +1,11 @@
+from opentelemetry import trace
+from opentelemetry.util.types import AttributeValue
+
+
+def set_span_attribute(attribute: str, value: AttributeValue) -> None:
+    trace.get_current_span().set_attribute(attribute, value)
+
+
+def get_span_attribute(attribute: str) -> AttributeValue | None:
+    attributes = getattr(trace.get_current_span(), "attributes", None) or {}
+    return attributes.get(attribute)

--- a/api/tests/unit/telemetry/conftest.py
+++ b/api/tests/unit/telemetry/conftest.py
@@ -1,0 +1,22 @@
+from collections.abc import Generator
+
+import pytest
+from opentelemetry import baggage
+from opentelemetry import context as otel_context
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.trace import Span
+
+
+@pytest.fixture()
+def mcp_baggage() -> Generator[None, None, None]:
+    ctx = baggage.set_baggage("flagsmith.client.name", "flagsmith-mcp")
+    token = otel_context.attach(ctx)
+    yield
+    otel_context.detach(token)
+
+
+@pytest.fixture()
+def recording_span() -> Generator[Span, None, None]:
+    tracer = TracerProvider().get_tracer("test")
+    with tracer.start_as_current_span("test") as span:
+        yield span

--- a/api/tests/unit/telemetry/test_unit_telemetry_middleware.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_middleware.py
@@ -1,77 +1,38 @@
-from collections.abc import Generator
-
 import pytest
-from opentelemetry import baggage
-from opentelemetry import context as otel_context
 from pytest_structlog import StructuredLogCapture
 from rest_framework.test import APIClient
 
 from environments.models import Environment
-from features.models import Feature, FeatureState
 from organisations.models import Organisation, OrganisationRole
-from projects.models import Project
 from users.models import FFAdminUser
 
 
-@pytest.fixture()
-def mcp_baggage() -> Generator[None, None, None]:
-    ctx = baggage.set_baggage("flagsmith.client.name", "flagsmith-mcp")
-    token = otel_context.attach(ctx)
-    yield
-    otel_context.detach(token)
-
-
+@pytest.mark.usefixtures("organisation")
 def test_mcp_usage_logger_middleware__no_mcp_baggage__logs_nothing(
-    admin_client_new: APIClient,
-    project: Project,
+    staff_client: APIClient,
     log: StructuredLogCapture,
 ) -> None:
     # Given / When
-    admin_client_new.get(f"/api/v1/projects/{project.pk}/")
+    response = staff_client.get("/api/v1/projects/")
 
     # Then
+    assert response.status_code == 200
     assert log.events == []
 
 
-@pytest.mark.parametrize(
-    "path_template",
-    [
-        # Organisation is obtained using `organisation_pk`
-        "/api/v1/organisations/{organisation_pk}/invites/",
-        # Organisation is obtained using `pk`
-        "/api/v1/organisations/{organisation_pk}/projects/",
-        # Organisation is obtained using `pk`
-        "/api/v1/projects/{project_pk}/",
-        "/api/v1/projects/{project_pk}/environments/",
-        # Organisation is obtained using `project_pk`
-        "/api/v1/projects/{project_pk}/features/",
-        # Organisation is obtained using `environment_pk`
-        "/api/v1/environments/{environment_pk}/features/{feature_pk}/versions/",
-        # Organisation is obtained using `environment_api_key`
-        "/api/v1/environments/{environment_api_key}/featurestates/{feature_state_pk}/",
-    ],
-)
-@pytest.mark.usefixtures("mcp_baggage")
-def test_mcp_usage_logger_middleware__resolvable_url__logs_expected(
-    admin_client_new: APIClient,
+@pytest.mark.usefixtures("mcp_baggage", "recording_span", "organisation")
+def test_mcp_usage_logger_middleware__organisation_id_span_attribute__logs_span_organisation_id(
+    staff_client: APIClient,
+    staff_user: FFAdminUser,
     log: StructuredLogCapture,
-    organisation: Organisation,
-    project: Project,
-    environment: Environment,
-    feature: Feature,
-    feature_state: FeatureState,
-    path_template: str,
 ) -> None:
-    # Given / When
-    response = admin_client_new.get(
-        path_template.format(
-            organisation_pk=organisation.pk,
-            project_pk=project.pk,
-            environment_pk=environment.pk,
-            environment_api_key=environment.api_key,
-            feature_pk=feature.pk,
-            feature_state_pk=feature_state.pk,
-        )
+    # Given
+    other_organisation = Organisation.objects.create(name="Other Org")
+    staff_user.add_organisation(other_organisation, role=OrganisationRole.ADMIN)
+
+    # When
+    response = staff_client.get(
+        f"/api/v1/organisations/{other_organisation.pk}/invites/"
     )
 
     # Then
@@ -80,44 +41,18 @@ def test_mcp_usage_logger_middleware__resolvable_url__logs_expected(
         {
             "level": "info",
             "event": "tool.called",
-            "organisation__id": organisation.pk,
+            "organisation__id": other_organisation.pk,
             "status": "success",
         }
     ]
 
 
 @pytest.mark.usefixtures("mcp_baggage")
-def test_mcp_usage_logger_middleware__feature_state_url__logs_expected(
-    admin_client_new: APIClient,
-    log: StructuredLogCapture,
-    organisation: Organisation,
-    feature_state: FeatureState,
-) -> None:
-    """Organisation is obtained using `pk` from /api/v1/features/featurestates/{pk}/."""
-    # Given / When
-    response = admin_client_new.get(
-        f"/api/v1/features/featurestates/{feature_state.pk}/"
-    )
-
-    # Then
-    assert response.status_code == 405
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "tool.called",
-            "organisation__id": organisation.pk,
-            "status": "error",
-        }
-    ]
-
-
-@pytest.mark.usefixtures("mcp_baggage")
-def test_mcp_usage_logger_middleware__user_with_single_organisation__logs_expected(
+def test_mcp_usage_logger_middleware__user_with_single_organisation__logs_user_organisation_id(
     staff_client: APIClient,
-    log: StructuredLogCapture,
     organisation: Organisation,
+    log: StructuredLogCapture,
 ) -> None:
-    """Organisation is obtained from the user when /api/v1/projects/ has no usable parameter."""
     # Given / When
     response = staff_client.get("/api/v1/projects/")
 
@@ -136,8 +71,8 @@ def test_mcp_usage_logger_middleware__user_with_single_organisation__logs_expect
 @pytest.mark.usefixtures("mcp_baggage")
 def test_mcp_usage_logger_middleware__user_without_organisations__logs_warning(
     staff_client: APIClient,
-    log: StructuredLogCapture,
     staff_user: FFAdminUser,
+    log: StructuredLogCapture,
 ) -> None:
     # Given
     assert not staff_user.organisations.exists()
@@ -160,8 +95,8 @@ def test_mcp_usage_logger_middleware__user_without_organisations__logs_warning(
 @pytest.mark.usefixtures("mcp_baggage", "organisation")
 def test_mcp_usage_logger_middleware__user_with_multiple_organisations__logs_warning(
     staff_client: APIClient,
-    log: StructuredLogCapture,
     staff_user: FFAdminUser,
+    log: StructuredLogCapture,
 ) -> None:
     # Given
     other_organisation = Organisation.objects.create(name="Other Org")
@@ -182,108 +117,8 @@ def test_mcp_usage_logger_middleware__user_with_multiple_organisations__logs_war
     ]
 
 
-@pytest.mark.usefixtures("mcp_baggage", "organisation")
-def test_mcp_usage_logger_middleware__user_with_multiple_organisations__logs_url_organisation(
-    staff_client: APIClient,
-    log: StructuredLogCapture,
-    staff_user: FFAdminUser,
-) -> None:
-    # Given
-    other_organisation = Organisation.objects.create(name="Other Org")
-    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
-
-    # When
-    response = staff_client.get(
-        f"/api/v1/organisations/{other_organisation.pk}/projects/"
-    )
-
-    # Then
-    assert response.status_code == 200
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "tool.called",
-            "organisation__id": other_organisation.pk,
-            "status": "success",
-        }
-    ]
-
-
-@pytest.mark.usefixtures("mcp_baggage", "organisation")
-def test_mcp_usage_logger_middleware__user_not_in_url_organisation__logs_warning(
-    staff_client: APIClient,
-    log: StructuredLogCapture,
-    staff_user: FFAdminUser,
-) -> None:
-    # Given
-    other_organisation = Organisation.objects.create(name="Other Org")
-    foreign_organisation = Organisation.objects.create(name="Foreign Org")
-    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
-
-    # When
-    response = staff_client.get(
-        f"/api/v1/organisations/{foreign_organisation.pk}/projects/"
-    )
-
-    # Then
-    assert response.status_code == 404
-    assert log.events == [
-        {
-            "level": "warning",
-            "event": "tool.called",
-            "organisation__id": None,
-            "status": "error",
-        }
-    ]
-
-
-@pytest.mark.usefixtures("mcp_baggage", "organisation")
-def test_mcp_usage_logger_middleware__user_not_in_url_param_organisation__logs_warning(
-    staff_client: APIClient,
-    log: StructuredLogCapture,
-    staff_user: FFAdminUser,
-) -> None:
-    # Given
-    other_organisation = Organisation.objects.create(name="Other Org")
-    foreign_organisation = Organisation.objects.create(name="Foreign Org")
-    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
-
-    # When
-    response = staff_client.get(
-        f"/api/v1/organisations/{foreign_organisation.pk}/invites/"
-    )
-
-    # Then
-    assert response.status_code == 403
-    assert log.events == [
-        {
-            "level": "warning",
-            "event": "tool.called",
-            "organisation__id": None,
-            "status": "error",
-        }
-    ]
-
-
 @pytest.mark.usefixtures("mcp_baggage")
-def test_mcp_usage_logger_middleware__sdk_request__logs_nothing(
-    api_client: APIClient,
-    log: StructuredLogCapture,
-    environment: Environment,
-) -> None:
-    # Given / When
-    response = api_client.get(
-        "/api/v1/flags/",
-        HTTP_X_ENVIRONMENT_KEY=environment.api_key,  # Doesn't authenticate
-    )
-
-    # Then
-    assert response.status_code == 200
-    assert log.events == []
-
-
-@pytest.mark.usefixtures("mcp_baggage")
-def test_mcp_usage_logger_middleware__unauthenticated__logs_nothing(
+def test_mcp_usage_logger_middleware__unauthenticated_request__logs_nothing(
     api_client: APIClient,
     log: StructuredLogCapture,
 ) -> None:
@@ -292,4 +127,42 @@ def test_mcp_usage_logger_middleware__unauthenticated__logs_nothing(
 
     # Then
     assert response.status_code == 401
+    assert log.events == []
+
+
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__error_response__logs_error_status(
+    staff_client: APIClient,
+    organisation: Organisation,
+    log: StructuredLogCapture,
+) -> None:
+    # Given / When
+    response = staff_client.get(f"/api/v1/organisations/{organisation.pk}/invites/")
+
+    # Then
+    assert response.status_code == 403
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "tool.called",
+            "organisation__id": organisation.pk,
+            "status": "error",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__sdk_request__logs_nothing(
+    api_client: APIClient,
+    environment: Environment,
+    log: StructuredLogCapture,
+) -> None:
+    # Given / When
+    response = api_client.get(
+        "/api/v1/flags/",
+        HTTP_X_ENVIRONMENT_KEY=environment.api_key,
+    )
+
+    # Then
+    assert response.status_code == 200
     assert log.events == []

--- a/api/tests/unit/telemetry/test_unit_telemetry_middleware.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_middleware.py
@@ -133,6 +133,30 @@ def test_mcp_usage_logger_middleware__user_with_single_organisation__logs_expect
     ]
 
 
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__user_without_organisations__logs_warning(
+    staff_client: APIClient,
+    log: StructuredLogCapture,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    assert not staff_user.organisations.exists()
+
+    # When
+    response = staff_client.get("/api/v1/projects/")
+
+    # Then
+    assert response.status_code == 200
+    assert log.events == [
+        {
+            "level": "warning",
+            "event": "tool.called",
+            "organisation__id": None,
+            "status": "success",
+        }
+    ]
+
+
 @pytest.mark.usefixtures("mcp_baggage", "organisation")
 def test_mcp_usage_logger_middleware__user_with_multiple_organisations__logs_warning(
     staff_client: APIClient,
@@ -239,6 +263,23 @@ def test_mcp_usage_logger_middleware__user_not_in_url_param_organisation__logs_w
             "status": "error",
         }
     ]
+
+
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__sdk_request__logs_nothing(
+    api_client: APIClient,
+    log: StructuredLogCapture,
+    environment: Environment,
+) -> None:
+    # Given / When
+    response = api_client.get(
+        "/api/v1/flags/",
+        HTTP_X_ENVIRONMENT_KEY=environment.api_key,  # Doesn't authenticate
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert log.events == []
 
 
 @pytest.mark.usefixtures("mcp_baggage")

--- a/api/tests/unit/telemetry/test_unit_telemetry_middleware.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_middleware.py
@@ -1,0 +1,254 @@
+from collections.abc import Generator
+
+import pytest
+from opentelemetry import baggage
+from opentelemetry import context as otel_context
+from pytest_structlog import StructuredLogCapture
+from rest_framework.test import APIClient
+
+from environments.models import Environment
+from features.models import Feature, FeatureState
+from organisations.models import Organisation, OrganisationRole
+from projects.models import Project
+from users.models import FFAdminUser
+
+
+@pytest.fixture()
+def mcp_baggage() -> Generator[None, None, None]:
+    ctx = baggage.set_baggage("flagsmith.client.name", "flagsmith-mcp")
+    token = otel_context.attach(ctx)
+    yield
+    otel_context.detach(token)
+
+
+def test_mcp_usage_logger_middleware__no_mcp_baggage__logs_nothing(
+    admin_client_new: APIClient,
+    project: Project,
+    log: StructuredLogCapture,
+) -> None:
+    # Given / When
+    admin_client_new.get(f"/api/v1/projects/{project.pk}/")
+
+    # Then
+    assert log.events == []
+
+
+@pytest.mark.parametrize(
+    "path_template",
+    [
+        # Organisation is obtained using `organisation_pk`
+        "/api/v1/organisations/{organisation_pk}/invites/",
+        # Organisation is obtained using `pk`
+        "/api/v1/organisations/{organisation_pk}/projects/",
+        # Organisation is obtained using `pk`
+        "/api/v1/projects/{project_pk}/",
+        "/api/v1/projects/{project_pk}/environments/",
+        # Organisation is obtained using `project_pk`
+        "/api/v1/projects/{project_pk}/features/",
+        # Organisation is obtained using `environment_pk`
+        "/api/v1/environments/{environment_pk}/features/{feature_pk}/versions/",
+        # Organisation is obtained using `environment_api_key`
+        "/api/v1/environments/{environment_api_key}/featurestates/{feature_state_pk}/",
+    ],
+)
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__resolvable_url__logs_expected(
+    admin_client_new: APIClient,
+    log: StructuredLogCapture,
+    organisation: Organisation,
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    feature_state: FeatureState,
+    path_template: str,
+) -> None:
+    # Given / When
+    response = admin_client_new.get(
+        path_template.format(
+            organisation_pk=organisation.pk,
+            project_pk=project.pk,
+            environment_pk=environment.pk,
+            environment_api_key=environment.api_key,
+            feature_pk=feature.pk,
+            feature_state_pk=feature_state.pk,
+        )
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "tool.called",
+            "organisation__id": organisation.pk,
+            "status": "success",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__feature_state_url__logs_expected(
+    admin_client_new: APIClient,
+    log: StructuredLogCapture,
+    organisation: Organisation,
+    feature_state: FeatureState,
+) -> None:
+    """Organisation is obtained using `pk` from /api/v1/features/featurestates/{pk}/."""
+    # Given / When
+    response = admin_client_new.get(
+        f"/api/v1/features/featurestates/{feature_state.pk}/"
+    )
+
+    # Then
+    assert response.status_code == 405
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "tool.called",
+            "organisation__id": organisation.pk,
+            "status": "error",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__user_with_single_organisation__logs_expected(
+    staff_client: APIClient,
+    log: StructuredLogCapture,
+    organisation: Organisation,
+) -> None:
+    """Organisation is obtained from the user when /api/v1/projects/ has no usable parameter."""
+    # Given / When
+    response = staff_client.get("/api/v1/projects/")
+
+    # Then
+    assert response.status_code == 200
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "tool.called",
+            "organisation__id": organisation.pk,
+            "status": "success",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage", "organisation")
+def test_mcp_usage_logger_middleware__user_with_multiple_organisations__logs_warning(
+    staff_client: APIClient,
+    log: StructuredLogCapture,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    other_organisation = Organisation.objects.create(name="Other Org")
+    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
+
+    # When
+    response = staff_client.get("/api/v1/projects/")
+
+    # Then
+    assert response.status_code == 200
+    assert log.events == [
+        {
+            "level": "warning",
+            "event": "tool.called",
+            "organisation__id": None,
+            "status": "success",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage", "organisation")
+def test_mcp_usage_logger_middleware__user_with_multiple_organisations__logs_url_organisation(
+    staff_client: APIClient,
+    log: StructuredLogCapture,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    other_organisation = Organisation.objects.create(name="Other Org")
+    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
+
+    # When
+    response = staff_client.get(
+        f"/api/v1/organisations/{other_organisation.pk}/projects/"
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "tool.called",
+            "organisation__id": other_organisation.pk,
+            "status": "success",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage", "organisation")
+def test_mcp_usage_logger_middleware__user_not_in_url_organisation__logs_warning(
+    staff_client: APIClient,
+    log: StructuredLogCapture,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    other_organisation = Organisation.objects.create(name="Other Org")
+    foreign_organisation = Organisation.objects.create(name="Foreign Org")
+    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
+
+    # When
+    response = staff_client.get(
+        f"/api/v1/organisations/{foreign_organisation.pk}/projects/"
+    )
+
+    # Then
+    assert response.status_code == 404
+    assert log.events == [
+        {
+            "level": "warning",
+            "event": "tool.called",
+            "organisation__id": None,
+            "status": "error",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage", "organisation")
+def test_mcp_usage_logger_middleware__user_not_in_url_param_organisation__logs_warning(
+    staff_client: APIClient,
+    log: StructuredLogCapture,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    other_organisation = Organisation.objects.create(name="Other Org")
+    foreign_organisation = Organisation.objects.create(name="Foreign Org")
+    staff_user.add_organisation(other_organisation, role=OrganisationRole.USER)
+
+    # When
+    response = staff_client.get(
+        f"/api/v1/organisations/{foreign_organisation.pk}/invites/"
+    )
+
+    # Then
+    assert response.status_code == 403
+    assert log.events == [
+        {
+            "level": "warning",
+            "event": "tool.called",
+            "organisation__id": None,
+            "status": "error",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mcp_baggage")
+def test_mcp_usage_logger_middleware__unauthenticated__logs_nothing(
+    api_client: APIClient,
+    log: StructuredLogCapture,
+) -> None:
+    # Given / When
+    response = api_client.get("/api/v1/projects/")
+
+    # Then
+    assert response.status_code == 401
+    assert log.events == []

--- a/api/tests/unit/telemetry/test_unit_telemetry_spans.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_spans.py
@@ -1,0 +1,37 @@
+import pytest
+
+from telemetry.spans import get_span_attribute, set_span_attribute
+
+
+@pytest.mark.usefixtures("recording_span")
+def test_set_span_attribute__recording_span__attribute_round_trips() -> None:
+    # Given
+    attribute = "organisation.id"
+
+    # When
+    set_span_attribute(attribute, 42)
+
+    # Then
+    assert get_span_attribute(attribute) == 42
+
+
+def test_set_span_attribute__no_recording_span__silently_ignored() -> None:
+    # Given
+    attribute = "organisation.id"
+
+    # When
+    set_span_attribute(attribute, 42)
+
+    # Then
+    assert get_span_attribute(attribute) is None
+
+
+def test_get_span_attribute__no_recording_span__returns_none() -> None:
+    # Given
+    attribute = "organisation.id"
+
+    # When
+    value = get_span_attribute(attribute)
+
+    # Then
+    assert value is None

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -318,9 +318,9 @@ Attributes:
 
 ### `mcp.tool.called`
 
-Logged at `warning` from:
- - `api/telemetry/middleware.py:57`
- - `api/telemetry/middleware.py:59`
+Logged at `info` from:
+ - `api/telemetry/middleware.py:56`
+ - `api/telemetry/middleware.py:58`
 
 Attributes:
  - `organisation.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -316,6 +316,15 @@ Attributes:
  - `project_id`
  - `retry_at`
 
+### `mcp.tool.called`
+
+Logged at `warning` from:
+ - `api/telemetry/middleware.py:57`
+ - `api/telemetry/middleware.py:59`
+
+Attributes:
+ - `organisation.id`
+
 ### `platform_hub.no_analytics_database_configured`
 
 Logged at `warning` from:

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -319,8 +319,8 @@ Attributes:
 ### `mcp.tool.called`
 
 Logged at `info` from:
- - `api/telemetry/middleware.py:56`
- - `api/telemetry/middleware.py:58`
+ - `api/telemetry/middleware.py:43`
+ - `api/telemetry/middleware.py:45`
 
 Attributes:
  - `organisation.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -319,8 +319,8 @@ Attributes:
 ### `mcp.tool.called`
 
 Logged at `info` from:
- - `api/telemetry/middleware.py:43`
- - `api/telemetry/middleware.py:45`
+ - `api/telemetry/middleware.py:38`
+ - `api/telemetry/middleware.py:40`
 
 Attributes:
  - `organisation.id`


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith-private/issues/152

Filter incoming requests from MCP servers and emit an `mcp.tool.called` log to OTel containing 1. the original W3C baggage from the request, and 2. the organisation ID.

Telemetry can then be exported so we can track usage.

## How did you test this code?

New unit + integration tests, and full local harness setup using an InfluxDB data storage as telemetry export target.