### PR TITLE
feat(code-references): prompt users to add required integrations

### DIFF
--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
@@ -3,6 +3,8 @@ import flagsmith from '@flagsmith/flagsmith'
 import { useGetFeatureCodeReferencesQuery } from 'common/services/useCodeReferences'
 import RepoCodeReferencesSection from './components/RepoCodeReferencesSection'
 import { FeatureCodeReferences } from 'common/types/responses'
+import { useHasGithubIntegration } from 'common/hooks/useHasGithubIntegration'
+import { useHasGitLabIntegration } from 'common/hooks/useHasGitLabIntegration'
 
 interface FeatureCodeReferencesContainerProps {
   featureId: number
@@ -18,6 +20,9 @@ const FeatureCodeReferencesContainer: React.FC<
     featureId: featureId,
     projectId: projectId,
   })
+  const { hasIntegration: hasGithubIntegration, organisationId } =
+    useHasGithubIntegration()
+  const { hasIntegration: hasGitlabIntegration } = useHasGitLabIntegration()
 
   const codeReferencesByRepo = useMemo(
     () =>
@@ -63,6 +68,16 @@ const FeatureCodeReferencesContainer: React.FC<
   }
 
   if (!data || data.length === 0) {
+    if (!hasGithubIntegration && !hasGitlabIntegration) {
+      return (
+        <div className='text-center text-muted'>
+          Set up{' '}
+          <a href={`/organisation/${organisationId}/integrations`}>GitHub</a> or{' '}
+          <a href={`/project/${projectId}/integrations`}>GitLab</a> integration
+          to enable code references.
+        </div>
+      )
+    }
     return (
       <div className='text-center text-muted'>
         No code references found for this feature.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✔] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [  ] I have added information to `docs/` if required so people know about the feature.
- [✔] I have filled in the "Changes" section below.
- [✔] I have filled in the "How did you test this code" section below.

## Changes

Closes #7436 

1. Code References feature only show text "No code references found for this feature.", but doesn't inform the user what they should to next.
2. Add existing hooks to detect if GItHub or GitLab has been integrated
3. If the GitHub or GitLab has been integrated but no code references, it will just show "No code references found for this feature."
4. If the GitHub or GitLab has not been integrated, then it will show text with hyperlink to prompt user for integration.

## How did you test this code?

1. Edit / Add a feature > go to usage tab
2. If no integration has been added, the text will prompt user to do it
3. if integration has been added but no code reference, the text will show "no code references"

After changes:
[codereferences_integration_prompt - testing.webm](https://github.com/user-attachments/assets/09881ec7-0899-40f4-b04d-da9c2e7f7189)

