### PR TITLE
feat(onboarding): connection terminal and flags table

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -404,6 +404,9 @@ export type User = {
   last_login: string
   uuid: string
   onboarding: Onboarding
+  // Set client-side at login (not returned by the API): true for a freshly
+  // signed-up user, used to route them into the getting-started flow.
+  isGettingStarted?: boolean
   // TODO: Use enum
   role: string
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -404,8 +404,7 @@ export type User = {
   last_login: string
   uuid: string
   onboarding: Onboarding
-  // Set client-side at login (not returned by the API): true for a freshly
-  // signed-up user, used to route them into the getting-started flow.
+  // Set client-side at login, not returned by the API.
   isGettingStarted?: boolean
   // TODO: Use enum
   role: string

--- a/frontend/documentation/pages/onboarding/OnboardingFlagsTable.stories.tsx
+++ b/frontend/documentation/pages/onboarding/OnboardingFlagsTable.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from 'storybook'
+
+import OnboardingFlagsTable, {
+  OnboardingFlagRow,
+} from 'components/pages/onboarding/OnboardingFlagsTable'
+
+const demoFlag: OnboardingFlagRow = {
+  description: 'Controls the demo button shown to your users',
+  enabled: true,
+  name: 'show_demo_button',
+}
+
+const meta: Meta<typeof OnboardingFlagsTable> = {
+  args: {
+    flags: [demoFlag],
+    onToggle: () => {},
+    status: 'connected',
+  },
+  component: OnboardingFlagsTable,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The "Your flags" card from the onboarding flow, reusing the product FeatureName / Tag / Switch. Prop-driven: the page owns the flag data and the persisted Dev toggle. `connected` lifts the card with the accent border and glow; `waiting` dims it until the first evaluation arrives.',
+      },
+    },
+    layout: 'padded',
+  },
+  title: 'Pages/Onboarding/OnboardingFlagsTable',
+}
+export default meta
+
+type Story = StoryObj<typeof OnboardingFlagsTable>
+
+export const Connected: Story = {}
+
+export const Waiting: Story = {
+  args: { status: 'waiting' },
+}
+
+export const Off: Story = {
+  args: { flags: [{ ...demoFlag, enabled: false }] },
+}
+
+export const WithTag: Story = {
+  args: {
+    flags: [{ ...demoFlag, tags: [{ color: '#6837FC', label: 'demo' }] }],
+  },
+}

--- a/frontend/documentation/pages/onboarding/OnboardingFlagsTable.stories.tsx
+++ b/frontend/documentation/pages/onboarding/OnboardingFlagsTable.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from 'storybook'
 
+import { Tag } from 'common/types/responses'
 import OnboardingFlagsTable, {
   OnboardingFlagRow,
 } from 'components/pages/onboarding/OnboardingFlagsTable'
@@ -44,6 +45,8 @@ export const Off: Story = {
 
 export const WithTag: Story = {
   args: {
-    flags: [{ ...demoFlag, tags: [{ color: '#6837FC', label: 'demo' }] }],
+    flags: [
+      { ...demoFlag, tags: [{ color: '#6837FC', label: 'demo' } as Tag] },
+    ],
   },
 }

--- a/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
+++ b/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
@@ -4,15 +4,17 @@ import OnboardingTerminal from 'components/pages/onboarding/OnboardingTerminal'
 
 const meta: Meta<typeof OnboardingTerminal> = {
   args: {
+    connected: false,
     featureName: 'show_demo_button',
-    status: 'listening',
+    installCopied: false,
+    snippetCopied: false,
   },
   component: OnboardingTerminal,
   parameters: {
     docs: {
       description: {
         component:
-          'The onboarding verify console. Driven by `status`: amber LISTENING with an unchecked checklist and a blinking cursor while waiting, green LIVE with a connection receipt once the first evaluation arrives. Always dark, since a terminal reads the same in light and dark mode.',
+          'The onboarding verify console. The checklist ticks as the user acts (copy install, copy snippet), and the first evaluation flips the badge to LIVE and prints the connection receipt. Always dark, since a terminal reads the same in light and dark mode.',
       },
     },
     layout: 'padded',
@@ -25,6 +27,14 @@ type Story = StoryObj<typeof OnboardingTerminal>
 
 export const Listening: Story = {}
 
+export const InstallCopied: Story = {
+  args: { installCopied: true },
+}
+
+export const SnippetsCopied: Story = {
+  args: { installCopied: true, snippetCopied: true },
+}
+
 export const Connected: Story = {
-  args: { status: 'connected' },
+  args: { connected: true, installCopied: true, snippetCopied: true },
 }

--- a/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
+++ b/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from 'storybook'
+
+import OnboardingTerminal from 'components/pages/onboarding/OnboardingTerminal'
+
+const meta: Meta<typeof OnboardingTerminal> = {
+  args: {
+    featureName: 'show_demo_button',
+    status: 'listening',
+  },
+  component: OnboardingTerminal,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The onboarding verify console. Driven by `status`: amber LISTENING with an unchecked checklist and a blinking cursor while waiting, green LIVE with a connection receipt once the first evaluation arrives. Always dark, since a terminal reads the same in light and dark mode.',
+      },
+    },
+    layout: 'padded',
+  },
+  title: 'Pages/Onboarding/OnboardingTerminal',
+}
+export default meta
+
+type Story = StoryObj<typeof OnboardingTerminal>
+
+export const Listening: Story = {}
+
+export const Connected: Story = {
+  args: { status: 'connected' },
+}

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '../test-setup';
+import { byId, createHelpers, getFlagsmith, log, visualSnapshot } from '../helpers';
+import { E2E_SIGN_UP_USER, PASSWORD } from '../config';
+
+// The single-page onboarding flow (onboarding_quickstart_flow) a new user lands
+// on at /getting-started. Mirror of the legacy signup test's guard: this runs
+// only when the flag is on, the legacy signup test runs only when it's off.
+//
+// Selectors are accessibility-first (roles / labels / text), not data-test ids:
+// the header inputs expose aria-labels, the copy buttons and the flag switch
+// carry accessible names, and the flags table is a labelled region.
+test.describe('Onboarding', () => {
+  test('New user connects via the single-page onboarding flow @oss', async ({
+    page,
+  }, testInfo) => {
+    const { addErrorLogging, click, setText, waitForElementVisible } =
+      createHelpers(page);
+    const flagsmith = await getFlagsmith();
+
+    test.skip(
+      !flagsmith.hasFeature('onboarding_quickstart_flow'),
+      'Onboarding flow is behind onboarding_quickstart_flow',
+    );
+
+    await addErrorLogging();
+
+    // The flow renders once bootstrap settles (it shows a loader, then an error
+    // heading on failure - so the welcome heading means "ready").
+    const flowReady = async () =>
+      page
+        .getByRole('heading', { name: /Welcome/ })
+        .waitFor({ state: 'visible', timeout: 30000 });
+
+    // Sign up a fresh user; with the flag on, a getting-started user is routed
+    // to /getting-started where the flow bootstraps the org / project / flag.
+    log('Sign up');
+    await page.goto('/');
+    await click(byId('jsSignup'));
+    await waitForElementVisible(byId('firstName'));
+    await setText(byId('firstName'), 'Bullet');
+    await setText(byId('lastName'), 'Train');
+    await setText(byId('email'), E2E_SIGN_UP_USER);
+    await setText(byId('password'), PASSWORD);
+    await click(byId('signup-btn'));
+
+    // Don't navigate manually - a goto here races the post-signup auth and gets
+    // bounced to /?redirect=. The app redirects a getting-started user to the
+    // flow itself once authenticated, so just wait for it to land there.
+    log('Land on the onboarding flow');
+    await page.waitForURL((url) => url.pathname === '/getting-started', {
+      timeout: 30000,
+    });
+    await flowReady();
+    await visualSnapshot(page, 'onboarding-flow', testInfo);
+
+    // The verify terminal starts pre-connection: LISTENING, nothing ticked.
+    await expect(page.getByText('LISTENING')).toBeVisible();
+    await expect(page.getByText('Copy install command')).not.toContainText('✓');
+
+    // Copying the install + wire snippets ticks the checklist (the visible
+    // [✓] prefix is the done state).
+    log('Copy snippets, checklist ticks');
+    await page.getByRole('button', { name: 'Copy install command' }).click();
+    await expect(page.getByText('Copy install command')).toContainText('✓');
+    await page.getByRole('button', { name: 'Copy code snippet' }).click();
+    await expect(page.getByText('Copy code snippet')).toContainText('✓');
+
+    // The flags table is locked until the app connects, and there's no real
+    // first evaluation in a test - so force the connected state via ?connected
+    // (the stub seam for #7767). The badge flips to LIVE and the toggle unlocks.
+    log('Force the connected state');
+    await page.goto('/getting-started?connected');
+    await flowReady();
+    await expect(page.getByText('LIVE', { exact: true })).toBeVisible();
+
+    // Now the Development toggle is enabled. Two switches on the page (theme +
+    // flag), so scope to the flags region.
+    log('Toggle the flag');
+    const flagsTable = page.getByRole('region', { name: 'Your flags' });
+    const flagSwitch = flagsTable.getByRole('switch');
+    await flagSwitch.waitFor({ state: 'visible' });
+    const wasChecked = (await flagSwitch.getAttribute('class'))?.includes(
+      'switch-checked',
+    );
+    await flagSwitch.click();
+    await expect(flagSwitch).toHaveClass(
+      wasChecked ? /switch-unchecked/ : /switch-checked/,
+    );
+
+    // The Onboarding badge (attached in bootstrap) shows in the flags table.
+    // Exact match: the header crumb also contains the word "Onboarding".
+    await expect(flagsTable.getByText('Onboarding', { exact: true })).toBeVisible();
+
+    // Rename the flag. Names are immutable, so this delete + recreates; the
+    // Onboarding tag must survive (the recreate carries the old flag's tags).
+    log('Rename the flag');
+    const flagInput = page.getByLabel('Flag name');
+    await flagInput.fill('renamed_demo_flag');
+    await flagInput.press('Enter');
+
+    // Wait for the rename to persist before reloading - it's a delete + recreate
+    // (two requests), and reloading too early aborts them. The success toast
+    // fires once both land.
+    await expect(page.getByText('Flag name updated')).toBeVisible({
+      timeout: 20000,
+    });
+
+    // Reload to prove the rename persisted server-side and the tag came with it
+    // (bootstrap is idempotent and reuses the renamed flag on revisit).
+    await page.reload();
+    await flowReady();
+    await expect(page.getByLabel('Flag name')).toHaveValue('renamed_demo_flag');
+    await expect(
+      page
+        .getByRole('region', { name: 'Your flags' })
+        .getByText('Onboarding', { exact: true }),
+    ).toBeVisible();
+    await visualSnapshot(page, 'onboarding-renamed', testInfo);
+  });
+});

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -2,13 +2,9 @@ import { test, expect } from '../test-setup';
 import { byId, createHelpers, getFlagsmith, log, visualSnapshot } from '../helpers';
 import { E2E_SIGN_UP_USER, PASSWORD } from '../config';
 
-// The single-page onboarding flow (onboarding_quickstart_flow) a new user lands
-// on at /getting-started. Mirror of the legacy signup test's guard: this runs
-// only when the flag is on, the legacy signup test runs only when it's off.
-//
-// Selectors are accessibility-first (roles / labels / text), not data-test ids:
-// the header inputs expose aria-labels, the copy buttons and the flag switch
-// carry accessible names, and the flags table is a labelled region.
+// The single-page onboarding flow (onboarding_quickstart_flow), at
+// /getting-started. Runs only when the flag is on (the legacy signup test runs
+// when it's off).
 test.describe('Onboarding', () => {
   test('New user connects via the single-page onboarding flow @oss', async ({
     page,
@@ -24,15 +20,12 @@ test.describe('Onboarding', () => {
 
     await addErrorLogging();
 
-    // The flow renders once bootstrap settles (it shows a loader, then an error
-    // heading on failure - so the welcome heading means "ready").
+    // The welcome heading means bootstrap settled (loader, then heading/error).
     const flowReady = async () =>
       page
         .getByRole('heading', { name: /Welcome/ })
         .waitFor({ state: 'visible', timeout: 30000 });
 
-    // Sign up a fresh user; with the flag on, a getting-started user is routed
-    // to /getting-started where the flow bootstraps the org / project / flag.
     log('Sign up');
     await page.goto('/');
     await click(byId('jsSignup'));
@@ -43,9 +36,8 @@ test.describe('Onboarding', () => {
     await setText(byId('password'), PASSWORD);
     await click(byId('signup-btn'));
 
-    // Don't navigate manually - a goto here races the post-signup auth and gets
-    // bounced to /?redirect=. The app redirects a getting-started user to the
-    // flow itself once authenticated, so just wait for it to land there.
+    // Don't navigate manually - a goto races the post-signup auth and bounces to
+    // /?redirect=. The app routes a getting-started user here itself, so just wait.
     log('Land on the onboarding flow');
     await page.waitForURL((url) => url.pathname === '/getting-started', {
       timeout: 30000,
@@ -53,28 +45,23 @@ test.describe('Onboarding', () => {
     await flowReady();
     await visualSnapshot(page, 'onboarding-flow', testInfo);
 
-    // The verify terminal starts pre-connection: LISTENING, nothing ticked.
     await expect(page.getByText('LISTENING')).toBeVisible();
     await expect(page.getByText('Copy install command')).not.toContainText('✓');
 
-    // Copying the install + wire snippets ticks the checklist (the visible
-    // [✓] prefix is the done state).
     log('Copy snippets, checklist ticks');
     await page.getByRole('button', { name: 'Copy install command' }).click();
     await expect(page.getByText('Copy install command')).toContainText('✓');
     await page.getByRole('button', { name: 'Copy code snippet' }).click();
     await expect(page.getByText('Copy code snippet')).toContainText('✓');
 
-    // The flags table is locked until the app connects, and there's no real
-    // first evaluation in a test - so force the connected state via ?connected
-    // (the stub seam for #7767). The badge flips to LIVE and the toggle unlocks.
+    // No real first evaluation in a test, so force the connected state via
+    // ?connected (the #7767 stub); that unlocks the toggle and flips LIVE.
     log('Force the connected state');
     await page.goto('/getting-started?connected');
     await flowReady();
     await expect(page.getByText('LIVE', { exact: true })).toBeVisible();
 
-    // Now the Development toggle is enabled. Two switches on the page (theme +
-    // flag), so scope to the flags region.
+    // Two switches on the page (theme + flag), so scope to the flags region.
     log('Toggle the flag');
     const flagsTable = page.getByRole('region', { name: 'Your flags' });
     const flagSwitch = flagsTable.getByRole('switch');
@@ -98,15 +85,13 @@ test.describe('Onboarding', () => {
     await flagInput.fill('renamed_demo_flag');
     await flagInput.press('Enter');
 
-    // Wait for the rename to persist before reloading - it's a delete + recreate
-    // (two requests), and reloading too early aborts them. The success toast
-    // fires once both land.
+    // Wait for the rename to persist before reloading - it's a delete + recreate,
+    // and reloading too early aborts the requests. The toast fires once both land.
     await expect(page.getByText('Flag name updated')).toBeVisible({
       timeout: 20000,
     });
 
-    // Reload to prove the rename persisted server-side and the tag came with it
-    // (bootstrap is idempotent and reuses the renamed flag on revisit).
+    // Reload to prove it persisted (bootstrap reuses the renamed flag).
     await page.reload();
     await flowReady();
     await expect(page.getByLabel('Flag name')).toHaveValue('renamed_demo_flag');

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -136,8 +136,17 @@ const App = class extends Component {
     }
 
     if (!AccountStore.getOrganisation() && !invite) {
-      // If user has no organisation redirect to /create
-      this.props.history.replace(`/create${query}`)
+      // New users with no organisation go through the single-page onboarding
+      // flow when it's enabled - it creates the organisation itself, so it
+      // replaces the legacy /create page. Everyone else still gets /create.
+      if (
+        AccountStore.getUser()?.isGettingStarted &&
+        Utils.getFlagsmithHasFeature('onboarding_quickstart_flow')
+      ) {
+        this.props.history.replace('/getting-started')
+      } else {
+        this.props.history.replace(`/create${query}`)
+      }
       return
     }
 

--- a/frontend/web/components/base/forms/GhostInput/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput/GhostInput.tsx
@@ -63,6 +63,11 @@ const GhostInput = ({
         onKeyDown={onKeyDown}
         aria-label={ariaLabel}
         spellCheck={false}
+        // Opt out of browser autofill + password-manager overlays (1Password,
+        // LastPass); their icons would overlap the trailing edit pencil.
+        autoComplete='off'
+        data-1p-ignore
+        data-lpignore='true'
         style={{ width: inputWidth }}
       />
     </span>

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/CodeCard.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/CodeCard.tsx
@@ -10,11 +10,18 @@ export type CodeCardProps = {
   language: string
   // Left side of the card header (e.g. the language label or npm/yarn pills).
   headerLeft: ReactNode
+  // Fires when the user copies the code (drives the verify checklist).
+  onCopy?: () => void
 }
 
 // Owns its own "Copied" feedback so each card is independent. Highlight escapes
 // the body for display; Copy uses the raw string.
-const CodeCard: FC<CodeCardProps> = ({ code, headerLeft, language }) => {
+const CodeCard: FC<CodeCardProps> = ({
+  code,
+  headerLeft,
+  language,
+  onCopy,
+}) => {
   const { copied, copy } = useCopyFeedback()
 
   return (
@@ -25,7 +32,10 @@ const CodeCard: FC<CodeCardProps> = ({ code, headerLeft, language }) => {
           theme='primary'
           size='small'
           className='ms-auto'
-          onClick={() => copy(code)}
+          onClick={() => {
+            copy(code)
+            onCopy?.()
+          }}
         >
           <span
             className='d-inline-flex align-items-center gap-1'

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/CodeCard.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/CodeCard.tsx
@@ -12,12 +12,17 @@ export type CodeCardProps = {
   headerLeft: ReactNode
   // Fires when the user copies the code (drives the verify checklist).
   onCopy?: () => void
+  // Accessible name for the copy button. The visible label is the same ("Copy
+  // Code") on every card, so this distinguishes them for screen readers;
+  // defaults to the visible label.
+  copyLabel?: string
 }
 
 // Owns its own "Copied" feedback so each card is independent. Highlight escapes
 // the body for display; Copy uses the raw string.
 const CodeCard: FC<CodeCardProps> = ({
   code,
+  copyLabel,
   headerLeft,
   language,
   onCopy,
@@ -32,6 +37,7 @@ const CodeCard: FC<CodeCardProps> = ({
           theme='primary'
           size='small'
           className='ms-auto'
+          aria-label={copyLabel}
           onClick={() => {
             copy(code)
             onCopy?.()

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/CodeCard.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/CodeCard.tsx
@@ -6,20 +6,15 @@ import { useCopyFeedback } from 'components/pages/onboarding/hooks/useCopyFeedba
 
 export type CodeCardProps = {
   code: string
-  // Syntax language for the body's highlighting (e.g. 'bash', 'javascript').
+  // highlight.js language for the body.
   language: string
-  // Left side of the card header (e.g. the language label or npm/yarn pills).
   headerLeft: ReactNode
-  // Fires when the user copies the code (drives the verify checklist).
+  // Drives the verify checklist.
   onCopy?: () => void
-  // Accessible name for the copy button. The visible label is the same ("Copy
-  // Code") on every card, so this distinguishes them for screen readers;
-  // defaults to the visible label.
+  // Accessible name; the visible "Copy Code" label is identical on every card.
   copyLabel?: string
 }
 
-// Owns its own "Copied" feedback so each card is independent. Highlight escapes
-// the body for display; Copy uses the raw string.
 const CodeCard: FC<CodeCardProps> = ({
   code,
   copyLabel,

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/ConnectYourCodePanel.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/ConnectYourCodePanel.tsx
@@ -46,6 +46,7 @@ const ConnectYourCodePanel: FC<ConnectYourCodePanelProps> = ({
           code={installCode}
           language='bash'
           onCopy={onCopyInstall}
+          copyLabel='Copy install command'
           headerLeft={
             sdkSnippet.installYarn ? (
               <div className='onboarding-connect__pm d-inline-flex'>
@@ -81,6 +82,7 @@ const ConnectYourCodePanel: FC<ConnectYourCodePanelProps> = ({
           code={sdkSnippet.wire}
           language={sdkSnippet.language}
           onCopy={onCopyWire}
+          copyLabel='Copy code snippet'
           headerLeft={
             <span className='onboarding-connect__codecard-lang'>
               {sdkLang.label}

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/ConnectYourCodePanel.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/ConnectYourCodePanel.tsx
@@ -12,13 +12,18 @@ const PACKAGE_MANAGERS: PackageManager[] = ['npm', 'yarn']
 export type ConnectYourCodePanelProps = {
   environmentKey: string
   featureName: string
+  onCopyInstall?: () => void
+  onCopyWire?: () => void
 }
 
 // "Connect your code" tab: pick an SDK, then copy the install + wire snippets,
-// pre-filled with the real env key and flag this onboarding created.
+// pre-filled with the real env key and flag this onboarding created. The copy
+// actions feed the verify checklist.
 const ConnectYourCodePanel: FC<ConnectYourCodePanelProps> = ({
   environmentKey,
   featureName,
+  onCopyInstall,
+  onCopyWire,
 }) => {
   const [sdkLang, setSdkLang] = useState<SdkLang>(SDK_LANGS[0])
   const [installPm, setInstallPm] = useState<PackageManager>('npm')
@@ -40,6 +45,7 @@ const ConnectYourCodePanel: FC<ConnectYourCodePanelProps> = ({
         <CodeCard
           code={installCode}
           language='bash'
+          onCopy={onCopyInstall}
           headerLeft={
             sdkSnippet.installYarn ? (
               <div className='onboarding-connect__pm d-inline-flex'>
@@ -74,6 +80,7 @@ const ConnectYourCodePanel: FC<ConnectYourCodePanelProps> = ({
         <CodeCard
           code={sdkSnippet.wire}
           language={sdkSnippet.language}
+          onCopy={onCopyWire}
           headerLeft={
             <span className='onboarding-connect__codecard-lang'>
               {sdkLang.label}

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/OnboardingConnectPanel.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/OnboardingConnectPanel.scss
@@ -17,7 +17,6 @@
 
   &__prompt-text {
     color: var(--color-text-default);
-    // No mono design token exists; literal stack, matching the verify console.
     font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
     font-size: 0.8125rem;
     line-height: 1.5;

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/OnboardingConnectPanel.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/OnboardingConnectPanel.scss
@@ -17,7 +17,8 @@
 
   &__prompt-text {
     color: var(--color-text-default);
-    font-family: var(--font-family-mono, monospace);
+    // No mono design token exists; literal stack, matching the verify console.
+    font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
     font-size: 0.8125rem;
     line-height: 1.5;
     background: transparent;

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/OnboardingConnectPanel.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/OnboardingConnectPanel.tsx
@@ -28,6 +28,8 @@ const CONNECT_TABS: OnboardingTab<ConnectTab>[] = [
 export type OnboardingConnectPanelProps = {
   environmentKey: string
   featureName: string
+  onCopyInstall?: () => void
+  onCopyWire?: () => void
 }
 
 // Two ways to connect an app to the pre-created flag: paste an agent-agnostic
@@ -37,6 +39,8 @@ export type OnboardingConnectPanelProps = {
 const OnboardingConnectPanel: FC<OnboardingConnectPanelProps> = ({
   environmentKey,
   featureName,
+  onCopyInstall,
+  onCopyWire,
 }) => {
   const [tab, setTab] = useState<ConnectTab>('manual')
 
@@ -68,6 +72,8 @@ const OnboardingConnectPanel: FC<OnboardingConnectPanelProps> = ({
         <ConnectYourCodePanel
           environmentKey={environmentKey}
           featureName={featureName}
+          onCopyInstall={onCopyInstall}
+          onCopyWire={onCopyWire}
         />
       </OnboardingTabPanel>
     </div>

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
@@ -1,0 +1,88 @@
+// "Your flags" card. A normal light/dark surface (unlike the terminal), so it
+// uses the semantic tokens. Connected lifts it with the action/purple border +
+// glow to draw the eye; waiting dims it until the first evaluation lands.
+.onboarding-flags {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+
+  &__title {
+    margin: 0;
+    color: var(--color-text-default);
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  &__table {
+    width: 100%;
+    max-width: 760px;
+    overflow: hidden;
+    border-radius: 12px;
+    background: var(--color-surface-default);
+    border: 1px solid var(--color-border-action);
+    box-shadow: var(--shadow-lg);
+    transition: opacity var(--duration-fast) var(--easing-standard),
+      box-shadow var(--duration-fast) var(--easing-standard),
+      border-color var(--duration-fast) var(--easing-standard);
+
+    // Until the SDK connects the flag is real but quiet: no accent, dimmed.
+    &--waiting {
+      border-color: var(--color-border-default);
+      box-shadow: none;
+      opacity: 0.7;
+    }
+  }
+
+  &__head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 20px;
+    border-bottom: 1px solid var(--color-border-default);
+  }
+
+  &__col {
+    color: var(--color-text-secondary);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+
+    &--feature {
+      flex: 1;
+    }
+    &--enabled {
+      width: 96px;
+    }
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px;
+  }
+
+  &__feature {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__desc {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+  }
+
+  &__toggle {
+    width: 56px;
+  }
+}

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
@@ -1,25 +1,22 @@
 // "Your flags" card. A normal light/dark surface (unlike the terminal), so it
 // uses the semantic tokens. Connected lifts it with the action/purple border +
 // glow to draw the eye; waiting dims it until the first evaluation lands.
+// Layout (flex / gap), the surface background and the radius are Bootstrap /
+// token utilities in the markup; this file keeps the bits with no utility
+// equivalent: the accent glow, the waiting state, and the non-standard metrics.
 .onboarding-flags {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  // gap has no standard utility step (14px), so it stays here.
   gap: 14px;
 
   &__title {
-    margin: 0;
     color: var(--color-text-default);
     font-size: 16px;
-    font-weight: 700;
   }
 
   &__table {
     width: 100%;
     max-width: 760px;
     overflow: hidden;
-    border-radius: var(--radius-xl);
-    background: var(--color-surface-default);
     // Accent border + purple glow to lift the connected card (matches the mock).
     // Derived from the action colour with oklch alpha so it tracks the theme.
     border: 1px solid oklch(from var(--color-border-action) l c h / 0.4);
@@ -38,8 +35,6 @@
   }
 
   &__head {
-    display: flex;
-    align-items: center;
     gap: 12px;
     padding: 8px 20px;
     border-bottom: 1px solid var(--color-border-default);
@@ -60,27 +55,15 @@
   }
 
   &__row {
-    display: flex;
-    align-items: center;
     gap: 12px;
     padding: 14px 20px;
   }
 
   &__feature {
-    display: flex;
     flex: 1;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  &__name-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
   }
 
   &__desc {
-    margin: 0;
     color: var(--color-text-secondary);
     font-size: 12px;
   }

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
@@ -85,7 +85,8 @@
     font-size: 12px;
   }
 
+  // Match the ENABLED header column width so the toggle lines up under it.
   &__toggle {
-    width: 56px;
+    width: 96px;
   }
 }

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
@@ -18,10 +18,13 @@
     width: 100%;
     max-width: 760px;
     overflow: hidden;
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     background: var(--color-surface-default);
-    border: 1px solid var(--color-border-action);
-    box-shadow: var(--shadow-lg);
+    // Accent border + purple glow to lift the connected card (matches the mock).
+    // Derived from the action colour with oklch alpha so it tracks the theme.
+    border: 1px solid oklch(from var(--color-border-action) l c h / 0.4);
+    box-shadow: 0 18px 44px 2px oklch(from var(--color-border-action) l c h / 0.2),
+      var(--shadow-md);
     transition: opacity var(--duration-fast) var(--easing-standard),
       box-shadow var(--duration-fast) var(--easing-standard),
       border-color var(--duration-fast) var(--easing-standard);

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
@@ -1,12 +1,7 @@
-// "Your flags" card. A normal light/dark surface (unlike the terminal), so it
-// uses the semantic tokens. Connected lifts it with the action/purple border +
-// glow to draw the eye; waiting dims it until the first evaluation lands.
-// Layout (flex / gap), the surface background and the radius are Bootstrap /
-// token utilities in the markup; this file keeps the bits with no utility
-// equivalent: the accent glow, the waiting state, and the non-standard metrics.
+// "Your flags" card. Layout/surface via utilities; this keeps the accent glow,
+// the waiting state, and the non-standard metrics.
 .onboarding-flags {
-  // gap has no standard utility step (14px), so it stays here.
-  gap: 14px;
+  gap: 14px; // no utility step for 14px
 
   &__title {
     color: var(--color-text-default);
@@ -17,8 +12,7 @@
     width: 100%;
     max-width: 760px;
     overflow: hidden;
-    // Accent border + purple glow to lift the connected card (matches the mock).
-    // Derived from the action colour with oklch alpha so it tracks the theme.
+    // Accent glow, oklch-derived from the action colour so it tracks the theme.
     border: 1px solid oklch(from var(--color-border-action) l c h / 0.4);
     box-shadow: 0 18px 44px 2px oklch(from var(--color-border-action) l c h / 0.2),
       var(--shadow-md);
@@ -26,7 +20,6 @@
       box-shadow var(--duration-fast) var(--easing-standard),
       border-color var(--duration-fast) var(--easing-standard);
 
-    // Until the SDK connects the flag is real but quiet: no accent, dimmed.
     &--waiting {
       border-color: var(--color-border-default);
       box-shadow: none;

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.scss
@@ -43,7 +43,7 @@
   &__col {
     color: var(--color-text-secondary);
     font-size: 11px;
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
     letter-spacing: 0.5px;
 
     &--feature {

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -37,14 +37,17 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
 }) => {
   const waiting = status === 'waiting'
   return (
-    <section className='onboarding-flags'>
-      <h3 className='onboarding-flags__title'>Your flags</h3>
+    <section className='onboarding-flags d-flex flex-column align-items-center'>
+      <h3 className='onboarding-flags__title m-0 fw-bold'>Your flags</h3>
       <div
-        className={classNames('onboarding-flags__table', {
-          'onboarding-flags__table--waiting': waiting,
-        })}
+        className={classNames(
+          'onboarding-flags__table bg-surface-default rounded-xl',
+          {
+            'onboarding-flags__table--waiting': waiting,
+          },
+        )}
       >
-        <div className='onboarding-flags__head'>
+        <div className='onboarding-flags__head d-flex align-items-center'>
           <span className='onboarding-flags__col onboarding-flags__col--feature'>
             FEATURE
           </span>
@@ -53,16 +56,19 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
           </span>
         </div>
         {flags.map((flag) => (
-          <div className='onboarding-flags__row' key={flag.name}>
-            <div className='onboarding-flags__feature'>
-              <div className='onboarding-flags__name-row'>
+          <div
+            className='onboarding-flags__row d-flex align-items-center'
+            key={flag.name}
+          >
+            <div className='onboarding-flags__feature d-flex flex-column gap-1'>
+              <div className='d-flex align-items-center gap-2'>
                 <FeatureName name={flag.name} />
                 {flag.tags?.map((tag) => (
                   <Tag key={tag.id ?? tag.label} tag={tag} />
                 ))}
               </div>
               {flag.description && (
-                <p className='onboarding-flags__desc'>{flag.description}</p>
+                <p className='onboarding-flags__desc m-0'>{flag.description}</p>
               )}
             </div>
             <div className='onboarding-flags__toggle'>

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -1,0 +1,82 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import { Tag as TTag } from 'common/types/responses'
+import FeatureName from 'components/feature-summary/FeatureName'
+import Tag from 'components/tags/Tag'
+import Switch from 'components/Switch'
+import './OnboardingFlagsTable.scss'
+
+export type OnboardingFlagsTableStatus = 'waiting' | 'connected'
+
+export type OnboardingFlagRow = {
+  name: string
+  description?: string
+  tags?: Partial<TTag>[]
+  enabled: boolean
+}
+
+export type OnboardingFlagsTableProps = {
+  status: OnboardingFlagsTableStatus
+  flags: OnboardingFlagRow[]
+  onToggle: (flag: OnboardingFlagRow, enabled: boolean) => void
+  // Name of the flag whose toggle is mid-flight, so its Switch disables.
+  togglingFlag?: string | null
+}
+
+// The "Your flags" card from the onboarding design: the pre-created flag(s) in a
+// real-looking table that reuses the product FeatureName / Tag / Switch. Prop
+// driven (the page owns the data and the persisted toggle, see
+// useUpdateFeatureStateMutation). `connected` lifts the card with the accent
+// border + glow and enables the toggle; `waiting` dims it until the first
+// evaluation arrives.
+const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
+  flags,
+  onToggle,
+  status,
+  togglingFlag,
+}) => {
+  const waiting = status === 'waiting'
+  return (
+    <section className='onboarding-flags'>
+      <h3 className='onboarding-flags__title'>Your flags</h3>
+      <div
+        className={classNames('onboarding-flags__table', {
+          'onboarding-flags__table--waiting': waiting,
+        })}
+      >
+        <div className='onboarding-flags__head'>
+          <span className='onboarding-flags__col onboarding-flags__col--feature'>
+            FEATURE
+          </span>
+          <span className='onboarding-flags__col onboarding-flags__col--enabled'>
+            ENABLED
+          </span>
+        </div>
+        {flags.map((flag) => (
+          <div className='onboarding-flags__row' key={flag.name}>
+            <div className='onboarding-flags__feature'>
+              <div className='onboarding-flags__name-row'>
+                <FeatureName name={flag.name} />
+                {flag.tags?.map((tag) => (
+                  <Tag key={tag.id ?? tag.label} tag={tag} />
+                ))}
+              </div>
+              {flag.description && (
+                <p className='onboarding-flags__desc'>{flag.description}</p>
+              )}
+            </div>
+            <div className='onboarding-flags__toggle'>
+              <Switch
+                checked={flag.enabled}
+                disabled={togglingFlag === flag.name}
+                onChange={(enabled) => onToggle(flag, enabled)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default OnboardingFlagsTable

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -19,19 +19,13 @@ export type OnboardingFlagsTableProps = {
   status: OnboardingFlagsTableStatus
   flags: OnboardingFlagRow[]
   onToggle: (flag: OnboardingFlagRow, enabled: boolean) => void
-  // Name of the flag whose toggle is mid-flight, so its Switch disables.
   togglingFlag?: string | null
-  // Whether the flag's state has loaded; the toggle stays disabled until then so
-  // a click can't no-op against an unresolved feature state. Defaults to true.
+  // Defaults true; while false the toggle stays disabled (state not loaded yet).
   togglesReady?: boolean
 }
 
-// The "Your flags" card from the onboarding design: the pre-created flag(s) in a
-// real-looking table that reuses the product FeatureName / Tag / Switch. Prop
-// driven (the page owns the data and the persisted toggle, see
-// useUpdateFeatureStateMutation). `connected` lifts the card with the accent
-// border + glow and enables the toggle; `waiting` dims it until the first
-// evaluation arrives.
+// "Your flags" card: the pre-created flag in a table that reuses the product
+// FeatureName / Tag / Switch. Connected lifts it with a glow; waiting dims it.
 const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
   flags,
   onToggle,
@@ -40,9 +34,7 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
   togglingFlag,
 }) => {
   const waiting = status === 'waiting'
-  // Toggles are interactive only once the app has connected and the flag state
-  // has loaded; before that the table is a dimmed preview and a click would
-  // no-op. (A mid-flight toggle also locks its own row, below.)
+  // Locked until connected and the flag state has loaded (else a click no-ops).
   const togglesLocked = waiting || !togglesReady
   return (
     <section

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -21,6 +21,9 @@ export type OnboardingFlagsTableProps = {
   onToggle: (flag: OnboardingFlagRow, enabled: boolean) => void
   // Name of the flag whose toggle is mid-flight, so its Switch disables.
   togglingFlag?: string | null
+  // Whether the flag's state has loaded; the toggle stays disabled until then so
+  // a click can't no-op against an unresolved feature state. Defaults to true.
+  togglesReady?: boolean
 }
 
 // The "Your flags" card from the onboarding design: the pre-created flag(s) in a
@@ -33,6 +36,7 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
   flags,
   onToggle,
   status,
+  togglesReady = true,
   togglingFlag,
 }) => {
   const waiting = status === 'waiting'
@@ -82,7 +86,12 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
             <div className='onboarding-flags__toggle'>
               <Switch
                 checked={flag.enabled}
-                disabled={togglingFlag === flag.name}
+                // Locked until the app connects (the first evaluation arrives)
+                // and the flag state has loaded - the table is a dimmed preview
+                // until then, and an early click must not no-op.
+                disabled={
+                  waiting || !togglesReady || togglingFlag === flag.name
+                }
                 onChange={(enabled) => onToggle(flag, enabled)}
                 aria-label={`Toggle ${flag.name}`}
               />

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -37,8 +37,16 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
 }) => {
   const waiting = status === 'waiting'
   return (
-    <section className='onboarding-flags d-flex flex-column align-items-center'>
-      <h3 className='onboarding-flags__title m-0 fw-bold'>Your flags</h3>
+    <section
+      className='onboarding-flags d-flex flex-column align-items-center'
+      aria-labelledby='onboarding-flags-title'
+    >
+      <h3
+        className='onboarding-flags__title m-0 fw-bold'
+        id='onboarding-flags-title'
+      >
+        Your flags
+      </h3>
       <div
         className={classNames(
           'onboarding-flags__table bg-surface-default rounded-xl',
@@ -76,6 +84,7 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
                 checked={flag.enabled}
                 disabled={togglingFlag === flag.name}
                 onChange={(enabled) => onToggle(flag, enabled)}
+                aria-label={`Toggle ${flag.name}`}
               />
             </div>
           </div>

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -40,6 +40,10 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
   togglingFlag,
 }) => {
   const waiting = status === 'waiting'
+  // Toggles are interactive only once the app has connected and the flag state
+  // has loaded; before that the table is a dimmed preview and a click would
+  // no-op. (A mid-flight toggle also locks its own row, below.)
+  const togglesLocked = waiting || !togglesReady
   return (
     <section
       className='onboarding-flags d-flex flex-column align-items-center'
@@ -86,12 +90,7 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
             <div className='onboarding-flags__toggle'>
               <Switch
                 checked={flag.enabled}
-                // Locked until the app connects (the first evaluation arrives)
-                // and the flag state has loaded - the table is a dimmed preview
-                // until then, and an early click must not no-op.
-                disabled={
-                  waiting || !togglesReady || togglingFlag === flag.name
-                }
+                disabled={togglesLocked || togglingFlag === flag.name}
                 onChange={(enabled) => onToggle(flag, enabled)}
                 aria-label={`Toggle ${flag.name}`}
               />

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/OnboardingFlagsTable.tsx
@@ -11,7 +11,7 @@ export type OnboardingFlagsTableStatus = 'waiting' | 'connected'
 export type OnboardingFlagRow = {
   name: string
   description?: string
-  tags?: Partial<TTag>[]
+  tags?: TTag[]
   enabled: boolean
 }
 
@@ -72,7 +72,7 @@ const OnboardingFlagsTable: FC<OnboardingFlagsTableProps> = ({
               <div className='d-flex align-items-center gap-2'>
                 <FeatureName name={flag.name} />
                 {flag.tags?.map((tag) => (
-                  <Tag key={tag.id ?? tag.label} tag={tag} />
+                  <Tag key={tag.id} tag={tag} />
                 ))}
               </div>
               {flag.description && (

--- a/frontend/web/components/pages/onboarding/OnboardingFlagsTable/index.ts
+++ b/frontend/web/components/pages/onboarding/OnboardingFlagsTable/index.ts
@@ -1,0 +1,6 @@
+export { default } from './OnboardingFlagsTable'
+export type {
+  OnboardingFlagRow,
+  OnboardingFlagsTableProps,
+  OnboardingFlagsTableStatus,
+} from './OnboardingFlagsTable'

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -68,6 +68,8 @@ const OnboardingFlow: FC = () => {
   // first-evaluation signal lands (#7767, behind useOnboardingConnection); the
   // Dev toggle is real now.
   const connection = useOnboardingConnection()
+  // Session-only and one-way: a reload resets them, so the checklist reflects
+  // what the user did this visit, not durable progress. Fine for onboarding.
   const [installCopied, setInstallCopied] = useState(false)
   const [snippetCopied, setSnippetCopied] = useState(false)
   const {

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -5,8 +5,15 @@ import Icon from 'components/icons/Icon'
 import OnboardingHeader from 'components/pages/onboarding/OnboardingHeader'
 import ThemeToggle from 'components/pages/onboarding/ThemeToggle'
 import OnboardingConnectPanel from 'components/pages/onboarding/OnboardingConnectPanel'
+import OnboardingTerminal, {
+  OnboardingTerminalStatus,
+} from 'components/pages/onboarding/OnboardingTerminal'
+import OnboardingFlagsTable, {
+  OnboardingFlagsTableStatus,
+} from 'components/pages/onboarding/OnboardingFlagsTable'
 import { useEnsureOnboardingResources } from 'components/pages/onboarding/hooks/useEnsureOnboardingResources'
 import { useOnboardingFlagRename } from 'components/pages/onboarding/hooks/useOnboardingFlagRename'
+import { useOnboardingFlag } from 'components/pages/onboarding/hooks/useOnboardingFlag'
 import { useUpdateOrganisationMutation } from 'common/services/useOrganisation'
 import { useUpdateProjectMutation } from 'common/services/useProject'
 import './OnboardingFlow.scss'
@@ -16,7 +23,7 @@ import './OnboardingFlow.scss'
 //
 // Resources (org / project / Dev + Prod / first flag) are bootstrapped
 // idempotently by useEnsureOnboardingResources, and the inline header chips
-// persist renames. TODO(#7766): the verify console / flags table land on top.
+// persist renames; the verify terminal and flags table render below (#7766).
 const OnboardingFlow: FC = () => {
   const {
     caseSensitive,
@@ -58,6 +65,16 @@ const OnboardingFlow: FC = () => {
     featureName,
     projectId,
   })
+
+  // Verify terminal + flags table. They stay in the pre-connection state until
+  // the first-evaluation signal lands (#7767); the Dev toggle is real now.
+  const terminalStatus: OnboardingTerminalStatus = 'listening'
+  const flagsStatus: OnboardingFlagsTableStatus = 'waiting'
+  const {
+    enabled: flagEnabled,
+    isToggling,
+    toggle: toggleFlag,
+  } = useOnboardingFlag(environment, projectId, featureName)
 
   // Org/project are single-field PATCHes; the shell nav adopts the new names on
   // its next load.
@@ -149,6 +166,19 @@ const OnboardingFlow: FC = () => {
       <OnboardingConnectPanel
         environmentKey={environmentKey}
         featureName={featureName}
+      />
+      <OnboardingTerminal status={terminalStatus} featureName={featureName} />
+      <OnboardingFlagsTable
+        status={flagsStatus}
+        flags={[
+          {
+            description: 'Controls the demo button shown to your users',
+            enabled: flagEnabled,
+            name: featureName,
+          },
+        ]}
+        onToggle={(_flag, next) => toggleFlag(next)}
+        togglingFlag={isToggling ? featureName : null}
       />
       <div className='d-flex justify-content-end'>
         <Button theme='text' onClick={skipToApp}>

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -63,10 +63,13 @@ const OnboardingFlow: FC = () => {
     projectId,
   })
 
-  // Verify terminal + flags table. The connection status is stubbed until the
+  // Verify terminal + flags table. The checklist ticks as the user copies the
+  // install / wire snippets; the connection step is stubbed until the
   // first-evaluation signal lands (#7767, behind useOnboardingConnection); the
   // Dev toggle is real now.
   const connection = useOnboardingConnection()
+  const [installCopied, setInstallCopied] = useState(false)
+  const [snippetCopied, setSnippetCopied] = useState(false)
   const {
     enabled: flagEnabled,
     isToggling,
@@ -164,8 +167,15 @@ const OnboardingFlow: FC = () => {
       <OnboardingConnectPanel
         environmentKey={environmentKey}
         featureName={featureName}
+        onCopyInstall={() => setInstallCopied(true)}
+        onCopyWire={() => setSnippetCopied(true)}
       />
-      <OnboardingTerminal status={connection} featureName={featureName} />
+      <OnboardingTerminal
+        featureName={featureName}
+        installCopied={installCopied}
+        snippetCopied={snippetCopied}
+        connected={connection === 'connected'}
+      />
       <OnboardingFlagsTable
         status={connection === 'connected' ? 'connected' : 'waiting'}
         flags={[

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -5,15 +5,12 @@ import Icon from 'components/icons/Icon'
 import OnboardingHeader from 'components/pages/onboarding/OnboardingHeader'
 import ThemeToggle from 'components/pages/onboarding/ThemeToggle'
 import OnboardingConnectPanel from 'components/pages/onboarding/OnboardingConnectPanel'
-import OnboardingTerminal, {
-  OnboardingTerminalStatus,
-} from 'components/pages/onboarding/OnboardingTerminal'
-import OnboardingFlagsTable, {
-  OnboardingFlagsTableStatus,
-} from 'components/pages/onboarding/OnboardingFlagsTable'
+import OnboardingTerminal from 'components/pages/onboarding/OnboardingTerminal'
+import OnboardingFlagsTable from 'components/pages/onboarding/OnboardingFlagsTable'
 import { useEnsureOnboardingResources } from 'components/pages/onboarding/hooks/useEnsureOnboardingResources'
 import { useOnboardingFlagRename } from 'components/pages/onboarding/hooks/useOnboardingFlagRename'
 import { useOnboardingFlag } from 'components/pages/onboarding/hooks/useOnboardingFlag'
+import { useOnboardingConnection } from 'components/pages/onboarding/hooks/useOnboardingConnection'
 import { useUpdateOrganisationMutation } from 'common/services/useOrganisation'
 import { useUpdateProjectMutation } from 'common/services/useProject'
 import './OnboardingFlow.scss'
@@ -66,10 +63,10 @@ const OnboardingFlow: FC = () => {
     projectId,
   })
 
-  // Verify terminal + flags table. They stay in the pre-connection state until
-  // the first-evaluation signal lands (#7767); the Dev toggle is real now.
-  const terminalStatus: OnboardingTerminalStatus = 'listening'
-  const flagsStatus: OnboardingFlagsTableStatus = 'waiting'
+  // Verify terminal + flags table. The connection status is stubbed until the
+  // first-evaluation signal lands (#7767, behind useOnboardingConnection); the
+  // Dev toggle is real now.
+  const connection = useOnboardingConnection()
   const {
     enabled: flagEnabled,
     isToggling,
@@ -167,9 +164,9 @@ const OnboardingFlow: FC = () => {
         environmentKey={environmentKey}
         featureName={featureName}
       />
-      <OnboardingTerminal status={terminalStatus} featureName={featureName} />
+      <OnboardingTerminal status={connection} featureName={featureName} />
       <OnboardingFlagsTable
-        status={flagsStatus}
+        status={connection === 'connected' ? 'connected' : 'waiting'}
         flags={[
           {
             description: 'Controls the demo button shown to your users',

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -70,6 +70,7 @@ const OnboardingFlow: FC = () => {
   const {
     enabled: flagEnabled,
     isToggling,
+    tags: flagTags,
     toggle: toggleFlag,
   } = useOnboardingFlag(environment, projectId, featureName)
 
@@ -172,6 +173,7 @@ const OnboardingFlow: FC = () => {
             description: 'Controls the demo button shown to your users',
             enabled: flagEnabled,
             name: featureName,
+            tags: flagTags,
           },
         ]}
         onToggle={(_flag, next) => toggleFlag(next)}

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -15,12 +15,8 @@ import { useUpdateOrganisationMutation } from 'common/services/useOrganisation'
 import { useUpdateProjectMutation } from 'common/services/useProject'
 import './OnboardingFlow.scss'
 
-// The new single-page onboarding experience, rendered at /getting-started when
-// the `onboarding_quickstart_flow` flag is on (see GettingStartedGate).
-//
-// Resources (org / project / Dev + Prod / first flag) are bootstrapped
-// idempotently by useEnsureOnboardingResources, and the inline header chips
-// persist renames; the verify terminal and flags table render below (#7766).
+// The single-page onboarding flow, rendered at /getting-started when
+// onboarding_quickstart_flow is on (see GettingStartedGate).
 const OnboardingFlow: FC = () => {
   const {
     caseSensitive,
@@ -38,17 +34,15 @@ const OnboardingFlow: FC = () => {
   const [updateOrganisation] = useUpdateOrganisationMutation()
   const [updateProject] = useUpdateProjectMutation()
 
-  // The flow is chromeless (no app nav), so it owns its only way out: skip to
-  // the org's projects and set things up manually.
+  // Chromeless flow, so it owns its only exit.
   const skipToApp = () =>
     history.push(
       organisationId !== null
         ? `/organisation/${organisationId}/projects`
         : '/',
     )
-  // Inline renames are optimistic and revert if the persist fails. The flag name
-  // also drives the connect-panel snippets/prompt, so it defaults to the
-  // bootstrapped flag (its real name, reused on revisit).
+  // Inline renames are optimistic, reverting on failure. featureName drives the
+  // snippets, so it defaults to the bootstrapped flag.
   const [renamedOrganisation, setRenamedOrganisation] = useState<string | null>(
     null,
   )
@@ -63,13 +57,9 @@ const OnboardingFlow: FC = () => {
     projectId,
   })
 
-  // Verify terminal + flags table. The checklist ticks as the user copies the
-  // install / wire snippets; the connection step is stubbed until the
-  // first-evaluation signal lands (#7767, behind useOnboardingConnection); the
-  // Dev toggle is real now.
+  // Connection is stubbed until #7767 (useOnboardingConnection); the toggle is real.
   const connection = useOnboardingConnection()
-  // Session-only and one-way: a reload resets them, so the checklist reflects
-  // what the user did this visit, not durable progress. Fine for onboarding.
+  // Session-only: a reload resets the checklist. Fine for onboarding.
   const [installCopied, setInstallCopied] = useState(false)
   const [snippetCopied, setSnippetCopied] = useState(false)
   const {
@@ -80,8 +70,7 @@ const OnboardingFlow: FC = () => {
     toggle: toggleFlag,
   } = useOnboardingFlag(environment, projectId, featureName)
 
-  // Org/project are single-field PATCHes; the shell nav adopts the new names on
-  // its next load.
+  // Single-field PATCHes; the shell adopts the new names on its next load.
   const renameOrganisation = async (name: string) => {
     if (organisationId === null) {
       return
@@ -113,8 +102,7 @@ const OnboardingFlow: FC = () => {
       toast('Couldn’t update your project name. Please try again.', 'danger')
     }
   }
-  // The flag and its snippet name must stay in lockstep, so this persists
-  // (delete + recreate). Optimistic, reverting on failure.
+  // Flag name and snippet stay in lockstep; persists via delete + recreate.
   const renameFeature = async (name: string) => {
     const previous = featureName
     setRenamedFeature(name)
@@ -122,8 +110,7 @@ const OnboardingFlow: FC = () => {
       toast('Flag name updated')
     } else {
       setRenamedFeature(previous)
-      // Only surface an error for a genuine failure - a rename attempted before
-      // the flag query settles also returns false, and shouldn't alarm the user.
+      // Don't alarm on a rename fired before the flag query settles.
       if (flagReady) {
         toast('Couldn’t rename your flag. Please try again.', 'danger')
       }
@@ -138,9 +125,7 @@ const OnboardingFlow: FC = () => {
     )
   }
 
-  // Bootstrap failed (e.g. a plan org cap, or a network error). Without this the
-  // flow would render with an empty environment key and broken snippets, so show
-  // a recoverable message instead. A reload re-runs the idempotent bootstrap.
+  // Bootstrap failed (e.g. a plan org cap). Recoverable; a reload re-runs it.
   if (status === 'error') {
     return (
       <div className='onboarding-flow mx-auto text-center'>

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -75,6 +75,7 @@ const OnboardingFlow: FC = () => {
   const {
     enabled: flagEnabled,
     isToggling,
+    ready: flagStateReady,
     tags: flagTags,
     toggle: toggleFlag,
   } = useOnboardingFlag(environment, projectId, featureName)
@@ -190,6 +191,7 @@ const OnboardingFlow: FC = () => {
         ]}
         onToggle={(_flag, next) => toggleFlag(next)}
         togglingFlag={isToggling ? featureName : null}
+        togglesReady={flagStateReady}
       />
       <div className='d-flex justify-content-end'>
         <Button theme='text' onClick={skipToApp}>

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
@@ -1,0 +1,144 @@
+// The onboarding verify console. Always dark (a terminal reads the same in
+// light and dark mode), so it uses the design's literal console palette rather
+// than the theme tokens. Colours match the Pencil "sdk console" frame.
+.onboarding-terminal {
+  overflow: hidden;
+  border-radius: 12px;
+  background: #0d1117;
+  font-family: var(--font-family-mono, monospace);
+  font-size: 13px;
+  line-height: 1.6;
+
+  &__bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background: #161b22;
+  }
+
+  &__dot {
+    flex-shrink: 0;
+    width: 12px;
+    height: 12px;
+    border-radius: 999px;
+
+    &--red {
+      background: #ff5f57;
+    }
+    &--amber {
+      background: #ffbd2e;
+    }
+    &--green {
+      background: #28c840;
+    }
+  }
+
+  &__title {
+    color: #8b949e;
+    font-size: 12px;
+  }
+
+  &__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+
+    &--listening {
+      background: #3d2b00;
+      color: #f0883e;
+    }
+    &--live {
+      background: #0d4429;
+      color: #3fb950;
+    }
+  }
+
+  &__badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: currentColor;
+  }
+
+  &__badge--listening &__badge-dot {
+    animation: onboarding-terminal-pulse 1.4s var(--easing-standard, ease-in-out)
+      infinite;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 20px 24px;
+  }
+
+  // Default line = pending checklist grey.
+  &__line {
+    margin: 0;
+    color: #6e7781;
+
+    &--ok {
+      color: #3fb950;
+    }
+    &--strong {
+      font-weight: 600;
+    }
+    &--dim {
+      color: #484f58;
+    }
+    &--muted {
+      color: #8b949e;
+    }
+    &--current {
+      color: #f0883e;
+    }
+    &--prompt {
+      color: #8b949e;
+    }
+  }
+
+  // Blinking cursor block after the prompt - the "typewriter" cue.
+  &__cursor {
+    display: inline-block;
+    width: 8px;
+    height: 1em;
+    vertical-align: text-bottom;
+    background: #3fb950;
+    animation: onboarding-terminal-blink 1.1s steps(1) infinite;
+  }
+}
+
+@keyframes onboarding-terminal-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@keyframes onboarding-terminal-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-terminal__badge-dot,
+  .onboarding-terminal__cursor {
+    animation: none;
+  }
+}

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
@@ -10,9 +10,6 @@
   line-height: 1.6;
 
   &__bar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
     padding: 12px 16px;
     background: #161b22;
   }
@@ -40,10 +37,6 @@
   }
 
   &__badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    margin-left: auto;
     padding: 3px 8px;
     border-radius: var(--radius-full);
     font-size: 11px;
@@ -73,9 +66,6 @@
   }
 
   &__body {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
     padding: 20px 24px;
   }
 

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
@@ -3,7 +3,7 @@
 // than the theme tokens. Colours match the Pencil "sdk console" frame.
 .onboarding-terminal {
   overflow: hidden;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   background: #0d1117;
   font-family: var(--font-family-mono, monospace);
   font-size: 13px;
@@ -21,7 +21,7 @@
     flex-shrink: 0;
     width: 12px;
     height: 12px;
-    border-radius: 999px;
+    border-radius: var(--radius-full);
 
     &--red {
       background: #ff5f57;
@@ -45,7 +45,7 @@
     gap: 4px;
     margin-left: auto;
     padding: 3px 8px;
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.5px;
@@ -63,7 +63,7 @@
   &__badge-dot {
     width: 6px;
     height: 6px;
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     background: currentColor;
   }
 

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
@@ -1,11 +1,8 @@
-// The onboarding verify console. Always dark (a terminal reads the same in
-// light and dark mode), so it uses the design's literal console palette rather
-// than the theme tokens. Colours match the Pencil "sdk console" frame.
+// Verify console. Always dark in both modes, so it uses a literal palette.
 .onboarding-terminal {
   overflow: hidden;
   border-radius: var(--radius-xl);
   background: #0d1117;
-  // No mono design token exists; a literal stack suits the always-dark console.
   font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
   font-size: 13px;
   line-height: 1.6;

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.scss
@@ -5,7 +5,8 @@
   overflow: hidden;
   border-radius: var(--radius-xl);
   background: #0d1117;
-  font-family: var(--font-family-mono, monospace);
+  // No mono design token exists; a literal stack suits the always-dark console.
+  font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
   font-size: 13px;
   line-height: 1.6;
 
@@ -40,7 +41,7 @@
     padding: 3px 8px;
     border-radius: var(--radius-full);
     font-size: 11px;
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
     letter-spacing: 0.5px;
 
     &--listening {

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
@@ -2,25 +2,33 @@ import React, { FC } from 'react'
 import classNames from 'classnames'
 import './OnboardingTerminal.scss'
 
-export type OnboardingTerminalStatus = 'listening' | 'connected'
-
 export type OnboardingTerminalProps = {
-  status: OnboardingTerminalStatus
-  // The flag the SDK is expected to evaluate; drives the checklist and receipt.
   featureName: string
+  installCopied: boolean
+  snippetCopied: boolean
+  // First SDK evaluation received (the connection signal, #7767).
+  connected: boolean
 }
 
-// Verify console for the onboarding flow, mirroring the design's "sdk console":
-// amber LISTENING with an unchecked checklist and a blinking cursor while
-// waiting, green LIVE with a connection receipt once the first evaluation
-// arrives. Driven entirely by `status` (the real connection signal lands in
-// #7767/#7623). Always dark - it's a terminal - so it carries its own palette
-// rather than the theme tokens.
+// Verify console for the onboarding flow, mirroring the design's "sdk console".
+// The checklist ticks as the user acts: copy install, copy snippet, then the
+// first evaluation flips the badge to LIVE and prints the connection receipt.
+// Always dark - it's a terminal - so it carries its own palette, not the theme
+// tokens.
 const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
+  connected,
   featureName,
-  status,
+  installCopied,
+  snippetCopied,
 }) => {
-  const connected = status === 'connected'
+  const steps = [
+    { done: installCopied, label: 'Copy install command' },
+    { done: snippetCopied, label: 'Copy code snippet' },
+    { done: connected, label: `First evaluation of '${featureName}'` },
+  ]
+  // The first unfinished step is the active one (amber).
+  const currentIndex = steps.findIndex((step) => !step.done)
+
   return (
     <div className='onboarding-terminal'>
       <div className='onboarding-terminal__bar'>
@@ -42,17 +50,26 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
       </div>
 
       <div className='onboarding-terminal__body' aria-live='polite'>
+        {!connected && (
+          <p className='onboarding-terminal__line onboarding-terminal__line--muted'>
+            awaiting first request
+          </p>
+        )}
+        {steps.map((step, index) => (
+          <p
+            key={step.label}
+            className={classNames('onboarding-terminal__line', {
+              'onboarding-terminal__line--current':
+                !step.done && index === currentIndex,
+              'onboarding-terminal__line--ok': step.done,
+            })}
+          >
+            {step.done ? '[✓]' : '[ ]'} {step.label}
+            {!step.done && index === steps.length - 1 ? '…' : ''}
+          </p>
+        ))}
         {connected ? (
           <>
-            <p className='onboarding-terminal__line onboarding-terminal__line--ok'>
-              [✓] Copy install command
-            </p>
-            <p className='onboarding-terminal__line onboarding-terminal__line--ok'>
-              [✓] Copy code snippet
-            </p>
-            <p className='onboarding-terminal__line onboarding-terminal__line--ok onboarding-terminal__line--strong'>
-              [✓] First evaluation of &apos;{featureName}&apos;
-            </p>
             <p className='onboarding-terminal__line onboarding-terminal__line--dim'>
               SDK initialized · flags loaded · {featureName}: true
             </p>
@@ -64,21 +81,9 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
             </p>
           </>
         ) : (
-          <>
-            <p className='onboarding-terminal__line onboarding-terminal__line--muted'>
-              awaiting first request
-            </p>
-            <p className='onboarding-terminal__line'>
-              [ ] Copy install command
-            </p>
-            <p className='onboarding-terminal__line'>[ ] Copy code snippet</p>
-            <p className='onboarding-terminal__line onboarding-terminal__line--current'>
-              [ ] First evaluation of &apos;{featureName}&apos;…
-            </p>
-            <p className='onboarding-terminal__line onboarding-terminal__line--prompt'>
-              $ <span className='onboarding-terminal__cursor' aria-hidden />
-            </p>
-          </>
+          <p className='onboarding-terminal__line onboarding-terminal__line--prompt'>
+            $ <span className='onboarding-terminal__cursor' aria-hidden />
+          </p>
         )}
       </div>
     </div>

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
@@ -31,7 +31,7 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
 
   return (
     <div className='onboarding-terminal'>
-      <div className='onboarding-terminal__bar'>
+      <div className='onboarding-terminal__bar d-flex align-items-center gap-2'>
         <span className='onboarding-terminal__dot onboarding-terminal__dot--red' />
         <span className='onboarding-terminal__dot onboarding-terminal__dot--amber' />
         <span className='onboarding-terminal__dot onboarding-terminal__dot--green' />
@@ -39,17 +39,23 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
           flagsmith — sdk console
         </span>
         <span
-          className={classNames('onboarding-terminal__badge', {
-            'onboarding-terminal__badge--listening': !connected,
-            'onboarding-terminal__badge--live': connected,
-          })}
+          className={classNames(
+            'onboarding-terminal__badge d-inline-flex align-items-center gap-1 ms-auto',
+            {
+              'onboarding-terminal__badge--listening': !connected,
+              'onboarding-terminal__badge--live': connected,
+            },
+          )}
         >
           <span className='onboarding-terminal__badge-dot' />
           {connected ? 'LIVE' : 'LISTENING'}
         </span>
       </div>
 
-      <div className='onboarding-terminal__body' aria-live='polite'>
+      <div
+        className='onboarding-terminal__body d-flex flex-column gap-2'
+        aria-live='polite'
+      >
         {!connected && (
           <p className='onboarding-terminal__line onboarding-terminal__line--muted'>
             awaiting first request

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
@@ -1,0 +1,88 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import './OnboardingTerminal.scss'
+
+export type OnboardingTerminalStatus = 'listening' | 'connected'
+
+export type OnboardingTerminalProps = {
+  status: OnboardingTerminalStatus
+  // The flag the SDK is expected to evaluate; drives the checklist and receipt.
+  featureName: string
+}
+
+// Verify console for the onboarding flow, mirroring the design's "sdk console":
+// amber LISTENING with an unchecked checklist and a blinking cursor while
+// waiting, green LIVE with a connection receipt once the first evaluation
+// arrives. Driven entirely by `status` (the real connection signal lands in
+// #7767/#7623). Always dark - it's a terminal - so it carries its own palette
+// rather than the theme tokens.
+const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
+  featureName,
+  status,
+}) => {
+  const connected = status === 'connected'
+  return (
+    <div className='onboarding-terminal'>
+      <div className='onboarding-terminal__bar'>
+        <span className='onboarding-terminal__dot onboarding-terminal__dot--red' />
+        <span className='onboarding-terminal__dot onboarding-terminal__dot--amber' />
+        <span className='onboarding-terminal__dot onboarding-terminal__dot--green' />
+        <span className='onboarding-terminal__title'>
+          flagsmith — sdk console
+        </span>
+        <span
+          className={classNames('onboarding-terminal__badge', {
+            'onboarding-terminal__badge--listening': !connected,
+            'onboarding-terminal__badge--live': connected,
+          })}
+        >
+          <span className='onboarding-terminal__badge-dot' />
+          {connected ? 'LIVE' : 'LISTENING'}
+        </span>
+      </div>
+
+      <div className='onboarding-terminal__body' aria-live='polite'>
+        {connected ? (
+          <>
+            <p className='onboarding-terminal__line onboarding-terminal__line--ok'>
+              [✓] Copy install command
+            </p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--ok'>
+              [✓] Copy code snippet
+            </p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--ok onboarding-terminal__line--strong'>
+              [✓] First evaluation of &apos;{featureName}&apos;
+            </p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--dim'>
+              SDK initialized · flags loaded · {featureName}: true
+            </p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--ok onboarding-terminal__line--strong'>
+              ✓ Connected
+            </p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--ok'>
+              ✓ {featureName} is live
+            </p>
+          </>
+        ) : (
+          <>
+            <p className='onboarding-terminal__line onboarding-terminal__line--muted'>
+              awaiting first request
+            </p>
+            <p className='onboarding-terminal__line'>
+              [ ] Copy install command
+            </p>
+            <p className='onboarding-terminal__line'>[ ] Copy code snippet</p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--current'>
+              [ ] First evaluation of &apos;{featureName}&apos;…
+            </p>
+            <p className='onboarding-terminal__line onboarding-terminal__line--prompt'>
+              $ <span className='onboarding-terminal__cursor' aria-hidden />
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OnboardingTerminal

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
@@ -6,15 +6,12 @@ export type OnboardingTerminalProps = {
   featureName: string
   installCopied: boolean
   snippetCopied: boolean
-  // First SDK evaluation received (the connection signal, #7767).
+  // First evaluation received (#7767).
   connected: boolean
 }
 
-// Verify console for the onboarding flow, mirroring the design's "sdk console".
-// The checklist ticks as the user acts: copy install, copy snippet, then the
-// first evaluation flips the badge to LIVE and prints the connection receipt.
-// Always dark - it's a terminal - so it carries its own palette, not the theme
-// tokens.
+// Verify console. Always dark (a terminal reads the same in both modes), so it
+// uses a literal palette rather than theme tokens.
 const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
   connected,
   featureName,

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/index.ts
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/index.ts
@@ -1,0 +1,5 @@
+export { default } from './OnboardingTerminal'
+export type {
+  OnboardingTerminalProps,
+  OnboardingTerminalStatus,
+} from './OnboardingTerminal'

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/index.ts
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/index.ts
@@ -1,5 +1,2 @@
 export { default } from './OnboardingTerminal'
-export type {
-  OnboardingTerminalProps,
-  OnboardingTerminalStatus,
-} from './OnboardingTerminal'
+export type { OnboardingTerminalProps } from './OnboardingTerminal'

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -27,8 +27,9 @@ const DEFAULT_PROJECT_NAME = 'My first project'
 const DEV_ENVIRONMENT_NAME = 'Development'
 const PROD_ENVIRONMENT_NAME = 'Production'
 // Attached to the demo flag so the flags table shows an "Onboarding" badge.
+// Green from the product tag palette (Constants.tagColors), not an arbitrary hex.
 const ONBOARDING_TAG = {
-  color: '#057A55',
+  color: '#3cb371',
   description: 'Created during onboarding',
   label: 'Onboarding',
 }

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -7,10 +7,12 @@ import {
   getEnvironments,
 } from 'common/services/useEnvironment'
 import { projectFlagService } from 'common/services/useProjectFlag'
+import { tagService } from 'common/services/useTag'
 import { Req } from 'common/types/requests'
 import {
   Environment,
   PagedResponse,
+  ProjectFlag,
   ProjectSummary,
 } from 'common/types/responses'
 import { SmartDefaults } from './useSmartDefaults'
@@ -24,6 +26,12 @@ const DEFAULT_PROJECT_NAME = 'My first project'
 // Written on create and matched by name on reuse, so the two must stay in step.
 const DEV_ENVIRONMENT_NAME = 'Development'
 const PROD_ENVIRONMENT_NAME = 'Production'
+// Attached to the demo flag so the flags table shows an "Onboarding" badge.
+const ONBOARDING_TAG = {
+  color: '#057A55',
+  description: 'Created during onboarding',
+  label: 'Onboarding',
+}
 
 type ExistingOrg = { id: number; name: string }
 
@@ -130,11 +138,11 @@ async function ensureEnvironments(
 
 // Reuse the project's existing flag (keeps a renamed flag and stops piling up
 // duplicates on revisit); only create the demo flag when there are none.
-// Returns the real flag name so the header shows what's actually there.
+// Returns the flag so callers see its real name and tags.
 async function ensureFlag(
   store: Store,
   project: ProjectSummary,
-): Promise<string> {
+): Promise<ProjectFlag | undefined> {
   const flags = await store
     .dispatch(
       projectFlagService.endpoints.getProjectFlags.initiate({
@@ -144,9 +152,9 @@ async function ensureFlag(
     .unwrap()
   const existing = flags?.results?.[0]
   if (existing) {
-    return existing.name
+    return existing
   }
-  const created = await store
+  return store
     .dispatch(
       projectFlagService.endpoints.createProjectFlag.initiate({
         body: {
@@ -158,7 +166,46 @@ async function ensureFlag(
       }),
     )
     .unwrap()
-  return created?.name ?? FLAG_NAME
+}
+
+// Attach the "Onboarding" tag to the demo flag (find-or-create), so the flags
+// table shows the badge from the design. Best-effort: tagging is cosmetic and
+// must never block the bootstrap.
+async function ensureOnboardingTag(
+  store: Store,
+  project: ProjectSummary,
+  flag: ProjectFlag,
+): Promise<void> {
+  try {
+    const tags = await store
+      .dispatch(
+        tagService.endpoints.getTags.initiate({ projectId: project.id }),
+      )
+      .unwrap()
+    const tag =
+      tags?.find((t) => t.label === ONBOARDING_TAG.label) ??
+      (await store
+        .dispatch(
+          tagService.endpoints.createTag.initiate({
+            projectId: project.id,
+            tag: ONBOARDING_TAG,
+          }),
+        )
+        .unwrap())
+    if (tag && !flag.tags?.includes(tag.id)) {
+      await store
+        .dispatch(
+          projectFlagService.endpoints.updateProjectFlag.initiate({
+            body: { ...flag, tags: [...(flag.tags ?? []), tag.id] },
+            feature_id: flag.id,
+            project_id: project.id,
+          }),
+        )
+        .unwrap()
+    }
+  } catch {
+    // Cosmetic only - never block onboarding on tagging.
+  }
 }
 
 // Idempotently bring up everything the single-page flow needs: org, project,
@@ -172,12 +219,15 @@ export async function bootstrapOnboarding(
   const organisation = await ensureOrganisation(store, input)
   const project = await ensureProject(store, organisation.id, input.defaults)
   const environment = await ensureEnvironments(store, project)
-  const featureName = await ensureFlag(store, project)
+  const flag = await ensureFlag(store, project)
+  if (flag) {
+    await ensureOnboardingTag(store, project, flag)
+  }
   // Refresh the legacy org store so the shell sees the project.
   AppActions.refreshOrganisation()
   return {
     environment,
-    featureName,
+    featureName: flag?.name ?? FLAG_NAME,
     organisationId: organisation.id,
     organisationName: organisation.name,
     project,

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -14,6 +14,7 @@ import {
   PagedResponse,
   ProjectFlag,
   ProjectSummary,
+  Tag,
 } from 'common/types/responses'
 import { SmartDefaults } from './useSmartDefaults'
 import { createOrganisationViaAccountStore } from './createOrganisationViaAccountStore'
@@ -137,9 +138,19 @@ async function ensureEnvironments(
     .unwrap()
 }
 
-// Reuse the project's existing flag (keeps a renamed flag and stops piling up
-// duplicates on revisit); only create the demo flag when there are none.
-// Returns the flag so callers see its real name and tags.
+// Find the project's Onboarding tag, if it's been created yet.
+async function findOnboardingTag(
+  store: Store,
+  projectId: number,
+): Promise<Tag | undefined> {
+  const tags = await store
+    .dispatch(tagService.endpoints.getTags.initiate({ projectId }))
+    .unwrap()
+  return tags?.find((t) => t.label === ONBOARDING_TAG.label)
+}
+
+// Reuse the onboarding flag, matched by its Onboarding tag (or its name) so we
+// never grab one of the user's other flags; else create the demo flag.
 async function ensureFlag(
   store: Store,
   project: ProjectSummary,
@@ -151,7 +162,11 @@ async function ensureFlag(
       }),
     )
     .unwrap()
-  const existing = flags?.results?.[0]
+  const onboardingTag = await findOnboardingTag(store, project.id)
+  const existing =
+    (onboardingTag &&
+      flags?.results?.find((f) => f.tags?.includes(onboardingTag.id))) ||
+    flags?.results?.find((f) => f.name === FLAG_NAME)
   if (existing) {
     return existing
   }
@@ -178,13 +193,8 @@ async function ensureOnboardingTag(
   flag: ProjectFlag,
 ): Promise<void> {
   try {
-    const tags = await store
-      .dispatch(
-        tagService.endpoints.getTags.initiate({ projectId: project.id }),
-      )
-      .unwrap()
     const tag =
-      tags?.find((t) => t.label === ONBOARDING_TAG.label) ??
+      (await findOnboardingTag(store, project.id)) ??
       (await store
         .dispatch(
           tagService.endpoints.createTag.initiate({

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
@@ -1,0 +1,20 @@
+import { useLocation } from 'react-router-dom'
+
+export type OnboardingConnectionStatus = 'listening' | 'connected'
+
+// Single source of truth for the verify console's connection status, so the
+// page never reads the raw signal directly.
+//
+// Today it reports the pre-connection state, with a `?connected` query-param
+// escape hatch so the connected UI can be exercised in the live flow (and
+// screenshots) before the real signal exists.
+//
+// TODO(#7767): replace the body with the real first-evaluation signal (poll /
+// subscribe for the first SDK evaluation of the demo flag). The caller
+// (OnboardingFlow) and the `?connected` test hook stay unchanged.
+export const useOnboardingConnection = (): OnboardingConnectionStatus => {
+  const { search } = useLocation()
+  return new URLSearchParams(search).has('connected')
+    ? 'connected'
+    : 'listening'
+}

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
@@ -2,16 +2,9 @@ import { useLocation } from 'react-router-dom'
 
 export type OnboardingConnectionStatus = 'listening' | 'connected'
 
-// Single source of truth for the verify console's connection status, so the
-// page never reads the raw signal directly.
-//
-// Today it reports the pre-connection state, with a `?connected` query-param
-// escape hatch so the connected UI can be exercised in the live flow (and
-// screenshots) before the real signal exists.
-//
-// TODO(#7767): replace the body with the real first-evaluation signal (poll /
-// subscribe for the first SDK evaluation of the demo flag). The caller
-// (OnboardingFlow) and the `?connected` test hook stay unchanged.
+// Connection status for the verify console. Reports the pre-connection state
+// with a `?connected` query-param hatch to exercise the connected UI.
+// TODO(#7767): replace with the real first-evaluation signal.
 export const useOnboardingConnection = (): OnboardingConnectionStatus => {
   const { search } = useLocation()
   return new URLSearchParams(search).has('connected')

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
@@ -38,15 +38,22 @@ export const useOnboardingFlag = (
 
   const [updateFeatureState, { isLoading }] = useUpdateFeatureStateMutation()
 
-  const toggle = (enabled: boolean) => {
+  // Persisted toggle. Not optimistic: the Switch reflects the RTK-cached state
+  // and is disabled mid-flight, so a failure just leaves the old value. Toast on
+  // failure, matching the header rename UX, rather than failing silently.
+  const toggle = async (enabled: boolean) => {
     if (!environment || !state) {
       return
     }
-    updateFeatureState({
-      body: { enabled },
-      environmentFlagId: state.id,
-      environmentId: environment.api_key,
-    })
+    try {
+      await updateFeatureState({
+        body: { enabled },
+        environmentFlagId: state.id,
+        environmentId: environment.api_key,
+      }).unwrap()
+    } catch {
+      toast('Couldn’t update your flag. Please try again.', 'danger')
+    }
   }
 
   return {

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
@@ -1,0 +1,48 @@
+import { useGetProjectFlagsQuery } from 'common/services/useProjectFlag'
+import {
+  useGetFeatureStatesQuery,
+  useUpdateFeatureStateMutation,
+} from 'common/services/useFeatureState'
+import { Environment } from 'common/types/responses'
+
+// Resolves the onboarding demo flag's Development feature state and exposes a
+// real, persisted toggle (updateFeatureState) for the flags table. Finds the
+// flag by name (the bootstrap returns the name, not the id), then its state in
+// the Dev environment.
+export const useOnboardingFlag = (
+  environment: Environment | null,
+  projectId: number | null,
+  featureName: string,
+) => {
+  const { data: flags } = useGetProjectFlagsQuery(
+    { project: `${projectId}` },
+    { skip: !projectId },
+  )
+  const flag = flags?.results?.find((f) => f.name === featureName)
+
+  const { data: states } = useGetFeatureStatesQuery(
+    { environment: environment?.id, feature: flag?.id },
+    { skip: !environment || !flag },
+  )
+  const state = states?.results?.[0]
+
+  const [updateFeatureState, { isLoading }] = useUpdateFeatureStateMutation()
+
+  const toggle = (enabled: boolean) => {
+    if (!environment || !state) {
+      return
+    }
+    updateFeatureState({
+      body: { enabled },
+      environmentFlagId: state.id,
+      environmentId: environment.api_key,
+    })
+  }
+
+  return {
+    enabled: !!state?.enabled,
+    isToggling: isLoading,
+    ready: !!state,
+    toggle,
+  }
+}

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
@@ -3,12 +3,14 @@ import {
   useGetFeatureStatesQuery,
   useUpdateFeatureStateMutation,
 } from 'common/services/useFeatureState'
-import { Environment } from 'common/types/responses'
+import { useGetTagsQuery } from 'common/services/useTag'
+import { Environment, Tag } from 'common/types/responses'
 
 // Resolves the onboarding demo flag's Development feature state and exposes a
 // real, persisted toggle (updateFeatureState) for the flags table. Finds the
 // flag by name (the bootstrap returns the name, not the id), then its state in
-// the Dev environment.
+// the Dev environment. Also resolves the flag's real tags, so attaching a tag
+// to the flag shows up in the onboarding table automatically.
 export const useOnboardingFlag = (
   environment: Environment | null,
   projectId: number | null,
@@ -19,6 +21,14 @@ export const useOnboardingFlag = (
     { skip: !projectId },
   )
   const flag = flags?.results?.find((f) => f.name === featureName)
+
+  const { data: projectTags } = useGetTagsQuery(
+    { projectId: projectId ?? 0 },
+    { skip: !projectId },
+  )
+  const tags = (flag?.tags ?? [])
+    .map((id) => projectTags?.find((tag) => tag.id === id))
+    .filter((tag): tag is Tag => !!tag)
 
   const { data: states } = useGetFeatureStatesQuery(
     { environment: environment?.id, feature: flag?.id },
@@ -43,6 +53,7 @@ export const useOnboardingFlag = (
     enabled: !!state?.enabled,
     isToggling: isLoading,
     ready: !!state,
+    tags,
     toggle,
   }
 }

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
@@ -7,11 +7,8 @@ import { useGetTagsQuery } from 'common/services/useTag'
 import { Environment, Tag } from 'common/types/responses'
 import { useFeatureRowState } from 'components/pages/features/hooks/useFeatureRowState'
 
-// Resolves the onboarding demo flag's Development feature state and exposes a
-// real, persisted toggle (updateFeatureState) for the flags table. Finds the
-// flag by name (the bootstrap returns the name, not the id), then its state in
-// the Dev environment. Also resolves the flag's real tags, so attaching a tag
-// to the flag shows up in the onboarding table automatically.
+// Resolves the demo flag (by name, since bootstrap returns the name) and its
+// Dev feature state, exposing a persisted toggle and the flag's tags.
 export const useOnboardingFlag = (
   environment: Environment | null,
   projectId: number | null,
@@ -39,9 +36,8 @@ export const useOnboardingFlag = (
 
   const [updateFeatureState] = useUpdateFeatureStateMutation()
 
-  // Optimistic toggle, mirroring the product feature row: the switch flips
-  // instantly via displayEnabled and reverts on failure, rather than waiting for
-  // the update + refetch round-trip (which left the switch visibly stuck).
+  // Optimistic (like the product row): displayEnabled flips instantly and
+  // reverts on failure, instead of waiting on the update + refetch.
   const { displayEnabled, isLoading, revertToggle, startToggle } =
     useFeatureRowState(state?.enabled)
 

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlag.ts
@@ -5,6 +5,7 @@ import {
 } from 'common/services/useFeatureState'
 import { useGetTagsQuery } from 'common/services/useTag'
 import { Environment, Tag } from 'common/types/responses'
+import { useFeatureRowState } from 'components/pages/features/hooks/useFeatureRowState'
 
 // Resolves the onboarding demo flag's Development feature state and exposes a
 // real, persisted toggle (updateFeatureState) for the flags table. Finds the
@@ -36,13 +37,16 @@ export const useOnboardingFlag = (
   )
   const state = states?.results?.[0]
 
-  const [updateFeatureState, { isLoading }] = useUpdateFeatureStateMutation()
+  const [updateFeatureState] = useUpdateFeatureStateMutation()
 
-  // Persisted toggle. Not optimistic: the Switch reflects the RTK-cached state
-  // and is disabled mid-flight, so a failure just leaves the old value. Toast on
-  // failure, matching the header rename UX, rather than failing silently.
+  // Optimistic toggle, mirroring the product feature row: the switch flips
+  // instantly via displayEnabled and reverts on failure, rather than waiting for
+  // the update + refetch round-trip (which left the switch visibly stuck).
+  const { displayEnabled, isLoading, revertToggle, startToggle } =
+    useFeatureRowState(state?.enabled)
+
   const toggle = async (enabled: boolean) => {
-    if (!environment || !state) {
+    if (!environment || !state || !startToggle(enabled)) {
       return
     }
     try {
@@ -52,12 +56,13 @@ export const useOnboardingFlag = (
         environmentId: environment.api_key,
       }).unwrap()
     } catch {
+      revertToggle()
       toast('Couldn’t update your flag. Please try again.', 'danger')
     }
   }
 
   return {
-    enabled: !!state?.enabled,
+    enabled: !!displayEnabled,
     isToggling: isLoading,
     ready: !!state,
     tags,

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlagRename.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlagRename.ts
@@ -12,11 +12,14 @@ type UseOnboardingFlagRenameArgs = {
   featureName: string
 }
 
-// "Rename" the onboarding flag. Feature names are immutable once created, so
-// this is a delete + recreate under the hood - safe here because the flag is
-// freshly bootstrapped and not yet depended on. Recreate first (names differ,
-// so no unique conflict) and only then drop the old one, so a flag always
-// exists even if the second call fails. Resolves true on success.
+// "Rename" the onboarding flag. Feature names are immutable once created
+// (UpdateFeatureSerializer marks `name` read-only), so this is a delete +
+// recreate under the hood - safe here because the flag is freshly bootstrapped
+// and not yet depended on. Recreate first (names differ, so no unique conflict)
+// and only then drop the old one, so a flag always exists even if the second
+// call fails. The recreate carries over the old flag's tags/type/description so
+// the Onboarding badge (and any other tag) survives the rename. Resolves true
+// on success.
 //
 // The toggle that will also act on this flag lives in #7766 (the flags table);
 // this hook is intentionally rename-only so the connect-panel issue doesn't pull
@@ -45,9 +48,11 @@ export const useOnboardingFlagRename = ({
     try {
       await createProjectFlag({
         body: {
+          description: flag.description,
           name,
           project: projectId,
-          type: 'STANDARD',
+          tags: flag.tags,
+          type: flag.type,
         } as Req['createProjectFlag']['body'],
         project_id: projectId,
       }).unwrap()

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlagRename.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlagRename.ts
@@ -12,18 +12,10 @@ type UseOnboardingFlagRenameArgs = {
   featureName: string
 }
 
-// "Rename" the onboarding flag. Feature names are immutable once created
-// (UpdateFeatureSerializer marks `name` read-only), so this is a delete +
-// recreate under the hood - safe here because the flag is freshly bootstrapped
-// and not yet depended on. Recreate first (names differ, so no unique conflict)
-// and only then drop the old one, so a flag always exists even if the second
-// call fails. The recreate carries over the old flag's tags/type/description so
-// the Onboarding badge (and any other tag) survives the rename. Resolves true
-// on success.
-//
-// The toggle that will also act on this flag lives in #7766 (the flags table);
-// this hook is intentionally rename-only so the connect-panel issue doesn't pull
-// in the feature-toggle path.
+// "Rename" the flag. Feature names are immutable (the API marks `name`
+// read-only), so this is a delete + recreate: create first (no name conflict),
+// then drop the old one, carrying over its tags/type/description so the
+// Onboarding badge survives. Resolves true on success.
 export const useOnboardingFlagRename = ({
   environment,
   featureName,
@@ -67,7 +59,6 @@ export const useOnboardingFlagRename = ({
     }
   }
 
-  // isReady distinguishes "rename failed" from "the flag hasn't loaded yet", so
-  // the caller doesn't show an error for a rename fired before the query settles.
+  // isReady lets the caller tell a real failure from a rename fired pre-load.
   return { isReady: !!flag, rename }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7766. Builds on the single-page onboarding flow (#7765, now merged): adds the verify console and the flags table below the connect panel.

- **Verify terminal** — a dark SDK console whose checklist ticks as you act: copy the install command, copy the wire snippet, then the first evaluation flips the badge to LIVE. The connection step is **stubbed** behind `useOnboardingConnection` (a `?connected` query param exercises the connected UI) pending the real first-evaluation signal in #7767, so it won't go LIVE on its own yet.
- **Flags table** — the pre-created flag in a real table reusing the product `FeatureName` / `Tag` / `Switch`, with a real persisted Development toggle. Bootstrap attaches an "Onboarding" tag so the badge shows.
- **New-user redirect** — after signup a new user has no organisation, so `onLogin` sent them to the legacy `/create` page before the getting-started check ran. With the flow enabled they now land on `/getting-started` (which creates the organisation itself).
- **Rename keeps tags** — feature names are immutable, so the inline "rename" is a delete + recreate; it now carries over the old flag's tags/type/description so the Onboarding badge survives.
- **Accessibility** — distinct accessible names for the two copy buttons, a per-flag name on the toggle, and the flags table as a labelled region.
- Browser autofill opt-out on the shared `GhostInput` (the contact icon was overlapping the inline edit pencil).
- **SCSS → utilities** — layout (flex/gap/margin) moved to Bootstrap utilities and the flags-table surface/radius to token utilities; the SCSS keeps only what has no utility equivalent (the accent glow, the waiting state, non-standard metrics, and the terminal's literal console palette).
- **E2E** — new-user happy path behind `onboarding_quickstart_flow`: sign up, land on the flow, copy the install/wire snippets (checklist ticks), toggle the flag, rename it (asserting the tag survives), and the `?connected` state. Accessibility-first selectors (roles / labels / text).

## How did you test this code?

The new e2e spec runs in CI (`run-e2e-tests`). Locally with `onboarding_quickstart_flow` on: resources bootstrap, the checklist ticks as the snippets are copied, the Development toggle persists, rename keeps the tag, and the connected state renders. Storybook stories cover the terminal and table states.
