### PR TITLE
test: Migrate to pytest-lazy-fixtures

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
     "responses>=0.22.0,<0.23.0",
     "pre-commit>=4.0.1,<5.0.0",
     "pytest-mock>=3.10.0,<3.11.0",
-    "pytest-lazy-fixture>=0.6.3,<0.7.0",
+    "pytest-lazy-fixtures>=1.4.0,<2.0.0",
     "moto>=4.1.3,<4.2.0",
     # TODO: move to https://github.com/adamchainz/time-machine
     "pytest-freezegun>=0.4.2,<0.5.0",
@@ -344,7 +344,6 @@ override-dependencies = [
     "pytest-cov==4.1.0",
     "pytest-django==4.8.0",
     "pytest-freezegun==0.4.2",
-    "pytest-lazy-fixture==0.6.3",
     "pytest-mock==3.10.0",
     "pytest-responses==0.5.1",
     "pytest-structlog==1.1",

--- a/api/tests/integration/core/test_commands.py
+++ b/api/tests/integration/core/test_commands.py
@@ -3,7 +3,7 @@ from django.core.management import call_command
 from django.db.models import Model
 from djoser.utils import decode_uid  # type: ignore[import-untyped]
 from pytest_django.fixtures import SettingsWrapper
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from organisations.models import (
     Organisation,
@@ -131,9 +131,9 @@ def test_bootstrap__cli_overrides_provided__creates_expected_entities(
 @pytest.mark.parametrize(
     "existing_data",
     [
-        lazy_fixture("admin_user"),
-        lazy_fixture("organisation"),
-        lazy_fixture("project"),
+        lf("admin_user"),
+        lf("organisation"),
+        lf("project"),
     ],
 )
 def test_bootstrap__used_instance__skip_expected(

--- a/api/tests/integration/core/test_user_rate_throttle.py
+++ b/api/tests/integration/core/test_user_rate_throttle.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_user_throttle__admin_endpoint_exceeds_rate_limit__returns_too_many_requests(
     client: APIClient, project: int, mocker: MockerFixture, reset_cache: None

--- a/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
@@ -8,7 +8,7 @@ import pytest
 from django.urls import reverse
 from mypy_boto3_dynamodb.service_resource import Table
 from mypy_boto3_dynamodb.type_defs import TableAttributeValueTypeDef
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.exceptions import NotFound
@@ -727,9 +727,7 @@ def test_edge_identities_create_featurestate__invalid_mv_allocation__returns_400
     assert "multivariate_feature_state_values" in response.json()
 
 
-@pytest.mark.parametrize(
-    "lazy_feature", [(lazy_fixture("feature")), (lazy_fixture("feature_name"))]
-)
+@pytest.mark.parametrize("lazy_feature", [(lf("feature")), (lf("feature_name"))])
 def test_edge_identities_with_identifier_create_featurestate__valid_data__creates_override(  # type: ignore[no-untyped-def]
     dynamodb_wrapper_v2,
     admin_client,
@@ -793,9 +791,7 @@ def test_edge_identities_with_identifier_create_featurestate__valid_data__create
     assert actual_feature_state["featurestate_uuid"] is not None
 
 
-@pytest.mark.parametrize(
-    "lazy_feature", [(lazy_fixture("feature")), (lazy_fixture("feature_name"))]
-)
+@pytest.mark.parametrize("lazy_feature", [(lf("feature")), (lf("feature_name"))])
 def test_edge_identities_with_identifier_delete_featurestate__valid_feature__removes_override(  # type: ignore[no-untyped-def]
     dynamodb_wrapper_v2,
     admin_client,

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -377,22 +377,22 @@ def transient_identifier(
     "identifier_data,expected_identifier",
     [
         pytest.param(
-            lazy_fixture("existing_identity_identifier_data"),
-            lazy_fixture("identity_identifier"),
+            lf("existing_identity_identifier_data"),
+            lf("identity_identifier"),
             id="existing-identifier",
         ),
         pytest.param({"identifier": "unseen"}, "unseen", id="new-identifier"),
         pytest.param(
             {"identifier": ""},
-            lazy_fixture("transient_identifier"),
+            lf("transient_identifier"),
             id="blank-identifier",
         ),
         pytest.param(
             {"identifier": None},
-            lazy_fixture("transient_identifier"),
+            lf("transient_identifier"),
             id="null-identifier",
         ),
-        pytest.param({}, lazy_fixture("transient_identifier"), id="missing-identifier"),
+        pytest.param({}, lf("transient_identifier"), id="missing-identifier"),
     ],
 )
 def test_get_feature_states_for_identity__segment_matching_traits__returns_segment_override(

--- a/api/tests/integration/environments/test_integration_environments.py
+++ b/api/tests/integration/environments/test_integration_environments.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from django.urls import reverse
 from pytest_django.fixtures import DjangoAssertNumQueries
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -16,7 +16,7 @@ from tests.integration.helpers import (
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_clone_environment__feature_states_with_value__clones_values(  # type: ignore[no-untyped-def]
     client: APIClient,

--- a/api/tests/integration/features/featurestate/test_environment_featurestate_viewset.py
+++ b/api/tests/integration/features/featurestate/test_environment_featurestate_viewset.py
@@ -2,13 +2,13 @@ import json
 
 import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_update_feature_state_value__new_value_provided__updates_value(  # type: ignore[no-untyped-def]
     client, environment, environment_api_key, feature, feature_state

--- a/api/tests/integration/features/featurestate/test_simple_featurestate_viewset.py
+++ b/api/tests/integration/features/featurestate/test_simple_featurestate_viewset.py
@@ -2,13 +2,13 @@ import json
 
 import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_create_feature_state__identity_override__returns_201(  # type: ignore[no-untyped-def]
     client, environment, identity, feature
@@ -34,7 +34,7 @@ def test_create_feature_state__identity_override__returns_201(  # type: ignore[n
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_create_feature_state__identity_with_identifier__returns_201(  # type: ignore[no-untyped-def]
     client, environment, identity, feature, identity_identifier
@@ -60,7 +60,7 @@ def test_create_feature_state__identity_with_identifier__returns_201(  # type: i
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_list_feature_states__filter_by_environment__returns_environment_states(  # type: ignore[no-untyped-def]
     client, environment, feature
@@ -82,7 +82,7 @@ def test_list_feature_states__filter_by_environment__returns_environment_states(
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_update_feature_state__new_value__returns_updated_value(  # type: ignore[no-untyped-def]
     client, environment, feature_state, feature, identity
@@ -109,7 +109,7 @@ def test_update_feature_state__new_value__returns_updated_value(  # type: ignore
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_update_feature_state__identity_with_identifier__returns_updated_value(  # type: ignore[no-untyped-def]
     client, environment, identity_featurestate, feature, identity, identity_identifier

--- a/api/tests/integration/features/featurestate/test_webhooks.py
+++ b/api/tests/integration/features/featurestate/test_webhooks.py
@@ -6,7 +6,7 @@ import pytest
 import responses
 from django.urls import reverse
 from freezegun import freeze_time
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -147,7 +147,7 @@ def test_update_segment_override__via_api__webhook_payload_has_correct_previous_
 
 @pytest.mark.parametrize(
     "webhook",
-    [lazy_fixture("environment_webhook"), lazy_fixture("organisation_webhook")],
+    [lf("environment_webhook"), lf("organisation_webhook")],
 )
 @responses.activate
 def test_update_multivariate_percentage__percentage_changed__webhook_payload_includes_multivariate_values(
@@ -243,7 +243,7 @@ def test_update_multivariate_percentage__percentage_changed__webhook_payload_inc
 
 @pytest.mark.parametrize(
     "webhook",
-    [lazy_fixture("environment_webhook"), lazy_fixture("organisation_webhook")],
+    [lf("environment_webhook"), lf("organisation_webhook")],
 )
 @responses.activate
 def test_update_feature_live__legacy_versioning__webhook_payload_has_correct_previous_and_new_states(
@@ -283,7 +283,7 @@ def test_update_feature_live__legacy_versioning__webhook_payload_has_correct_pre
 
 @pytest.mark.parametrize(
     "webhook",
-    [lazy_fixture("environment_webhook"), lazy_fixture("organisation_webhook")],
+    [lf("environment_webhook"), lf("organisation_webhook")],
 )
 @responses.activate
 def test_update_feature_scheduled__legacy_versioning__webhook_payload_has_correct_previous_and_new_states(

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -15,7 +15,7 @@ from users.models import FFAdminUser
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_mv_option__valid_data__returns_created(  # type: ignore[no-untyped-def]
     client, project, mv_option_50_percent, feature
@@ -305,8 +305,8 @@ def test_update_mv_option__duplicate_sibling_key__returns_bad_request(
 @pytest.mark.parametrize(
     "client, feature_id",
     [
-        (lazy_fixture("admin_client"), "undefined"),
-        (lazy_fixture("admin_client"), "89809"),
+        (lf("admin_client"), "undefined"),
+        (lf("admin_client"), "89809"),
     ],
 )
 def test_create_mv_option__invalid_feature_id__returns_not_found(  # type: ignore[no-untyped-def]
@@ -368,7 +368,7 @@ def test_create_mv_option__user_not_project_member__returns_forbidden(project): 
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_list_mv_options__option_exists__returns_option(  # type: ignore[no-untyped-def]
     project, mv_option_50_percent, client, feature
@@ -391,7 +391,7 @@ def test_list_mv_options__option_exists__returns_option(  # type: ignore[no-unty
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_mv_option__total_allocation_exceeds_100__returns_bad_request(  # type: ignore[no-untyped-def]
     project, mv_option_50_percent, client, feature
@@ -422,7 +422,7 @@ def test_create_mv_option__total_allocation_exceeds_100__returns_bad_request(  #
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_mv_option__valid_allocation__returns_updated_option(  # type: ignore[no-untyped-def]
     project, mv_option_50_percent, client, feature
@@ -453,7 +453,7 @@ def test_update_mv_option__valid_allocation__returns_updated_option(  # type: ig
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_mv_option__total_allocation_exceeds_100__returns_bad_request(  # type: ignore[no-untyped-def]
     project, mv_option_50_percent, client, feature
@@ -504,7 +504,7 @@ def test_update_mv_option__total_allocation_exceeds_100__returns_bad_request(  #
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_delete_mv_option__option_exists__returns_no_content(  # type: ignore[no-untyped-def]
     project, mv_option_50_percent, client, feature
@@ -538,7 +538,7 @@ def test_delete_mv_option__option_exists__returns_no_content(  # type: ignore[no
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_feature_state__two_mv_options_at_50_percent__returns_ok(  # type: ignore[no-untyped-def]
     project, environment, environment_api_key, client, feature
@@ -635,7 +635,7 @@ def test_update_feature_state__two_mv_options_at_50_percent__returns_ok(  # type
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_feature_state__swap_variation_weights__returns_ok(  # type: ignore[no-untyped-def]
     project, environment, environment_api_key, client, feature

--- a/api/tests/unit/api/test_unit_api.py
+++ b/api/tests/unit/api/test_unit_api.py
@@ -1,6 +1,6 @@
 import pytest
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -15,7 +15,7 @@ from rest_framework.test import APIClient
 )
 @pytest.mark.parametrize(
     "client",
-    (lazy_fixture("api_client"), lazy_fixture("admin_client")),
+    (lf("api_client"), lf("admin_client")),
 )
 def test_swagger_docs_generation__valid_url__returns_ok(
     url: str, client: APIClient

--- a/api/tests/unit/api_keys/test_user.py
+++ b/api/tests/unit/api_keys/test_user.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from api_keys.models import MasterAPIKey
 from api_keys.user import APIKeyUser
@@ -31,8 +31,8 @@ def test_api_key_user__str__returns_name(master_api_key_object):  # type: ignore
 @pytest.mark.parametrize(
     "for_organisation, expected_result",
     [
-        (lazy_fixture("organisation"), True),
-        (lazy_fixture("organisation_two"), False),
+        (lf("organisation"), True),
+        (lf("organisation_two"), False),
     ],
 )
 def test_api_key_user__belongs_to__returns_expected_result(  # type: ignore[no-untyped-def]
@@ -48,16 +48,16 @@ def test_api_key_user__belongs_to__returns_expected_result(  # type: ignore[no-u
 @pytest.mark.parametrize(
     "for_project, for_master_api_key, expected_is_admin",
     [
-        (lazy_fixture("project"), lazy_fixture("admin_master_api_key_object"), True),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), False),
+        (lf("project"), lf("admin_master_api_key_object"), True),
+        (lf("project"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             False,
         ),
     ],
@@ -80,19 +80,19 @@ def test_api_key_user__is_project_admin__returns_expected_result(  # type: ignor
     "for_environment, for_master_api_key, expected_is_admin",
     [
         (
-            lazy_fixture("environment"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("environment"),
+            lf("admin_master_api_key_object"),
             True,
         ),
-        (lazy_fixture("environment"), lazy_fixture("master_api_key_object"), False),
+        (lf("environment"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two_project_one_environment_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one_environment_one"),
+            lf("admin_master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two_project_one_environment_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one_environment_one"),
+            lf("master_api_key_object"),
             False,
         ),
     ],
@@ -113,16 +113,16 @@ def test_api_key_user__is_environment_admin__returns_expected_result(  # type: i
 @pytest.mark.parametrize(
     "for_project, for_master_api_key, expected_has_permission",
     [
-        (lazy_fixture("project"), lazy_fixture("admin_master_api_key_object"), True),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), False),
+        (lf("project"), lf("admin_master_api_key_object"), True),
+        (lf("project"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             False,
         ),
     ],
@@ -148,19 +148,19 @@ def test_api_key_user__has_project_permission__returns_expected_result(  # type:
     "for_environment, for_master_api_key, expected_has_permission",
     [
         (
-            lazy_fixture("environment"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("environment"),
+            lf("admin_master_api_key_object"),
             True,
         ),
-        (lazy_fixture("environment"), lazy_fixture("master_api_key_object"), False),
+        (lf("environment"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two_project_one_environment_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one_environment_one"),
+            lf("admin_master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two_project_one_environment_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one_environment_one"),
+            lf("master_api_key_object"),
             False,
         ),
     ],
@@ -186,19 +186,19 @@ def test_api_key_user__has_environment_permission__returns_expected_result(  # t
     "for_organisation, for_master_api_key, expected_has_permission",
     [
         (
-            lazy_fixture("organisation"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation"),
+            lf("admin_master_api_key_object"),
             True,
         ),
-        (lazy_fixture("organisation"), lazy_fixture("master_api_key_object"), False),
+        (lf("organisation"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two"),
+            lf("master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two"),
+            lf("admin_master_api_key_object"),
             False,
         ),
     ],
@@ -223,19 +223,19 @@ def test_api_key_user__has_organisation_permission__returns_expected_result(  # 
     "for_project, for_master_api_key, expected_project",
     [
         (
-            lazy_fixture("project"),
-            lazy_fixture("admin_master_api_key_object"),
-            lazy_fixture("project"),
+            lf("project"),
+            lf("admin_master_api_key_object"),
+            lf("project"),
         ),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), None),
+        (lf("project"), lf("master_api_key_object"), None),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             None,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             None,
         ),
     ],
@@ -264,19 +264,19 @@ def test_api_key_user__get_permitted_projects__returns_expected_projects(  # typ
     "for_project, for_master_api_key, expected_environment",
     [
         (
-            lazy_fixture("project"),
-            lazy_fixture("admin_master_api_key_object"),
-            lazy_fixture("environment"),
+            lf("project"),
+            lf("admin_master_api_key_object"),
+            lf("environment"),
         ),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), None),
+        (lf("project"), lf("master_api_key_object"), None),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             None,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             None,
         ),
     ],

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -1,7 +1,7 @@
 import pytest
 from django.test import RequestFactory
 from django.utils import timezone
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 
 from api_keys.user import APIKeyUser
@@ -61,8 +61,8 @@ def test_edge_identity_feature_state_serializer__missing_mvfsvs__saves_successfu
 @pytest.mark.parametrize(
     "user",
     [
-        lazy_fixture("api_key_user"),
-        lazy_fixture("admin_user"),
+        lf("api_key_user"),
+        lf("admin_user"),
     ],
 )
 def test_edge_identity_feature_state_serializer__new_override__calls_webhook(  # type: ignore[no-untyped-def]

--- a/api/tests/unit/edge_api/identities/test_edge_identity_models.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_models.py
@@ -6,7 +6,7 @@ import shortuuid
 from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django import DjangoAssertNumQueries
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 
 from api_keys.user import APIKeyUser
@@ -278,8 +278,8 @@ def test_save__no_changes__does_not_generate_audit_records(  # type: ignore[no-u
 @pytest.mark.parametrize(
     "user, user_id, api_key_id",
     [
-        (lazy_fixture("api_key_user"), None, lazy_fixture("master_api_key_id")),
-        (lazy_fixture("admin_user"), lazy_fixture("admin_user_id"), None),
+        (lf("api_key_user"), None, lf("master_api_key_id")),
+        (lf("admin_user"), lf("admin_user_id"), None),
     ],
 )
 def test_edge_identity_save_called__feature_override_added__expected_tasks_called(
@@ -347,8 +347,8 @@ def test_edge_identity_save_called__feature_override_added__expected_tasks_calle
 @pytest.mark.parametrize(
     "user, user_id, api_key_id",
     [
-        (lazy_fixture("api_key_user"), None, lazy_fixture("master_api_key_id")),
-        (lazy_fixture("admin_user"), lazy_fixture("admin_user_id"), None),
+        (lf("api_key_user"), None, lf("master_api_key_id")),
+        (lf("admin_user"), lf("admin_user_id"), None),
     ],
 )
 def test_edge_identity_save_called__feature_override_removed__expected_tasks_called(

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -10,7 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from flag_engine.segments.constants import EQUAL
 from pytest_django import DjangoAssertNumQueries
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -198,11 +198,11 @@ def test_create_environment__valid_data__creates_audit_log_entry(
     "client, master_api_key, author",
     [
         (
-            lazy_fixture("admin_master_api_key_client"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("admin_master_api_key_client"),
+            lf("admin_master_api_key_object"),
             None,
         ),
-        (lazy_fixture("admin_client_original"), None, lazy_fixture("admin_user")),
+        (lf("admin_client_original"), None, lf("admin_user")),
     ],
 )
 def test_update_feature_state__valid_data__creates_audit_log_entry(
@@ -614,8 +614,8 @@ def test_delete_api_key__existing_key__deletes_key(
 @pytest.mark.parametrize(
     "client, is_admin_master_api_key_client",
     [
-        (lazy_fixture("admin_master_api_key_client"), True),
-        (lazy_fixture("admin_client_original"), False),
+        (lf("admin_master_api_key_client"), True),
+        (lf("admin_client_original"), False),
     ],
 )
 def test_create_environment__valid_data__returns_201_with_defaults(  # type: ignore[no-untyped-def]

--- a/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
+++ b/api/tests/unit/environments/test_unit_environments_views_sdk_environment.py
@@ -6,7 +6,7 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import http_date
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -138,8 +138,8 @@ def test_get_environment_document__valid_api_key__returns_full_document(
 @pytest.mark.parametrize(
     "environment_",
     (
-        lazy_fixture("environment"),
-        lazy_fixture("environment_v2_versioning"),
+        lf("environment"),
+        lf("environment_v2_versioning"),
     ),
 )
 def test_get_environment_document__identity_overrides__returns_override_data(

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -10,7 +10,7 @@ from common.projects.permissions import VIEW_PROJECT
 from django.conf import settings
 from django.urls import reverse
 from pytest_django import DjangoAssertNumQueries
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -37,11 +37,11 @@ from users.models import FFAdminUser
     "client, num_queries",
     [
         (
-            lazy_fixture("admin_client"),
+            lf("admin_client"),
             6,
         ),  # 1 for paging, 3 for permissions, 1 for result, 1 for getting the current live version
         (
-            lazy_fixture("admin_master_api_key_client"),
+            lf("admin_master_api_key_client"),
             4,
         ),  # one for each for master_api_key
     ],
@@ -84,11 +84,11 @@ def test_list_feature_segments__without_rbac__returns_expected_results(
     "client, num_queries",
     [
         (
-            lazy_fixture("admin_client"),
+            lf("admin_client"),
             7,
         ),  # 1 for paging, 4 for permissions, 1 for result, 1 for getting the current live version
         (
-            lazy_fixture("admin_master_api_key_client"),
+            lf("admin_master_api_key_client"),
             4,
         ),  # one for each for master_api_key
     ],
@@ -145,7 +145,7 @@ def _list_feature_segment_setup_data(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")],
+    [lf("admin_client"), lf("admin_master_api_key_client")],
 )
 def test_list_feature_segments__feature_specific_segment__returns_is_feature_specific(  # type: ignore[no-untyped-def]
     segment,
@@ -177,7 +177,7 @@ def test_list_feature_segments__feature_specific_segment__returns_is_feature_spe
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_feature_segment__valid_data__returns_201(  # type: ignore[no-untyped-def]
     segment, feature, environment, client
@@ -277,7 +277,7 @@ def test_create_feature_segment__staff_wrong_permission__returns_403(  # type: i
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_delete_feature_segment__existing_segment__returns_204(  # type: ignore[no-untyped-def]
     segment, feature, environment, client
@@ -298,7 +298,7 @@ def test_delete_feature_segment__existing_segment__returns_204(  # type: ignore[
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_priority__multiple_feature_segments__reorders_successfully(  # type: ignore[no-untyped-def]
     feature_segment,
@@ -388,7 +388,7 @@ def test_update_priority__no_permission__returns_403(  # type: ignore[no-untyped
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_priorities__empty_list__returns_empty_response(client):  # type: ignore[no-untyped-def]
     # Given
@@ -404,7 +404,7 @@ def test_update_priorities__empty_list__returns_empty_response(client):  # type:
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_get_feature_segment__by_uuid__returns_correct_segment(  # type: ignore[no-untyped-def]
     feature_segment, project, client, environment, feature
@@ -472,7 +472,7 @@ def test_get_feature_segment__by_uuid_without_access__returns_404(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_get_feature_segment__by_id__returns_correct_segment(  # type: ignore[no-untyped-def]
     feature_segment, project, client, environment, feature
@@ -520,7 +520,7 @@ def test_get_feature_segment__by_id_for_staff__returns_correct_segment(  # type:
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment_override__wrong_feature_for_feature_based_segment__returns_400(  # type: ignore[no-untyped-def]
     client, feature_based_segment, project, environment
@@ -548,7 +548,7 @@ def test_create_segment_override__wrong_feature_for_feature_based_segment__retur
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment_override__correct_feature_for_feature_based_segment__returns_201(  # type: ignore[no-untyped-def]
     client, feature_based_segment, project, environment, feature
@@ -569,7 +569,7 @@ def test_create_segment_override__correct_feature_for_feature_based_segment__ret
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment_override__max_limit_reached__returns_400(  # type: ignore[no-untyped-def]
     client, segment, environment, project, feature, feature_based_segment, settings

--- a/api/tests/unit/features/feature_states/test_unit_feature_states_views.py
+++ b/api/tests/unit/features/feature_states/test_unit_feature_states_views.py
@@ -4,7 +4,7 @@ import typing
 import pytest
 from common.environments.permissions import UPDATE_FEATURE_STATE
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -29,7 +29,7 @@ from tests.types import WithEnvironmentPermissionsCallable
 )
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__by_feature_name__updates_feature_state(
     staff_client: APIClient,
@@ -71,7 +71,7 @@ def test_update_flag_v1__by_feature_name__updates_feature_state(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__by_feature_id__updates_feature_state(
     staff_client: APIClient,
@@ -110,7 +110,7 @@ def test_update_flag_v1__by_feature_id__updates_feature_state(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__both_name_and_id_provided__returns_400(
     staff_client: APIClient,
@@ -145,7 +145,7 @@ def test_update_flag_v1__both_name_and_id_provided__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__both_name_and_id_for_different_features__returns_400(
     staff_client: APIClient,
@@ -187,7 +187,7 @@ def test_update_flag_v1__both_name_and_id_for_different_features__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__neither_name_nor_id_provided__returns_400(
     staff_client: APIClient,
@@ -222,7 +222,7 @@ def test_update_flag_v1__neither_name_nor_id_provided__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__feature_not_found_by_name__returns_400(
     staff_client: APIClient,
@@ -254,7 +254,7 @@ def test_update_flag_v1__feature_not_found_by_name__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__feature_not_found_by_id__returns_400(
     staff_client: APIClient,
@@ -286,7 +286,7 @@ def test_update_flag_v1__feature_not_found_by_id__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__segment_override_by_name__creates_override(
     staff_client: APIClient,
@@ -337,7 +337,7 @@ def test_update_flag_v1__segment_override_by_name__creates_override(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__segment_override_no_existing_feature_segment__creates_feature_segment(
     staff_client: APIClient,
@@ -457,7 +457,7 @@ def test_update_flag_v1__new_segment_override_at_priority_zero__reorders_existin
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v2__new_segment_overrides__creates_overrides(
     staff_client: APIClient,
@@ -545,7 +545,7 @@ def test_update_flag_v2__new_segment_overrides__creates_overrides(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v2__environment_default_only__updates_default_state(
     staff_client: APIClient,
@@ -638,7 +638,7 @@ def test_update_flag_v2__duplicate_segment_ids__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v1__existing_segment_override_with_new_priority__updates_priority(
     staff_client: APIClient,
@@ -700,7 +700,7 @@ def test_update_flag_v1__existing_segment_override_with_new_priority__updates_pr
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_update_flag_v2__existing_segment_override_with_new_priority__updates_priority(
     staff_client: APIClient,
@@ -1054,7 +1054,7 @@ def test_update_flag_v1__nonexistent_environment__returns_403(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__existing_override__removes_override(
     staff_client: APIClient,
@@ -1119,7 +1119,7 @@ def test_delete_segment_override__existing_override__removes_override(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__by_feature_id__returns_204(
     staff_client: APIClient,
@@ -1174,7 +1174,7 @@ def test_delete_segment_override__by_feature_id__returns_204(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__feature_not_found__returns_400(
     staff_client: APIClient,
@@ -1209,7 +1209,7 @@ def test_delete_segment_override__feature_not_found__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__segment_not_in_project__returns_400(
     staff_client: APIClient,
@@ -1243,7 +1243,7 @@ def test_delete_segment_override__segment_not_in_project__returns_400(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__no_existing_override__returns_404(
     staff_client: APIClient,
@@ -1280,7 +1280,7 @@ def test_delete_segment_override__no_existing_override__returns_404(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__no_permission__returns_403(
     staff_client: APIClient,
@@ -1312,7 +1312,7 @@ def test_delete_segment_override__no_permission__returns_403(
 
 @pytest.mark.parametrize(
     "environment_",
-    (lazy_fixture("environment"), lazy_fixture("environment_v2_versioning")),
+    (lf("environment"), lf("environment_v2_versioning")),
 )
 def test_delete_segment_override__workflow_enabled__returns_403(
     staff_client: APIClient,

--- a/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
+++ b/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
@@ -6,7 +6,7 @@ from common.projects.permissions import (
     VIEW_PROJECT,
 )
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 
 from features.multivariate.views import MultivariateFeatureOptionViewSet
@@ -35,7 +35,7 @@ def test_multivariate_feature_options_view_set__get_permissions__returns_expecte
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_get_mv_feature_option_by_uuid__valid_uuid__returns_option(  # type: ignore[no-untyped-def]
     client, project, multivariate_feature
@@ -57,7 +57,7 @@ def test_get_mv_feature_option_by_uuid__valid_uuid__returns_option(  # type: ign
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_get_mv_feature_option_by_uuid__nonexistent_uuid__returns_404(  # type: ignore[no-untyped-def]
     client, project

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -6,7 +6,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.utils import timezone
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 
 from environments.identities.models import Identity
@@ -489,7 +489,7 @@ def test_feature_state_gt__environment_default__returns_expected(
     "feature_identity, expected_result",
     [
         (
-            lazy_fixture("identity"),
+            lf("identity"),
             "Identity test_identity - Project Test Project - Environment Test Environment - Feature Test Feature1 - Enabled: False",
         ),
         (

--- a/api/tests/unit/features/test_unit_features_tasks.py
+++ b/api/tests/unit/features/test_unit_features_tasks.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 
 from api_keys.models import MasterAPIKey
@@ -15,11 +15,11 @@ from webhooks.webhooks import WebhookEventType
 @pytest.mark.parametrize(
     "user, api_key, changed_by",
     [
-        (lazy_fixture("admin_user"), None, lazy_fixture("admin_user_email")),
+        (lf("admin_user"), None, lf("admin_user_email")),
         (
             None,
-            lazy_fixture("master_api_key_object"),
-            lazy_fixture("master_api_key_name"),
+            lf("master_api_key_object"),
+            lf("master_api_key_name"),
         ),
     ],
 )

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django import DjangoAssertNumQueries
 from pytest_django.fixtures import SettingsWrapper
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -3248,7 +3248,7 @@ def test_update_feature_state__change_feature__returns_400(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_feature__missing_required_metadata__returns_400(
     project: Project,
@@ -3272,7 +3272,7 @@ def test_create_feature__missing_required_metadata__returns_400(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_feature__with_optional_metadata__returns_201(
     project: Project,
@@ -3308,7 +3308,7 @@ def test_create_feature__with_optional_metadata__returns_201(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_feature__with_required_metadata__returns_201(
     project: Project,
@@ -3344,7 +3344,7 @@ def test_create_feature__with_required_metadata__returns_201(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_feature__required_metadata_org_content_type__returns_201(
     project: Project,

--- a/api/tests/unit/integrations/dynatrace/test_unit_dynatrace.py
+++ b/api/tests/unit/integrations/dynatrace/test_unit_dynatrace.py
@@ -2,7 +2,7 @@ from typing import Type
 
 import pytest
 from django.contrib.auth.models import AbstractUser
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 
 from audit.models import AuditLog
@@ -35,17 +35,17 @@ def test_dynatrace_wrapper__valid_config__initializes_correctly():  # type: igno
     (
         (
             RelatedObjectType.FEATURE.name,
-            lazy_fixture("feature"),
+            lf("feature"),
             "Flagsmith Deployment - Flag Changed: Test Feature1",
         ),
         (
             RelatedObjectType.FEATURE_STATE.name,
-            lazy_fixture("feature_state"),
+            lf("feature_state"),
             "Flagsmith Deployment - Flag Changed: Test Feature1",
         ),
         (
             RelatedObjectType.SEGMENT.name,
-            lazy_fixture("segment"),
+            lf("segment"),
             "Flagsmith Deployment - Segment Changed: segment",
         ),
     ),

--- a/api/tests/unit/integrations/github/test_unit_github_views.py
+++ b/api/tests/unit/integrations/github/test_unit_github_views.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 import responses
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.response import Response
@@ -662,15 +662,15 @@ def test_fetch_repositories__valid_installation__returns_repositories(
     "client, reverse_url",
     [
         (
-            lazy_fixture("admin_master_api_key_client"),
+            lf("admin_master_api_key_client"),
             "api-v1:organisations:get-github-issues",
         ),
         (
-            lazy_fixture("admin_master_api_key_client"),
+            lf("admin_master_api_key_client"),
             "api-v1:organisations:get-github-pulls",
         ),
-        (lazy_fixture("admin_client"), "api-v1:organisations:get-github-issues"),
-        (lazy_fixture("admin_client"), "api-v1:organisations:get-github-pulls"),
+        (lf("admin_client"), "api-v1:organisations:get-github-issues"),
+        (lf("admin_client"), "api-v1:organisations:get-github-pulls"),
     ],
 )
 def test_fetch_issues_and_pulls__integration_not_configured__returns_400(

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import AbstractUser
 from django.urls import reverse
 from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock.plugin import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -340,8 +340,8 @@ def test_update_invite__put_request__returns_405(  # type: ignore[no-untyped-def
 @pytest.mark.parametrize(
     "invite_object, url",
     [
-        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
-        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
+        (lf("invite"), "api-v1:users:user-join-organisation"),
+        (lf("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
 def test_join_organisation__exceeds_plan_limit_saas__returns_400(
@@ -368,8 +368,8 @@ def test_join_organisation__exceeds_plan_limit_saas__returns_400(
 @pytest.mark.parametrize(
     "invite_object, url",
     [
-        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
-        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
+        (lf("invite"), "api-v1:users:user-join-organisation"),
+        (lf("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
 def test_join_organisation__exceeds_plan_limit_self_hosted__returns_400(
@@ -400,8 +400,8 @@ def test_join_organisation__exceeds_plan_limit_self_hosted__returns_400(
 @pytest.mark.parametrize(
     "invite_object, url",
     [
-        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
-        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
+        (lf("invite"), "api-v1:users:user-join-organisation"),
+        (lf("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
 def test_join_organisation__payment_fails__returns_400(

--- a/api/tests/unit/organisations/subscriptions/test_unit_subscriptions_permissions.py
+++ b/api/tests/unit/organisations/subscriptions/test_unit_subscriptions_permissions.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework.request import Request
 
 from organisations.models import Organisation, Subscription
@@ -13,10 +13,10 @@ from organisations.subscriptions.permissions import require_minimum_plan
 @pytest.mark.parametrize(
     "subscription_fixture, expected",
     [
-        (lazy_fixture("free_subscription"), False),
-        (lazy_fixture("startup_subscription"), False),
-        (lazy_fixture("scale_up_subscription"), True),
-        (lazy_fixture("enterprise_subscription"), True),
+        (lf("free_subscription"), False),
+        (lf("startup_subscription"), False),
+        (lf("scale_up_subscription"), True),
+        (lf("enterprise_subscription"), True),
     ],
 )
 def test_require_minimum_plan__has_permission__plan_matrix(
@@ -38,10 +38,10 @@ def test_require_minimum_plan__has_permission__plan_matrix(
 @pytest.mark.parametrize(
     "subscription_fixture, expected",
     [
-        (lazy_fixture("free_subscription"), False),
-        (lazy_fixture("startup_subscription"), False),
-        (lazy_fixture("scale_up_subscription"), True),
-        (lazy_fixture("enterprise_subscription"), True),
+        (lf("free_subscription"), False),
+        (lf("startup_subscription"), False),
+        (lf("scale_up_subscription"), True),
+        (lf("enterprise_subscription"), True),
     ],
 )
 def test_require_minimum_plan__has_object_permission__plan_matrix(
@@ -125,18 +125,18 @@ def test_require_minimum_plan_has_object_permission__obj_without_organisation__r
 @pytest.mark.parametrize(
     "minimum, subscription_fixture, allowed",
     [
-        (SubscriptionPlanFamily.START_UP, lazy_fixture("free_subscription"), False),
-        (SubscriptionPlanFamily.START_UP, lazy_fixture("startup_subscription"), True),
-        (SubscriptionPlanFamily.SCALE_UP, lazy_fixture("startup_subscription"), False),
-        (SubscriptionPlanFamily.SCALE_UP, lazy_fixture("scale_up_subscription"), True),
+        (SubscriptionPlanFamily.START_UP, lf("free_subscription"), False),
+        (SubscriptionPlanFamily.START_UP, lf("startup_subscription"), True),
+        (SubscriptionPlanFamily.SCALE_UP, lf("startup_subscription"), False),
+        (SubscriptionPlanFamily.SCALE_UP, lf("scale_up_subscription"), True),
         (
             SubscriptionPlanFamily.ENTERPRISE,
-            lazy_fixture("scale_up_subscription"),
+            lf("scale_up_subscription"),
             False,
         ),
         (
             SubscriptionPlanFamily.ENTERPRISE,
-            lazy_fixture("enterprise_subscription"),
+            lf("enterprise_subscription"),
             True,
         ),
     ],

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django.fixtures import SettingsWrapper
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from pytz import UTC
 from rest_framework import status
@@ -225,7 +225,7 @@ def test_create_organisation__saml_user__returns_403(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_organisation__valid_data__returns_200(
     client: APIClient,
@@ -505,7 +505,7 @@ def test_invite_user__as_user_role__creates_user_invite(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("staff_client")],
+    [lf("admin_master_api_key_client"), lf("staff_client")],
 )
 def test_list_projects__valid_organisation__returns_projects(
     organisation: Organisation,
@@ -608,7 +608,7 @@ def test_update_subscription__valid_hosted_page__updates_from_chargebee(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_delete_organisation__with_related_objects__soft_deletes(
     organisation: Organisation,

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
@@ -6,7 +6,7 @@ from common.environments.permissions import (
     UPDATE_FEATURE_STATE,
     VIEW_ENVIRONMENT,
 )
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from environments.models import Environment
 from environments.permissions.models import (
@@ -42,8 +42,8 @@ def test_get_permitted_environments_for_user__org_admin__returns_all_environment
 @pytest.mark.parametrize(
     "project_admin",
     [
-        (lazy_fixture("project_admin_via_user_permission")),
-        (lazy_fixture("project_admin_via_user_permission_group")),
+        (lf("project_admin_via_user_permission")),
+        (lf("project_admin_via_user_permission_group")),
     ],
 )
 def test_get_permitted_environments_for_user__project_admin__returns_all_environments(  # noqa: E501
@@ -69,8 +69,8 @@ def test_get_permitted_environments_for_user__project_admin__returns_all_environ
 @pytest.mark.parametrize(
     "environment_admin",
     [
-        (lazy_fixture("environment_admin_via_user_permission")),
-        (lazy_fixture("environment_admin_via_user_permission_group")),
+        (lf("environment_admin_via_user_permission")),
+        (lf("environment_admin_via_user_permission_group")),
     ],
 )
 def test_get_permitted_environments_for_user__environment_admin__returns_environment(  # noqa: E501

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_projects_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_projects_for_user.py
@@ -6,7 +6,7 @@ from common.projects.permissions import (
     DELETE_FEATURE,
     VIEW_PROJECT,
 )
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from organisations.models import Organisation, UserOrganisation
 from permissions.models import PermissionModel
@@ -34,8 +34,8 @@ def test_get_permitted_projects_for_user__org_admin__returns_all_projects(  # ty
 @pytest.mark.parametrize(
     "project_admin",
     [
-        (lazy_fixture("project_admin_via_user_permission")),
-        (lazy_fixture("project_admin_via_user_permission_group")),
+        (lf("project_admin_via_user_permission")),
+        (lf("project_admin_via_user_permission_group")),
     ],
 )
 def test_get_permitted_projects_for_user__project_admin__returns_single_project(

--- a/api/tests/unit/permissions/permission_service/test_is_user_environment_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_environment_admin.py
@@ -2,7 +2,7 @@ import typing
 
 import pytest
 from django.conf import settings
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from environments.models import Environment
 from environments.permissions.models import (
@@ -28,8 +28,8 @@ def test_is_user_environment_admin__org_admin__returns_true(admin_user, environm
 @pytest.mark.parametrize(
     "project_admin",
     [
-        (lazy_fixture("project_admin_via_user_permission")),
-        (lazy_fixture("project_admin_via_user_permission_group")),
+        (lf("project_admin_via_user_permission")),
+        (lf("project_admin_via_user_permission_group")),
     ],
 )
 def test_is_user_environment_admin__project_admin__returns_true(
@@ -47,8 +47,8 @@ def test_is_user_environment_admin__project_admin__returns_true(
 @pytest.mark.parametrize(
     "environment_admin",
     [
-        (lazy_fixture("environment_admin_via_user_permission")),
-        (lazy_fixture("environment_admin_via_user_permission_group")),
+        (lf("environment_admin_via_user_permission")),
+        (lf("environment_admin_via_user_permission_group")),
     ],
 )
 def test_is_user_environment_admin__environment_admin__returns_true(  # type: ignore[no-untyped-def]

--- a/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
@@ -1,7 +1,7 @@
 import typing
 
 import pytest
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from organisations.models import Organisation, UserOrganisation
 from permissions.permission_service import is_user_project_admin
@@ -24,8 +24,8 @@ def test_is_user_project_admin__org_admin__returns_true(admin_user, project):  #
 @pytest.mark.parametrize(
     "project_admin",
     [
-        (lazy_fixture("project_admin_via_user_permission")),
-        (lazy_fixture("project_admin_via_user_permission_group")),
+        (lf("project_admin_via_user_permission")),
+        (lf("project_admin_via_user_permission_group")),
     ],
 )
 def test_is_user_project_admin__project_admin__returns_true(

--- a/api/tests/unit/permissions/permission_service/test_master_api_key_permission_service.py
+++ b/api/tests/unit/permissions/permission_service/test_master_api_key_permission_service.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 
 from environments.permissions.models import EnvironmentPermissionModel
 from organisations.permissions.models import OrganisationPermissionModel
@@ -16,16 +16,16 @@ from projects.models import ProjectPermissionModel
 @pytest.mark.parametrize(
     "for_project, for_master_api_key, expected_is_admin",
     [
-        (lazy_fixture("project"), lazy_fixture("admin_master_api_key_object"), True),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), False),
+        (lf("project"), lf("admin_master_api_key_object"), True),
+        (lf("project"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             False,
         ),
     ],
@@ -48,19 +48,19 @@ def test_is_master_api_key_project_admin__given_key_and_project__returns_expecte
     "for_environment, for_master_api_key, expected_is_admin",
     [
         (
-            lazy_fixture("environment"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("environment"),
+            lf("admin_master_api_key_object"),
             True,
         ),
-        (lazy_fixture("environment"), lazy_fixture("master_api_key_object"), False),
+        (lf("environment"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two_project_one_environment_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one_environment_one"),
+            lf("admin_master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two_project_one_environment_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one_environment_one"),
+            lf("master_api_key_object"),
             False,
         ),
     ],
@@ -81,16 +81,16 @@ def test_is_master_api_key_environment_admin__given_key_and_environment__returns
 @pytest.mark.parametrize(
     "for_project, for_master_api_key, expected_count",
     [
-        (lazy_fixture("project"), lazy_fixture("admin_master_api_key_object"), 1),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), 0),
+        (lf("project"), lf("admin_master_api_key_object"), 1),
+        (lf("project"), lf("master_api_key_object"), 0),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             0,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             0,
         ),
     ],
@@ -116,16 +116,16 @@ def test_get_permitted_projects_for_master_api_key__given_key__returns_expected_
 @pytest.mark.parametrize(
     "for_project, for_master_api_key, expected_count",
     [
-        (lazy_fixture("project"), lazy_fixture("admin_master_api_key_object"), 2),
-        (lazy_fixture("project"), lazy_fixture("master_api_key_object"), 0),
+        (lf("project"), lf("admin_master_api_key_object"), 2),
+        (lf("project"), lf("master_api_key_object"), 0),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("master_api_key_object"),
             0,
         ),
         (
-            lazy_fixture("organisation_two_project_one"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two_project_one"),
+            lf("admin_master_api_key_object"),
             0,
         ),
     ],
@@ -157,19 +157,19 @@ def test_get_permitted_environments_for_master_api_key__given_key_and_project__r
     "for_organisation, for_master_api_key, expected_has_permission",
     [
         (
-            lazy_fixture("organisation"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation"),
+            lf("admin_master_api_key_object"),
             True,
         ),
-        (lazy_fixture("organisation"), lazy_fixture("master_api_key_object"), False),
+        (lf("organisation"), lf("master_api_key_object"), False),
         (
-            lazy_fixture("organisation_two"),
-            lazy_fixture("master_api_key_object"),
+            lf("organisation_two"),
+            lf("master_api_key_object"),
             False,
         ),
         (
-            lazy_fixture("organisation_two"),
-            lazy_fixture("admin_master_api_key_object"),
+            lf("organisation_two"),
+            lf("admin_master_api_key_object"),
             False,
         ),
     ],

--- a/api/tests/unit/projects/tags/test_unit_projects_tags_views.py
+++ b/api/tests/unit/projects/tags/test_unit_projects_tags_views.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from common.projects.permissions import VIEW_PROJECT
 from django.urls import reverse
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -14,7 +14,7 @@ from tests.types import WithProjectPermissionsCallable
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_get_tag_by_uuid__valid_client__returns_tag(  # type: ignore[no-untyped-def]
     client: APIClient, project: Project, tag: Tag

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -11,7 +11,7 @@ from common.projects.permissions import (
 from django.urls import reverse
 from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -111,7 +111,7 @@ def test_create_project__admin_master_api_key_client__returns_201_and_creates_pr
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_update_project__valid_data__returns_200_and_updates_project(
     client: APIClient,
@@ -165,7 +165,7 @@ def test_update_project__different_organisation__does_not_change_organisation(
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_list_project_permissions__valid_client__returns_all_permissions(
     client: APIClient, project: Project
@@ -711,7 +711,7 @@ def test_list_projects__non_numeric_organisation__returns_400(  # type: ignore[n
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_get_project_by_uuid__existing_project__returns_project(  # type: ignore[no-untyped-def]
     client, project, mocker, settings, organisation
@@ -730,10 +730,10 @@ def test_get_project_by_uuid__existing_project__returns_project(  # type: ignore
 @pytest.mark.parametrize(
     "subscription, can_update_realtime",
     [
-        (lazy_fixture("free_subscription"), False),
-        (lazy_fixture("startup_subscription"), False),
-        (lazy_fixture("scale_up_subscription"), False),
-        (lazy_fixture("enterprise_subscription"), True),
+        (lf("free_subscription"), False),
+        (lf("startup_subscription"), False),
+        (lf("scale_up_subscription"), False),
+        (lf("enterprise_subscription"), True),
     ],
 )
 def test_enable_realtime_updates__subscription_tier__returns_expected_value(  # type: ignore[no-untyped-def]
@@ -763,7 +763,7 @@ def test_enable_realtime_updates__subscription_tier__returns_expected_value(  # 
 
 @pytest.mark.parametrize(
     "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
+    [(lf("admin_master_api_key_client")), (lf("admin_client"))],
 )
 def test_update_project__read_only_fields__does_not_update_read_only_fields(  # type: ignore[no-untyped-def]
     client, project, mocker, settings, organisation
@@ -796,7 +796,7 @@ def test_update_project__read_only_fields__does_not_update_read_only_fields(  # 
 
 @pytest.mark.parametrize(
     "client",
-    (lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")),
+    (lf("admin_client"), lf("admin_master_api_key_client")),
 )
 def test_list_projects__existing_project__returns_project_data(client, organisation):  # type: ignore[no-untyped-def]
     # Given
@@ -842,7 +842,7 @@ def test_list_projects__existing_project__returns_project_data(client, organisat
 
 @pytest.mark.parametrize(
     "client",
-    (lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")),
+    (lf("admin_client"), lf("admin_master_api_key_client")),
 )
 def test_get_project__with_features_and_segments__returns_detailed_data(
     client: APIClient, organisation: Organisation, project: Project

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -13,7 +13,7 @@ from django.urls import reverse
 from flag_engine.segments.constants import EQUAL
 from pytest_django import DjangoAssertNumQueries
 from pytest_django.fixtures import SettingsWrapper
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -41,7 +41,7 @@ User = get_user_model()
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_list_segments__filter_by_identity__returns_only_matching_segments(  # type: ignore[no-untyped-def]
     project, client, environment, identity, trait, identity_matching_segment, segment
@@ -59,7 +59,7 @@ def test_list_segments__filter_by_identity__returns_only_matching_segments(  # t
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__no_rules_provided__returns_400(project, client):  # type: ignore[no-untyped-def]
     # Given
@@ -75,7 +75,7 @@ def test_create_segment__no_rules_provided__returns_400(project, client):  # typ
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__boolean_condition__returns_201(project, client):  # type: ignore[no-untyped-def]
     # Given
@@ -103,7 +103,7 @@ def test_create_segment__boolean_condition__returns_201(project, client):  # typ
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__is_system_segment_flag__ignores_system_segment_flag(  # type: ignore[no-untyped-def]
     project: Project, client: APIClient
@@ -139,7 +139,7 @@ def test_create_segment__is_system_segment_flag__ignores_system_segment_flag(  #
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__condition_with_null_value__returns_201(project, client):  # type: ignore[no-untyped-def]
     # Given
@@ -165,7 +165,7 @@ def test_create_segment__condition_with_null_value__returns_201(project, client)
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__max_segments_limit_reached__returns_400(  # type: ignore[no-untyped-def]
     project, client, settings
@@ -286,7 +286,7 @@ def test_create_segment__old_segment_versions_exist__ignores_old_versions_in_lim
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_segment__valid_data__creates_audit_log(
     client: APIClient,
@@ -318,7 +318,7 @@ def test_update_segment__valid_data__creates_audit_log(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_patch_segment__valid_data__returns_200(project, segment, client):  # type: ignore[no-untyped-def]
     # Given
@@ -341,7 +341,7 @@ def test_patch_segment__valid_data__returns_200(project, segment, client):  # ty
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_delete_segment__existing_segment__creates_audit_log(project, segment, client):  # type: ignore[no-untyped-def]
     # Given
@@ -367,7 +367,7 @@ def test_delete_segment__existing_segment__creates_audit_log(project, segment, c
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_delete_segment__system_segment__returns_404(
     project: Project, system_segment: Segment, client: APIClient
@@ -387,7 +387,7 @@ def test_delete_segment__system_segment__returns_404(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__valid_data__creates_audit_log(project, client):  # type: ignore[no-untyped-def]
     # Given
@@ -414,7 +414,7 @@ def test_create_segment__valid_data__creates_audit_log(project, client):  # type
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_list_segments__filter_by_edge_identity__returns_only_matching_segments(  # type: ignore[no-untyped-def]
     project,
@@ -449,7 +449,7 @@ def test_list_segments__filter_by_edge_identity__returns_only_matching_segments(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_associated_features__segment_with_feature_override__returns_associated_features(  # type: ignore[no-untyped-def]
     project, environment, feature, segment, segment_featurestate, client
@@ -476,7 +476,7 @@ def test_associated_features__segment_with_feature_override__returns_associated_
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_associated_features__v2_versioning_with_multiple_versions__returns_only_latest(
     project: Project,
@@ -545,7 +545,7 @@ def test_associated_features__v2_versioning_with_multiple_versions__returns_only
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__feature_based__returns_201_with_feature_id(  # type: ignore[no-untyped-def]
     project, client, feature
@@ -569,7 +569,7 @@ def test_create_segment__feature_based__returns_201_with_feature_id(  # type: ig
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_get_segment_by_uuid__existing_segment__returns_segment_data(  # type: ignore[no-untyped-def]
     client, project, segment
@@ -594,8 +594,8 @@ def test_get_segment_by_uuid__existing_segment__returns_segment_data(  # type: i
 @pytest.mark.parametrize(
     "client, num_queries",
     [
-        (lazy_fixture("admin_master_api_key_client"), 13),
-        (lazy_fixture("admin_client"), 15),
+        (lf("admin_master_api_key_client"), 13),
+        (lf("admin_client"), 15),
     ],
 )
 def test_list_segments__without_rbac__expected_num_queries(
@@ -651,8 +651,8 @@ def test_list_segments__system_segment_exists__excludes_system_segment(
 @pytest.mark.parametrize(
     "client, num_queries",
     [
-        (lazy_fixture("admin_master_api_key_client"), 13),
-        (lazy_fixture("admin_client"), 16),
+        (lf("admin_master_api_key_client"), 13),
+        (lf("admin_client"), 16),
     ],
 )
 def test_list_segments__with_rbac__expected_num_queries(
@@ -703,7 +703,7 @@ def _list_segment_setup_data(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_list_segments__search_by_name__returns_matching_segment(  # type: ignore[no-untyped-def]
     django_assert_num_queries, project, client
@@ -741,7 +741,7 @@ def test_list_segments__search_by_name__returns_matching_segment(  # type: ignor
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__condition_with_description__returns_description_in_response(  # type: ignore[no-untyped-def]
     project, client
@@ -1212,7 +1212,7 @@ def test_update_segment__exception_during_update__does_not_change_version(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_segment__delete_existing_condition__removes_condition(  # type: ignore[no-untyped-def]
     project, client, segment, segment_rule
@@ -1266,7 +1266,7 @@ def test_update_segment__delete_existing_condition__removes_condition(  # type: 
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_update_segment__delete_existing_rule__removes_rule(  # type: ignore[no-untyped-def]
     project, client, segment, segment_rule
@@ -1310,7 +1310,7 @@ def test_update_segment__delete_existing_rule__removes_rule(  # type: ignore[no-
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__multiple_segments_with_metadata__creates_correct_metadata_count(
     project: Project,
@@ -1373,7 +1373,7 @@ def test_create_segment__multiple_segments_with_metadata__creates_correct_metada
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__with_required_metadata__returns_201(
     project: Project,
@@ -1411,7 +1411,7 @@ def test_create_segment__with_required_metadata__returns_201(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__required_metadata_with_org_content_type__returns_201(
     project: Project,
@@ -1449,7 +1449,7 @@ def test_create_segment__required_metadata_with_org_content_type__returns_201(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__missing_required_metadata__returns_400(
     project: Project,
@@ -1552,7 +1552,7 @@ def test_update_segment__exceeds_max_conditions__returns_400(
 
 @pytest.mark.parametrize(
     "client",
-    [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],
+    [lf("admin_master_api_key_client"), lf("admin_client")],
 )
 def test_create_segment__with_optional_metadata__returns_201(
     project: Project,

--- a/api/tests/unit/sse/test_sse_service.py
+++ b/api/tests/unit/sse/test_sse_service.py
@@ -3,7 +3,7 @@ import pytest
 from botocore.exceptions import ClientError
 from django.conf import settings
 from moto import mock_s3  # type: ignore[import-untyped]
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
+from pytest_lazy_fixtures import lf
 from pytest_mock import MockerFixture
 
 from sse.dataclasses import SSEAccessLogs
@@ -35,12 +35,12 @@ def test_send_environment_update_message_for_project__sse_enabled__schedules_tas
     "test_settings, test_project",
     [
         (
-            lazy_fixture("sse_enabled_settings"),
-            lazy_fixture("project"),
+            lf("sse_enabled_settings"),
+            lf("project"),
         ),
         (
-            lazy_fixture("sse_disabled_settings"),
-            lazy_fixture("realtime_enabled_project"),
+            lf("sse_disabled_settings"),
+            lf("realtime_enabled_project"),
         ),
     ],
 )
@@ -63,12 +63,12 @@ def test_send_environment_update_message_for_project__sse_or_realtime_disabled__
     "test_settings, test_environment ",
     [
         (
-            lazy_fixture("sse_enabled_settings"),
-            lazy_fixture("environment"),
+            lf("sse_enabled_settings"),
+            lf("environment"),
         ),
         (
-            lazy_fixture("sse_disabled_settings"),
-            lazy_fixture("realtime_enabled_project_environment_one"),
+            lf("sse_disabled_settings"),
+            lf("realtime_enabled_project_environment_one"),
         ),
     ],
 )

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -183,7 +183,6 @@ overrides = [
     { name = "pytest-cov", specifier = "==4.1.0" },
     { name = "pytest-django", specifier = "==4.8.0" },
     { name = "pytest-freezegun", specifier = "==0.4.2" },
-    { name = "pytest-lazy-fixture", specifier = "==0.6.3" },
     { name = "pytest-mock", specifier = "==3.10.0" },
     { name = "pytest-responses", specifier = "==0.5.1" },
     { name = "pytest-structlog", specifier = "==1.1" },
@@ -1487,7 +1486,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-freezegun" },
-    { name = "pytest-lazy-fixture" },
+    { name = "pytest-lazy-fixtures" },
     { name = "pytest-mock" },
     { name = "pytest-responses" },
     { name = "pytest-structlog" },
@@ -1592,7 +1591,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0,<4.2.0" },
     { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.8.0,<5.0.0" },
     { name = "pytest-freezegun", marker = "extra == 'dev'", specifier = ">=0.4.2,<0.5.0" },
-    { name = "pytest-lazy-fixture", marker = "extra == 'dev'", specifier = ">=0.6.3,<0.7.0" },
+    { name = "pytest-lazy-fixtures", marker = "extra == 'dev'", specifier = ">=1.4.0,<2.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0,<3.11.0" },
     { name = "pytest-responses", marker = "extra == 'dev'", specifier = ">=0.5.1,<0.6.0" },
     { name = "pytest-structlog", marker = "extra == 'dev'", specifier = ">=1.1,<2.0.0" },
@@ -3160,15 +3159,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-lazy-fixture"
-version = "0.6.3"
+name = "pytest-lazy-fixtures"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/82/ae6d2f6903719c4ec410dcd31ee24e3bce74b2cef3c5b9150ad36e8594b6/pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac", size = 7878, upload-time = "2020-02-01T18:04:02.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/05/030c4efe596bc31bcb4fefb31f5fcefc8917df99bd745a920763c5e81863/pytest_lazy_fixtures-1.4.0.tar.gz", hash = "sha256:f544b60c96b909b307558a62cc1f28f026f11e9f03d7f583a1dc636de3dbcb10", size = 36188, upload-time = "2025-09-16T18:42:31.797Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/a1/2f2c1c2353350d66c4d110d283e422e4943eb5ad10effa9357ba66f7b5b9/pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6", size = 4948, upload-time = "2020-02-01T18:04:00.347Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/a07399bd4842282fe3c2da264746069d5216640bc0940b7a359e2c950aa6/pytest_lazy_fixtures-1.4.0-py3-none-any.whl", hash = "sha256:c5db4506fa0ade5887189d1a18857fec4c329b4f49043fef6732c67c9553389a", size = 9680, upload-time = "2025-09-16T18:42:30.534Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7759

`pytest-lazy-fixture` 0.6.3 has been unmaintained since 2020 and is incompatible with pytest 8+ — it relies on pytest's internal `CallSpec2.funcargs`, removed in pytest 9, causing every test module that imports it to error at collection. This currently forces us to keep pytest capped below 8 (see #7756).

This PR migrates to the maintained [`pytest-lazy-fixtures`](https://pypi.org/project/pytest-lazy-fixtures/) fork:

- Replaced `pytest-lazy-fixture>=0.6.3,<0.7.0` with `pytest-lazy-fixtures>=1.4.0,<2.0.0` in the `dev` extra, and dropped the `pytest-lazy-fixture==0.6.3` entry from `[tool.uv].override-dependencies`.
- Rewrote all ~300 `lazy_fixture("name")` call sites across 35 test files to the new `lf("name")` API. The change is purely mechanical — no test logic touched.
- Removed the `# type: ignore[import-untyped]` comments on the imports, since `pytest-lazy-fixtures` ships type hints (`py.typed`).

The remaining acceptance criteria on #7759 (lifting the `pytest<8` cap and removing the TODO markers) live on the #7756 branch and will be handled there once this is merged.

## How did you test this code?

- `make typecheck` — `Success: no issues found in 1697 source files`.
- Ran the full test set for every migrated file locally against the dev database: 1,872 passed, 7 skipped, 0 failures across three batches (unit permissions/api_keys/edge_api/sse, unit environments/projects/features/integrations/organisations/segments, and the migrated `tests/integration` modules).