### PR TITLE
fix(project-settings): add spacing between project name input and Update button when hasVariation is False

### DIFF
--- a/frontend/web/components/pages/project-settings/tabs/general-tab/sections/ProjectInformation.tsx
+++ b/frontend/web/components/pages/project-settings/tabs/general-tab/sections/ProjectInformation.tsx
@@ -113,7 +113,7 @@ export const ProjectInformation = ({ project }: ProjectInformationProps) => {
           </div>
         )}
 
-        <div className='text-right'>
+        <div className='text-right mt-4'>
           <Button
             type='submit'
             id='save-proj-btn'

--- a/frontend/web/components/pages/project-settings/tabs/general-tab/sections/ProjectInformation.tsx
+++ b/frontend/web/components/pages/project-settings/tabs/general-tab/sections/ProjectInformation.tsx
@@ -113,7 +113,7 @@ export const ProjectInformation = ({ project }: ProjectInformationProps) => {
           </div>
         )}
 
-        <div className='text-right mt-4'>
+        <div className={classNames('text-right', { 'mt-4': !hasVersioning })}>
           <Button
             type='submit'
             id='save-proj-btn'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [✔] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [  ] I have added information to `docs/` if required so people know about the feature.
- [✔] I have filled in the "Changes" section below.
- [✔] I have filled in the "How did you test this code" section below.

## Changes

Closes #7881 

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

1. There is no spacing between Input project name and Update Button when `hasVersioning` is False, which causes it to look odd.
2. Add margin styling in the div of the update button

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Before changes:
<img width="1549" height="869" alt="Screenshot from 2026-06-26 11-09-18" src="https://github.com/user-attachments/assets/29cd223b-713f-4398-a6dd-71f9613165b9" />

After changes:
<img width="1549" height="869" alt="Screenshot from 2026-06-26 11-02-16" src="https://github.com/user-attachments/assets/5207b417-d1f6-4dea-b4e5-b5cc95591b5c" />
