### PR TITLE
feat(MCP): Serve MCP at the bare server URL

### DIFF
--- a/mcp/src/flagsmith_mcp/constants.py
+++ b/mcp/src/flagsmith_mcp/constants.py
@@ -4,3 +4,10 @@ OAUTH_SCOPES = ["mcp"]
 
 # How this service identifies itself as a client of the Flagsmith API.
 FLAGSMITH_CLIENT_NAME = "flagsmith-mcp"
+
+# Path the streamable HTTP transport is served on. Advertised in OAuth
+# protected-resource metadata and used to route bare-URL requests.
+STREAMABLE_HTTP_PATH = "/mcp"
+
+# Where browsers landing on the bare server URL are sent.
+MCP_DOCS_URL = "https://docs.flagsmith.com/integrating-with-flagsmith/mcp-server"

--- a/mcp/src/flagsmith_mcp/middleware.py
+++ b/mcp/src/flagsmith_mcp/middleware.py
@@ -1,0 +1,40 @@
+from starlette.datastructures import Headers
+from starlette.responses import RedirectResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from flagsmith_mcp import constants
+
+
+class RootRouterMiddleware:
+    """Make the bare server URL usable.
+
+    Both MCP clients that drop the ``/mcp`` suffix and humans who open the URL
+    in a browser land on ``/``. Browsers (``Accept: text/html``) are redirected
+    to the docs; every other request is dispatched to the MCP handler so the
+    bare URL works as an endpoint in its own right. Requests to any other path
+    pass through untouched.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        docs_url: str = constants.MCP_DOCS_URL,
+        mcp_path: str = constants.STREAMABLE_HTTP_PATH,
+    ) -> None:
+        self.app = app
+        self.docs_url = docs_url
+        self.mcp_path = mcp_path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope["path"] == "/":
+            if "text/html" in Headers(scope=scope).get("accept", ""):
+                response = RedirectResponse(self.docs_url, status_code=302)
+                await response(scope, receive, send)
+                return
+            scope = {
+                **scope,
+                "path": self.mcp_path,
+                "raw_path": self.mcp_path.encode(),
+            }
+        await self.app(scope, receive, send)

--- a/mcp/src/flagsmith_mcp/server.py
+++ b/mcp/src/flagsmith_mcp/server.py
@@ -8,6 +8,7 @@ from fastmcp.utilities.openapi.models import HttpMethod, HTTPRoute
 from mcp.types import ToolAnnotations
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from prometheus_client import start_http_server
+from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
@@ -15,6 +16,7 @@ from flagsmith_mcp import config, constants
 from flagsmith_mcp.auth import FlagsmithAuth
 from flagsmith_mcp.events import EventLoggingMiddleware
 from flagsmith_mcp.metrics import PrometheusMiddleware
+from flagsmith_mcp.middleware import RootRouterMiddleware
 from flagsmith_mcp.oauth import FlagsmithResourceAuth
 from flagsmith_mcp.telemetry import propagate_span_attributes, setup_telemetry
 
@@ -97,6 +99,8 @@ def run() -> None:
         server.run(
             transport=settings.transport,
             show_banner=False,
+            path=constants.STREAMABLE_HTTP_PATH,
+            middleware=[Middleware(RootRouterMiddleware)],
             # Let uvicorn log records propagate to the root logger so they
             # are rendered by the configured formatter.
             uvicorn_config={"log_config": None},

--- a/mcp/tests/integration/conftest.py
+++ b/mcp/tests/integration/conftest.py
@@ -13,9 +13,11 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 from respx import MockRouter
+from starlette.middleware import Middleware
 
 from flagsmith_mcp import config, constants
 from flagsmith_mcp import server as server_module
+from flagsmith_mcp.middleware import RootRouterMiddleware
 from flagsmith_mcp.telemetry import ClientInfoSpanProcessor
 
 HTTPClientFactoryFixture = Callable[[FastMCP], AsyncIterator[httpx.AsyncClient]]
@@ -89,7 +91,12 @@ async def client(server: FastMCP) -> AsyncIterator[Client[FastMCPTransport]]:
 @pytest.fixture
 def http_client_factory() -> HTTPClientFactoryFixture:
     async def factory(server: FastMCP) -> AsyncIterator[httpx.AsyncClient]:
-        transport = httpx.ASGITransport(app=server.http_app())
+        transport = httpx.ASGITransport(
+            app=server.http_app(
+                path=constants.STREAMABLE_HTTP_PATH,
+                middleware=[Middleware(RootRouterMiddleware)],
+            )
+        )
         async with httpx.AsyncClient(
             transport=transport, base_url="http://testserver"
         ) as connected:

--- a/mcp/tests/integration/test_root.py
+++ b/mcp/tests/integration/test_root.py
@@ -1,0 +1,37 @@
+import httpx
+import pytest
+
+from flagsmith_mcp import constants
+
+PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
+
+
+async def test_root__browser_accept__redirects_to_docs(
+    http_client: httpx.AsyncClient,
+) -> None:
+    # When a browser (Accept: text/html) opens the bare server URL
+    response = await http_client.get(
+        "/", headers={"Accept": "text/html,application/xhtml+xml"}
+    )
+
+    # Then it is redirected to the MCP docs
+    assert response.status_code == 302
+    assert response.headers["location"] == constants.MCP_DOCS_URL
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+async def test_root__non_browser_request__dispatched_to_mcp_handler(
+    http_client: httpx.AsyncClient,
+    method: str,
+) -> None:
+    # When an MCP client hits the bare URL (no `/mcp` suffix, no credential)
+    response = await http_client.request(
+        method,
+        "/",
+        headers={"Accept": "application/json, text/event-stream"},
+    )
+
+    # Then the request reaches the MCP handler, which gates on the missing
+    # credential and points the client at the protected-resource metadata
+    assert response.status_code == 401
+    assert PRM_PATH in response.headers["www-authenticate"]

--- a/mcp/tests/unit/test_server.py
+++ b/mcp/tests/unit/test_server.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from respx import MockRouter
 
 from flagsmith_mcp import config, constants, server
+from flagsmith_mcp.middleware import RootRouterMiddleware
 
 
 @pytest.mark.parametrize(
@@ -193,9 +194,12 @@ def test_run__http_transport__banner_off_uvicorn_logs_propagated(
     # When
     server.run()
 
-    # Then
-    create_server_mock.return_value.run.assert_called_once_with(
-        transport="http",
-        show_banner=False,
-        uvicorn_config={"log_config": None},
-    )
+    # Then the server is served on the streamable HTTP path, with logs
+    # propagated and the root router installed
+    _, kwargs = create_server_mock.return_value.run.call_args
+    assert kwargs["transport"] == "http"
+    assert kwargs["show_banner"] is False
+    assert kwargs["path"] == constants.STREAMABLE_HTTP_PATH
+    assert kwargs["uvicorn_config"] == {"log_config": None}
+    (root_router,) = kwargs["middleware"]
+    assert root_router.cls is RootRouterMiddleware


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`https://mcp.flagsmith.com` (without `/mcp`) currently 404s, so `claude mcp add ... https://mcp.flagsmith.com` fails. Add middleware on `/`: browsers → 302 to docs, MCP clients → served at `/mcp`.

## How did you test this code?

New integration tests + 100% coverage; `make lint`/`typecheck` clean.