### PR TITLE
fix(infra): Task processor tasks killed during startup by health check

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -29,7 +29,7 @@
                 "interval": 10,
                 "timeout": 2,
                 "retries": 5,
-                "startPeriod": 5
+                "startPeriod": 120
             },
             "essential": true,
             "environment": [

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -24,7 +24,7 @@
                 "interval": 10,
                 "timeout": 2,
                 "retries": 5,
-                "startPeriod": 5
+                "startPeriod": 120
             },
             "essential": true,
             "environment": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Raises the task-processor container health check `startPeriod` from 5s to 120s, in both the production and staging ECS task definitions.

With `startPeriod: 5` along with `interval 10 / retries 5`, ECS only tolerated ~55s before marking the container unhealthy, often killing tasks just as they were about to come up. This has been recycling task-processor ECS tasks several times a day, and makes deploys flap.

`startPeriod: 120` covers the observed cold start and its variance, while `interval 10 / timeout 2 / retries 5` still flags a genuinely hung task ~50s after the grace window closes.

This is a temporary change until we figure out boot time improvements.

## How did you test this code?

N/A