### PR TITLE
fix(clickhouse): Intermittent migration failures from replica metadata lag

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1495,6 +1495,10 @@ if CLICKHOUSE_ENABLED:
             "settings": {
                 # ClickHouse Cloud 25.12 requires this for `JSON`-column DDL.
                 "allow_experimental_json_type": 1,
+                # Block each DDL statement until every replica has applied it.
+                # Prevents replicated deployments (e.g. ClickHouse Cloud)
+                # from breaking migrations with Error 517.
+                "alter_sync": 2,
             },
         },
     }

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -260,6 +260,10 @@
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:FLAGSMITH_ON_FLAGSMITH_SERVER_KEY::"
                 },
                 {
+                    "name": "CLICKHOUSE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:clickhouse-url-kB2CK9"
+                },
+                {
                     "name": "EXPERIMENTATION_CLICKHOUSE_URL",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:EXPERIMENTATION_CLICKHOUSE_URL::"
                 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7836

`migrate --database clickhouse` runs DDL against ClickHouse Cloud, whose endpoint load-balances across replicas. With no synchronisation, a migrate run can land on a replica whose metadata version still lags Keeper's and fail with `Code 517`, intermittently breaking deployments.

- Set `alter_sync=2` on the `clickhouse` connection so each DDL statement blocks until every replica has applied it. This is a no-op on single-node deployments.
- Restore the `CLICKHOUSE_URL` secret on the production task processor task definition (removed as a stopgap in #7835), so the `segment_membership` tasks regain ClickHouse access.

## How did you test this code?

- Confirmed the task definition remains valid JSON and carries the `CLICKHOUSE_URL` secret.
- `alter_sync=2` is applied via the existing `clickhouse` connection `OPTIONS["settings"]`, alongside `allow_experimental_json_type`.