### PR TITLE
fix: return 404 for missing versioning parents

### DIFF
--- a/api/features/versioning/permissions.py
+++ b/api/features/versioning/permissions.py
@@ -5,6 +5,7 @@ from common.environments.permissions import (
     UPDATE_FEATURE_STATE,
     VIEW_ENVIRONMENT,
 )
+from django.shortcuts import get_object_or_404
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.viewsets import GenericViewSet
@@ -21,14 +22,16 @@ class EnvironmentFeatureVersionPermissions(BasePermission):
             return True
 
         environment_pk = view.kwargs["environment_pk"]
-        environment = Environment.objects.get(id=environment_pk)
+        environment = get_object_or_404(Environment, id=environment_pk)
 
         tag_ids = None
         required_permission = UPDATE_FEATURE_STATE
 
         if required_permission in TAG_SUPPORTED_ENVIRONMENT_PERMISSIONS:
             feature_id = view.kwargs["feature_pk"]
-            feature = Feature.objects.get(id=feature_id, project=environment.project)
+            feature = get_object_or_404(
+                Feature, id=feature_id, project=environment.project
+            )
             tag_ids = list(feature.tags.values_list("id", flat=True))
 
         return request.user.has_environment_permission(  # type: ignore[union-attr,no-any-return]
@@ -70,7 +73,7 @@ class EnvironmentFeatureVersionRetrievePermissions(BasePermission):
 class EnvironmentFeatureVersionFeatureStatePermissions(BasePermission):
     def has_permission(self, request: Request, view: GenericViewSet) -> bool:  # type: ignore[override,type-arg]
         environment_pk = view.kwargs["environment_pk"]
-        environment = Environment.objects.get(id=environment_pk)
+        environment = get_object_or_404(Environment, id=environment_pk)
 
         if view.action == "list":
             return request.user.has_environment_permission(  # type: ignore[union-attr,no-any-return]

--- a/api/tests/unit/features/versioning/test_unit_versioning_permissions.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_permissions.py
@@ -1,0 +1,54 @@
+import pytest
+from django.http import Http404
+from pytest_mock import MockerFixture
+from rest_framework.request import Request
+from rest_framework.viewsets import GenericViewSet
+
+from environments.models import Environment
+from features.models import Feature
+from features.versioning.permissions import (
+    EnvironmentFeatureVersionFeatureStatePermissions,
+    EnvironmentFeatureVersionPermissions,
+)
+from users.models import FFAdminUser
+
+pytestmark = pytest.mark.django_db
+
+
+def test_environment_feature_version_feature_state_permissions__missing_environment__raises_404(
+    admin_user: FFAdminUser,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    request = mocker.MagicMock(spec=Request, user=admin_user)
+    view = mocker.MagicMock(
+        spec=GenericViewSet,
+        action="list",
+        kwargs={"environment_pk": 1000000},
+    )
+
+    # When / Then
+    with pytest.raises(Http404):
+        EnvironmentFeatureVersionFeatureStatePermissions().has_permission(request, view)
+
+
+def test_environment_feature_version_permissions__missing_feature__raises_404(
+    admin_user: FFAdminUser,
+    environment: Environment,
+    feature: Feature,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    request = mocker.MagicMock(spec=Request, user=admin_user)
+    view = mocker.MagicMock(
+        spec=GenericViewSet,
+        action="create",
+        kwargs={
+            "environment_pk": environment.id,
+            "feature_pk": feature.id + 1000000,
+        },
+    )
+
+    # When / Then
+    with pytest.raises(Http404):
+        EnvironmentFeatureVersionPermissions().has_permission(request, view)


### PR DESCRIPTION
## Changes

- Return 404 when feature-versioning permission checks encounter a missing nested environment or feature parent.
- Add focused regression coverage for missing parent resources in the feature-versioning permission classes.

## Root cause

DRF runs permission checks before the feature-versioning view `initial()` methods. These permission classes used direct `Environment.objects.get(...)` / `Feature.objects.get(...)` lookups, so missing nested parents could raise raw `DoesNotExist` exceptions instead of returning a 404 response.

Fixes #6556

## Testing

- `uv run ruff check features/versioning/permissions.py tests/unit/features/versioning/test_unit_versioning_permissions.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DATABASE_URL=postgresql://postgres:password@localhost:5433/flagsmith ANALYTICS_DATABASE_URL=postgresql://postgres:password@localhost:5433/analytics uv run pytest -p django -p xdist.plugin -p pytest_mock tests/unit/features/versioning/test_unit_versioning_permissions.py -n0`

Note: I used the explicit pytest plugins above because local Windows plugin autoload hits a `pyreadline` compatibility issue. The broader versioning view module also hits a Windows-only `gunicorn`/`fcntl` import path in this local environment.