### PR TITLE
fix(frontend): gate app boot on ConfigStore.hasLoaded to avoid loader deadlock

### DIFF
--- a/frontend/common/providers/ConfigProvider.js
+++ b/frontend/common/providers/ConfigProvider.js
@@ -8,7 +8,7 @@ export default (WrappedComponent) => {
       super(props)
       this.state = {
         error: ConfigStore.error,
-        isLoading: ConfigStore.model ? ConfigStore.isLoading : true,
+        isLoading: ConfigStore.hasLoaded ? ConfigStore.isLoading : true,
       }
       ES6Component(this)
     }

--- a/frontend/common/providers/ConfigProvider.js
+++ b/frontend/common/providers/ConfigProvider.js
@@ -20,6 +20,14 @@ export default (WrappedComponent) => {
           isLoading: ConfigStore.isLoading,
         })
       })
+      // Re-sync: the store can finish loading before this subscription
+      // exists, and no further change event arrives to recover.
+      if (ConfigStore.hasLoaded || ConfigStore.error) {
+        this.setState({
+          error: ConfigStore.error,
+          isLoading: ConfigStore.isLoading,
+        })
+      }
     }
 
     render() {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Root cause of the intermittent E2E failures blocking the production deploy gate since Jun 9 (see [Slack thread](https://flagsmith.slack.com/archives/C095QUM2SKW/p1781283172471409)). Replaces #7775 (closed; GitHub blocks reopening after a force-push).

Two stacked problems in the app's boot gate:

1. `ConfigProvider` decides whether the app is still loading by checking `ConfigStore.model` — but `model` is **never populated** (`flagsmith.getAllFlags()` returns nothing at the point `config-store.js` assigns it; instrumentation showed `hasLoaded: true, model: null` while the SDK itself held 132 flags). So every mount starts in the loading state regardless of the store's actual state.
2. The only escape is the store's one-shot `change` event, which the provider subscribes to in `componentDidMount`. If the SDK's `onChange` fires before that subscription (fast edge response + slow runner), the event is lost. In E2E mode `realtime`, `enableEvents` and `enableAnalytics` are all disabled, so **no later event ever arrives** and the app sits on the boot loader permanently — tests time out waiting for the login form on a page that never booted. Real users are rescued by realtime/analytics-driven events, which is why this only surfaced in E2E.

Fix, one commit each: gate the initial state on `hasLoaded` (which is reliably set), and re-read the store after subscribing so an event landing in the constructor→subscription gap cannot strand the boot.

## How did you test this code?

Deterministic A/B validation by artificially forcing the race (subscription delayed 3s so the SDK's `onChange` always lands in the gap), then loading `/login` on 15 fresh browser contexts per build:

| Build | Result |
|---|---|
| main's behaviour | stuck on loader, exact CI failure signature (`[name="email"]` timeout) |
| fix gated on `model` | 15/15 stuck — confirmed `model` is never set |
| fix gated on `hasLoaded` (this PR) | **0/15 stuck**, boots every run |

Also reproduced the original hang locally via `environment-permission-test.pw.ts` against production (the test that failed on every red deploy run — it re-logs in 6+ times, so it rolls the boot race most often).