### PR TITLE
chore(CODEOWNERS): Assign /mcp to back-end team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 /frontend/       @flagsmith/flagsmith-front-end
 /infrastructure/ @flagsmith/flagsmith-infrastructure
 /docs/           @flagsmith/flagsmith-docs
+/mcp/            @flagsmith/flagsmith-back-end
 
 # Event changes are relevant to the product team
 /docs/docs/deployment-self-hosting/observability/_events-catalogue.md @flagsmith/flagsmith-product


### PR DESCRIPTION
## Changes

Assign `/mcp/` to `@flagsmith/flagsmith-back-end`.

## How did you test this code?

N/A.