### PR TITLE
fix(segments): warn before discarding an unsaved feature-specific seg…

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -291,7 +291,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
   const [valueChanged, setValueChanged] = useState(false)
   const [metadataValueChanged, setMetadataValueChanged] = useState(false)
   const onClosing = useCallback(() => {
-    return new Promise((resolve) => {
+    return new Promise<boolean>((resolve) => {
       if (valueChanged) {
         openConfirm({
           body: 'Closing this will discard your unsaved changes.',
@@ -306,6 +306,19 @@ const CreateSegment: FC<CreateSegmentType> = ({
       }
     })
   }, [valueChanged])
+  // The condensed/inline drawer (e.g. creating a feature-specific segment) is
+  // closed via the `onCancel` prop, which bypasses the modal's intercept-close
+  // handler above. Guard it so unsaved changes prompt the same confirmation (#5368).
+  const handleCancel = useCallback(() => {
+    if (!onCancel) {
+      return
+    }
+    onClosing().then((shouldClose) => {
+      if (shouldClose) {
+        onCancel()
+      }
+    })
+  }, [onCancel, onClosing])
   const onCreateChangeRequest = async (changeRequestData: {
     approvals: []
     description: string
@@ -569,7 +582,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 isSaving={isSaving}
                 isValid={isValid}
                 isLimitReached={isLimitReached}
-                onCancel={onCancel}
+                onCancel={handleCancel}
                 topLevelRuleType={topLevelRuleType}
                 setTopLevelRuleType={setTopLevelRuleType}
               />
@@ -646,7 +659,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 isSaving={isSaving}
                 isValid={isValid}
                 isLimitReached={isLimitReached}
-                onCancel={onCancel}
+                onCancel={handleCancel}
                 topLevelRuleType={topLevelRuleType}
                 setTopLevelRuleType={setTopLevelRuleType}
               />
@@ -685,7 +698,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               isSaving={isSaving}
               isValid={isValid}
               isLimitReached={isLimitReached}
-              onCancel={onCancel}
+              onCancel={handleCancel}
               topLevelRuleType={topLevelRuleType}
               setTopLevelRuleType={setTopLevelRuleType}
             />


### PR DESCRIPTION
 Description (replace the blank template with this):
  - [x] I have read the Contributing Guide.
  - [ ] I have added information to `docs/` if required so people know about the feature.
  - [x] I have filled in the "Changes" section below.
  - [x] I have filled in the "How did you test this code" section below.
  
  ## Changes
  
  Closes #5368
  
  When creating a feature-specific segment from the feature panel, the segment is
  built in an inline drawer that is closed via the `onCancel` prop. That path
  bypasses the modal's intercept-close handler, so closing the drawer silently
  discarded any unsaved work.
  
  This routes the drawer's cancel action through the existing `onClosing` guard,
  so the user is asked to confirm before their unsaved changes are discarded —
  the same confirmation already used when closing the full segment modal.
  
  ## How did you test this code?
  
  Manually:
  
  1. Open a feature, go to the Segment Overrides tab and click to create a new
     feature-specific segment. 
  2. Enter a name / add a rule, then click Cancel on the drawer.
  3. Confirm a "Discard changes" prompt now appears; choosing Cancel keeps the
     drawer open, choosing Ok discards and closes it.
  4. Confirm that closing the drawer with no changes still closes immediately
     (no prompt). 
     
  Also ran `npm run typecheck` and `eslint` on the changed file (no new errors).