### PR TITLE
test(e2e): drop waitForLoadState('networkidle') from helpers

### DIFF
--- a/frontend/e2e/helpers/e2e-helpers.playwright.ts
+++ b/frontend/e2e/helpers/e2e-helpers.playwright.ts
@@ -228,7 +228,6 @@ export class E2EHelpers {
     const userRow = this.page.locator('[data-test^="user-item-"]').filter({ hasText: identifier }).first();
     await userRow.waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
     await userRow.locator('a').first().click();
-    await this.page.waitForLoadState('networkidle');
     await this.waitForElementVisible('#add-trait');
   }
 
@@ -434,7 +433,6 @@ export class E2EHelpers {
     // Wait for modal and General tab content to fully load before switching tabs
     await this.waitForElementVisible('.modal-open');
     await this.waitForElementVisible(byId('role-name'));
-    await this.page.waitForLoadState('networkidle');
     await this.click(byId('members-tab'));
     await this.click(byId('assigned-users'));
     for (const userId of users) {
@@ -628,7 +626,6 @@ export class E2EHelpers {
 
   // Create an environment
   async createEnvironment(name: string) {
-    await this.page.waitForLoadState('networkidle');
     await this.waitForElementVisible('[name="envName"]');
     const nameInput = this.page.locator('[name="envName"]').first();
     await nameInput.click();
@@ -888,7 +885,6 @@ export class E2EHelpers {
     await this.waitForElementVisible('#create-feature-modal');
 
     // Click the "Add Tag" button to open tag interface
-    await this.page.waitForLoadState('networkidle');
     const addTagButton = this.page.locator('button').filter({ hasText: 'Add Tag' });
     await addTagButton.waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
     await addTagButton.scrollIntoViewIfNeeded();


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Another intermittent E2E failure on the production deploy gate, distinct from the boot deadlock (#7776) and the permission write-race (#7782). Here the app is fully booted and on the right page, but `page.waitForLoadState('networkidle')` times out after 20s.

The dashboard loads HubSpot, LinkedIn, Google Ads and Chargebee scripts that fire tracking pixels and polling indefinitely, so the network never goes idle for 500ms and `networkidle` can't resolve regardless of whether the page is ready. Playwright explicitly discourages `networkidle` for this reason.

All four uses in the helpers (`gotoTraits`, the role-assignment helper, `createEnvironment`, `createTag`) were immediately followed by a concrete element wait — the real readiness signal — so the `networkidle` calls are redundant as well as flaky. Removed all four.

## How did you test this code?

Observed the timeout in two captured failures (`gotoTraits` line 231 in environment-permission-test, and `createTag` line 915 in flag-tests), both with a fully-rendered page in the snapshot. Confirmed each removed call is followed by a deterministic `waitForElementVisible`/`waitFor` that already gates readiness.