### PR TITLE
ci(frontend): lint changed files on pull requests

### DIFF
--- a/.github/workflows/frontend-pull-request.yml
+++ b/.github/workflows/frontend-pull-request.yml
@@ -34,3 +34,42 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit -- --passWithNoTests
+
+  lint:
+    name: Lint changed files
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # needed to diff against the PR base
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Diff-scoped: the frontend has a large pre-existing eslint/tsc backlog,
+      # so a whole-repo gate isn't viable yet.
+      - name: Lint changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          CHANGED=$(git diff --name-only --diff-filter=ACMR --relative \
+            "$BASE_SHA" HEAD -- '*.ts' '*.tsx' '*.js')
+          if [ -z "$CHANGED" ]; then
+            echo "No frontend JS/TS files changed — skipping."
+            exit 0
+          fi
+          echo "Linting changed files:"
+          echo "$CHANGED"
+          echo "$CHANGED" | xargs npx eslint


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds a `lint` job to the frontend PR workflow that runs `eslint` on only the files changed in the PR, hard-failing on errors.

Diff-scoped because the frontend has a large pre-existing backlog (~1,650 `tsc` errors + eslint violations), so a whole-repo gate isn't viable yet — this stops *new* lint/format debt without blocking on legacy. eslint extends `plugin:prettier/recommended`, so formatting is covered too. Fails on error-level rules only (conservative v1).

## How did you test this code?

Pushed a temp nested-ternary into a changed `.ts` file on this branch: the job hard-failed with a file/line annotation; removing it made the job skip and pass. Also ran the diff-scoped command locally against #7733 (caught 7 real errors).