### PR TITLE
fix: trigger get warehouse stat request

### DIFF
--- a/frontend/common/services/useWarehouseConnection.ts
+++ b/frontend/common/services/useWarehouseConnection.ts
@@ -42,25 +42,7 @@ export const warehouseConnectionService = service
         Res['warehouseConnections'][number],
         Req['testWarehouseConnection']
       >({
-        async onQueryStarted({ environmentId }, { dispatch, queryFulfilled }) {
-          try {
-            const { data } = await queryFulfilled
-            dispatch(
-              warehouseConnectionService.util.updateQueryData(
-                'getWarehouseConnections',
-                { environmentId, exclude_event_stats: true },
-                (draft) => {
-                  const index = draft.findIndex(
-                    (connection) => connection.id === data.id,
-                  )
-                  if (index !== -1) draft[index] = data
-                },
-              ),
-            )
-          } catch {
-            return
-          }
-        },
+        invalidatesTags: [{ id: 'LIST', type: 'WarehouseConnection' }],
         query: ({ environmentId, id }) => ({
           method: 'POST',
           url: `environments/${environmentId}/warehouse-connections/${id}/test-warehouse-connection/`,

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -17,6 +17,7 @@ type WarehouseConnectionCardProps = {
   onEdit?: () => void
   onSendTestEvent: () => void
   isSendingTestEvent: boolean
+  isLoadingStats?: boolean
 }
 
 const STATUS_COLOUR: Record<WarehouseConnectionStatus, string> = {
@@ -40,6 +41,7 @@ const TYPE_LABEL: Partial<Record<WarehouseType, string>> = {
 
 const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
   connection,
+  isLoadingStats,
   isSendingTestEvent,
   onDelete,
   onEdit,
@@ -114,6 +116,7 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
       <WarehouseStats
         errored={connection.status === 'errored'}
         lastEventReceived='-'
+        loading={isLoadingStats}
         totalEventsReceived={connection.total_events_received}
         uniqueEventsCount={connection.unique_events_count}
       />

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseStats.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseStats.tsx
@@ -1,19 +1,32 @@
 import React, { FC } from 'react'
 import Icon from 'components/icons/Icon'
+import Skeleton from 'components/Skeleton'
 
 type WarehouseStatsProps = {
   errored: boolean
   lastEventReceived: string
   totalEventsReceived: number | null
   uniqueEventsCount: number | null
+  loading?: boolean
 }
 
 const formatCount = (value: number | null): string =>
   value !== null ? value.toLocaleString() : '-'
 
+const StatValue: FC<{ value: number | null; loading?: boolean }> = ({
+  loading,
+  value,
+}) =>
+  loading && value === null ? (
+    <Skeleton variant='text' width={56} height={14} />
+  ) : (
+    <span className='font-weight-medium'>{formatCount(value)}</span>
+  )
+
 const WarehouseStats: FC<WarehouseStatsProps> = ({
   errored,
   lastEventReceived,
+  loading,
   totalEventsReceived,
   uniqueEventsCount,
 }) => (
@@ -30,17 +43,13 @@ const WarehouseStats: FC<WarehouseStatsProps> = ({
       <span className='text-muted'>Last event received:</span>
       <span className='font-weight-medium'>{lastEventReceived}</span>
     </div>
-    <div className='d-flex flex-row gap-2'>
+    <div className='d-flex flex-row align-items-center gap-2'>
       <span className='text-muted'>Total events received:</span>
-      <span className='font-weight-medium'>
-        {formatCount(totalEventsReceived)}
-      </span>
+      <StatValue loading={loading} value={totalEventsReceived} />
     </div>
-    <div className='d-flex flex-row gap-2'>
+    <div className='d-flex flex-row align-items-center gap-2'>
       <span className='text-muted'>Number of unique events:</span>
-      <span className='font-weight-medium'>
-        {formatCount(uniqueEventsCount)}
-      </span>
+      <StatValue loading={loading} value={uniqueEventsCount} />
     </div>
   </div>
 )

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
@@ -41,20 +41,19 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
   const [updateConnection] = useUpdateWarehouseConnectionMutation()
 
   const baseConnection = connections?.[0]
-  const statsConnection = connectionsWithStats?.find(
-    (item) => item.id === baseConnection?.id,
-  )
-  const connection = useMemo(
-    () =>
-      baseConnection && statsConnection
-        ? {
-            ...baseConnection,
-            total_events_received: statsConnection.total_events_received,
-            unique_events_count: statsConnection.unique_events_count,
-          }
-        : baseConnection,
-    [baseConnection, statsConnection],
-  )
+  const connection = useMemo(() => {
+    if (!baseConnection) return undefined
+    const statsConnection = connectionsWithStats?.find(
+      (item) => item.id === baseConnection.id,
+    )
+    return statsConnection
+      ? {
+          ...baseConnection,
+          total_events_received: statsConnection.total_events_received,
+          unique_events_count: statsConnection.unique_events_count,
+        }
+      : baseConnection
+  }, [baseConnection, connectionsWithStats])
   const connectionId = connection?.id
   const connectionStatus = connection?.status
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import {
   useCreateWarehouseConnectionMutation,
   useDeleteWarehouseConnectionMutation,
@@ -30,12 +30,31 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
     { environmentId, exclude_event_stats: true },
     { skip: !environmentId },
   )
+  const { data: connectionsWithStats, isFetching: isFetchingStats } =
+    useGetWarehouseConnectionsQuery(
+      { environmentId, exclude_event_stats: false },
+      { skip: !environmentId },
+    )
   const [createConnection, { isLoading: isCreating }] =
     useCreateWarehouseConnectionMutation()
   const [deleteConnection] = useDeleteWarehouseConnectionMutation()
   const [updateConnection] = useUpdateWarehouseConnectionMutation()
 
-  const connection = connections?.[0]
+  const baseConnection = connections?.[0]
+  const statsConnection = connectionsWithStats?.find(
+    (item) => item.id === baseConnection?.id,
+  )
+  const connection = useMemo(
+    () =>
+      baseConnection && statsConnection
+        ? {
+            ...baseConnection,
+            total_events_received: statsConnection.total_events_received,
+            unique_events_count: statsConnection.unique_events_count,
+          }
+        : baseConnection,
+    [baseConnection, statsConnection],
+  )
   const connectionId = connection?.id
   const connectionStatus = connection?.status
 
@@ -183,6 +202,7 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
         }
         onSendTestEvent={handleSendTestEvent}
         isSendingTestEvent={isSendingTestEvent}
+        isLoadingStats={isFetchingStats}
       />
     </div>
   )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Fix a regression that made all requests in the Warehouse Connection tab excluding the stats
- Trigger a background request with stats (to still display the connection while the service wakes up)

## How did you test this code?
- Against prod