### PR TITLE
fix: Normalise heap base url and add request coverage

### DIFF
--- a/api/integrations/heap/heap.py
+++ b/api/integrations/heap/heap.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 class HeapWrapper(AbstractBaseIdentityIntegrationWrapper):  # type: ignore[type-arg]
     def __init__(self, config: HeapConfiguration):
         self.api_key = config.api_key
-        self.url = f"{config.base_url or DEFAULT_HEAP_API_URL}/api/track"
+        base_url = (config.base_url or DEFAULT_HEAP_API_URL).rstrip("/")
+        self.url = f"{base_url}/api/track"
 
     def _identify_user(self, user_data: dict) -> None:  # type: ignore[type-arg]
         response = requests.post(self.url, json=user_data)

--- a/api/tests/unit/integrations/heap/test_unit_heap.py
+++ b/api/tests/unit/integrations/heap/test_unit_heap.py
@@ -7,6 +7,10 @@ from environments.models import Environment
 from features.models import FeatureState
 from integrations.heap.heap import HeapWrapper
 from integrations.heap.models import HeapConfiguration
+from integrations.integration import identify_integrations
+
+if typing.TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.mark.django_db
@@ -58,3 +62,37 @@ def test_heap_wrapper__eu_base_url__uses_eu_url() -> None:
 
     # Then
     assert heap_wrapper.url == "https://eu.heapanalytics.com/api/track"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "base_url, expected_url",
+    [
+        (None, "https://heapanalytics.com/api/track"),
+        ("", "https://heapanalytics.com/api/track"),
+        ("https://eu.heapanalytics.com", "https://eu.heapanalytics.com/api/track"),
+        ("https://eu.heapanalytics.com/", "https://eu.heapanalytics.com/api/track"),
+    ],
+)
+def test_identify_integrations__heap_configured__posts_to_expected_url(
+    mocker: "MockerFixture",
+    environment: Environment,
+    identity: Identity,
+    base_url: str | None,
+    expected_url: str,
+) -> None:
+    # Given
+    api_key = "abc-123"
+    HeapConfiguration.objects.create(
+        environment=environment,
+        api_key=api_key,
+        base_url=base_url,
+    )
+    mocked_post = mocker.patch("integrations.heap.heap.requests.post")
+
+    # When
+    identify_integrations(identity, identity.get_all_feature_states())  # type: ignore[no-untyped-call]
+
+    # Then
+    assert mocked_post.call_args.args[0] == expected_url
+    assert mocked_post.call_args.kwargs["json"]["app_id"] == api_key


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- New tests asserting `identify_integrations` posts to the correct Heap URL for default, empty, and EU `base_url` values
- Small fix surfaced by the test: normalising trailing slash to avoid `//api/track`

## How did you test this code?
- tests