### PR TITLE
refactor(multivariate): move-mv-option-saves-to-rtk-query

### DIFF
--- a/frontend/common/services/useMultivariateOption.ts
+++ b/frontend/common/services/useMultivariateOption.ts
@@ -35,41 +35,42 @@ export const multivariateOptionService = service.injectEndpoints({
           (flagRes.data as ProjectFlag)?.multivariate_options || []
         const errors: Record<number, any> = {}
         // Results are written back by input index — downstream feature
-        // state saves map weights to option ids positionally.
+        // state saves map weights to option ids positionally. Requests run
+        // sequentially so newly created options get ascending ids in input
+        // order, which is the order the UI displays.
         const ordered: MultivariateOption[] = []
-        await Promise.all(
-          args.multivariate_options.map(async (v, i) => {
-            let original
-            if (v.id) {
-              original = serverOptions.find((m) => m.id === v.id)
-            } else if (v.key) {
-              original = serverOptions.find((m) => !!m.key && m.key === v.key)
-            }
-            const body = {
-              ...v,
-              default_percentage_allocation: 0,
-              feature: args.feature_id,
-            }
-            const res = await baseQuery(
-              original
-                ? {
-                    body,
-                    method: 'PUT',
-                    url: `${featureUrl}mv-options/${original.id}/`,
-                  }
-                : {
-                    body,
-                    method: 'POST',
-                    url: `${featureUrl}mv-options/`,
-                  },
-            )
-            if (res.error) {
-              errors[i] = (res.error as { data?: any })?.data ?? null
-            } else {
-              ordered[i] = res.data as MultivariateOption
-            }
-          }),
-        )
+        for (let i = 0; i < args.multivariate_options.length; i++) {
+          const v = args.multivariate_options[i]
+          let original
+          if (v.id) {
+            original = serverOptions.find((m) => m.id === v.id)
+          } else if (v.key) {
+            original = serverOptions.find((m) => !!m.key && m.key === v.key)
+          }
+          const body = {
+            ...v,
+            default_percentage_allocation: 0,
+            feature: args.feature_id,
+          }
+          const res = await baseQuery(
+            original
+              ? {
+                  body,
+                  method: 'PUT',
+                  url: `${featureUrl}mv-options/${original.id}/`,
+                }
+              : {
+                  body,
+                  method: 'POST',
+                  url: `${featureUrl}mv-options/`,
+                },
+          )
+          if (res.error) {
+            errors[i] = (res.error as { data?: any })?.data ?? null
+          } else {
+            ordered[i] = res.data as MultivariateOption
+          }
+        }
         if (Object.keys(errors).length) {
           return { data: { errors, multivariate_options: ordered } }
         }

--- a/frontend/common/services/useMultivariateOption.ts
+++ b/frontend/common/services/useMultivariateOption.ts
@@ -1,4 +1,4 @@
-import { Res } from 'common/types/responses'
+import { MultivariateOption, ProjectFlag, Res } from 'common/types/responses'
 import { Req } from 'common/types/requests'
 import { service } from 'common/service'
 
@@ -24,6 +24,83 @@ export const multivariateOptionService = service
           method: 'DELETE',
           url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
         }),
+      }),
+      saveMultivariateOptions: builder.mutation<
+        Res['saveMultivariateOptions'],
+        Req['saveMultivariateOptions']
+      >({
+        invalidatesTags: (res, _, arg) =>
+          res && !res.errors
+            ? [{ id: arg.feature_id, type: 'ProjectFlag' }]
+            : [],
+        queryFn: async (args, _, _2, baseQuery) => {
+          const featureUrl = `projects/${args.project_id}/features/${args.feature_id}/`
+          // Diff against the server's current options rather than any client
+          // cache, so stale state can never turn an update into a duplicate
+          // create.
+          const flagRes = await baseQuery({ method: 'GET', url: featureUrl })
+          if (flagRes.error) {
+            return { error: flagRes.error }
+          }
+          const serverOptions =
+            (flagRes.data as ProjectFlag)?.multivariate_options || []
+          const errors: Record<number, any> = {}
+          // Results are written back by input index — downstream feature
+          // state saves map weights to option ids positionally.
+          const ordered: MultivariateOption[] = []
+          await Promise.all(
+            args.multivariate_options.map(async (v, i) => {
+              let original
+              if (v.id) {
+                original = serverOptions.find((m) => m.id === v.id)
+              } else if (v.key) {
+                original = serverOptions.find((m) => !!m.key && m.key === v.key)
+              }
+              const body = {
+                ...v,
+                default_percentage_allocation: 0,
+                feature: args.feature_id,
+              }
+              const res = await baseQuery(
+                original
+                  ? {
+                      body,
+                      method: 'PUT',
+                      url: `${featureUrl}mv-options/${original.id}/`,
+                    }
+                  : {
+                      body,
+                      method: 'POST',
+                      url: `${featureUrl}mv-options/`,
+                    },
+              )
+              if (res.error) {
+                errors[i] = (res.error as { data?: any })?.data ?? null
+              } else {
+                ordered[i] = res.data as MultivariateOption
+              }
+            }),
+          )
+          if (Object.keys(errors).length) {
+            return { data: { errors, multivariate_options: ordered } }
+          }
+          const deleted = serverOptions.filter(
+            (m) => !ordered.find((o) => o?.id === m.id),
+          )
+          const deleteResults = await Promise.all(
+            deleted.map((m) =>
+              baseQuery({
+                method: 'DELETE',
+                url: `${featureUrl}mv-options/${m.id}/`,
+              }),
+            ),
+          )
+          const failedDelete = deleteResults.find((r) => r.error)
+          if (failedDelete) {
+            return { error: failedDelete.error }
+          }
+          return { data: { errors: null, multivariate_options: ordered } }
+        },
       }),
       updateMultivariateOption: builder.mutation<
         Res['multivariateOption'],
@@ -82,9 +159,25 @@ export async function deleteMultivariateOption(
   )
 }
 
+export async function saveMultivariateOptions(
+  store: any,
+  data: Req['saveMultivariateOptions'],
+  options?: Parameters<
+    typeof multivariateOptionService.endpoints.saveMultivariateOptions.initiate
+  >[1],
+) {
+  return store.dispatch(
+    multivariateOptionService.endpoints.saveMultivariateOptions.initiate(
+      data,
+      options,
+    ),
+  )
+}
+
 export const {
   useCreateMultivariateOptionMutation,
   useDeleteMultivariateOptionMutation,
+  useSaveMultivariateOptionsMutation,
   useUpdateMultivariateOptionMutation,
   // END OF EXPORTS
 } = multivariateOptionService

--- a/frontend/common/services/useMultivariateOption.ts
+++ b/frontend/common/services/useMultivariateOption.ts
@@ -1,0 +1,90 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const multivariateOptionService = service
+  .enhanceEndpoints({ addTagTypes: ['ProjectFlag'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      createMultivariateOption: builder.mutation<
+        Res['multivariateOption'],
+        Req['createMultivariateOption']
+      >({
+        query: (query) => ({
+          body: query.body,
+          method: 'POST',
+          url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/`,
+        }),
+      }),
+      deleteMultivariateOption: builder.mutation<
+        void,
+        Req['deleteMultivariateOption']
+      >({
+        query: (query) => ({
+          method: 'DELETE',
+          url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
+        }),
+      }),
+      updateMultivariateOption: builder.mutation<
+        Res['multivariateOption'],
+        Req['updateMultivariateOption']
+      >({
+        query: (query) => ({
+          body: query.body,
+          method: 'PUT',
+          url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function createMultivariateOption(
+  store: any,
+  data: Req['createMultivariateOption'],
+  options?: Parameters<
+    typeof multivariateOptionService.endpoints.createMultivariateOption.initiate
+  >[1],
+) {
+  return store.dispatch(
+    multivariateOptionService.endpoints.createMultivariateOption.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function updateMultivariateOption(
+  store: any,
+  data: Req['updateMultivariateOption'],
+  options?: Parameters<
+    typeof multivariateOptionService.endpoints.updateMultivariateOption.initiate
+  >[1],
+) {
+  return store.dispatch(
+    multivariateOptionService.endpoints.updateMultivariateOption.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function deleteMultivariateOption(
+  store: any,
+  data: Req['deleteMultivariateOption'],
+  options?: Parameters<
+    typeof multivariateOptionService.endpoints.deleteMultivariateOption.initiate
+  >[1],
+) {
+  return store.dispatch(
+    multivariateOptionService.endpoints.deleteMultivariateOption.initiate(
+      data,
+      options,
+    ),
+  )
+}
+
+export const {
+  useCreateMultivariateOptionMutation,
+  useDeleteMultivariateOptionMutation,
+  useUpdateMultivariateOptionMutation,
+  // END OF EXPORTS
+} = multivariateOptionService

--- a/frontend/common/services/useMultivariateOption.ts
+++ b/frontend/common/services/useMultivariateOption.ts
@@ -2,119 +2,117 @@ import { MultivariateOption, ProjectFlag, Res } from 'common/types/responses'
 import { Req } from 'common/types/requests'
 import { service } from 'common/service'
 
-export const multivariateOptionService = service
-  .enhanceEndpoints({ addTagTypes: ['ProjectFlag'] })
-  .injectEndpoints({
-    endpoints: (builder) => ({
-      createMultivariateOption: builder.mutation<
-        Res['multivariateOption'],
-        Req['createMultivariateOption']
-      >({
-        query: (query) => ({
-          body: query.body,
-          method: 'POST',
-          url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/`,
-        }),
+export const multivariateOptionService = service.injectEndpoints({
+  endpoints: (builder) => ({
+    createMultivariateOption: builder.mutation<
+      Res['multivariateOption'],
+      Req['createMultivariateOption']
+    >({
+      query: (query) => ({
+        body: query.body,
+        method: 'POST',
+        url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/`,
       }),
-      deleteMultivariateOption: builder.mutation<
-        void,
-        Req['deleteMultivariateOption']
-      >({
-        query: (query) => ({
-          method: 'DELETE',
-          url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
-        }),
-      }),
-      saveMultivariateOptions: builder.mutation<
-        Res['saveMultivariateOptions'],
-        Req['saveMultivariateOptions']
-      >({
-        invalidatesTags: (res, _, arg) =>
-          res && !res.errors
-            ? [{ id: arg.feature_id, type: 'ProjectFlag' }]
-            : [],
-        queryFn: async (args, _, _2, baseQuery) => {
-          const featureUrl = `projects/${args.project_id}/features/${args.feature_id}/`
-          // Diff against the server's current options rather than any client
-          // cache, so stale state can never turn an update into a duplicate
-          // create.
-          const flagRes = await baseQuery({ method: 'GET', url: featureUrl })
-          if (flagRes.error) {
-            return { error: flagRes.error }
-          }
-          const serverOptions =
-            (flagRes.data as ProjectFlag)?.multivariate_options || []
-          const errors: Record<number, any> = {}
-          // Results are written back by input index — downstream feature
-          // state saves map weights to option ids positionally.
-          const ordered: MultivariateOption[] = []
-          await Promise.all(
-            args.multivariate_options.map(async (v, i) => {
-              let original
-              if (v.id) {
-                original = serverOptions.find((m) => m.id === v.id)
-              } else if (v.key) {
-                original = serverOptions.find((m) => !!m.key && m.key === v.key)
-              }
-              const body = {
-                ...v,
-                default_percentage_allocation: 0,
-                feature: args.feature_id,
-              }
-              const res = await baseQuery(
-                original
-                  ? {
-                      body,
-                      method: 'PUT',
-                      url: `${featureUrl}mv-options/${original.id}/`,
-                    }
-                  : {
-                      body,
-                      method: 'POST',
-                      url: `${featureUrl}mv-options/`,
-                    },
-              )
-              if (res.error) {
-                errors[i] = (res.error as { data?: any })?.data ?? null
-              } else {
-                ordered[i] = res.data as MultivariateOption
-              }
-            }),
-          )
-          if (Object.keys(errors).length) {
-            return { data: { errors, multivariate_options: ordered } }
-          }
-          const deleted = serverOptions.filter(
-            (m) => !ordered.find((o) => o?.id === m.id),
-          )
-          const deleteResults = await Promise.all(
-            deleted.map((m) =>
-              baseQuery({
-                method: 'DELETE',
-                url: `${featureUrl}mv-options/${m.id}/`,
-              }),
-            ),
-          )
-          const failedDelete = deleteResults.find((r) => r.error)
-          if (failedDelete) {
-            return { error: failedDelete.error }
-          }
-          return { data: { errors: null, multivariate_options: ordered } }
-        },
-      }),
-      updateMultivariateOption: builder.mutation<
-        Res['multivariateOption'],
-        Req['updateMultivariateOption']
-      >({
-        query: (query) => ({
-          body: query.body,
-          method: 'PUT',
-          url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
-        }),
-      }),
-      // END OF ENDPOINTS
     }),
-  })
+    deleteMultivariateOption: builder.mutation<
+      void,
+      Req['deleteMultivariateOption']
+    >({
+      query: (query) => ({
+        method: 'DELETE',
+        url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
+      }),
+    }),
+    saveMultivariateOptions: builder.mutation<
+      Res['saveMultivariateOptions'],
+      Req['saveMultivariateOptions']
+    >({
+      // No invalidatesTags: every save chain already ends with a broad
+      // invalidateTags(['ProjectFlag', 'FeatureList']) once the downstream
+      // feature-state save completes — invalidating here too would refetch
+      // every subscribed query twice per save.
+      queryFn: async (args, _, _2, baseQuery) => {
+        const featureUrl = `projects/${args.project_id}/features/${args.feature_id}/`
+        // Diff against the server's current options rather than any client
+        // cache, so stale state can never turn an update into a duplicate
+        // create.
+        const flagRes = await baseQuery({ method: 'GET', url: featureUrl })
+        if (flagRes.error) {
+          return { error: flagRes.error }
+        }
+        const serverOptions =
+          (flagRes.data as ProjectFlag)?.multivariate_options || []
+        const errors: Record<number, any> = {}
+        // Results are written back by input index — downstream feature
+        // state saves map weights to option ids positionally.
+        const ordered: MultivariateOption[] = []
+        await Promise.all(
+          args.multivariate_options.map(async (v, i) => {
+            let original
+            if (v.id) {
+              original = serverOptions.find((m) => m.id === v.id)
+            } else if (v.key) {
+              original = serverOptions.find((m) => !!m.key && m.key === v.key)
+            }
+            const body = {
+              ...v,
+              default_percentage_allocation: 0,
+              feature: args.feature_id,
+            }
+            const res = await baseQuery(
+              original
+                ? {
+                    body,
+                    method: 'PUT',
+                    url: `${featureUrl}mv-options/${original.id}/`,
+                  }
+                : {
+                    body,
+                    method: 'POST',
+                    url: `${featureUrl}mv-options/`,
+                  },
+            )
+            if (res.error) {
+              errors[i] = (res.error as { data?: any })?.data ?? null
+            } else {
+              ordered[i] = res.data as MultivariateOption
+            }
+          }),
+        )
+        if (Object.keys(errors).length) {
+          return { data: { errors, multivariate_options: ordered } }
+        }
+        const deleted = serverOptions.filter(
+          (m) => !ordered.find((o) => o?.id === m.id),
+        )
+        const deleteResults = await Promise.all(
+          deleted.map((m) =>
+            baseQuery({
+              method: 'DELETE',
+              url: `${featureUrl}mv-options/${m.id}/`,
+            }),
+          ),
+        )
+        const failedDelete = deleteResults.find((r) => r.error)
+        if (failedDelete) {
+          return { error: failedDelete.error }
+        }
+        return { data: { errors: null, multivariate_options: ordered } }
+      },
+    }),
+    updateMultivariateOption: builder.mutation<
+      Res['multivariateOption'],
+      Req['updateMultivariateOption']
+    >({
+      query: (query) => ({
+        body: query.body,
+        method: 'PUT',
+        url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
+      }),
+    }),
+    // END OF ENDPOINTS
+  }),
+})
 
 export async function createMultivariateOption(
   store: any,

--- a/frontend/common/services/useMultivariateOption.ts
+++ b/frontend/common/services/useMultivariateOption.ts
@@ -14,15 +14,6 @@ export const multivariateOptionService = service.injectEndpoints({
         url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/`,
       }),
     }),
-    deleteMultivariateOption: builder.mutation<
-      void,
-      Req['deleteMultivariateOption']
-    >({
-      query: (query) => ({
-        method: 'DELETE',
-        url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
-      }),
-    }),
     saveMultivariateOptions: builder.mutation<
       Res['saveMultivariateOptions'],
       Req['saveMultivariateOptions']
@@ -100,16 +91,6 @@ export const multivariateOptionService = service.injectEndpoints({
         return { data: { errors: null, multivariate_options: ordered } }
       },
     }),
-    updateMultivariateOption: builder.mutation<
-      Res['multivariateOption'],
-      Req['updateMultivariateOption']
-    >({
-      query: (query) => ({
-        body: query.body,
-        method: 'PUT',
-        url: `projects/${query.project_id}/features/${query.feature_id}/mv-options/${query.mv_id}/`,
-      }),
-    }),
     // END OF ENDPOINTS
   }),
 })
@@ -128,35 +109,6 @@ export async function createMultivariateOption(
     ),
   )
 }
-export async function updateMultivariateOption(
-  store: any,
-  data: Req['updateMultivariateOption'],
-  options?: Parameters<
-    typeof multivariateOptionService.endpoints.updateMultivariateOption.initiate
-  >[1],
-) {
-  return store.dispatch(
-    multivariateOptionService.endpoints.updateMultivariateOption.initiate(
-      data,
-      options,
-    ),
-  )
-}
-export async function deleteMultivariateOption(
-  store: any,
-  data: Req['deleteMultivariateOption'],
-  options?: Parameters<
-    typeof multivariateOptionService.endpoints.deleteMultivariateOption.initiate
-  >[1],
-) {
-  return store.dispatch(
-    multivariateOptionService.endpoints.deleteMultivariateOption.initiate(
-      data,
-      options,
-    ),
-  )
-}
-
 export async function saveMultivariateOptions(
   store: any,
   data: Req['saveMultivariateOptions'],
@@ -174,8 +126,6 @@ export async function saveMultivariateOptions(
 
 export const {
   useCreateMultivariateOptionMutation,
-  useDeleteMultivariateOptionMutation,
   useSaveMultivariateOptionsMutation,
-  useUpdateMultivariateOptionMutation,
   // END OF EXPORTS
 } = multivariateOptionService

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -46,8 +46,7 @@ import BaseStore from './base/_store'
 import data from 'common/data/base/_data'
 import {
   createMultivariateOption,
-  deleteMultivariateOption,
-  updateMultivariateOption,
+  saveMultivariateOptions,
 } from 'common/services/useMultivariateOption'
 import { createSegmentOverride } from 'common/services/useSegmentOverride'
 import { getStore } from 'common/store'
@@ -257,87 +256,41 @@ const controller = {
       store.model && store.model.features
         ? store.model.features.find((v) => v.id === flag.id)
         : flag
+    // Standard flags carry no multivariate data — skip the round-trip.
+    if (
+      !flag.multivariate_options?.length &&
+      !originalFlag?.multivariate_options?.length
+    ) {
+      if (onComplete) {
+        onComplete(flag)
+      }
+      return
+    }
     store.error = null
-    Promise.all(
-      (flag.multivariate_options || []).map((v, i) => {
-        let originalMV = null
-        if (originalFlag?.multivariate_options) {
-          if (v.id) {
-            originalMV = originalFlag.multivariate_options.find(
-              (m: MultivariateOption) => m.id === v.id,
-            )
-          } else if (v.key) {
-            originalMV = originalFlag.multivariate_options.find(
-              (m: MultivariateOption) => !!m.key && m.key === v.key,
-            )
-          }
-        }
-        const mvData = {
-          ...v,
-          default_percentage_allocation: 0,
-          feature: flag.id,
-        }
-        return (
-          originalMV
-            ? updateMultivariateOption(getStore(), {
-                body: mvData,
-                feature_id: flag.id,
-                mv_id: originalMV.id,
-                project_id: projectId,
-              })
-            : createMultivariateOption(getStore(), {
-                body: mvData,
-                feature_id: flag.id,
-                project_id: projectId,
-              })
-        ).then((res) => {
-          if (res.error) {
-            return Promise.reject({ mvIndex: i, source: res.error })
-          }
-          // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
-          flag.multivariate_options[i] = res.data
-          return {
-            ...v,
-            id: res.data.id,
-          }
-        })
-      }),
-    )
-      .then(() => {
-        const deletedMv = (originalFlag?.multivariate_options || []).filter(
-          (v) => !flag.multivariate_options.find((x) => v.id === x.id),
-        )
-        return Promise.all(
-          deletedMv.map((v) =>
-            deleteMultivariateOption(getStore(), {
-              feature_id: flag.id,
-              mv_id: v.id,
-              project_id: projectId,
-            }).then((res) => {
-              if (res.error) {
-                throw res.error
-              }
-            }),
-          ),
-        )
-      })
-      .then(() => {
-        if (onComplete) {
-          onComplete(flag)
-        }
-      })
-      .catch((e) => {
-        if (typeof e?.mvIndex !== 'number') {
-          API.ajaxHandler(store, e)
-          return
-        }
-        // Attribute the failure to the option that caused it so the UI
-        // can surface it on the right variation.
-        store.error = {
-          multivariate_options: { [e.mvIndex]: e.source?.data ?? null },
-        } as any
+    saveMultivariateOptions(getStore(), {
+      feature_id: flag.id,
+      multivariate_options: flag.multivariate_options || [],
+      project_id: projectId,
+    }).then((res) => {
+      if (res.error) {
+        API.ajaxHandler(store, res.error)
+        return
+      }
+      if (res.data.errors) {
+        store.error = { multivariate_options: res.data.errors } as any
         store.goneABitWest()
-      })
+        return
+      }
+      // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
+      res.data.multivariate_options.forEach(
+        (v: MultivariateOption, i: number) => {
+          flag.multivariate_options[i] = v
+        },
+      )
+      if (onComplete) {
+        onComplete(flag)
+      }
+    })
   },
   editFeatureState: async (
     projectId,

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -252,6 +252,7 @@ const controller = {
       })
       return
     }
+    store.error = null
     const originalFlag =
       store.model && store.model.features
         ? store.model.features.find((v) => v.id === flag.id)
@@ -266,7 +267,6 @@ const controller = {
       }
       return
     }
-    store.error = null
     saveMultivariateOptions(getStore(), {
       feature_id: flag.id,
       multivariate_options: flag.multivariate_options || [],

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -118,30 +118,27 @@ const controller = {
       }),
       project_id: projectId,
     })
-      .then((res) => {
+      .then(async (res) => {
         if (res.error) {
           throw res.error?.error || res.error
         }
-        return Promise.all(
-          (flag.multivariate_options || []).map((v) =>
-            createMultivariateOption(getStore(), {
-              body: {
-                ...v,
-                feature: res.data.id,
-              },
-              feature_id: res.data.id,
-              project_id: projectId,
-            }).then((mvRes) => {
-              if (mvRes.error) {
-                throw mvRes.error
-              }
-              return res.data
-            }),
-          ),
-        ).then(() =>
-          data.get(
-            `${Project.api}projects/${projectId}/features/${res.data.id}/`,
-          ),
+        // Sequential so options get ascending ids in input order, which is
+        // the order the UI displays.
+        for (const v of flag.multivariate_options || []) {
+          const mvRes = await createMultivariateOption(getStore(), {
+            body: {
+              ...v,
+              feature: res.data.id,
+            },
+            feature_id: res.data.id,
+            project_id: projectId,
+          })
+          if (mvRes.error) {
+            throw mvRes.error
+          }
+        }
+        return data.get(
+          `${Project.api}projects/${projectId}/features/${res.data.id}/`,
         )
       })
       .then(() =>
@@ -159,7 +156,7 @@ const controller = {
             feature: v.id,
           }))
           store.model = {
-            features: features.results,
+            features: features.results.map(controller.parseFlag),
             keyedEnvironmentFeatures:
               environmentFeatures && keyBy(environmentFeatures, 'feature'),
           }
@@ -992,6 +989,14 @@ const controller = {
           ...fs,
           segment: fs.segment.id,
         })),
+      // The API returns multivariate options in unspecified order, which
+      // can change after any update — keep creation order stable for the
+      // UI and for index-based weight mapping.
+      multivariate_options:
+        flag.multivariate_options &&
+        [...flag.multivariate_options].sort(
+          (a: MultivariateOption, b: MultivariateOption) => a.id - b.id,
+        ),
     }
   },
   searchFeatures: throttle(

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -44,6 +44,11 @@ import { FEATURES_PAGE_SIZE } from 'common/services/useProjectFlag'
 import Dispatcher from 'common/dispatcher/dispatcher'
 import BaseStore from './base/_store'
 import data from 'common/data/base/_data'
+import {
+  createMultivariateOption,
+  deleteMultivariateOption,
+  updateMultivariateOption,
+} from 'common/services/useMultivariateOption'
 import { createSegmentOverride } from 'common/services/useSegmentOverride'
 import { getStore } from 'common/store'
 let createdFirstFeature = false
@@ -120,15 +125,19 @@ const controller = {
         }
         return Promise.all(
           (flag.multivariate_options || []).map((v) =>
-            data
-              .post(
-                `${Project.api}projects/${projectId}/features/${res.data.id}/mv-options/`,
-                {
-                  ...v,
-                  feature: res.data.id,
-                },
-              )
-              .then(() => res.data),
+            createMultivariateOption(getStore(), {
+              body: {
+                ...v,
+                feature: res.data.id,
+              },
+              feature_id: res.data.id,
+              project_id: projectId,
+            }).then((mvRes) => {
+              if (mvRes.error) {
+                throw mvRes.error
+              }
+              return res.data
+            }),
           ),
         ).then(() =>
           data.get(
@@ -263,7 +272,6 @@ const controller = {
             )
           }
         }
-        const url = `${Project.api}projects/${projectId}/features/${flag.id}/mv-options/`
         const mvData = {
           ...v,
           default_percentage_allocation: 0,
@@ -271,18 +279,28 @@ const controller = {
         }
         return (
           originalMV
-            ? data.put(`${url}${originalMV.id}/`, mvData)
-            : data.post(url, mvData)
-        )
-          .then((res) => {
-            // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
-            flag.multivariate_options[i] = res
-            return {
-              ...v,
-              id: res.id,
-            }
-          })
-          .catch((e) => Promise.reject({ mvIndex: i, source: e }))
+            ? updateMultivariateOption(getStore(), {
+                body: mvData,
+                feature_id: flag.id,
+                mv_id: originalMV.id,
+                project_id: projectId,
+              })
+            : createMultivariateOption(getStore(), {
+                body: mvData,
+                feature_id: flag.id,
+                project_id: projectId,
+              })
+        ).then((res) => {
+          if (res.error) {
+            return Promise.reject({ mvIndex: i, source: res.error })
+          }
+          // It's important to preserve the original order of multivariate_options, so that editing feature states can use the updated ID
+          flag.multivariate_options[i] = res.data
+          return {
+            ...v,
+            id: res.data.id,
+          }
+        })
       }),
     )
       .then(() => {
@@ -291,9 +309,15 @@ const controller = {
         )
         return Promise.all(
           deletedMv.map((v) =>
-            data.delete(
-              `${Project.api}projects/${projectId}/features/${flag.id}/mv-options/${v.id}/`,
-            ),
+            deleteMultivariateOption(getStore(), {
+              feature_id: flag.id,
+              mv_id: v.id,
+              project_id: projectId,
+            }).then((res) => {
+              if (res.error) {
+                throw res.error
+              }
+            }),
           ),
         )
       })
@@ -309,24 +333,10 @@ const controller = {
         }
         // Attribute the failure to the option that caused it so the UI
         // can surface it on the right variation.
-        const surface = (body: any) => {
-          store.error = { multivariate_options: { [e.mvIndex]: body } } as any
-          store.goneABitWest()
-        }
-        if (typeof e.source?.text === 'function') {
-          e.source
-            .text()
-            .then((text: string) => {
-              let body = text
-              try {
-                body = JSON.parse(text)
-              } catch {}
-              surface(body)
-            })
-            .catch(() => surface(null))
-        } else {
-          surface(e.source ?? null)
-        }
+        store.error = {
+          multivariate_options: { [e.mvIndex]: e.source?.data ?? null },
+        } as any
+        store.goneABitWest()
       })
   },
   editFeatureState: async (

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -1044,12 +1044,6 @@ export type Req = {
     feature_id: number
     body: Partial<MultivariateOption> & { feature: number }
   }
-  updateMultivariateOption: Req['createMultivariateOption'] & { mv_id: number }
-  deleteMultivariateOption: {
-    project_id: string | number
-    feature_id: number
-    mv_id: number
-  }
   saveMultivariateOptions: {
     project_id: string | number
     feature_id: number

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -1039,5 +1039,21 @@ export type Req = {
     body: Req['createMetric']['body']
   }
   deleteMetric: { environmentId: string; metricId: number }
+  createMultivariateOption: {
+    project_id: string | number
+    feature_id: number
+    body: Partial<MultivariateOption> & { feature: number }
+  }
+  updateMultivariateOption: Req['createMultivariateOption'] & { mv_id: number }
+  deleteMultivariateOption: {
+    project_id: string | number
+    feature_id: number
+    mv_id: number
+  }
+  saveMultivariateOptions: {
+    project_id: string | number
+    feature_id: number
+    multivariate_options: Partial<MultivariateOption>[]
+  }
   // END OF TYPES
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1413,5 +1413,12 @@ export type Res = {
   experiment: Experiment
   metric: Metric
   metrics: PagedResponse<Metric>
+  multivariateOption: MultivariateOption
+  saveMultivariateOptions: {
+    multivariate_options: MultivariateOption[]
+    // Per-option API errors keyed by the input option's index; null when all
+    // requests succeeded.
+    errors: Record<number, any> | null
+  }
   // END OF TYPES
 }

--- a/frontend/e2e/tests/mv-options-tests.pw.ts
+++ b/frontend/e2e/tests/mv-options-tests.pw.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '../test-setup';
-import { byId, getFlagsmith, log, createHelpers, LONG_TIMEOUT } from '../helpers';
+import { byId, log, createHelpers, LONG_TIMEOUT } from '../helpers';
 import { E2E_USER, PASSWORD, E2E_TEST_PROJECT } from '../config';
 import type { Page } from '@playwright/test';
 
 // Regression tests for the multivariate option save flow: variants must
-// never duplicate on repeated saves, deletes must apply, and labels/weights
-// must survive a save under v2 feature versioning.
+// never duplicate on repeated saves and deletes must apply. The v2
+// feature versioning coverage lives in versioning-tests.pw.ts, which
+// owns the (irreversible) versioned environment setup.
 
 const openFeature = async (page: Page, name: string) => {
   const featureRow = page.locator('[data-test^="feature-item-"]').filter({
@@ -103,87 +104,6 @@ test.describe('Multivariate Options', () => {
     await expect(page.locator(byId('featureVariationWeightkeep'))).toBeVisible();
     await expect(page.locator(byId('featureVariationWeightadded'))).toBeVisible();
     await expect(page.locator(byId('featureVariationWeightdrop'))).toHaveCount(0);
-    await closeModal();
-    await waitForElementNotExist('#create-feature-modal');
-  });
-
-  test('Variant labels and weights persist under v2 feature versioning @oss', async ({ page }) => {
-    const {
-      click,
-      closeModal,
-      createOrganisationAndProject,
-      createRemoteConfig,
-      gotoFeatures,
-      login,
-      setText,
-      waitForElementNotExist,
-      waitForElementVisible,
-      waitForToast,
-      waitForToastsToClear,
-    } = createHelpers(page);
-    const flagsmith = await getFlagsmith();
-    const hasFeature = flagsmith.hasFeature('feature_versioning');
-
-    log('Login');
-    await login(E2E_USER, PASSWORD);
-
-    if (!hasFeature) {
-      log('Skipping mv versioning test, feature not enabled.');
-      test.skip();
-      return;
-    }
-
-    await createOrganisationAndProject('Mv Options Versioning Org', 'Mv Options Versioning Project');
-    await waitForElementVisible(byId('features-page'));
-    await click('#env-settings-link');
-    await click(byId('enable-versioning'));
-    await click('#confirm-btn-yes');
-    // Feature versioning takes up to a minute to enable on the backend
-    await waitForElementVisible(byId('feature-versioning-enabled'));
-    await waitForElementVisible('.toast-message');
-    await waitForToastsToClear();
-
-    log('Create multivariate flag in versioned environment');
-    await createRemoteConfig({ name: 'mv_v2_flag', value: 'root_val', mvs: [
-      { value: 'one', weight: 100 },
-      { value: 'two', weight: 0 },
-    ]});
-    // Short delay between synchronising mv options and the next edit
-    await page.waitForTimeout(1000);
-
-    log('Edit label, flip weights and add a variant in one save');
-    await gotoFeatures();
-    await openFeature(page, 'mv_v2_flag');
-    await click(byId('featureVariationKeyEdit0'));
-    await setText(byId('featureVariationKeyInput0'), 'primary');
-    await click(byId('featureVariationKeySave0'));
-    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary');
-    for (const { value, weight } of [
-      { value: 'one', weight: 0 },
-      { value: 'two', weight: 100 },
-    ]) {
-      const input = page.locator(byId(`featureVariationWeight${value}`));
-      await input.clear();
-      await input.fill(`${weight}`);
-      await input.blur();
-      await page.waitForTimeout(200);
-    }
-    await click(byId('add-variation'));
-    await page.waitForTimeout(200);
-    await setText(byId('featureVariationValue2'), 'three');
-    await page.waitForTimeout(500);
-    await click(byId('update-feature-btn'));
-    await waitForToast();
-    await closeModal();
-    await waitForElementNotExist('#create-feature-modal');
-
-    log('Label, weights and the new variant survived the versioned save');
-    await gotoFeatures();
-    await openFeature(page, 'mv_v2_flag');
-    await expect(variantCards(page)).toHaveCount(3);
-    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary');
-    await expect(page.locator(byId('featureVariationWeighttwo'))).toHaveValue('100');
-    await expect(page.locator(byId('featureVariationWeightthree'))).toBeVisible();
     await closeModal();
     await waitForElementNotExist('#create-feature-modal');
   });

--- a/frontend/e2e/tests/mv-options-tests.pw.ts
+++ b/frontend/e2e/tests/mv-options-tests.pw.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '../test-setup';
+import { byId, getFlagsmith, log, createHelpers, LONG_TIMEOUT } from '../helpers';
+import { E2E_USER, PASSWORD, E2E_TEST_PROJECT } from '../config';
+import type { Page } from '@playwright/test';
+
+// Regression tests for the multivariate option save flow: variants must
+// never duplicate on repeated saves, deletes must apply, and labels/weights
+// must survive a save under v2 feature versioning.
+
+const openFeature = async (page: Page, name: string) => {
+  const featureRow = page.locator('[data-test^="feature-item-"]').filter({
+    has: page.locator(`span:text-is("${name}")`),
+  }).first();
+  await featureRow.waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
+  await featureRow.dispatchEvent('click');
+  await page.locator(byId('update-feature-btn')).first().waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
+};
+
+const variantCards = (page: Page) => page.locator('#create-feature-modal .variant-card');
+
+test.describe('Multivariate Options', () => {
+  test('Repeated saves keep the variant set stable @oss', async ({ page }) => {
+    const {
+      closeModal,
+      createRemoteConfig,
+      editRemoteConfig,
+      editVariantLabel,
+      gotoFeatures,
+      gotoProject,
+      login,
+      waitForElementNotExist,
+    } = createHelpers(page);
+
+    log('Login');
+    await login(E2E_USER, PASSWORD);
+    await gotoProject(E2E_TEST_PROJECT);
+
+    log('Create multivariate flag');
+    await createRemoteConfig({ name: 'mv_repeat_save', value: 'ctrl_value', mvs: [
+      { value: 'va', weight: 0 },
+      { value: 'vb', weight: 0 },
+    ]});
+
+    log('First save: label-only edit');
+    await editVariantLabel('mv_repeat_save', 0, 'first_variant');
+
+    log('Second save: value and weights, without structural changes');
+    await editRemoteConfig('mv_repeat_save', 'ctrl_value2', false, [
+      { value: 'va', weight: 30 },
+      { value: 'vb', weight: 20 },
+    ]);
+
+    log('Variant set is unchanged after both saves');
+    await gotoFeatures();
+    await openFeature(page, 'mv_repeat_save');
+    await expect(variantCards(page)).toHaveCount(2);
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('first_variant');
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+  });
+
+  test('Variants can be added and removed in a single save @oss', async ({ page }) => {
+    const {
+      click,
+      closeModal,
+      createRemoteConfig,
+      gotoFeatures,
+      gotoProject,
+      login,
+      setText,
+      waitForElementNotExist,
+      waitForToast,
+    } = createHelpers(page);
+
+    log('Login');
+    await login(E2E_USER, PASSWORD);
+    await gotoProject(E2E_TEST_PROJECT);
+
+    log('Create multivariate flag');
+    await createRemoteConfig({ name: 'mv_add_remove', value: 'root_val', mvs: [
+      { value: 'keep', weight: 0 },
+      { value: 'drop', weight: 0 },
+    ]});
+
+    log('Remove one variant and add another in the same edit');
+    await openFeature(page, 'mv_add_remove');
+    await page.locator('#create-feature-modal #delete-multivariate').nth(1).click();
+    await click('#confirm-btn-yes');
+    await expect(variantCards(page)).toHaveCount(1);
+    await click(byId('add-variation'));
+    await page.waitForTimeout(200);
+    await setText(byId('featureVariationValue1'), 'added');
+    await page.waitForTimeout(500);
+    await click(byId('update-feature-btn'));
+    await waitForToast();
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+
+    log('Saved set is exactly the kept and added variants');
+    await gotoFeatures();
+    await openFeature(page, 'mv_add_remove');
+    await expect(variantCards(page)).toHaveCount(2);
+    await expect(page.locator(byId('featureVariationWeightkeep'))).toBeVisible();
+    await expect(page.locator(byId('featureVariationWeightadded'))).toBeVisible();
+    await expect(page.locator(byId('featureVariationWeightdrop'))).toHaveCount(0);
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+  });
+
+  test('Variant labels and weights persist under v2 feature versioning @oss', async ({ page }) => {
+    const {
+      click,
+      closeModal,
+      createOrganisationAndProject,
+      createRemoteConfig,
+      gotoFeatures,
+      login,
+      setText,
+      waitForElementNotExist,
+      waitForElementVisible,
+      waitForToast,
+      waitForToastsToClear,
+    } = createHelpers(page);
+    const flagsmith = await getFlagsmith();
+    const hasFeature = flagsmith.hasFeature('feature_versioning');
+
+    log('Login');
+    await login(E2E_USER, PASSWORD);
+
+    if (!hasFeature) {
+      log('Skipping mv versioning test, feature not enabled.');
+      test.skip();
+      return;
+    }
+
+    await createOrganisationAndProject('Mv Options Versioning Org', 'Mv Options Versioning Project');
+    await waitForElementVisible(byId('features-page'));
+    await click('#env-settings-link');
+    await click(byId('enable-versioning'));
+    await click('#confirm-btn-yes');
+    // Feature versioning takes up to a minute to enable on the backend
+    await waitForElementVisible(byId('feature-versioning-enabled'));
+    await waitForElementVisible('.toast-message');
+    await waitForToastsToClear();
+
+    log('Create multivariate flag in versioned environment');
+    await createRemoteConfig({ name: 'mv_v2_flag', value: 'root_val', mvs: [
+      { value: 'one', weight: 100 },
+      { value: 'two', weight: 0 },
+    ]});
+    // Short delay between synchronising mv options and the next edit
+    await page.waitForTimeout(1000);
+
+    log('Edit label, flip weights and add a variant in one save');
+    await gotoFeatures();
+    await openFeature(page, 'mv_v2_flag');
+    await click(byId('featureVariationKeyEdit0'));
+    await setText(byId('featureVariationKeyInput0'), 'primary');
+    await click(byId('featureVariationKeySave0'));
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary');
+    for (const { value, weight } of [
+      { value: 'one', weight: 0 },
+      { value: 'two', weight: 100 },
+    ]) {
+      const input = page.locator(byId(`featureVariationWeight${value}`));
+      await input.clear();
+      await input.fill(`${weight}`);
+      await input.blur();
+      await page.waitForTimeout(200);
+    }
+    await click(byId('add-variation'));
+    await page.waitForTimeout(200);
+    await setText(byId('featureVariationValue2'), 'three');
+    await page.waitForTimeout(500);
+    await click(byId('update-feature-btn'));
+    await waitForToast();
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+
+    log('Label, weights and the new variant survived the versioned save');
+    await gotoFeatures();
+    await openFeature(page, 'mv_v2_flag');
+    await expect(variantCards(page)).toHaveCount(3);
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary');
+    await expect(page.locator(byId('featureVariationWeighttwo'))).toHaveValue('100');
+    await expect(page.locator(byId('featureVariationWeightthree'))).toBeVisible();
+    await closeModal();
+    await waitForElementNotExist('#create-feature-modal');
+  });
+});

--- a/frontend/e2e/tests/versioning-tests.pw.ts
+++ b/frontend/e2e/tests/versioning-tests.pw.ts
@@ -12,16 +12,22 @@ test('Versioning tests - Create, edit, and compare feature versions @oss', async
     const {
         assertNumberOfVersions,
         click,
+        closeModal,
         compareVersion,
         createFeature,
         createOrganisationAndProject,
         createRemoteConfig,
         editRemoteConfig,
+        gotoFeature,
+        gotoFeatures,
         login,
+        setText,
         toggleFeature,
         tryItExpect,
+        waitForElementNotExist,
         waitForElementVisible,
         waitForFeatureSwitch,
+        waitForToast,
         waitForToastsToClear,
     } = createHelpers(page)
     const flagsmith = await getFlagsmith()
@@ -78,6 +84,38 @@ test('Versioning tests - Create, edit, and compare feature versions @oss', async
     await compareVersion('a', 0, null, true, true, 'small', 'medium')
     await compareVersion('b', 0, null, true, true, 'small', 'small')
     await compareVersion('c', 0, null, false, true, null, null)
+
+    // ===================================================================================
+    // Test: Multivariate option edits in a versioned environment
+    // A label edit plus a structural change (new variant) in a single save must
+    // survive a reopen — the versioned save consumes option ids positionally
+    // from the multivariate save, so this pins that contract under v2.
+    // ===================================================================================
+    log('Edit variant label and add a variant in one save (versioned env)')
+    await gotoFeatures()
+    await gotoFeature('b')
+    await click(byId('featureVariationKeyEdit0'))
+    await setText(byId('featureVariationKeyInput0'), 'primary')
+    await click(byId('featureVariationKeySave0'))
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary')
+    await click(byId('add-variation'))
+    await page.waitForTimeout(200)
+    await setText(byId('featureVariationValue2'), 'huge')
+    await page.waitForTimeout(500)
+    await click(byId('update-feature-btn'))
+    await waitForToast()
+    await closeModal()
+    await waitForElementNotExist('#create-feature-modal')
+
+    log('Label and new variant survived the versioned save')
+    await gotoFeatures()
+    await gotoFeature('b')
+    await expect(page.locator('#create-feature-modal .variant-card')).toHaveCount(3)
+    await expect(page.locator(byId('featureVariationKey0'))).toHaveText('primary')
+    await expect(page.locator(byId('featureVariationWeightbig'))).toHaveValue('100')
+    await expect(page.locator(byId('featureVariationWeighthuge'))).toBeVisible()
+    await closeModal()
+    await waitForElementNotExist('#create-feature-modal')
 
     // ===================================================================================
     // Test: Row toggle in versioned environment

--- a/frontend/web/components/base/forms/InputGroup.js
+++ b/frontend/web/components/base/forms/InputGroup.js
@@ -29,7 +29,10 @@ const InputGroup = class extends Component {
         {this.props.tooltip ? (
           <Tooltip
             title={
-              <label htmlFor={id} className='cols-sm-2 control-label'>
+              <label
+                htmlFor={id}
+                className='cols-sm-2 control-label cursor-pointer'
+              >
                 <div>
                   {props.title}{' '}
                   {!props.hideTooltipIcon && <Icon name='info-outlined' />}{' '}

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -221,7 +221,9 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
       <span className='ml-1'>
         <Icon name='info-outlined' />
       </span>
-      <span className='chip chip--xs ml-2'>{controlPercentage}%</span>
+      <span className='chip chip--xs ml-2'>
+        {Math.max(0, controlPercentage)}%
+      </span>
     </span>
   ) : (
     'Value'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Migrates the multivariate option save flow from the legacy Flux store to a single RTK Query mutation.

- New `saveMultivariateOptions` mutation diffs submitted options against the server's current state before upserting/deleting, so stale client state can no longer create duplicate variants.
- `editFeatureMv` becomes a thin adapter preserving the existing contracts: store events, per-card error attribution, and the positional option ordering consumed by both v1 and v2 feature-state saves. All failing options now surface errors, not just the first.
- Variants are now sorted by id at store ingress and created sequentially, so their order no longer reshuffles after a save (the API returns them unordered; a backend `ordering` fix will follow separately).

Out of scope (follow-up): retiring the store's event system and converting the modal to mutation hooks.

## How did you test this code?

- Unit tests and E2E tests (including new mv-option E2E coverage for repeated saves, add/remove in one save, and v2 versioning).
