### PR TITLE
fix(api): Remove Django pin from uv override-dependencies and upgrade to `5.2.15`

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -200,7 +200,6 @@ override-dependencies = [
     "dill==0.3.8",
     "distlib==0.3.9",
     "dj-database-url==3.0.1",
-    "django==5.2.14",
     "django-admin-sso==5.2.0",
     "django-axes==8.1.0",
     "django-cockroachdb==4.2",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -41,7 +41,6 @@ overrides = [
     { name = "dill", specifier = "==0.3.8" },
     { name = "distlib", specifier = "==0.3.9" },
     { name = "dj-database-url", specifier = "==3.0.1" },
-    { name = "django", specifier = "==5.2.14" },
     { name = "django-admin-sso", specifier = "==5.2.0" },
     { name = "django-axes", specifier = "==8.1.0" },
     { name = "django-cockroachdb", specifier = "==4.2" },
@@ -842,16 +841,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "5.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Removes the override for django added in the `uv` migration in order to update to `5.2.15` to resolve a CVE. 

## How did you test this code?

- Ran `uv lock --upgrade-package django` locally — confirmed Django moves from 5.2.14 → 5.2.15 in `uv.lock` with no other package changes.
- After merge, the next scheduled Renovate run (or a manual workflow dispatch of `.github/workflows/renovate.yml`) should produce the `renovate/pypi-django-vulnerability` PR rather than parking it on the dashboard.