### PR TITLE
feat(Code References): Allow empty code reference scans to clear references

### DIFF
--- a/api/projects/code_references/serializers.py
+++ b/api/projects/code_references/serializers.py
@@ -38,9 +38,7 @@ class FeatureFlagCodeReferencesScanSerializer(
         default=VCSProvider.GITHUB,
     )
     revision = serializers.CharField(max_length=100)
-    code_references = _CodeReferenceSubmitSerializer(
-        many=True, required=True, allow_empty=False
-    )
+    code_references = _CodeReferenceSubmitSerializer(many=True, required=True)
 
 
 class FeatureFlagCodeReferencesRepositorySummarySerializer(

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
@@ -76,6 +76,60 @@ def test_create_code_reference__valid_payload__returns_201_with_accepted_referen
     ]
 
 
+def test_create_code_reference__empty_references__returns_201_and_clears_previous_references(
+    admin_client_new: APIClient,
+    feature: Feature,
+    project: Project,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    with freezegun.freeze_time("2099-06-01T12:00:00+00:00"):
+        admin_client_new.post(
+            f"/api/v1/projects/{project.pk}/code-references/",
+            data={
+                "repository_url": "https://github.flagsmith.com/",
+                "revision": "rev-1",
+                "code_references": [
+                    {
+                        "feature_name": feature.name,
+                        "file_path": "path/to/file.py",
+                        "line_number": 1,
+                    },
+                ],
+            },
+            format="json",
+        )
+    assert ScannedCodeReferences.objects.filter(feature=feature).exists()
+
+    # When
+    with freezegun.freeze_time("2099-06-02T12:00:00+00:00"):
+        response = admin_client_new.post(
+            f"/api/v1/projects/{project.pk}/code-references/",
+            data={
+                "repository_url": "https://github.flagsmith.com/",
+                "revision": "rev-2",
+                "code_references": [],
+            },
+            format="json",
+        )
+
+    # Then
+    assert response.status_code == 201
+    assert response.data["code_references"] == []
+    references_response = admin_client_new.get(
+        f"/api/v1/projects/{project.pk}/features/{feature.pk}/code-references/",
+    )
+    assert references_response.status_code == 200
+    assert references_response.json() == []
+    assert log.events[-1] == {
+        "event": "scan.created",
+        "level": "info",
+        "organisation__id": project.organisation_id,
+        "code_references__count": 0,
+        "feature__count": 0,
+    }
+
+
 def test_create_code_reference__not_authenticated__returns_401(
     client: APIClient,
     project: Project,


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7763.

Allow pushing empty code references, meaning "clear all code references in given repository".

## How did you test this code?

Included new test case.