### PR TITLE
fix(organisation): disable delete button when active subscription exists

### DIFF
--- a/frontend/web/components/pages/organisation-settings/tabs/general-tab/sections/DeleteOrganisation.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/general-tab/sections/DeleteOrganisation.tsx
@@ -53,7 +53,11 @@ export const DeleteOrganisation = ({
           data-test='delete-org-btn'
           onClick={handleDelete}
           theme='danger'
-          disabled={isLoading}
+          disabled={
+            isLoading ||
+            (organisation.subscription.plan !== null &&
+              organisation.subscription.cancellation_date === null)
+          }
         >
           {isLoading ? 'Deleting...' : 'Delete Organisation'}
         </Button>

--- a/frontend/web/components/pages/organisation-settings/tabs/general-tab/sections/DeleteOrganisation.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/general-tab/sections/DeleteOrganisation.tsx
@@ -38,6 +38,9 @@ export const DeleteOrganisation = ({
       'p-0',
     )
   }
+  const isDeleteButtonDisabled =
+    Utils.getPlanName(organisation.subscription?.plan ?? '') !==
+      planNames.free && !organisation.subscription?.cancellation_date
 
   return (
     <>
@@ -54,15 +57,18 @@ export const DeleteOrganisation = ({
           data-test='delete-org-btn'
           onClick={handleDelete}
           theme='danger'
-          disabled={
-            isLoading ||
-            (Utils.getPlanName(organisation.subscription?.plan ?? '') !==
-              planNames.free &&
-              !organisation.subscription?.cancellation_date)
-          }
+          disabled={isLoading || isDeleteButtonDisabled}
         >
           {isLoading ? 'Deleting...' : 'Delete Organisation'}
         </Button>
+        {isDeleteButtonDisabled && (
+          <div className='col-md-7'>
+            <p className='text-danger'>
+              You need to cancel your active subscriptions before deleting your
+              organisation.
+            </p>
+          </div>
+        )}
       </Row>
     </>
   )

--- a/frontend/web/components/pages/organisation-settings/tabs/general-tab/sections/DeleteOrganisation.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/general-tab/sections/DeleteOrganisation.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
+import { planNames } from 'common/utils/utils'
 import { Organisation } from 'common/types/responses'
 import { useDeleteOrganisationWithToast } from 'components/pages/organisation-settings/hooks'
 import ConfirmRemoveOrganisation from 'components/modals/ConfirmRemoveOrganisation'
@@ -55,8 +56,9 @@ export const DeleteOrganisation = ({
           theme='danger'
           disabled={
             isLoading ||
-            (organisation.subscription.plan !== null &&
-              organisation.subscription.cancellation_date === null)
+            (Utils.getPlanName(organisation.subscription?.plan ?? '') !==
+              planNames.free &&
+              !organisation.subscription?.cancellation_date)
           }
         >
           {isLoading ? 'Deleting...' : 'Delete Organisation'}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✔] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [  ] I have added information to `docs/` if required so people know about the feature.
- [✔] I have filled in the "Changes" section below.
- [✔] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7700 

1. In `DeleteOrganisation.tsx`, the button Delete Organisation is disabled only when `isLoading` is true.
2. However to prevent it being active, we need to add more condition which is related to billing subscription.
3. The component `DeleteOrganisation` receives `Organisation` data, which has `Subscription` property.
4. The interface `Subscription` itself accepts 2 properties; `plan` and `cancellation_date`, for which we can use them as the guarding condition.
5. The Delete Organisation button will remain disabled if `plan !== null` and `cancellation_date === null`.

## How did you test this code?

1. In local, it's quite difficult for me to find the Billing tab under Organisation Settings and make sure both of the condition has disabled Delete Organisation button, though I can see it in the deployed flagsmith app (https://app.flagsmith.com/).
2. To navigate through this, I use Python Shell to manipulate the database's data, and console.log to see the manipulated value of `plan` and `cancellation_date`.

Before changes:
[Screencast from 18-06-26 08:44:50.webm](https://github.com/user-attachments/assets/a88d1f89-ad25-41b3-9de1-ab75bbe598bd)

Input for python shell:
```python
from organisations.models import Subscription
sub = Subscription.objects.first()
sub.plan = 'startup'
sub.cancellation_date = None
sub.save()
print(sub.id, sub.plan, sub.cancellation_date)
``` 
Input for console.log:
```typescript
{console.log(
          organisation.subscription.plan,
          organisation.subscription.cancellation_date,
        )}
``` 

Output of python shell:
<img width="682" height="181" alt="image" src="https://github.com/user-attachments/assets/215ece02-9394-4b27-871b-b5fe04ba7e17" />

Output of console.log:
[Screencast from 18-06-26 09:11:24.webm](https://github.com/user-attachments/assets/5cb95058-de3c-4ce9-96c3-27980217c410)



