### PR TITLE
ci(frontend): upload Playwright artifacts when E2E tests fail

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -64,3 +64,17 @@ runs:
         SLACK_TOKEN: ${{ inputs.slack_token }}
         ENV: ${{ inputs.environment == 'production' && 'prod' || inputs.environment }}
         GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    # Short retention because traces capture network payloads, including the
+    # (throwaway, reseeded-per-run) e2e users' auth tokens.
+    - name: Upload Playwright test results
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        # run_attempt avoids the v4 immutable-name collision when a failed job is re-run
+        name: e2e-test-results-${{ inputs.environment }}-attempt-${{ github.run_attempt }}
+        path: |
+          frontend/e2e/test-results
+          frontend/e2e/playwright-report
+        retention-days: 7
+        if-no-files-found: ignore


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

When the E2E gate fails on the production deploy (or staging/ECS runs), the Playwright traces, screenshots and DOM snapshots die with the runner, so failures like the ones blocking today's deploy can only be debugged by reproducing locally.

This uploads `e2e/test-results` and the Playwright report as a run artifact when the E2E step fails:

- 7-day retention, since traces capture network payloads including the (throwaway, reseeded-per-run) e2e users' auth tokens.
- Artifact name includes `github.run_attempt` to avoid the immutable-name collision in `upload-artifact@v4` when a failed job is re-run.
- No-op on green runs (`if: failure()`), and `if-no-files-found: ignore` covers failures before Playwright starts.

## How did you test this code?

Validated the action YAML parses. The step only runs on E2E failure in CI; the paths match Playwright's configured `outputDir` (`e2e/test-results`) and report directory, verified against a local failing run.