### PR TITLE
fix(features): return 400 instead of 500 on feature name race condition

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -11,7 +11,7 @@ from common.features.serializers import (
     FeatureStateValueSerializer,
 )
 from common.projects.permissions import VIEW_PROJECT
-from django.db import models
+from django.db import IntegrityError, models
 from drf_spectacular.utils import extend_schema_field
 from drf_writable_nested import (  # type: ignore[attr-defined]
     WritableNestedModelSerializer,
@@ -57,6 +57,11 @@ from .feature_types import FEATURE_TYPE_CHOICES, MULTIVARIATE
 from .models import Feature, FeatureState
 from .multivariate.models import MultivariateFeatureOption
 from .multivariate.serializers import NestedMultivariateFeatureOptionSerializer
+
+DUPLICATE_FEATURE_NAME_ERROR = (
+    "Feature with that name already exists for this project. Note that feature "
+    "names are case insensitive."
+)
 
 
 class FeatureStateSerializerSmall(serializers.ModelSerializer):  # type: ignore[type-arg]
@@ -275,7 +280,14 @@ class CreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerializer):
         group_owners: list[UserPermissionGroup] = validated_data.pop("group_owners", [])
 
         user = validated_data.pop("user", None)
-        instance = super(CreateFeatureSerializer, self).create(validated_data)  # type: ignore[no-untyped-call]
+        try:
+            instance = super(CreateFeatureSerializer, self).create(validated_data)  # type: ignore[no-untyped-call]
+        except IntegrityError:
+            # A concurrent request may create a feature with the same name after
+            # `validate_name` has run but before this insert, tripping the
+            # case-insensitive unique constraint. Surface this as a 400 rather
+            # than letting the IntegrityError bubble up as an HTTP 500.
+            raise serializers.ValidationError({"name": [DUPLICATE_FEATURE_NAME_ERROR]})
 
         if owners:
             instance.owners.add(*owners)
@@ -369,11 +381,7 @@ class CreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerializer):
             )
 
         if existing_feature_queryset.exists():
-            raise serializers.ValidationError(
-                "Feature with that name already exists for this "
-                "project. Note that feature names are case "
-                "insensitive."
-            )
+            raise serializers.ValidationError(DUPLICATE_FEATURE_NAME_ERROR)
 
         return name
 

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -1806,6 +1806,35 @@ def test_create_feature__name_does_not_match_regex__returns_400(
     )
 
 
+def test_create_feature__name_race_condition__returns_400(
+    admin_client_new: APIClient,
+    project: Project,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    # Simulate a race where `validate_name` passes (e.g. a concurrent request
+    # creates the feature after validation runs) but the database's
+    # case-insensitive unique constraint rejects the duplicate name on insert.
+    mocker.patch(
+        "features.serializers.CreateFeatureSerializer.validate_name",
+        side_effect=lambda name: name,
+    )
+
+    url = reverse("api-v1:projects:project-features-list", args=[project.id])
+    data = {"name": feature.name, "type": STANDARD, "project": project.id}
+
+    # When
+    response = admin_client_new.post(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["name"][0] == (
+        "Feature with that name already exists for this project. Note that "
+        "feature names are case insensitive."
+    )
+
+
 def test_create_feature__valid_data__creates_audit_log(
     admin_client_new: APIClient,
     project: Project,


### PR DESCRIPTION
 Description (replace the blank template with this):
  - [x] I have read the Contributing Guide.
  - [ ] I have added information to `docs/` if required so people know about the feature.
  - [x] I have filled in the "Changes" section below.
  - [x] I have filled in the "How did you test this code" section below.
  
  ## Changes
  
  Closes #6617
  
  When two requests create a feature with the same name concurrently, both can
  pass `validate_name` before either is persisted. The second insert then trips
  the case-insensitive `lowercase_feature_name` unique constraint, raising an
  unhandled `IntegrityError` that surfaces to the client as an HTTP 500.
  
  This catches the `IntegrityError` during creation and re-raises it as a
  validation error, so the client receives a clear 400 response consistent with
  the existing duplicate-name validation. The duplicate-name message is extracted
  into a shared constant so both code paths stay in sync.
  
  ## How did you test this code?
  
  Added a unit test (`test_create_feature__name_race_condition__returns_400`) that
  simulates the race by letting `validate_name` pass while the database still 
  rejects the duplicate name, and asserts the endpoint responds with a 400 and the
  expected error message. Verified locally against Postgres:
  
  ```
  make test opts='tests/unit/features/test_unit_features_views.py -k name_race_condition'
  ```
