### PR TITLE
fix(frontend): keep dev-server overlay to compile errors only

### DIFF
--- a/frontend/rspack/rspack.config.local.js
+++ b/frontend/rspack/rspack.config.local.js
@@ -1,6 +1,8 @@
 // rspack.config.local.js (dev)
 const rspack = require('@rspack/core')
-const { ReactRefreshRspackPlugin: ReactRefreshPlugin } = require('@rspack/plugin-react-refresh')
+const {
+  ReactRefreshRspackPlugin: ReactRefreshPlugin,
+} = require('@rspack/plugin-react-refresh')
 const path = require('path')
 const express = require('express')
 
@@ -9,11 +11,14 @@ const base = require('../rspack.config')
 module.exports = {
   ...base,
   devServer: {
+    app: async () => express(),
+    // Overlay only for compile errors — the overlay iframe blocks all
+    // pointer events, and warnings/runtime rejections fire routinely.
+    client: { overlay: { runtimeErrors: false, warnings: false } },
     historyApiFallback: true,
     hot: true,
     liveReload: false,
     port: process.env.PORT || 8080,
-    app: async () => express(),
     setupMiddlewares: (middlewares, devServer) => {
       // Register the Express routes from api/index on the dev server's app
       require('../api/dev-routes')(devServer.app)
@@ -46,6 +51,12 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
+              // The codebase still uses @import; the deprecation fires on
+              // every build and is not actionable here.
+              sassOptions: {
+                silenceDeprecations: ['import'],
+              },
+
               sourceMap: true,
             },
           },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In local dev (`ENV=local npm run dev`), the rspack dev-server overlay renders a full-screen iframe that intercepts all pointer events. Two things trigger it constantly:

- the Dart Sass `@import` deprecation warning, which fires on every compile (the `@use`/`@forward` migration is a separate effort), and
- runtime errors / unhandled promise rejections, e.g. uncaught legacy `data.*` Response rejections.

Both hijack the screen and block the app — and any E2E run pointed at the dev server. This keeps the overlay for compile errors (where it's genuinely useful), turns it off for warnings and runtime errors, and silences the non-actionable Sass `@import` deprecation. Warnings still appear in the terminal and browser console.

## How did you test this code?

Manually: `ENV=local npm run dev`, confirmed the app loads and stays interactive with Sass deprecation warnings present and after a runtime rejection; compile errors still show the overlay.