### PR TITLE
fix(frontend): Allow change request deletion based on API permissions

### DIFF
--- a/frontend/web/components/pages/ChangeRequestDetailPage.tsx
+++ b/frontend/web/components/pages/ChangeRequestDetailPage.tsx
@@ -89,6 +89,11 @@ const ChangeRequestDetailPage: FC<ChangeRequestPageType> = ({ match }) => {
     permission: EnvironmentPermission.UPDATE_FEATURE_STATE,
     tags: projectFlag?.tags,
   })
+  const isEnvironmentAdmin = useHasPermission({
+    id: environmentId,
+    level: 'environment',
+    permission: EnvironmentPermission.ADMIN,
+  })
 
   useEffect(() => {
     AppActions.getChangeRequest(id, projectId, environmentId)
@@ -338,6 +343,7 @@ const ChangeRequestDetailPage: FC<ChangeRequestPageType> = ({ match }) => {
       />
       <ChangeRequestPageInner
         hidePublish={!projectFlag}
+        canManageChangeRequests={isEnvironmentAdmin?.permission}
         publishChangeRequest={publishChangeRequest}
         approvePermission={approvePermission?.permission}
         approveChangeRequest={approveChangeRequest}
@@ -420,6 +426,7 @@ type ChangeRequestPageInnerType = {
   approvePermission: boolean | undefined
   publishPermission: boolean | undefined
   isScheduled: boolean
+  canManageChangeRequests?: boolean
   hidePublish?: boolean
   scheduledDate?: moment.Moment | null
   changeRequest: ProjectChangeRequest | ChangeRequest | undefined
@@ -434,6 +441,7 @@ export const ChangeRequestPageInner: FC<ChangeRequestPageInnerType> = ({
   addOwner,
   approveChangeRequest,
   approvePermission,
+  canManageChangeRequests,
   changeRequest,
   deleteChangeRequest,
   editChangeRequest,
@@ -539,13 +547,13 @@ export const ChangeRequestPageInner: FC<ChangeRequestPageInnerType> = ({
     changeRequest &&
     changeRequest.user &&
     orgUsers.find((v) => v.id === changeRequest.user)
-  const isYours = AccountStore.getUserId() === changeRequest.user
+
   return (
     <div>
       <PageTitle
         cta={
           (!changeRequest.committed_at || isScheduled) &&
-          isYours && (
+          (isYourChangeRequest || !!canManageChangeRequests) && (
             <Row>
               <Button theme='secondary' onClick={deleteChangeRequest}>
                 Delete
@@ -564,7 +572,7 @@ export const ChangeRequestPageInner: FC<ChangeRequestPageInnerType> = ({
         by {user ? `${user.first_name} ${user.last_name}` : 'Unknown user'}
       </PageTitle>
       <p className='mt-2'>{changeRequest.description}</p>
-      {hasApprovals && isYours && !changeRequest.committed_at && (
+      {hasApprovals && isYourChangeRequest && !changeRequest.committed_at && (
         <div className='col-md-6 mb-4'>
           <InfoMessage>
             This change request has been approved and can no longer be edited.
@@ -652,7 +660,9 @@ export const ChangeRequestPageInner: FC<ChangeRequestPageInnerType> = ({
                     <Row
                       key={g.id}
                       onClick={
-                        hasApprovals ? undefined : () => removeOwner(g.id, false)
+                        hasApprovals
+                          ? undefined
+                          : () => removeOwner(g.id, false)
                       }
                       className='chip'
                       style={{

--- a/frontend/web/components/pages/ProjectChangeRequestDetailPage.tsx
+++ b/frontend/web/components/pages/ProjectChangeRequestDetailPage.tsx
@@ -45,6 +45,11 @@ const ProjectChangeRequestDetailPage: FC<ProjectChangeRequestPageType> = ({
     level: 'project',
     permission: ProjectPermission.MANAGE_SEGMENTS,
   })
+  const manageChangeRequestsPermission = useHasPermission({
+    id: projectId,
+    level: 'project',
+    permission: ProjectPermission.MANAGE_PROJECT_LEVEL_CHANGE_REQUESTS,
+  })
   const { data: project } = useGetProjectQuery({ id: projectId })
   const [actionChangeRequest, { isLoading: isActioning }] =
     useActionProjectChangeRequestMutation({})
@@ -168,7 +173,7 @@ const ProjectChangeRequestDetailPage: FC<ProjectChangeRequestPageType> = ({
         </div>
       ),
       onYes: () => {
-        if(!changeRequest) return
+        if (!changeRequest) return
         actionChangeRequest({
           actionType: 'commit',
           id: `${changeRequest.id}`,
@@ -225,6 +230,7 @@ const ProjectChangeRequestDetailPage: FC<ProjectChangeRequestPageType> = ({
         currentPage={changeRequest.title}
       />
       <ChangeRequestPageInner
+        canManageChangeRequests={manageChangeRequestsPermission?.permission}
         isScheduled={false}
         publishChangeRequest={publishChangeRequest}
         approvePermission={approvePermission?.permission}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Previously, the Delete/Edit buttons on the change request detail page were only shown to the change request author, even though the API allows other users to perform these actions. This maps the frontend visibility to the API permissions:

- `ChangeRequestPageInner` accepts a new `canManageChangeRequests` prop; the Delete/Edit CTA now shows when the viewer is the author **or** has this permission.
- Environment-level change requests pass an `EnvironmentPermission.ADMIN` check.
- Project-level change requests pass a `ProjectPermission.MANAGE_PROJECT_LEVEL_CHANGE_REQUESTS` check.

## How did you test this code?

Manually:

1. As a user with environment admin (but not the CR author), open an environment change request — Delete/Edit buttons are shown.
2. As a user with `MANAGE_PROJECT_LEVEL_CHANGE_REQUESTS` (but not the CR author), open a project change request — Delete button is shown.
3. As a user with neither permission who is not the author, confirm the buttons remain hidden.

Lint and typecheck pass on the changed files.