### PR TITLE
ci(frontend): skip Chromatic on fork PRs

### DIFF
--- a/.github/workflows/frontend-chromatic.yml
+++ b/.github/workflows/frontend-chromatic.yml
@@ -23,12 +23,15 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
-    # Dependabot PRs use a separate secrets store, so they can't read
-    # CHROMATIC_PROJECT_TOKEN. main's post-merge push runs Chromatic
-    # with full secrets, so coverage isn't lost.
+    # Fork PRs (incl. Dependabot) can't read CHROMATIC_PROJECT_TOKEN — GitHub
+    # withholds repo secrets from pull_request runs originating from forks, so
+    # Chromatic would fail with "Missing project token". Skip them here; main's
+    # post-merge push runs Chromatic with full secrets, so coverage isn't lost.
     if: |
       github.actor != 'dependabot[bot]'
       && (github.event_name == 'push' || github.event.pull_request.draft == false)
+      && (github.event_name == 'push'
+        || github.event.pull_request.head.repo.full_name == github.repository)
 
     defaults:
       run:


### PR DESCRIPTION
## Changes

Chromatic fails with `✖ Missing project token` on every **community / fork PR** (e.g. #7733). GitHub deliberately withholds repo secrets from `pull_request` runs originating from forks, so `CHROMATIC_PROJECT_TOKEN` is empty and the job can't run.

This guards the `chromatic` job to run only for **same-repo PRs and pushes**:

```yaml
&& (github.event_name == 'push'
  || github.event.pull_request.head.repo.full_name == github.repository)
```

Fork PRs now **skip** Chromatic instead of showing a spurious red check. Visual coverage isn't lost — the existing post-merge `push: [main]` run executes Chromatic with full secrets (the same fallback the workflow already relied on for Dependabot).

This extends the existing Dependabot handling to all forks, since it's the same root cause (no secret access on fork runs).

## How did you test this code?

- Validated the workflow YAML parses and the `if` evaluates correctly for each case: push → runs, same-repo PR → runs, fork PR → skips, Dependabot → skips.
- The full fork-skip path only manifests on an actual fork PR; this PR (same-repo) still runs Chromatic, which is the intended behaviour.