### PR TITLE
chore(segments): Address review feedback on membership refresh tests

### DIFF
--- a/api/tests/integration/segments/test_segment_membership_refresh.py
+++ b/api/tests/integration/segments/test_segment_membership_refresh.py
@@ -1,6 +1,3 @@
-import json
-
-from django.urls import reverse
 from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -18,19 +15,16 @@ def test_update_segment__edit__enqueues_membership_refresh(
     enqueue_membership_refresh_mock = mocker.patch(
         "segments.serializers.enqueue_membership_refresh"
     )
-    url = reverse(
-        "api-v1:projects:project-segments-detail",
-        args=[project, segment],
-    )
-    data = {
-        "name": "renamed",
-        "project": project,
-        "rules": [{"type": "ALL", "rules": [], "conditions": []}],
-    }
 
     # When
     response = admin_client.put(
-        url, data=json.dumps(data), content_type="application/json"
+        f"/api/v1/projects/{project}/segments/{segment}/",
+        data={
+            "name": "renamed",
+            "project": project,
+            "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+        },
+        format="json",
     )
 
     # Then
@@ -49,16 +43,16 @@ def test_create_segment__new_segment__enqueues_membership_refresh(
     enqueue_membership_refresh_mock = mocker.patch(
         "segments.serializers.enqueue_membership_refresh"
     )
-    url = reverse("api-v1:projects:project-segments-list", args=[project])
-    data = {
-        "name": "new-segment",
-        "project": project,
-        "rules": [{"type": "ALL", "rules": [], "conditions": []}],
-    }
 
     # When
     response = admin_client.post(
-        url, data=json.dumps(data), content_type="application/json"
+        f"/api/v1/projects/{project}/segments/",
+        data={
+            "name": "new-segment",
+            "project": project,
+            "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+        },
+        format="json",
     )
 
     # Then
@@ -78,15 +72,12 @@ def test_clone_segment__clone__enqueues_membership_refresh(
     enqueue_membership_refresh_mock = mocker.patch(
         "segments.views.enqueue_membership_refresh"
     )
-    url = reverse(
-        "api-v1:projects:project-segments-clone",
-        args=[project, segment],
-    )
-    data = {"name": "cloned-segment"}
 
     # When
     response = admin_client.post(
-        url, data=json.dumps(data), content_type="application/json"
+        f"/api/v1/projects/{project}/segments/{segment}/clone/",
+        data={"name": "cloned-segment"},
+        format="json",
     )
 
     # Then

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -661,9 +661,7 @@ def test_process_import_request__import__enqueues_membership_refresh(
     )
 
     # When
-    # the import (which bulk-creates segments) completes
     process_import_request(import_request)
 
     # Then
-    # it triggers a single membership refresh for the imported project
     enqueue_membership_refresh_mock.assert_called_once_with(project)

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -235,7 +235,6 @@ def test_enqueue_membership_refresh__flag_on__enqueues_refresh(
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
-    # an org with the flag on
     enable_features("segment_membership_inspection")
     settings.CLICKHOUSE_ENABLED = True
     mocker.patch("segment_membership.tasks.open_clickhouse_cursor")
@@ -249,7 +248,6 @@ def test_enqueue_membership_refresh__flag_on__enqueues_refresh(
     run_tasks(num_tasks=2)
 
     # Then
-    # exactly one refresh runs, for the project
     compute_segment_counts_for_project_mock.assert_called_once_with(project, mocker.ANY)
 
 
@@ -260,7 +258,6 @@ def test_enqueue_membership_refresh__flag_off__does_not_enqueue(
     project: Project,
 ) -> None:
     # Given
-    # the org's flag is off
     settings.CLICKHOUSE_ENABLED = True
     mocker.patch("segment_membership.tasks.open_clickhouse_cursor")
     compute_segment_counts_for_project_mock = mocker.patch(
@@ -273,7 +270,6 @@ def test_enqueue_membership_refresh__flag_off__does_not_enqueue(
     run_tasks(num_tasks=1)
 
     # Then
-    # no refresh runs
     compute_segment_counts_for_project_mock.assert_not_called()
 
 
@@ -285,7 +281,6 @@ def test_enqueue_membership_refresh__refresh_already_pending__debounces(
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
-    # a refresh for the same project is already pending
     enable_features("segment_membership_inspection")
     settings.CLICKHOUSE_ENABLED = True
     mocker.patch("segment_membership.tasks.open_clickhouse_cursor")
@@ -300,7 +295,6 @@ def test_enqueue_membership_refresh__refresh_already_pending__debounces(
     run_tasks(num_tasks=2)
 
     # Then
-    # the call did not enqueue a second refresh -- only the pending one ran
     compute_segment_counts_for_project_mock.assert_called_once_with(project, mocker.ANY)
 
 
@@ -313,7 +307,6 @@ def test_enqueue_membership_refresh__pending_for_other_project__still_enqueues(
     enable_features: EnableFeaturesFixture,
 ) -> None:
     # Given
-    # a refresh is pending for a different project only
     enable_features("segment_membership_inspection")
     settings.CLICKHOUSE_ENABLED = True
     mocker.patch("segment_membership.tasks.open_clickhouse_cursor")
@@ -328,7 +321,6 @@ def test_enqueue_membership_refresh__pending_for_other_project__still_enqueues(
     run_tasks(num_tasks=3)
 
     # Then
-    # the debounce is scoped per project: both refreshes run
     assert compute_segment_counts_for_project_mock.call_count == 2
     compute_segment_counts_for_project_mock.assert_has_calls(
         [mocker.call(project, mocker.ANY), mocker.call(project_b, mocker.ANY)],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #7828 addressing test review feedback:

- Segment membership integration tests now call the endpoints with their literal paths and dict bodies via `format="json"`, matching the surrounding integration-test style.
- Removed the explanatory sub-comments under the Given/When/Then markers across the membership service tests and the LaunchDarkly import test, keeping the bare structure markers.

No production code changes.

## How did you test this code?

`make test` over the affected suites; `ruff`, `isort`, `black`, and `mypy` (strict) all pass.