### PR TITLE
fix(frontend): add guard against null model

### DIFF
--- a/frontend/common/stores/project-store.js
+++ b/frontend/common/stores/project-store.js
@@ -176,8 +176,10 @@ const store = Object.assign({}, BaseStore, {
   getEnvironmentById: (id) =>
     store.model && find(store.model.environments, { id }),
   getEnvironmentIdFromKey: (api_key) => {
-    const env = find(store.model.environments, { api_key })
-    return env && env.id
+    if (store.model) {
+      const env = find(store.model.environments, { api_key })
+      return env && env.id
+    }
   },
   getEnvironmentIdFromKeyAsync: async (projectId, apiKey) => {
     if (store.model && `${store.model.id}` === `${projectId}`) {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✓] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [✓] I have added information to `docs/` if required so people know about the feature.
- [✓] I have filled in the "Changes" section below.
- [✓] I have filled in the "How did you test this code" section below.

## Changes

Closes #7511 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

1. Error happens when `CompareIdentities` component is trying to access variable `environments`
2. That variable is accessed by calling `ProjectStore` component, and then executing method `getEnvironmentIdFromKey()`
3. By observing method `getEnvironmentIdFromKey()` inside file _project-store.js,_ it can be deduced that the error happens when object `store.model` is still null
4. To prevent this error when component `CompareIdentities` is still rendered, I add guard to ensure `store.model ` is accessed only when it has value.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. I try to reproduce the issue in my local environment, by observing the console before and after the fix has been applied.
2. However, it seems that the error is quite difficult to be reproduced, as this error seems to happen in Sentry environment. CMIIW.

Before fix:
[Screencast from 13-06-26 07:26:56.webm](https://github.com/user-attachments/assets/7efe2460-cf1b-4fec-aaab-09c104c107f9)


After fix:
[Screencast from 13-06-26 07:30:07.webm](https://github.com/user-attachments/assets/9ede3778-1a31-4a0b-b0c1-5cc7eccec139)


