### PR TITLE
feat(experimentation): allow updating rollout while experiment is running

### DIFF
--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -575,7 +575,7 @@ def _sync_rollout_segment(experiment: Experiment, rollout_percentage: float) -> 
 
 
 def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
-    if experiment.status in (ExperimentStatus.RUNNING, ExperimentStatus.COMPLETED):
+    if experiment.status == ExperimentStatus.COMPLETED:
         raise ValidationError(
             f"Cannot change the rollout of a {experiment.status} experiment."
         )

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -1984,7 +1984,7 @@ def test_action_rollout__valid__updates_percentage(
     assert condition.value == "75.0"
 
 
-def test_action_rollout__running_experiment__returns_400(
+def test_action_rollout__running_experiment__updates_percentage(
     admin_client_new: APIClient,
     environment: Environment,
     experiment_with_rollout: Experiment,
@@ -1994,6 +1994,48 @@ def test_action_rollout__running_experiment__returns_400(
     # Given
     enable_features(EXPERIMENT_FLAG)
     experiment_with_rollout.status = ExperimentStatus.RUNNING
+    experiment_with_rollout.save()
+    option_a, option_b, _ = multivariate_options
+
+    # When
+    response = admin_client_new.patch(
+        _action_url(environment, experiment_with_rollout, "rollout"),
+        data={
+            "enabled": True,
+            "rollout_percentage": 75,
+            "feature_state_value": {"type": "string", "value": "control"},
+            "multivariate_feature_state_values": [
+                {
+                    "multivariate_feature_option": option_a.id,
+                    "percentage_allocation": 50,
+                },
+                {
+                    "multivariate_feature_option": option_b.id,
+                    "percentage_allocation": 50,
+                },
+            ],
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    condition = Condition.objects.get(
+        rule__segment=experiment_with_rollout.rollout_segment
+    )
+    assert condition.value == "75.0"
+
+
+def test_action_rollout__completed_experiment__returns_400(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment_with_rollout: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    experiment_with_rollout.status = ExperimentStatus.COMPLETED
     experiment_with_rollout.save()
     option_a, option_b, _ = multivariate_options
 

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1392,18 +1392,13 @@ def test_apply_experiment_rollout__existing_segment__updates_percentage_and_enab
     assert override.enabled is False
 
 
-@pytest.mark.parametrize(
-    "status",
-    [ExperimentStatus.RUNNING, ExperimentStatus.COMPLETED],
-)
-def test_apply_experiment_rollout__running_or_completed__raises(
-    status: ExperimentStatus,
+def test_apply_experiment_rollout__completed__raises(
     experiment_with_rollout: Experiment,
     admin_user: FFAdminUser,
 ) -> None:
     # Given
     experiment = experiment_with_rollout
-    experiment.status = status
+    experiment.status = ExperimentStatus.COMPLETED
     experiment.save()
 
     # When / Then
@@ -1419,6 +1414,38 @@ def test_apply_experiment_rollout__running_or_completed__raises(
                 author=AuthorData(user=admin_user),
             ),
         )
+
+
+@pytest.mark.parametrize(
+    "status",
+    [ExperimentStatus.RUNNING, ExperimentStatus.PAUSED],
+)
+def test_apply_experiment_rollout__running_or_paused__updates_rollout(
+    status: ExperimentStatus,
+    experiment_with_rollout: Experiment,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    experiment = experiment_with_rollout
+    experiment.status = status
+    experiment.save()
+
+    # When
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=True,
+            rollout_percentage=50.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # Then
+    condition = Condition.objects.get(rule__segment=experiment.rollout_segment)
+    assert condition.value == "50.0"
 
 
 def test_apply_experiment_rollout__duplicate_options__raises(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to experiment rollout management.

The rollout endpoint (`PATCH .../experiments/{id}/rollout/`) previously rejected any change once an experiment was running. This relaxes the guard in `apply_experiment_rollout` so a **running** or **paused** experiment's rollout can still be tuned; only a **completed** (terminal) experiment locks its rollout.

Backend only — the frontend UI to edit a rollout on a running experiment will follow in a separate PR.

## How did you test this code?

Unit tests, run locally:

- `test_services.py`: `apply_experiment_rollout__completed__raises` (still blocked) and `apply_experiment_rollout__running_or_paused__updates_rollout` (RUNNING/PAUSED now succeed and update the percentage).
- `test_experiment_views.py`: `action_rollout__running_experiment__updates_percentage` (200 + updated condition) and `action_rollout__completed_experiment__returns_400`.

`ruff` and `mypy` clean on the changed files.