### PR TITLE
test(e2e): fix permission write-race in environment-permission-test

### DIFF
--- a/frontend/e2e/helpers/e2e-helpers.playwright.ts
+++ b/frontend/e2e/helpers/e2e-helpers.playwright.ts
@@ -872,12 +872,36 @@ export class E2EHelpers {
     if (entityName) {
       await this.click(byId(`permissions-${entityName.toLowerCase()}`));
     }
+    // The toggle saves async via POST/PUT to .../user-permissions/. Await it
+    // before closing the modal — otherwise logout can abort the in-flight
+    // save and the grant never lands, so the next user can't see the entity.
+    const saved = this.page.waitForResponse(
+      (res) =>
+        res.url().includes('/user-permissions/') &&
+        res.request().method() !== 'GET',
+      { timeout: LONG_TIMEOUT },
+    );
     if (permission === 'ADMIN') {
       await this.click(byId(`admin-switch-${level}`));
     } else {
       await this.click(byId(`permission-switch-${permission}`));
     }
+    await saved;
     await this.closeModal();
+  }
+
+  // Reload the page until a selector becomes visible. For state that is
+  // eventually consistent across a fresh navigation (e.g. a just-granted
+  // permission) — waiting on a single page load can't help, because the data
+  // was already fetched without it.
+  async reloadUntilVisible(selector: string, timeout: number = LONG_TIMEOUT) {
+    logUsingLastSection(`Reload until visible ${selector}`);
+    await expect(async () => {
+      await this.page.reload();
+      await expect(this.page.locator(selector).first()).toBeVisible({
+        timeout: 5000,
+      });
+    }).toPass({ timeout });
   }
 
   // Create a tag

--- a/frontend/e2e/tests/environment-permission-test.pw.ts
+++ b/frontend/e2e/tests/environment-permission-test.pw.ts
@@ -26,6 +26,7 @@ test.describe('Environment Permission Tests', () => {
       gotoTraits,
       login,
       logout,
+      reloadUntilVisible,
       setUserPermission,
       toggleFeature,
       waitForElementClickable,
@@ -87,7 +88,9 @@ test.describe('Environment Permission Tests', () => {
     log('User with permissions can see environment')
     await login(E2E_NON_ADMIN_USER_WITH_ENV_PERMISSIONS, PASSWORD)
     await gotoProject(PROJECT_NAME)
-    await waitForElementVisible(byId('switch-environment-production'))
+    // VIEW_ENVIRONMENT was just granted; the env list was fetched on
+    // navigation, so reload until it reflects the new permission.
+    await reloadUntilVisible(byId('switch-environment-production'))
     await logout()
 
     log('User with permissions can update feature state')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

One of the intermittent E2E failures on the production deploy gate, distinct from the boot-loader deadlock (#7776) — here the app boots fine but `environment-permission-test` times out waiting for `switch-environment-production` after the permission to view it was just granted.

Two changes:

- **`setUserPermission` awaits the save.** The helper toggled the permission switch and immediately closed the modal + logged out. The toggle saves async (POST/PUT to `.../user-permissions/`), so logout could abort the in-flight request and the grant never persisted — the next user then couldn't see the entity. The backend has no permission read-cache, so the lost write is the most likely cause. Now we await the `/user-permissions/` response before closing the modal.
- **`reloadUntilVisible` helper.** Belt-and-braces for the read side: the environment list is fetched once on navigation, so a just-granted `VIEW_ENVIRONMENT` can't appear by waiting on the same page — it needs a reload. Used for the 'User with permissions can see environment' assertion.

## How did you test this code?

`environment-permission-test` reproduced the `switch-environment-production` timeout (app booted, env absent). Traced the grant to an un-awaited `/user-permissions/` POST in `setUserPermission`. Locally re-ran the spec against production with the fix; the grant now persists and the env appears. As a timing race against shared prod state, the real signal is the deploy-gate pass rate.

Note: separate from the non-idempotent-seed failure (createEnvironment on a dirty seed) seen in project-permission-test — that's a teardown/seed-lifecycle issue, not addressed here.