### PR TITLE
fix: include role in organisation invite list/retrieve responses

### DIFF
--- a/api/organisations/invites/serializers.py
+++ b/api/organisations/invites/serializers.py
@@ -16,4 +16,11 @@ class InviteListSerializer(serializers.ModelSerializer):  # type: ignore[type-ar
 
     class Meta:
         model = Invite
-        fields = ("id", "email", "date_created", "invited_by", "permission_groups")
+        fields = (
+            "id",
+            "email",
+            "date_created",
+            "invited_by",
+            "permission_groups",
+            "role",
+        )

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -303,6 +303,41 @@ def test_retrieve_invite__valid_invite__returns_200(  # type: ignore[no-untyped-
     response = admin_client.get(url)
     # Then
     assert response.status_code == status.HTTP_200_OK
+    assert response.json()["role"] == invite.role
+
+
+def test_list_invites__returns_role_for_each_invite(
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    Invite.objects.create(
+        organisation=organisation,
+        email="admin-invite@example.com",
+        role=OrganisationRole.ADMIN.name,
+    )
+    Invite.objects.create(
+        organisation=organisation,
+        email="user-invite@example.com",
+        role=OrganisationRole.USER.name,
+    )
+    url = reverse(
+        "api-v1:organisations:organisation-invites-list",
+        args=[organisation.id],
+    )
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    roles_by_email = {
+        invite["email"]: invite["role"] for invite in response.json()["results"]
+    }
+    assert roles_by_email == {
+        "admin-invite@example.com": OrganisationRole.ADMIN.name,
+        "user-invite@example.com": OrganisationRole.USER.name,
+    }
 
 
 def test_delete_invite__valid_invite__returns_204(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`InviteSerializer` (used by the `create` action of
`/api/v1/organisations/{id}/invites/`) exposes the invite's organisation
`role`, but `InviteListSerializer` (used by the `list` and `retrieve`
actions) omits it:

```python
class InviteListSerializer(serializers.ModelSerializer):
    invited_by = UserListSerializer()

    class Meta:
        model = Invite
        fields = ("id", "email", "date_created", "invited_by", "permission_groups")
        #                                                       ^ no "role"
```

As a result, an invite created with role `USER` is returned with **no role
field at all** when listed or retrieved. API consumers (and the dashboard's
pending-invites UI) then have nothing to display and fall back to a default
of `ADMIN`, so a pending invite appears to have a different role than it was
created with. The role is persisted correctly — only the read path drops it.

This PR adds `role` to `InviteListSerializer.fields` so `list`/`retrieve`
responses report the persisted role, consistent with `create` and with
`InviteLinkSerializer` (which already exposes `role`). The change is purely
additive and backward compatible.

## How did you test this code?

- Added `test_list_invites__returns_role_for_each_invite`, which creates one
  `ADMIN` and one `USER` invite and asserts the list endpoint returns the
  correct role for each.
- Extended `test_retrieve_invite__valid_invite__returns_200` to assert the
  retrieve response includes `role` matching the invite.

Both new assertions fail against `main` (the field is absent) and pass with
this change.