### PR TITLE
fix(frontend): gate app boot on ConfigStore.hasLoaded to avoid loader deadlock

### DIFF
--- a/frontend/common/providers/ConfigProvider.js
+++ b/frontend/common/providers/ConfigProvider.js
@@ -8,7 +8,7 @@ export default (WrappedComponent) => {
       super(props)
       this.state = {
         error: ConfigStore.error,
-        isLoading: ConfigStore.model ? ConfigStore.isLoading : true,
+        isLoading: ConfigStore.hasLoaded ? ConfigStore.isLoading : true,
       }
       ES6Component(this)
     }

--- a/frontend/common/providers/ConfigProvider.js
+++ b/frontend/common/providers/ConfigProvider.js
@@ -20,6 +20,14 @@ export default (WrappedComponent) => {
           isLoading: ConfigStore.isLoading,
         })
       })
+      // Re-sync: the store can finish loading before this subscription
+      // exists, and no further change event arrives to recover.
+      if (ConfigStore.hasLoaded || ConfigStore.error) {
+        this.setState({
+          error: ConfigStore.error,
+          isLoading: ConfigStore.isLoading,
+        })
+      }
     }
 
     render() {


### PR DESCRIPTION
## Changes

Fixes the intermittent E2E failure blocking the production deploy gate: the app booting into a permanent loader.

`ConfigProvider` derived `isLoading` from `ConfigStore.model`, which is never populated, so it always started loading and relied on the store's one-shot `change` event to release it. If the Flagsmith SDK's `onChange` fired before `componentDidMount` subscribed, that event was lost — and with realtime/events disabled in E2E, nothing recovered it, so the app stuck on the loader.

- Gate the initial state on `ConfigStore.hasLoaded` instead of `model`.
- Re-read the store after subscribing, so an event in the constructor→subscription gap can't strand the boot.

## How did you test this code?

Forced the race (delayed the subscription so `onChange` always lands in the gap) and loaded `/login` on 15 fresh contexts: **main 15/15 stuck on the loader, this fix 0/15**.