### PR TITLE
feat: support a default expiry for organisation invite links

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1194,6 +1194,10 @@ BUCKETED_ANALYTICS_DATA_RETENTION_DAYS = env.int(
 )
 
 DISABLE_INVITE_LINKS = env.bool("DISABLE_INVITE_LINKS", False)
+# Number of days after which a newly created invite link expires when no explicit
+# expiry is provided. Defaults to None, which keeps the previous behaviour of
+# links never expiring unless an expiry date is set explicitly.
+INVITE_LINK_EXPIRY_DAYS = env.int("INVITE_LINK_EXPIRY_DAYS", default=None)
 PREVENT_SIGNUP = env.bool("PREVENT_SIGNUP", default=False)
 PREVENT_EMAIL_PASSWORD = env.bool("PREVENT_EMAIL_PASSWORD", default=False)
 COOKIE_AUTH_ENABLED = env.bool("COOKIE_AUTH_ENABLED", default=False)

--- a/api/organisations/invites/models.py
+++ b/api/organisations/invites/models.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
@@ -52,6 +54,13 @@ class InviteLink(
     def validate_invite_links_are_enabled(self):  # type: ignore[no-untyped-def]
         if settings.DISABLE_INVITE_LINKS:
             raise InviteLinksDisabledError()
+
+    @hook(BEFORE_CREATE)
+    def set_default_expiry(self) -> None:
+        if self.expires_at is None and settings.INVITE_LINK_EXPIRY_DAYS is not None:
+            self.expires_at = timezone.now() + timedelta(
+                days=settings.INVITE_LINK_EXPIRY_DAYS
+            )
 
 
 class Invite(LifecycleModelMixin, AbstractBaseInviteModel):  # type: ignore[misc]

--- a/api/tests/unit/organisations/invites/test_unit_invites_models.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_models.py
@@ -59,6 +59,54 @@ def test_invite_link_is_expired__no_expiry_date__returns_false(
     assert not is_expired
 
 
+def test_create_invite_link__default_expiry_setting__sets_expires_at(
+    organisation: Organisation,
+    settings: "SettingsWrapper",
+) -> None:
+    # Given
+    settings.INVITE_LINK_EXPIRY_DAYS = 7
+    before = timezone.now()
+
+    # When
+    invite_link = InviteLink.objects.create(organisation=organisation)
+
+    # Then
+    assert invite_link.expires_at is not None
+    expected = before + timedelta(days=7)
+    assert abs((invite_link.expires_at - expected).total_seconds()) < 60
+
+
+def test_create_invite_link__no_default_expiry_setting__stays_indefinite(
+    organisation: Organisation,
+    settings: "SettingsWrapper",
+) -> None:
+    # Given
+    settings.INVITE_LINK_EXPIRY_DAYS = None
+
+    # When
+    invite_link = InviteLink.objects.create(organisation=organisation)
+
+    # Then
+    assert invite_link.expires_at is None
+
+
+def test_create_invite_link__explicit_expiry__not_overridden_by_default(
+    organisation: Organisation,
+    settings: "SettingsWrapper",
+) -> None:
+    # Given
+    settings.INVITE_LINK_EXPIRY_DAYS = 7
+    explicit_expiry = timezone.now() + timedelta(days=1)
+
+    # When
+    invite_link = InviteLink.objects.create(
+        organisation=organisation, expires_at=explicit_expiry
+    )
+
+    # Then
+    assert invite_link.expires_at == explicit_expiry
+
+
 @pytest.mark.django_db
 def test_create_invite_link__invite_links_disabled__raises_error(
     settings: "SettingsWrapper",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`InviteLink.expires_at` is nullable and, when left blank, the link never
expires (`is_expired` returns `False` while `expires_at` is `None`). There is
currently no way for an operator to make invite links expire by default — each
link would have to be created with an explicit `expires_at`.

This PR adds an opt-in `INVITE_LINK_EXPIRY_DAYS` setting:

- When set, a newly created `InviteLink` **without** an explicit `expires_at`
  defaults to `now + INVITE_LINK_EXPIRY_DAYS` days (applied via a
  `BEFORE_CREATE` lifecycle hook).
- The setting defaults to `None`, preserving today's indefinite behaviour, so
  this is fully backward compatible.
- An explicitly provided `expires_at` is never overridden.

## How did you test this code?

Added unit tests in `test_unit_invites_models.py`:

- `…default_expiry_setting__sets_expires_at` — with the setting configured, a
  link created without an expiry gets `expires_at ≈ now + N days`.
- `…no_default_expiry_setting__stays_indefinite` — with the setting unset, a
  link created without an expiry stays `expires_at = None`.
- `…explicit_expiry__not_overridden_by_default` — an explicit `expires_at` is
  preserved even when the setting is configured.