### PR TITLE
fix(clickhouse): Task processor startup queries ClickHouse migrations on every boot

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -63,7 +63,6 @@ docker-build:
 wait-for-db:
 	uv run python manage.py waitfordb
 	uv run python manage.py waitfordb --database analytics
-	uv run python manage.py waitfordb --database clickhouse
 
 .PHONY: test
 test: docker-up wait-for-db

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -45,9 +45,6 @@ run_task_processor() {
     if [ -n "$TASK_PROCESSOR_DATABASE_URL" ] || [ -n "$TASK_PROCESSOR_DATABASE_NAME" ]; then
         waitfordb --waitfor 30 --migrations --database task_processor
     fi
-    if [ -n "$CLICKHOUSE_URL" ] || [ -n "$CLICKHOUSE_HOST" ]; then
-        waitfordb --waitfor 30 --migrations --database clickhouse
-    fi
     exec flagsmith start \
              --bind 0.0.0.0:8000 \
              --access-logfile $ACCESS_LOG_LOCATION \


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://flagsmith.sentry.io/issues/7508759326/

The task processor entrypoint gated startup on `waitfordb --waitfor 30 --migrations --database clickhouse`. Constructing a `MigrationExecutor` against the ClickHouse connection reads the applied-migrations state, which forces a query against ClickHouse on every startup. On CH Cloud this wakes an idle data warehouse, and while ALTERs were in flight it intermittently failed with `Code: 517` (replica metadata version lag), surfacing as the Sentry error above and an overly aggressive task-processor startup gate.

The check is redundant: the entrypoint already runs `migrate --database clickhouse` before `run_task_processor`, so ClickHouse migrations are applied before the task processor starts. This PR removes the ClickHouse migration wait from task-processor startup while keeping the Postgres, analytics, and task_processor migration waits intact.

Also drops the equivalent `waitfordb --database clickhouse` from the `wait-for-db` Make target used by the test setup.

## How did you test this code?

Manually traced the failing path from the Sentry event's `sys.argv` (`waitfordb --migrations --database clickhouse`) through `waitfordb.py` and confirmed the ClickHouse migrations are already applied earlier in the entrypoint via `migrate_clickhouse_db`. Verified the remaining Postgres/analytics/task_processor waits are unchanged.
