### PR TITLE
fix(frontend): prevent crash if redirect param is undefined

### DIFF
--- a/frontend/web/components/pages/HomePage.tsx
+++ b/frontend/web/components/pages/HomePage.tsx
@@ -135,11 +135,11 @@ const HomePage: React.FC = () => {
 
     if (document.location.href.indexOf('invite') !== -1) {
       const invite = params.redirect
-      if (invite.includes('invite-link')) {
+      if (invite?.includes('invite-link')) {
         const id = invite.split('invite-link/')[1]
         API.setInviteType('INVITE_LINK')
         API.setInvite(id)
-      } else if (invite.includes('invite')) {
+      } else if (invite?.includes('invite')) {
         const id = invite.split('invite/')[1]
         API.setInviteType('INVITE_EMAIL')
         API.setInvite(id)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✔] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [   ] I have added information to `docs/` if required so people know about the feature.
- [✔] I have filled in the "Changes" section below.
- [✔] I have filled in the "How did you test this code" section below.

## Changes

Closes #7524 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

1. A crash on the home page happens when the URL contains "invite" but has no `redirect` query parameter, causing `invite` to be `undefined`
3. I Added optional chaining (`?.`) before `.includes()` calls on the `invite` variable in `HomePage.tsx`.

## How did you test this code?

1. Navigate to home page with URL containing "invite" but no `redirect`
2. I try to add console.log message in my local just to see if variable `invite` has any value
3. I could see the error happens when there is no `redirect` param in the URL
4. After adding the optional chaining, the error disappears

Before changes:
[Screencast from 16-06-26 08:22:04.webm](https://github.com/user-attachments/assets/411668b9-c0a7-4f3b-a556-6863f9f19d6d)

After changes:
[Screencast from 16-06-26 08:48:55.webm](https://github.com/user-attachments/assets/afc78c92-80e4-4426-8128-b6f81c927db5)



