### PR TITLE
feat(experimentation): enable rollout when an experiment starts

### DIFF
--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import ValidationError
 
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
+from core.dataclasses import AuthorData
 from experimentation.constants import (
     CONTROL_VARIANT_KEY,
     EXPERIMENT_FLAG,
@@ -629,6 +630,25 @@ def get_experiment_rollout(experiment: Experiment) -> dict[str, typing.Any] | No
             for mv in feature_state.multivariate_feature_state_values.all()
         ],
     }
+
+
+def enable_experiment_rollout(experiment: Experiment, author: AuthorData) -> None:
+    rollout = get_experiment_rollout(experiment)
+    if rollout is None or rollout["enabled"]:
+        return
+
+    value = rollout["feature_state_value"]
+    update_flag(
+        experiment.environment,
+        experiment.feature,
+        FlagChangeSet(
+            author=author,
+            enabled=True,
+            feature_state_value=value["value"],
+            type_=value["type"],
+            segment_id=experiment.rollout_segment_id,
+        ),
+    )
 
 
 def mark_warehouse_pending_connection(

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -16,6 +16,7 @@ from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from app.pagination import CustomPagination
+from core.dataclasses import AuthorData
 from environments.views import NestedEnvironmentViewSet
 from experimentation.constants import (
     EXPOSURES_REFRESH_MIN_INTERVAL,
@@ -54,6 +55,7 @@ from experimentation.services import (
     create_experiment_audit_log,
     create_metric_audit_log,
     create_warehouse_audit_log,
+    enable_experiment_rollout,
     mark_warehouse_pending_connection,
     refresh_warehouse_connection_status,
     transition_experiment_status,
@@ -285,7 +287,12 @@ class ExperimentViewSet(
 
     @action(detail=True, methods=["post"])
     def start(self, request: Request, **kwargs: object) -> Response:
-        return self._transition_status(ExperimentStatus.RUNNING)
+        response = self._transition_status(ExperimentStatus.RUNNING)
+        if status.is_success(response.status_code):
+            enable_experiment_rollout(
+                self.get_object(), AuthorData.from_request(request)
+            )
+        return response
 
     @action(detail=True, methods=["post"])
     def pause(self, request: Request, **kwargs: object) -> Response:

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -2,7 +2,7 @@ import logging
 from datetime import timedelta
 from typing import Any
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Count, Prefetch, Q, QuerySet
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -287,11 +287,12 @@ class ExperimentViewSet(
 
     @action(detail=True, methods=["post"])
     def start(self, request: Request, **kwargs: object) -> Response:
-        response = self._transition_status(ExperimentStatus.RUNNING)
-        if status.is_success(response.status_code):
-            enable_experiment_rollout(
-                self.get_object(), AuthorData.from_request(request)
-            )
+        with transaction.atomic():
+            response = self._transition_status(ExperimentStatus.RUNNING)
+            if status.is_success(response.status_code):
+                enable_experiment_rollout(
+                    self.get_object(), AuthorData.from_request(request)
+                )
         return response
 
     @action(detail=True, methods=["post"])

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -652,6 +652,47 @@ def test_action__start__sets_started_at(
     assert response.json()["started_at"] is not None
 
 
+def test_action__start__enables_disabled_rollout(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment_with_rollout: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given an experiment whose rollout override is disabled
+    enable_features(EXPERIMENT_FLAG)
+    option_a, option_b, _ = multivariate_options
+    admin_client_new.patch(
+        _action_url(environment, experiment_with_rollout, "rollout"),
+        data={
+            "enabled": False,
+            "rollout_percentage": 20,
+            "feature_state_value": {"type": "string", "value": "control"},
+            "multivariate_feature_state_values": [
+                {
+                    "multivariate_feature_option": option_a.id,
+                    "percentage_allocation": 50,
+                },
+                {
+                    "multivariate_feature_option": option_b.id,
+                    "percentage_allocation": 50,
+                },
+            ],
+        },
+        format="json",
+    )
+
+    # When the experiment is started
+    response = admin_client_new.post(
+        _action_url(environment, experiment_with_rollout, "start")
+    )
+
+    # Then the rollout override is enabled
+    assert response.status_code == status.HTTP_200_OK
+    detail = admin_client_new.get(_detail_url(environment, experiment_with_rollout))
+    assert detail.json()["experiment_rollout"]["enabled"] is True
+
+
 def test_action__complete__sets_ended_at(
     admin_client_new: APIClient,
     environment: Environment,

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -693,6 +693,30 @@ def test_action__start__enables_disabled_rollout(
     assert detail.json()["experiment_rollout"]["enabled"] is True
 
 
+def test_action__start_rollout_enable_fails__rolls_back_transition(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    enable_features: EnableFeaturesFixture,
+    mocker: MockerFixture,
+) -> None:
+    # Given enabling the rollout will fail while starting
+    enable_features(EXPERIMENT_FLAG)
+    mocker.patch(
+        "experimentation.views.enable_experiment_rollout",
+        side_effect=RuntimeError("boom"),
+    )
+
+    # When
+    with pytest.raises(RuntimeError):
+        admin_client_new.post(_action_url(environment, experiment, "start"))
+
+    # Then the status transition is rolled back
+    experiment.refresh_from_db()
+    assert experiment.status == ExperimentStatus.CREATED
+    assert experiment.started_at is None
+
+
 def test_action__complete__sets_ended_at(
     admin_client_new: APIClient,
     environment: Environment,

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1574,3 +1574,70 @@ def test_get_experiment_rollout__boolean_value__returns_lowercase_string(
     # Then
     assert rollout is not None
     assert rollout["feature_state_value"] == {"type": "boolean", "value": "true"}
+
+
+def test_enable_experiment_rollout__disabled_rollout__enables_and_preserves_allocations(
+    experiment: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+) -> None:
+    # Given a disabled rollout with a 50/50 multivariate split
+    option_a, option_b, _ = multivariate_options
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=False,
+            rollout_percentage=20.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 50.0),
+                MultivariateValueChangeSet(option_b.id, 50.0),
+            ],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # When
+    services.enable_experiment_rollout(experiment, AuthorData(user=admin_user))
+
+    # Then the override is enabled with its allocations preserved
+    rollout = services.get_experiment_rollout(experiment)
+    assert rollout is not None
+    assert rollout["enabled"] is True
+    assert {
+        (mv["multivariate_feature_option"], mv["percentage_allocation"])
+        for mv in rollout["multivariate_feature_state_values"]
+    } == {(option_a.id, 50.0), (option_b.id, 50.0)}
+
+
+def test_enable_experiment_rollout__already_enabled__no_op(
+    experiment_with_rollout: Experiment,
+    admin_user: FFAdminUser,
+    mocker: MockerFixture,
+) -> None:
+    # Given a rollout that is already enabled
+    update_flag = mocker.patch("experimentation.services.update_flag")
+
+    # When
+    services.enable_experiment_rollout(
+        experiment_with_rollout, AuthorData(user=admin_user)
+    )
+
+    # Then no flag write is made
+    update_flag.assert_not_called()
+
+
+def test_enable_experiment_rollout__no_rollout__no_op(
+    experiment: Experiment,
+    admin_user: FFAdminUser,
+    mocker: MockerFixture,
+) -> None:
+    # Given an experiment without a rollout
+    update_flag = mocker.patch("experimentation.services.update_flag")
+
+    # When
+    services.enable_experiment_rollout(experiment, AuthorData(user=admin_user))
+
+    # Then nothing is written
+    update_flag.assert_not_called()

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -494,7 +494,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:664`
+ - `api/experimentation/services.py:684`
 
 Attributes:
  - `environment.id`
@@ -503,7 +503,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:644`
+ - `api/experimentation/services.py:664`
 
 Attributes:
  - `environment.id`
@@ -512,7 +512,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:391`
+ - `api/experimentation/services.py:392`
 
 Attributes:
  - `environment.id`
@@ -522,7 +522,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:377`
+ - `api/experimentation/services.py:378`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to experiment rollout work.

Auto-enables an experiment's rollout segment override when the experiment starts, so a started experiment immediately serves its split to traffic.

- `enable_experiment_rollout(experiment, author)` service helper: re-applies the existing rollout override as-is but enabled, going through `update_flag` so the change is versioned like any other flag write. Multivariate allocations are preserved (omitted from the change set). No-op when the experiment has no rollout or the override is already enabled.
- The `start` action calls it once the experiment successfully transitions to `RUNNING`.

## How did you test this code?

Added unit tests:

- Service: disabled rollout → enabled with allocations preserved; already-enabled → no-op (no flag write); no rollout → no-op.
- View: `start` enables a previously-disabled rollout (verified via the detail endpoint), for both user and master-API-key auth.

`make typecheck`, `make lint`, and the new tests all pass locally.
