### PR TITLE
fix(Tagging): TagType evaluated incorrectly in database queries

### DIFF
--- a/api/features/feature_external_resources/models.py
+++ b/api/features/feature_external_resources/models.py
@@ -110,7 +110,7 @@ class FeatureExternalResource(LifecycleModelMixin, models.Model):  # type: ignor
                     label=tag_by_type_and_state[self.type][state],
                     project=self.feature.project,
                     is_system_tag=True,
-                    type=TagType.GITHUB.value,
+                    type=TagType.GITHUB,
                 )
                 self.feature.tags.add(github_tag)
                 self.feature.save()

--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -84,13 +84,13 @@ def tag_feature_per_github_event(
             label=tag_by_event_type[event_type][action],
             project=feature.project,
             is_system_tag=True,
-            type=TagType.GITHUB.value,
+            type=TagType.GITHUB,
         )
         tag_label_pattern = "Issue" if event_type == "issues" else "PR"
         # Remove all GITHUB tags from the feature which label starts with issue or pr depending on event_type
         feature.tags.remove(
             *feature.tags.filter(
-                Q(type=TagType.GITHUB.value) & Q(label__startswith=tag_label_pattern)
+                Q(type=TagType.GITHUB) & Q(label__startswith=tag_label_pattern)
             )
         )
 

--- a/api/integrations/github/models.py
+++ b/api/integrations/github/models.py
@@ -111,5 +111,5 @@ class GitHubRepository(LifecycleModelMixin, SoftDeleteExportableModel):  # type:
                 label=tag_label.value,
                 project=self.project,
                 is_system_tag=True,
-                type=TagType.GITHUB.value,
+                type=TagType.GITHUB,
             )

--- a/api/integrations/gitlab/services/tagging.py
+++ b/api/integrations/gitlab/services/tagging.py
@@ -29,7 +29,7 @@ def set_gitlab_tag(feature: Feature, new_label: GitLabTagLabel) -> None:
 
     feature.tags.remove(
         *feature.tags.filter(
-            type=TagType.GITLAB.value,
+            type=TagType.GITLAB,
             label__startswith=GITLAB_TAG_KIND_BY_LABEL[new_label],
         )
     )
@@ -37,7 +37,7 @@ def set_gitlab_tag(feature: Feature, new_label: GitLabTagLabel) -> None:
         label=label_value,
         project=feature.project,
         is_system_tag=True,
-        type=TagType.GITLAB.value,
+        type=TagType.GITLAB,
         defaults={
             "color": GITLAB_TAG_COLOR,
             "description": GITLAB_TAG_DESCRIPTION_BY_LABEL[new_label],
@@ -98,7 +98,7 @@ def clear_tag_for_resource(resource: FeatureExternalResource) -> None:
         return
     resource.feature.tags.remove(
         *resource.feature.tags.filter(
-            type=TagType.GITLAB.value,
+            type=TagType.GITLAB,
             label__startswith=kind,
         )
     )

--- a/api/projects/tags/models.py
+++ b/api/projects/tags/models.py
@@ -4,7 +4,7 @@ from core.models import AbstractBaseExportableModel
 from projects.models import Project
 
 
-class TagType(models.Choices):
+class TagType(models.TextChoices):
     NONE = "NONE"
     STALE = "STALE"
     GITHUB = "GITHUB"
@@ -29,7 +29,7 @@ class Tag(AbstractBaseExportableModel):
         help_text="When applied to a feature, it means this feature should be excluded from stale flags logic.",
     )
     type = models.CharField(
-        default=TagType.NONE.value,
+        default=TagType.NONE,
         choices=TagType.choices,
         help_text="Field used to provide a consistent identifier for the FE and API to use for business logic.",
         max_length=100,

--- a/api/tests/integration/features/feature_lifecycle/conftest.py
+++ b/api/tests/integration/features/feature_lifecycle/conftest.py
@@ -13,7 +13,7 @@ from app_analytics.models import FeatureEvaluationBucket
 from features.models import Feature
 from projects.code_references.models import ScannedCodeReferences, VCSRepository
 from projects.code_references.types import StoredCodeReference, VCSProvider
-from projects.tags.models import Tag, TagType
+from projects.tags.models import Tag
 
 MakeCodeReferencesFixture = Callable[
     [Feature, list[StoredCodeReference]], ScannedCodeReferences
@@ -26,7 +26,7 @@ def stale_tag(project: int) -> Tag:
     return Tag.objects.create(  # type: ignore[no-any-return]
         project_id=project,
         is_system_tag=True,
-        type=TagType.STALE,
+        type="STALE",
     )
 
 

--- a/api/tests/integration/features/test_gitlab_external_resources.py
+++ b/api/tests/integration/features/test_gitlab_external_resources.py
@@ -10,7 +10,6 @@ from features.models import Feature
 from integrations.github.models import GithubConfiguration
 from integrations.gitlab.models import GitLabConfiguration, GitLabWebhook
 from projects.models import Project
-from projects.tags.models import TagType
 
 
 def test_create_external_resource__gitlab_issue__returns_201(
@@ -210,7 +209,7 @@ def test_create_external_resource__gitlab_issue__registers_webhook_and_tags_feat
 
     # Feature tagged `Issue Open`
     assert list(Feature.objects.get(id=feature).tags.values_list("label", "type")) == [
-        ("Issue Open", TagType.GITLAB.value)
+        ("Issue Open", "GITLAB")
     ]
 
     assert log.events == [
@@ -292,7 +291,7 @@ def test_create_external_resource__gitlab_mr__registers_webhook_and_tags_feature
         gitlab_path_with_namespace="testorg/testrepo",
     ).exists()
     assert list(Feature.objects.get(id=feature).tags.values_list("label", "type")) == [
-        ("MR Open", TagType.GITLAB.value)
+        ("MR Open", "GITLAB")
     ]
     assert log.events == [
         {
@@ -370,7 +369,7 @@ def test_create_external_resource__second_link_same_gitlab_project__reuses_webho
 
     # Feature tagged with `MR Open`
     assert list(Feature.objects.get(id=feature).tags.values_list("label", "type")) == [
-        ("MR Open", TagType.GITLAB.value)
+        ("MR Open", "GITLAB")
     ]
 
     assert log.events == [

--- a/api/tests/unit/integrations/gitlab/test_tagging.py
+++ b/api/tests/unit/integrations/gitlab/test_tagging.py
@@ -10,7 +10,7 @@ from integrations.gitlab.services.tagging import (
     clear_tag_for_resource,
 )
 from projects.models import Project
-from projects.tags.models import Tag, TagType
+from projects.tags.models import Tag
 
 
 @pytest.mark.django_db
@@ -26,7 +26,7 @@ def test_clear_tag_for_resource__only_resource_of_kind__removes_tag(
     )
     apply_initial_tag(resource)
     assert sorted(
-        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+        feature.tags.filter(type="GITLAB").values_list("label", flat=True)
     ) == ["Issue Open"]
 
     # When
@@ -34,12 +34,7 @@ def test_clear_tag_for_resource__only_resource_of_kind__removes_tag(
 
     # Then
     assert (
-        sorted(
-            feature.tags.filter(type=TagType.GITLAB.value).values_list(
-                "label", flat=True
-            )
-        )
-        == []
+        sorted(feature.tags.filter(type="GITLAB").values_list("label", flat=True)) == []
     )
 
 
@@ -62,7 +57,7 @@ def test_clear_tag_for_resource__other_resource_of_same_kind_remains__keeps_tag(
     )
     apply_initial_tag(first)
     assert sorted(
-        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+        feature.tags.filter(type="GITLAB").values_list("label", flat=True)
     ) == ["Issue Open"]
 
     # When
@@ -70,7 +65,7 @@ def test_clear_tag_for_resource__other_resource_of_same_kind_remains__keeps_tag(
 
     # Then
     assert sorted(
-        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+        feature.tags.filter(type="GITLAB").values_list("label", flat=True)
     ) == ["Issue Open"]
 
 
@@ -94,7 +89,7 @@ def test_clear_tag_for_resource__different_kind_remains__keeps_other_kind_tag(
     apply_initial_tag(issue)
     apply_initial_tag(mr)
     assert sorted(
-        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+        feature.tags.filter(type="GITLAB").values_list("label", flat=True)
     ) == ["Issue Open", "MR Open"]
 
     # When
@@ -102,7 +97,7 @@ def test_clear_tag_for_resource__different_kind_remains__keeps_other_kind_tag(
 
     # Then
     assert sorted(
-        feature.tags.filter(type=TagType.GITLAB.value).values_list("label", flat=True)
+        feature.tags.filter(type="GITLAB").values_list("label", flat=True)
     ) == ["MR Open"]
 
 
@@ -113,14 +108,14 @@ def test_clear_tag_for_resource__non_gitlab_type__leaves_tags_intact(
 ) -> None:
     # Given — feature has both a GitHub tag and a GitLab tag already.
     expected_tags = [
-        ("Issue Open", TagType.GITHUB.value),
-        ("Issue Open", TagType.GITLAB.value),
+        ("Issue Open", "GITHUB"),
+        ("Issue Open", "GITLAB"),
     ]
 
     github_tag = Tag.objects.create(
         label="Issue Open",
         project=project,
-        type=TagType.GITHUB.value,
+        type="GITHUB",
         is_system_tag=True,
     )
     gitlab_issue = FeatureExternalResource.objects.create(

--- a/api/tests/unit/platform_hub/test_services.py
+++ b/api/tests/unit/platform_hub/test_services.py
@@ -14,7 +14,7 @@ from organisations.models import (
 )
 from platform_hub import services
 from projects.models import Project
-from projects.tags.models import Tag, TagType
+from projects.tags.models import Tag
 from users.models import FFAdminUser
 
 
@@ -474,7 +474,7 @@ def test_get_stale_flags_per_project__stale_tagged_feature__counts_correctly(
     stale_tag = Tag.objects.create(
         label="Stale",
         project=platform_hub_project,
-        type=TagType.STALE,
+        type="STALE",
         is_system_tag=True,
     )
     feature.tags.add(stale_tag)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith/issues/7433

Fixes a bug in which tag-based querying won't bring results because SQL is evaluated with non-str object representation, e.g. `WHERE type = '<TagType.STALE>'`.

Normalise `TagType` interfacing:
- `TextChoices` provides reliable ergonomics
- Tests are dumbimised and stick to bare value (ensures contract)

## How did you test this code?

Running tests.
