### PR TITLE
fix(MCP): Bare server URL fails OAuth resource validation

### DIFF
--- a/mcp/src/flagsmith_mcp/oauth.py
+++ b/mcp/src/flagsmith_mcp/oauth.py
@@ -58,6 +58,11 @@ class FlagsmithResourceAuth(RemoteAuthProvider):
             scopes_supported=OAUTH_SCOPES,
         )
 
+    def _get_resource_url(self, path: str | None = None) -> AnyHttpUrl | None:
+        # Advertise the server origin as the protected resource
+        # to enable client registration for both the root path and the /mcp path
+        return super()._get_resource_url(None)
+
     def get_middleware(self) -> list[Middleware]:
         return [
             Middleware(AuthenticationMiddleware, backend=_AnySchemeBackend()),

--- a/mcp/tests/integration/test_oauth.py
+++ b/mcp/tests/integration/test_oauth.py
@@ -8,7 +8,7 @@ from fastmcp import FastMCP
 from flagsmith_mcp import config
 from flagsmith_mcp import server as server_module
 
-PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
+PRM_PATH = "/.well-known/oauth-protected-resource"
 
 
 @pytest.fixture
@@ -33,9 +33,11 @@ async def test_http_no_token__serves_protected_resource_metadata(
     # Given OAuth discovery is active (server fixture: http, no static token)
     response = await http_client.get(PRM_PATH)
 
-    # Then it advertises the Flagsmith AS and the mcp scope (RFC 9728)
+    # Then it advertises the Flagsmith AS and the mcp scope (RFC 9728), and the
+    # resource is the server origin
     assert response.status_code == 200
     body = response.json()
+    assert body["resource"] == "http://127.0.0.1:8000/"
     assert body["authorization_servers"] == ["https://api.flagsmith.com/"]
     assert body["scopes_supported"] == ["mcp"]
 

--- a/mcp/tests/integration/test_root.py
+++ b/mcp/tests/integration/test_root.py
@@ -3,7 +3,7 @@ import pytest
 
 from flagsmith_mcp import constants
 
-PRM_PATH = "/.well-known/oauth-protected-resource/mcp"
+PRM_PATH = "/.well-known/oauth-protected-resource"
 
 
 async def test_root__browser_accept__redirects_to_docs(


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #7797. The bare URL reaches the MCP handler but still fails to connect: clients match the advertised protected resource against the URL they registered (or its origin, RFC 9728), and the default `https://host/mcp` matches neither a bare-URL registration nor its origin.

Advertise the origin as the resource. PRM moves to root `/.well-known/oauth-protected-resource`; both `/` and `/mcp` 401s point there, so either registration validates. Handler stays at `/mcp`. Token validation is unaffected — DOT doesn't bind tokens to a `resource`/audience.

## How did you test this code?

Updated integration tests + 100% coverage; `make lint`/`typecheck` clean.