### PR TITLE
ci(frontend): lint changed lines via eslint-plugin-diff

### DIFF
--- a/.github/workflows/frontend-pull-request.yml
+++ b/.github/workflows/frontend-pull-request.yml
@@ -58,18 +58,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Diff-scoped: the frontend has a large pre-existing eslint/tsc backlog,
-      # so a whole-repo gate isn't viable yet.
-      - name: Lint changed files
+      # Lints only the lines this PR changed (eslint-plugin-diff), so the
+      # pre-existing backlog doesn't fail PRs. Fork-safe: pure eslint + git.
+      - name: Lint changed lines
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          CHANGED=$(git diff --name-only --diff-filter=ACMR --relative \
-            "$BASE_SHA" HEAD -- '*.ts' '*.tsx' '*.js')
-          if [ -z "$CHANGED" ]; then
-            echo "No frontend JS/TS files changed — skipping."
-            exit 0
-          fi
-          echo "Linting changed files:"
-          echo "$CHANGED"
-          echo "$CHANGED" | xargs npx eslint
+          ESLINT_PLUGIN_DIFF_COMMIT: ${{ github.event.pull_request.base.sha }}
+        run: npm run lint

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -11,6 +11,9 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:@dword-design/import-alias/recommended',
     'plugin:storybook/recommended',
+    // Lints only changed lines in CI (no-op locally), so the pre-existing
+    // eslint backlog doesn't fail PRs that merely touch a file.
+    'plugin:diff/ci',
   ],
   'globals': {
     '$': true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -123,6 +123,7 @@
         "chromatic": "^15.2.0",
         "eslint": "^8.0.1",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-diff": "^2.1.7",
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-import-alias": "^1.2.0",
         "eslint-plugin-prettier": "^3.4.0",
@@ -12228,6 +12229,19 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-diff": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-diff/-/eslint-plugin-diff-2.1.7.tgz",
+      "integrity": "sha512-F0EP5knbELQRPX7A4ogFFty+Pyru6CtUFmt52VSJ+7I84UsOj5s+BtY/ZhQFdvmPkFzKqVy+g5IHP+iiaUu/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.7.0"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -161,6 +161,7 @@
     "chromatic": "^15.2.0",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-diff": "^2.1.7",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-import-alias": "^1.2.0",
     "eslint-plugin-prettier": "^3.4.0",


### PR DESCRIPTION
## Changes

The `Lint changed files` job lints **whole** changed files. With the frontend's large pre-existing eslint backlog, touching any debt-laden file fails the PR on errors it never introduced — which nudges contributors toward project-wide `npm run lint:fix` (see #7733, where that swept ~21 unrelated files into the PR).

This switches the job to **eslint-plugin-diff** (`plugin:diff/ci`), which filters lint messages to the **lines a PR changed**:

- No-op locally and in editors; active only under CI (the `CI` env var Actions sets).
- Pure eslint + git — **no `GITHUB_TOKEN` writes**, so it works on **fork PRs** too.
- Diff base is the PR base commit (`ESLINT_PLUGIN_DIFF_COMMIT`).
- Errors block, warnings don't (unchanged).

The workflow step is now just `npm run lint` with that env var — no bespoke script, no third-party CI action.

## How did you test this code?

Locally: with `CI=true ESLINT_PLUGIN_DIFF_COMMIT=<base>`, eslint reported only the appended error and ignored the pre-existing ones. This PR's CI run confirms the same in the Actions runner via the temp commit.