### PR TITLE
feat(clickhouse): Add ingested_at and source to IDENTITIES

### DIFF
--- a/api/clickhouse/migrations/0002_identities_ingested_at_and_source.py
+++ b/api/clickhouse/migrations/0002_identities_ingested_at_and_source.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+_FORWARD_DDL = """\
+ALTER TABLE IDENTITIES
+    ADD COLUMN IF NOT EXISTS ingested_at DateTime DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS source LowCardinality(String) DEFAULT 'backfill'
+"""
+
+_REVERSE_DDL = """\
+ALTER TABLE IDENTITIES
+    DROP COLUMN IF EXISTS ingested_at,
+    DROP COLUMN IF EXISTS source
+"""
+
+
+class Migration(migrations.Migration):
+    # ClickHouse has no transactional DDL.
+    atomic = False
+
+    dependencies = [
+        ("clickhouse", "0001_create_identities"),
+    ]
+
+    operations = [
+        migrations.RunSQL(_FORWARD_DDL, reverse_sql=_REVERSE_DDL),
+    ]


### PR DESCRIPTION
## Changes

Contributes to https://github.com/Flagsmith/edge-api/issues/612

Adds two observability columns to the ClickHouse `IDENTITIES` table so we can measure the Edge CDC pipeline's write-to-visible latency as an SLI.

- `ingested_at DateTime DEFAULT now()` — stamped by ClickHouse at insert time. Paired with `inserted_at` (the source DynamoDB write time, set by the CDC writer) it yields per-row pipeline lag: `dateDiff('second', inserted_at, ingested_at)`.
- `source LowCardinality(String) DEFAULT 'backfill'` — the Edge CDC writer will set `'cdc'` explicitly; any backfill, including current daily task, omits the column and so defaults to `'backfill'`. The SLI will omit all rows with `source != 'cdc'`.

Both are `ADD COLUMN IF NOT EXISTS` (metadata-only on the `ReplacingMergeTree`), reversible via `DROP COLUMN IF EXISTS`.

## How did you test this code?

- `python manage.py makemigrations clickhouse --check --dry-run`
- Will extensively test on staging
