### PR TITLE
fix(infra): add EXPERIMENTATION_CLICKHOUSE_URL to task processor task defs

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -258,6 +258,10 @@
                 {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_KEY",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:FLAGSMITH_ON_FLAGSMITH_SERVER_KEY::"
+                },
+                {
+                    "name": "EXPERIMENTATION_CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:EXPERIMENTATION_CLICKHOUSE_URL::"
                 }
             ],
             "logConfiguration": {

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -237,6 +237,10 @@
                 {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_KEY",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:FLAGSMITH_ON_FLAGSMITH_SERVER_KEY::"
+                },
+                {
+                    "name": "EXPERIMENTATION_CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:EXPERIMENTATION_CLICKHOUSE_URL::"
                 }
             ],
             "logConfiguration": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds the `EXPERIMENTATION_CLICKHOUSE_URL` secret to the prod and staging **task processor** task definitions (same Secrets Manager source as `admin-api`).

`compute_experiment_exposures` runs on the task processor, which lacked the secret. The DSN resolved to `None`, so `parse_url(None)` raised `TypeError: a bytes-like object is required, not 'str'` every refresh cycle — the recurring `experimentation.exposures.compute_failed` Sentry alert.

## How did you test this code?

- Reproduced the `TypeError` locally via `parse_url(None)`.
- Confirmed `admin-api` had the secret and the task processor did not.
- Validated both JSON files with `python -m json.tool`.
