### PR TITLE
feat(clickhouse): add is_deleted to IDENTITIES

### DIFF
--- a/api/clickhouse/migrations/0003_identities_is_deleted.py
+++ b/api/clickhouse/migrations/0003_identities_is_deleted.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+_FORWARD_DDL = """\
+ALTER TABLE IDENTITIES
+    ADD COLUMN IF NOT EXISTS is_deleted Bool DEFAULT false
+"""
+
+_REVERSE_DDL = """\
+ALTER TABLE IDENTITIES
+    DROP COLUMN IF EXISTS is_deleted
+"""
+
+
+class Migration(migrations.Migration):
+    # ClickHouse has no transactional DDL.
+    atomic = False
+
+    dependencies = [
+        ("clickhouse", "0002_identities_ingested_at_and_source"),
+    ]
+
+    operations = [
+        migrations.RunSQL(_FORWARD_DDL, reverse_sql=_REVERSE_DDL),
+    ]


### PR DESCRIPTION
## Changes

Contributes to https://github.com/Flagsmith/edge-api/issues/612.

Adds `is_deleted Bool DEFAULT false` to the ClickHouse `IDENTITIES` table.

The Edge CDC writer emits `is_deleted=true` for `REMOVE` DynamoDB stream records so deleted identities can be excluded from segment membership downstream. The daily backfill omits the column and defaults to `false`.

`ADD COLUMN IF NOT EXISTS` is metadata-only on the `ReplacingMergeTree`, reversible via `DROP COLUMN IF EXISTS`.

## How did you test this code?

N/A