### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/docker/common/db/.pgpool.yml
+++ b/docker/common/db/.pgpool.yml
@@ -3,7 +3,7 @@
 
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:15
+    image: docker.io/soldevelo/postgresql-repmgr:15
     ports:
       - 5432
     environment:
@@ -20,7 +20,7 @@ services:
       - REPMGR_PASSWORD=repmgrpassword
 
   pg-1:
-    image: docker.io/bitnami/postgresql-repmgr:15
+    image: docker.io/soldevelo/postgresql-repmgr:15
     ports:
       - 5432
     environment:
@@ -37,7 +37,7 @@ services:
       - REPMGR_PASSWORD=repmgrpassword
 
   pgpool:
-    image: docker.io/bitnami/pgpool:4
+    image: docker.io/soldevelo/pgpool:4
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/postgresql-repmgr:15` → [`soldevelo/postgresql-repmgr:15`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)
- `bitnami/pgpool:4` → [`soldevelo/pgpool:4`](https://hub.docker.com/r/soldevelo/pgpool)