### PR TITLE
fix(Utils): add guard against null rule value in validateRule

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -816,6 +816,9 @@ const Utils = Object.assign({}, BaseUtils, {
     }
 
     if (operatorObj?.value?.toLowerCase?.().includes('semver')) {
+      if (rule.value == null) {
+        return false
+      }
       return !!semver.valid(`${rule.value.split(':')[0]}`)
     }
 
@@ -826,7 +829,7 @@ const Utils = Object.assign({}, BaseUtils, {
       }
       case 'REGEX': {
         try {
-          if (!rule.value) {
+          if (rule.value == null) {
             throw new Error('')
           }
           new RegExp(`${rule.value}`)
@@ -836,6 +839,9 @@ const Utils = Object.assign({}, BaseUtils, {
         }
       }
       case 'MODULO': {
+        if (rule.value == null) {
+          return false
+        }
         const valueSplit = rule.value.split('|')
         if (valueSplit.length === 2) {
           const [divisor, remainder] = [

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -816,7 +816,7 @@ const Utils = Object.assign({}, BaseUtils, {
     }
 
     if (operatorObj?.value?.toLowerCase?.().includes('semver')) {
-      if (rule.value == null) {
+      if (!rule.value) {
         return false
       }
       return !!semver.valid(`${rule.value.split(':')[0]}`)
@@ -829,7 +829,7 @@ const Utils = Object.assign({}, BaseUtils, {
       }
       case 'REGEX': {
         try {
-          if (rule.value == null) {
+          if (!rule.value) {
             throw new Error('')
           }
           new RegExp(`${rule.value}`)
@@ -839,7 +839,7 @@ const Utils = Object.assign({}, BaseUtils, {
         }
       }
       case 'MODULO': {
-        if (rule.value == null) {
+        if (!rule.value) {
           return false
         }
         const valueSplit = rule.value.split('|')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✔] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [✔] I have added information to `docs/` if required so people know about the feature.
- [✔] I have filled in the "Changes" section below.
- [✔] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7536 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

1. Error happens when `CreateSegment` component is trying to call method `validateRule()` by passing an object.
2. The method crashes when `split()` method is executed on a variable that isn't string-type. 
3. Inside method `validateRule()`, only _value_ prop that is accessed and doesn't have its own guard, so the method crashes when it's empty (either _null_ or _undefined_).
4. I add _loose equality guard_, to catch only _null_ and _undefined_ value.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. I try to simulate this on my local by manually creating the Segment via UI, but it seems no error happens, because the button Create Segment itself is already been greyed out.
2. I deduce that this error happens via API backend hit.

[Screencast from 14-06-26 11:46:58.webm](https://github.com/user-attachments/assets/d6d8d390-aac1-45ce-94eb-c60e15422cf9)

