### PR TITLE
feat: freeze flag editing when flag is in a running experiment

### DIFF
--- a/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
+++ b/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
@@ -1,0 +1,151 @@
+jest.mock('common/services/useExperiment', () => ({
+  useGetExperimentsQuery: jest.fn(),
+}))
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useMemo: (fn: () => any) => fn(),
+}))
+
+import { useFeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
+import { useGetExperimentsQuery } from 'common/services/useExperiment'
+import { Experiment } from 'common/types/responses'
+
+const mockUseGetExperimentsQuery =
+  useGetExperimentsQuery as jest.MockedFunction<typeof useGetExperimentsQuery>
+
+const makeExperiment = (
+  overrides: Partial<Experiment> & { featureId: number },
+): Experiment => ({
+  created_at: '',
+  ended_at: null,
+  feature: {
+    id: overrides.featureId,
+    initial_value: null,
+    multivariate_options: [],
+    name: 'test-flag',
+    type: 'MULTIVARIATE',
+  },
+  hypothesis: '',
+  id: 1,
+  metrics: [],
+  name: 'Test Experiment',
+  started_at: null,
+  status: overrides.status ?? 'running',
+  updated_at: '',
+  ...overrides,
+})
+
+describe('useFeatureExperimentFreeze', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns isFrozen true when a running experiment exists for the feature', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: {
+        results: [makeExperiment({ featureId: 42, status: 'running' })],
+      },
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(true)
+    expect(result.experiment?.id).toBe(1)
+    expect(result.isLoading).toBe(false)
+  })
+
+  it('returns isFrozen true when a paused experiment exists for the feature', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: {
+        results: [makeExperiment({ featureId: 42, status: 'paused' })],
+      },
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(true)
+  })
+
+  it('returns isFrozen false when experiment is created (not yet started)', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: {
+        results: [makeExperiment({ featureId: 42, status: 'created' })],
+      },
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+    expect(result.experiment).toBeNull()
+  })
+
+  it('returns isFrozen false when experiment is completed', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: {
+        results: [makeExperiment({ featureId: 42, status: 'completed' })],
+      },
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+    expect(result.experiment).toBeNull()
+  })
+
+  it('returns isFrozen false when no experiments exist', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: { results: [] },
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+    expect(result.experiment).toBeNull()
+  })
+
+  it('returns isFrozen false when experiment belongs to a different feature', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: {
+        results: [makeExperiment({ featureId: 99, status: 'running' })],
+      },
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+  })
+
+  it('returns isLoading true while experiments are loading', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+    expect(result.isLoading).toBe(true)
+  })
+
+  it('skips query when featureId is undefined', () => {
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as any)
+
+    const result = useFeatureExperimentFreeze(undefined, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentId: 'env-123' }),
+      expect.objectContaining({ skip: true }),
+    )
+  })
+})

--- a/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
+++ b/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
@@ -99,6 +99,18 @@ describe('useFeatureExperimentFreeze', () => {
     )
   })
 
+  it('skips query when environmentId is empty', () => {
+    mockUseGetExperimentsQuery.mockReturnValue(empty)
+
+    const result = useFeatureExperimentFreeze(42, '')
+
+    expect(result.isFrozen).toBe(false)
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledWith(
+      { environmentId: '', status: 'running' },
+      { skip: true },
+    )
+  })
+
   it('queries only running experiments', () => {
     mockUseGetExperimentsQuery.mockReturnValue(empty)
 

--- a/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
+++ b/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
@@ -36,18 +36,23 @@ const makeExperiment = (
   ...overrides,
 })
 
+const empty = { data: { results: [] }, isLoading: false } as any
+const loading = { data: undefined, isLoading: true } as any
+
+const withResults = (experiments: Experiment[]) =>
+  ({ data: { results: experiments }, isLoading: false } as any)
+
 describe('useFeatureExperimentFreeze', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   it('returns isFrozen true when a running experiment exists for the feature', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: {
-        results: [makeExperiment({ featureId: 42, status: 'running' })],
-      },
-      isLoading: false,
-    } as any)
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(
+        withResults([makeExperiment({ featureId: 42, status: 'running' })]),
+      )
+      .mockReturnValueOnce(empty)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -57,51 +62,21 @@ describe('useFeatureExperimentFreeze', () => {
   })
 
   it('returns isFrozen true when a paused experiment exists for the feature', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: {
-        results: [makeExperiment({ featureId: 42, status: 'paused' })],
-      },
-      isLoading: false,
-    } as any)
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(empty)
+      .mockReturnValueOnce(
+        withResults([makeExperiment({ featureId: 42, status: 'paused' })]),
+      )
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
     expect(result.isFrozen).toBe(true)
   })
 
-  it('returns isFrozen false when experiment is created (not yet started)', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: {
-        results: [makeExperiment({ featureId: 42, status: 'created' })],
-      },
-      isLoading: false,
-    } as any)
-
-    const result = useFeatureExperimentFreeze(42, 'env-123')
-
-    expect(result.isFrozen).toBe(false)
-    expect(result.experiment).toBeNull()
-  })
-
-  it('returns isFrozen false when experiment is completed', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: {
-        results: [makeExperiment({ featureId: 42, status: 'completed' })],
-      },
-      isLoading: false,
-    } as any)
-
-    const result = useFeatureExperimentFreeze(42, 'env-123')
-
-    expect(result.isFrozen).toBe(false)
-    expect(result.experiment).toBeNull()
-  })
-
   it('returns isFrozen false when no experiments exist', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: { results: [] },
-      isLoading: false,
-    } as any)
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(empty)
+      .mockReturnValueOnce(empty)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -110,23 +85,21 @@ describe('useFeatureExperimentFreeze', () => {
   })
 
   it('returns isFrozen false when experiment belongs to a different feature', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: {
-        results: [makeExperiment({ featureId: 99, status: 'running' })],
-      },
-      isLoading: false,
-    } as any)
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(
+        withResults([makeExperiment({ featureId: 99, status: 'running' })]),
+      )
+      .mockReturnValueOnce(empty)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
     expect(result.isFrozen).toBe(false)
   })
 
-  it('returns isLoading true while experiments are loading', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-    } as any)
+  it('returns isLoading true while either query is loading', () => {
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(empty)
+      .mockReturnValueOnce(loading)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -134,18 +107,43 @@ describe('useFeatureExperimentFreeze', () => {
     expect(result.isLoading).toBe(true)
   })
 
-  it('skips query when featureId is undefined', () => {
-    mockUseGetExperimentsQuery.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as any)
+  it('skips both queries when featureId is undefined', () => {
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(empty)
+      .mockReturnValueOnce(empty)
 
     const result = useFeatureExperimentFreeze(undefined, 'env-123')
 
     expect(result.isFrozen).toBe(false)
-    expect(mockUseGetExperimentsQuery).toHaveBeenCalledWith(
-      expect.objectContaining({ environmentId: 'env-123' }),
-      expect.objectContaining({ skip: true }),
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledTimes(2)
+    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
+      1,
+      { environmentId: 'env-123', status: 'running' },
+      { skip: true },
+    )
+    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
+      2,
+      { environmentId: 'env-123', status: 'paused' },
+      { skip: true },
+    )
+  })
+
+  it('passes status filter to each query', () => {
+    mockUseGetExperimentsQuery
+      .mockReturnValueOnce(empty)
+      .mockReturnValueOnce(empty)
+
+    useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
+      1,
+      { environmentId: 'env-123', status: 'running' },
+      { skip: false },
+    )
+    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
+      2,
+      { environmentId: 'env-123', status: 'paused' },
+      { skip: false },
     )
   })
 })

--- a/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
+++ b/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
@@ -48,11 +48,9 @@ describe('useFeatureExperimentFreeze', () => {
   })
 
   it('returns isFrozen true when a running experiment exists for the feature', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(
-        withResults([makeExperiment({ featureId: 42, status: 'running' })]),
-      )
-      .mockReturnValueOnce(empty)
+    mockUseGetExperimentsQuery.mockReturnValue(
+      withResults([makeExperiment({ featureId: 42, status: 'running' })]),
+    )
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -61,22 +59,8 @@ describe('useFeatureExperimentFreeze', () => {
     expect(result.isLoading).toBe(false)
   })
 
-  it('returns isFrozen true when a paused experiment exists for the feature', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(empty)
-      .mockReturnValueOnce(
-        withResults([makeExperiment({ featureId: 42, status: 'paused' })]),
-      )
-
-    const result = useFeatureExperimentFreeze(42, 'env-123')
-
-    expect(result.isFrozen).toBe(true)
-  })
-
   it('returns isFrozen false when no experiments exist', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(empty)
-      .mockReturnValueOnce(empty)
+    mockUseGetExperimentsQuery.mockReturnValue(empty)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -85,21 +69,17 @@ describe('useFeatureExperimentFreeze', () => {
   })
 
   it('returns isFrozen false when experiment belongs to a different feature', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(
-        withResults([makeExperiment({ featureId: 99, status: 'running' })]),
-      )
-      .mockReturnValueOnce(empty)
+    mockUseGetExperimentsQuery.mockReturnValue(
+      withResults([makeExperiment({ featureId: 99, status: 'running' })]),
+    )
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
     expect(result.isFrozen).toBe(false)
   })
 
-  it('returns isLoading true while either query is loading', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(empty)
-      .mockReturnValueOnce(loading)
+  it('returns isLoading true while the query is loading', () => {
+    mockUseGetExperimentsQuery.mockReturnValue(loading)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -107,42 +87,26 @@ describe('useFeatureExperimentFreeze', () => {
     expect(result.isLoading).toBe(true)
   })
 
-  it('skips both queries when featureId is undefined', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(empty)
-      .mockReturnValueOnce(empty)
+  it('skips query when featureId is undefined', () => {
+    mockUseGetExperimentsQuery.mockReturnValue(empty)
 
     const result = useFeatureExperimentFreeze(undefined, 'env-123')
 
     expect(result.isFrozen).toBe(false)
-    expect(mockUseGetExperimentsQuery).toHaveBeenCalledTimes(2)
-    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
-      1,
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledWith(
       { environmentId: 'env-123', status: 'running' },
-      { skip: true },
-    )
-    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
-      2,
-      { environmentId: 'env-123', status: 'paused' },
       { skip: true },
     )
   })
 
-  it('passes status filter to each query', () => {
-    mockUseGetExperimentsQuery
-      .mockReturnValueOnce(empty)
-      .mockReturnValueOnce(empty)
+  it('queries only running experiments', () => {
+    mockUseGetExperimentsQuery.mockReturnValue(empty)
 
     useFeatureExperimentFreeze(42, 'env-123')
 
-    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
-      1,
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledTimes(1)
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledWith(
       { environmentId: 'env-123', status: 'running' },
-      { skip: false },
-    )
-    expect(mockUseGetExperimentsQuery).toHaveBeenNthCalledWith(
-      2,
-      { environmentId: 'env-123', status: 'paused' },
       { skip: false },
     )
   })

--- a/frontend/common/hooks/useFeatureExperimentFreeze.ts
+++ b/frontend/common/hooks/useFeatureExperimentFreeze.ts
@@ -12,7 +12,7 @@ export function useFeatureExperimentFreeze(
   featureId: number | undefined,
   environmentId: string,
 ): FeatureExperimentFreeze {
-  const skip = !featureId
+  const skip = !featureId || !environmentId
   const { data, isLoading } = useGetExperimentsQuery(
     { environmentId, status: 'running' },
     { skip },

--- a/frontend/common/hooks/useFeatureExperimentFreeze.ts
+++ b/frontend/common/hooks/useFeatureExperimentFreeze.ts
@@ -13,23 +13,15 @@ export function useFeatureExperimentFreeze(
   environmentId: string,
 ): FeatureExperimentFreeze {
   const skip = !featureId
-  const { data: runningData, isLoading: loadingRunning } =
-    useGetExperimentsQuery({ environmentId, status: 'running' }, { skip })
-  const { data: pausedData, isLoading: loadingPaused } = useGetExperimentsQuery(
-    { environmentId, status: 'paused' },
+  const { data, isLoading } = useGetExperimentsQuery(
+    { environmentId, status: 'running' },
     { skip },
   )
 
-  const isLoading = loadingRunning || loadingPaused
-
   const experiment = useMemo(() => {
-    if (!featureId) return null
-    const all = [
-      ...(runningData?.results ?? []),
-      ...(pausedData?.results ?? []),
-    ]
-    return all.find((e) => e.feature?.id === featureId) ?? null
-  }, [runningData?.results, pausedData?.results, featureId])
+    if (!featureId || !data?.results) return null
+    return data.results.find((e) => e.feature?.id === featureId) ?? null
+  }, [data?.results, featureId])
 
   return {
     experiment,

--- a/frontend/common/hooks/useFeatureExperimentFreeze.ts
+++ b/frontend/common/hooks/useFeatureExperimentFreeze.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react'
+import { useGetExperimentsQuery } from 'common/services/useExperiment'
+import type { Experiment, ExperimentStatus } from 'common/types/responses'
+
+const FREEZE_STATUSES: ExperimentStatus[] = ['running', 'paused']
+
+export function useFeatureExperimentFreeze(
+  featureId: number | undefined,
+  environmentId: string,
+): {
+  isFrozen: boolean
+  experiment: Experiment | null
+  isLoading: boolean
+} {
+  const { data, isLoading } = useGetExperimentsQuery(
+    { environmentId, page_size: 100 },
+    { skip: !featureId },
+  )
+
+  const experiment = useMemo(() => {
+    if (!featureId || !data?.results) return null
+    return (
+      data.results.find(
+        (e) =>
+          e.feature?.id === featureId && FREEZE_STATUSES.includes(e.status),
+      ) ?? null
+    )
+  }, [data?.results, featureId])
+
+  return {
+    experiment,
+    isFrozen: experiment !== null,
+    isLoading,
+  }
+}

--- a/frontend/common/hooks/useFeatureExperimentFreeze.ts
+++ b/frontend/common/hooks/useFeatureExperimentFreeze.ts
@@ -1,31 +1,35 @@
 import { useMemo } from 'react'
 import { useGetExperimentsQuery } from 'common/services/useExperiment'
-import type { Experiment, ExperimentStatus } from 'common/types/responses'
+import type { Experiment } from 'common/types/responses'
 
-const FREEZE_STATUSES: ExperimentStatus[] = ['running', 'paused']
+export type FeatureExperimentFreeze = {
+  isFrozen: boolean
+  experiment: Experiment | null
+  isLoading: boolean
+}
 
 export function useFeatureExperimentFreeze(
   featureId: number | undefined,
   environmentId: string,
-): {
-  isFrozen: boolean
-  experiment: Experiment | null
-  isLoading: boolean
-} {
-  const { data, isLoading } = useGetExperimentsQuery(
-    { environmentId, page_size: 100 },
-    { skip: !featureId },
+): FeatureExperimentFreeze {
+  const skip = !featureId
+  const { data: runningData, isLoading: loadingRunning } =
+    useGetExperimentsQuery({ environmentId, status: 'running' }, { skip })
+  const { data: pausedData, isLoading: loadingPaused } = useGetExperimentsQuery(
+    { environmentId, status: 'paused' },
+    { skip },
   )
 
+  const isLoading = loadingRunning || loadingPaused
+
   const experiment = useMemo(() => {
-    if (!featureId || !data?.results) return null
-    return (
-      data.results.find(
-        (e) =>
-          e.feature?.id === featureId && FREEZE_STATUSES.includes(e.status),
-      ) ?? null
-    )
-  }, [data?.results, featureId])
+    if (!featureId) return null
+    const all = [
+      ...(runningData?.results ?? []),
+      ...(pausedData?.results ?? []),
+    ]
+    return all.find((e) => e.feature?.id === featureId) ?? null
+  }, [runningData?.results, pausedData?.results, featureId])
 
   return {
     experiment,

--- a/frontend/web/components/modals/create-feature/components/ExperimentFreezeNotice/ExperimentFreezeNotice.tsx
+++ b/frontend/web/components/modals/create-feature/components/ExperimentFreezeNotice/ExperimentFreezeNotice.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react'
+import InfoMessage from 'components/InfoMessage'
+
+type FreezeExperiment = {
+  id: number
+  name: string
+  status: string
+}
+
+type ExperimentFreezeNoticeProps = {
+  experiment: FreezeExperiment
+  projectId: number | string
+  environmentId: string
+}
+
+const ExperimentFreezeNotice: FC<ExperimentFreezeNoticeProps> = ({
+  environmentId,
+  experiment,
+  projectId,
+}) => {
+  const experimentUrl = `/project/${projectId}/environment/${environmentId}/experiments/${experiment.id}`
+
+  return (
+    <InfoMessage>
+      This flag is part of the experiment{' '}
+      <a href={experimentUrl}>
+        <strong>{experiment.name}</strong>
+      </a>{' '}
+      which is currently {experiment.status}. Editing is restricted to prevent
+      skewing experiment results.
+    </InfoMessage>
+  )
+}
+
+export default ExperimentFreezeNotice

--- a/frontend/web/components/modals/create-feature/components/ExperimentFreezeNotice/index.ts
+++ b/frontend/web/components/modals/create-feature/components/ExperimentFreezeNotice/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExperimentFreezeNotice'

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -110,8 +110,10 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
   } = props
   const flagId = props.environmentFlag?.id
 
-  const { experiment: freezingExperiment, isFrozen: experimentFrozen } =
-    useFeatureExperimentFreeze(props.projectFlag?.id, environmentId)
+  const freeze = useFeatureExperimentFreeze(
+    props.projectFlag?.id,
+    environmentId,
+  )
 
   const [projectFlag, setProjectFlag] = useState<any>(() =>
     props.projectFlag
@@ -659,8 +661,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       error={error}
                       projectId={projectId}
                       noPermissions={!!noPermissions}
-                      experimentFrozen={experimentFrozen}
-                      freezingExperiment={freezingExperiment}
+                      freeze={freeze}
                       featureState={environmentFlag}
                       projectFlag={projectFlag}
                       environmentFlag={props.environmentFlag}
@@ -698,8 +699,7 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                         <SegmentOverridesTab
                           projectId={projectId}
                           environmentId={environmentId}
-                          experimentFrozen={experimentFrozen}
-                          freezingExperiment={freezingExperiment}
+                          freeze={freeze}
                           projectFlag={projectFlag}
                           segmentOverrides={segmentOverrides}
                           updateSegments={updateSegments}
@@ -811,8 +811,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       <FeatureSettings
                         identity={identity}
                         projectId={projectId}
-                        experimentFrozen={experimentFrozen}
-                        freezingExperiment={freezingExperiment}
+                        environmentId={environmentId}
+                        freeze={freeze}
                         projectFlag={projectFlag}
                         isSaving={isSaving}
                         invalid={invalid}

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -11,6 +11,7 @@ import moment from 'moment'
 import { useProjectEnvironments } from 'common/hooks/useProjectEnvironments'
 import { useHasGithubIntegration } from 'common/hooks/useHasGithubIntegration'
 import { useHasGitLabIntegration } from 'common/hooks/useHasGitLabIntegration'
+import { useFeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
 import FeatureListStore from 'common/stores/feature-list-store'
 import IdentityProvider from 'common/providers/IdentityProvider'
 import FeatureListProvider from 'common/providers/FeatureListProvider'
@@ -108,6 +109,9 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
     updateSegments,
   } = props
   const flagId = props.environmentFlag?.id
+
+  const { experiment: freezingExperiment, isFrozen: experimentFrozen } =
+    useFeatureExperimentFreeze(props.projectFlag?.id, environmentId)
 
   const [projectFlag, setProjectFlag] = useState<any>(() =>
     props.projectFlag
@@ -655,6 +659,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       error={error}
                       projectId={projectId}
                       noPermissions={!!noPermissions}
+                      experimentFrozen={experimentFrozen}
+                      freezingExperiment={freezingExperiment}
                       featureState={environmentFlag}
                       projectFlag={projectFlag}
                       environmentFlag={props.environmentFlag}
@@ -692,6 +698,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                         <SegmentOverridesTab
                           projectId={projectId}
                           environmentId={environmentId}
+                          experimentFrozen={experimentFrozen}
+                          freezingExperiment={freezingExperiment}
                           projectFlag={projectFlag}
                           segmentOverrides={segmentOverrides}
                           updateSegments={updateSegments}
@@ -803,6 +811,8 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       <FeatureSettings
                         identity={identity}
                         projectId={projectId}
+                        experimentFrozen={experimentFrozen}
+                        freezingExperiment={freezingExperiment}
                         projectFlag={projectFlag}
                         isSaving={isSaving}
                         invalid={invalid}

--- a/frontend/web/components/modals/create-feature/tabs/FeatureSettingsTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureSettingsTab.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
-import { ProjectFlag } from 'common/types/responses'
+import { Experiment, ProjectFlag } from 'common/types/responses'
 import Constants from 'common/constants'
 import InfoMessage from 'components/InfoMessage'
 import InputGroup from 'components/base/forms/InputGroup'
@@ -34,6 +34,8 @@ import { getSupportedContentType } from 'common/services/useSupportedContentType
 type FeatureSettingsTabProps = {
   identity?: string
   projectId: number | string
+  experimentFrozen?: boolean
+  freezingExperiment?: Experiment | null
   projectFlag: ProjectFlag | null
   isSaving?: boolean
   invalid?: boolean
@@ -48,6 +50,8 @@ type FeatureSettingsTabProps = {
 }
 
 const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
+  experimentFrozen,
+  freezingExperiment,
   groupOwnerIds,
   hasMetadataRequired,
   identity,
@@ -121,6 +125,14 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
 
   return (
     <div className={`${identity ? 'mx-3' : ''}`}>
+      {experimentFrozen && freezingExperiment && (
+        <InfoMessage>
+          This flag is part of the experiment{' '}
+          <strong>{freezingExperiment.name}</strong> which is currently{' '}
+          {freezingExperiment.status}. Some settings are restricted to prevent
+          skewing experiment results.
+        </InfoMessage>
+      )}
       {!identity && projectFlag?.tags && (
         <FormGroup className='mb-3 setting'>
           <InputGroup
@@ -175,10 +187,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
                 })
                   .unwrap()
                   .catch((e) =>
-                    toast(
-                      e?.data?.[0] || 'Failed to remove owner.',
-                      'danger',
-                    ),
+                    toast(e?.data?.[0] || 'Failed to remove owner.', 'danger'),
                   )
               }
             />
@@ -282,6 +291,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
               onChange={(is_server_key_only) =>
                 onChange({ ...projectFlag, is_server_key_only })
               }
+              disabled={!!experimentFrozen}
               className='ml-0'
             />
             <Tooltip
@@ -305,6 +315,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
               onChange={(is_archived) =>
                 onChange({ ...projectFlag, is_archived })
               }
+              disabled={!!experimentFrozen}
               className='ml-0'
             />
             <Tooltip

--- a/frontend/web/components/modals/create-feature/tabs/FeatureSettingsTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureSettingsTab.tsx
@@ -1,7 +1,9 @@
 import React, { FC, useEffect, useState } from 'react'
-import { Experiment, ProjectFlag } from 'common/types/responses'
+import { ProjectFlag } from 'common/types/responses'
 import Constants from 'common/constants'
 import InfoMessage from 'components/InfoMessage'
+import { FeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
+import ExperimentFreezeNotice from 'components/modals/create-feature/components/ExperimentFreezeNotice'
 import InputGroup from 'components/base/forms/InputGroup'
 import AddEditTags from 'components/tags/AddEditTags'
 import AddMetadataToEntity from 'components/metadata/AddMetadataToEntity'
@@ -34,8 +36,8 @@ import { getSupportedContentType } from 'common/services/useSupportedContentType
 type FeatureSettingsTabProps = {
   identity?: string
   projectId: number | string
-  experimentFrozen?: boolean
-  freezingExperiment?: Experiment | null
+  environmentId?: string
+  freeze?: FeatureExperimentFreeze
   projectFlag: ProjectFlag | null
   isSaving?: boolean
   invalid?: boolean
@@ -50,8 +52,8 @@ type FeatureSettingsTabProps = {
 }
 
 const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
-  experimentFrozen,
-  freezingExperiment,
+  environmentId,
+  freeze,
   groupOwnerIds,
   hasMetadataRequired,
   identity,
@@ -125,13 +127,12 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
 
   return (
     <div className={`${identity ? 'mx-3' : ''}`}>
-      {experimentFrozen && freezingExperiment && (
-        <InfoMessage>
-          This flag is part of the experiment{' '}
-          <strong>{freezingExperiment.name}</strong> which is currently{' '}
-          {freezingExperiment.status}. Some settings are restricted to prevent
-          skewing experiment results.
-        </InfoMessage>
+      {freeze?.isFrozen && freeze.experiment && environmentId && (
+        <ExperimentFreezeNotice
+          experiment={freeze.experiment}
+          projectId={projectId}
+          environmentId={environmentId}
+        />
       )}
       {!identity && projectFlag?.tags && (
         <FormGroup className='mb-3 setting'>
@@ -291,7 +292,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
               onChange={(is_server_key_only) =>
                 onChange({ ...projectFlag, is_server_key_only })
               }
-              disabled={!!experimentFrozen}
+              disabled={!!freeze?.isFrozen || !!freeze?.isLoading}
               className='ml-0'
             />
             <Tooltip
@@ -315,7 +316,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
               onChange={(is_archived) =>
                 onChange({ ...projectFlag, is_archived })
               }
-              disabled={!!experimentFrozen}
+              disabled={!!freeze?.isFrozen || !!freeze?.isLoading}
               className='ml-0'
             />
             <Tooltip

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -506,41 +506,38 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
         </div>
       )}
 
-      {environmentId &&
-        onSaveFeatureValue &&
-        !freeze?.isFrozen &&
-        !freeze?.isLoading && (
-          <>
-            <JSONReference
-              className='mb-3'
-              showNamesButton
-              title={'Feature'}
-              json={projectFlag}
-            />
-            <JSONReference
-              className='mb-3'
-              title={'Feature state'}
-              json={environmentFlag}
-            />
-            <FlagValueFooter
-              is4Eyes={!!is4Eyes}
-              isVersioned={!!isVersioned}
-              projectId={
-                typeof projectId === 'string'
-                  ? parseInt(projectId, 10)
-                  : projectId
-              }
-              projectFlag={projectFlag}
-              environmentId={environmentId}
-              environmentName={environmentName || ''}
-              isSaving={!!isSaving}
-              featureName={projectFlag.name}
-              isInvalid={!!invalid}
-              existingChangeRequest={!!existingChangeRequest}
-              onSaveFeatureValue={onSaveFeatureValue}
-            />
-          </>
-        )}
+      {environmentId && onSaveFeatureValue && !freeze?.isFrozen && (
+        <>
+          <JSONReference
+            className='mb-3'
+            showNamesButton
+            title={'Feature'}
+            json={projectFlag}
+          />
+          <JSONReference
+            className='mb-3'
+            title={'Feature state'}
+            json={environmentFlag}
+          />
+          <FlagValueFooter
+            is4Eyes={!!is4Eyes}
+            isVersioned={!!isVersioned}
+            projectId={
+              typeof projectId === 'string'
+                ? parseInt(projectId, 10)
+                : projectId
+            }
+            projectFlag={projectFlag}
+            environmentId={environmentId}
+            environmentName={environmentName || ''}
+            isSaving={!!isSaving || !!freeze?.isLoading}
+            featureName={projectFlag.name}
+            isInvalid={!!invalid}
+            existingChangeRequest={!!existingChangeRequest}
+            onSaveFeatureValue={onSaveFeatureValue}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -16,6 +16,7 @@ import CompareSegmentOverride from 'components/diff/CompareSegmentOverride'
 import { FlagValueFooter } from 'components/modals/FlagValueFooter'
 import Utils from 'common/utils/utils'
 import {
+  Experiment,
   FeatureState,
   MultivariateOption,
   ProjectFlag,
@@ -39,6 +40,8 @@ type FeatureValueTabProps = {
   projectId: number | string
   identity?: string
   noPermissions: boolean
+  experimentFrozen?: boolean
+  freezingExperiment?: Experiment | null
   featureState: FeatureState
   projectFlag: ProjectFlag
   environmentFlag?: FeatureState
@@ -62,7 +65,9 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   environmentName,
   error,
   existingChangeRequest,
+  experimentFrozen,
   featureState,
+  freezingExperiment,
   identity,
   is4Eyes,
   isSaving,
@@ -77,6 +82,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   projectId,
 }) => {
   const isEdit = !!projectFlag?.id
+  const isDisabled = !!noPermissions || !!experimentFrozen
 
   const { permission: createFeature } = useHasPermission({
     id: projectId,
@@ -294,6 +300,14 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
 
   return (
     <div className={`${identity ? 'mx-3' : ''}`}>
+      {experimentFrozen && freezingExperiment && (
+        <InfoMessage>
+          This flag is part of the experiment{' '}
+          <strong>{freezingExperiment.name}</strong> which is currently{' '}
+          {freezingExperiment.status}. Editing is restricted to prevent skewing
+          experiment results.
+        </InfoMessage>
+      )}
       <FormGroup className='mb-4'>
         <Tooltip
           title={
@@ -301,7 +315,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
               <Switch
                 data-test='toggle-feature-button'
                 defaultChecked={default_enabled}
-                disabled={noPermissions}
+                disabled={isDisabled}
                 checked={default_enabled}
                 onChange={(enabled) => onEnvironmentFlagChange({ enabled })}
                 className='ml-0'
@@ -338,7 +352,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
                   )
                   onEnvironmentFlagChange({ feature_state_value })
                 }}
-                disabled={noPermissions}
+                disabled={isDisabled}
                 placeholder="e.g. 'big' "
               />
             }
@@ -444,7 +458,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
                 Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
                 <AddVariationButton
                   multivariateOptions={multivariate_options}
-                  disabled={!createFeature || noPermissions}
+                  disabled={!createFeature || isDisabled}
                   onClick={addVariation}
                 />,
               )}
@@ -454,7 +468,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
             {(!!environmentVariations || !isEdit) && (
               <VariationOptions
                 canCreateFeature={createFeature}
-                disabled={!!identity || noPermissions}
+                disabled={!!identity || isDisabled}
                 controlValue={featureState.feature_state_value}
                 controlPercentage={controlPercentage}
                 variationOverrides={environmentVariations as any}
@@ -484,7 +498,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
                 Constants.projectPermissions(ProjectPermission.CREATE_FEATURE),
                 <AddVariationButton
                   multivariateOptions={multivariate_options}
-                  disabled={!createFeature || noPermissions}
+                  disabled={!createFeature || isDisabled}
                   onClick={addVariation}
                 />,
               )}
@@ -493,7 +507,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
         </div>
       )}
 
-      {environmentId && onSaveFeatureValue && (
+      {environmentId && onSaveFeatureValue && !experimentFrozen && (
         <>
           <JSONReference
             className='mb-3'

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -16,11 +16,12 @@ import CompareSegmentOverride from 'components/diff/CompareSegmentOverride'
 import { FlagValueFooter } from 'components/modals/FlagValueFooter'
 import Utils from 'common/utils/utils'
 import {
-  Experiment,
   FeatureState,
   MultivariateOption,
   ProjectFlag,
 } from 'common/types/responses'
+import { FeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
+import ExperimentFreezeNotice from 'components/modals/create-feature/components/ExperimentFreezeNotice'
 import { useHasPermission } from 'common/providers/Permission'
 import { ProjectPermission } from 'common/types/permissions.types'
 
@@ -40,8 +41,7 @@ type FeatureValueTabProps = {
   projectId: number | string
   identity?: string
   noPermissions: boolean
-  experimentFrozen?: boolean
-  freezingExperiment?: Experiment | null
+  freeze?: FeatureExperimentFreeze
   featureState: FeatureState
   projectFlag: ProjectFlag
   environmentFlag?: FeatureState
@@ -65,9 +65,8 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   environmentName,
   error,
   existingChangeRequest,
-  experimentFrozen,
   featureState,
-  freezingExperiment,
+  freeze,
   identity,
   is4Eyes,
   isSaving,
@@ -82,7 +81,8 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   projectId,
 }) => {
   const isEdit = !!projectFlag?.id
-  const isDisabled = !!noPermissions || !!experimentFrozen
+  const isDisabled =
+    !!noPermissions || !!freeze?.isFrozen || !!freeze?.isLoading
 
   const { permission: createFeature } = useHasPermission({
     id: projectId,
@@ -300,13 +300,12 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
 
   return (
     <div className={`${identity ? 'mx-3' : ''}`}>
-      {experimentFrozen && freezingExperiment && (
-        <InfoMessage>
-          This flag is part of the experiment{' '}
-          <strong>{freezingExperiment.name}</strong> which is currently{' '}
-          {freezingExperiment.status}. Editing is restricted to prevent skewing
-          experiment results.
-        </InfoMessage>
+      {freeze?.isFrozen && freeze.experiment && environmentId && (
+        <ExperimentFreezeNotice
+          experiment={freeze.experiment}
+          projectId={projectId}
+          environmentId={environmentId}
+        />
       )}
       <FormGroup className='mb-4'>
         <Tooltip
@@ -507,38 +506,41 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
         </div>
       )}
 
-      {environmentId && onSaveFeatureValue && !experimentFrozen && (
-        <>
-          <JSONReference
-            className='mb-3'
-            showNamesButton
-            title={'Feature'}
-            json={projectFlag}
-          />
-          <JSONReference
-            className='mb-3'
-            title={'Feature state'}
-            json={environmentFlag}
-          />
-          <FlagValueFooter
-            is4Eyes={!!is4Eyes}
-            isVersioned={!!isVersioned}
-            projectId={
-              typeof projectId === 'string'
-                ? parseInt(projectId, 10)
-                : projectId
-            }
-            projectFlag={projectFlag}
-            environmentId={environmentId}
-            environmentName={environmentName || ''}
-            isSaving={!!isSaving}
-            featureName={projectFlag.name}
-            isInvalid={!!invalid}
-            existingChangeRequest={!!existingChangeRequest}
-            onSaveFeatureValue={onSaveFeatureValue}
-          />
-        </>
-      )}
+      {environmentId &&
+        onSaveFeatureValue &&
+        !freeze?.isFrozen &&
+        !freeze?.isLoading && (
+          <>
+            <JSONReference
+              className='mb-3'
+              showNamesButton
+              title={'Feature'}
+              json={projectFlag}
+            />
+            <JSONReference
+              className='mb-3'
+              title={'Feature state'}
+              json={environmentFlag}
+            />
+            <FlagValueFooter
+              is4Eyes={!!is4Eyes}
+              isVersioned={!!isVersioned}
+              projectId={
+                typeof projectId === 'string'
+                  ? parseInt(projectId, 10)
+                  : projectId
+              }
+              projectFlag={projectFlag}
+              environmentId={environmentId}
+              environmentName={environmentName || ''}
+              isSaving={!!isSaving}
+              featureName={projectFlag.name}
+              isInvalid={!!invalid}
+              existingChangeRequest={!!existingChangeRequest}
+              onSaveFeatureValue={onSaveFeatureValue}
+            />
+          </>
+        )}
     </div>
   )
 }

--- a/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
@@ -11,7 +11,7 @@ import WarningMessage from 'components/WarningMessage'
 import ModalHR from 'components/modals/ModalHR'
 import FeatureInPipelineGuard from 'components/release-pipelines/FeatureInPipelineGuard'
 import Utils from 'common/utils/utils'
-import { ProjectFlag } from 'common/types/responses'
+import { Experiment, ProjectFlag } from 'common/types/responses'
 import { EnvironmentPermission } from 'common/types/permissions.types'
 
 export type SegmentOverrideValue = {
@@ -34,6 +34,8 @@ type SegmentOverridesTabProps = {
   error: any
   existingChangeRequest?: { id: number }
   noPermissions?: boolean
+  experimentFrozen?: boolean
+  freezingExperiment?: Experiment | null
   disableCreate?: boolean
   highlightSegmentId?: number
 }
@@ -45,6 +47,8 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
   environmentId,
   error,
   existingChangeRequest,
+  experimentFrozen,
+  freezingExperiment,
   highlightSegmentId,
   invalid,
   isSaving,
@@ -159,7 +163,8 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
             {!isComparing &&
               !showCreateSegment &&
               manageSegmentOverrides &&
-              !disableCreate && (
+              !disableCreate &&
+              !experimentFrozen && (
                 <div className='text-right'>
                   <Button
                     size='small'
@@ -172,17 +177,28 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
                   </Button>
                 </div>
               )}
-            {!isComparing && !showCreateSegment && !noPermissions && (
-              <Button
-                onClick={() => changeSegment(segmentOverrides || [])}
-                type='button'
-                theme='secondary'
-                size='small'
-              >
-                {enabledSegment ? 'Enable All' : 'Disable All'}
-              </Button>
-            )}
+            {!isComparing &&
+              !showCreateSegment &&
+              !noPermissions &&
+              !experimentFrozen && (
+                <Button
+                  onClick={() => changeSegment(segmentOverrides || [])}
+                  type='button'
+                  theme='secondary'
+                  size='small'
+                >
+                  {enabledSegment ? 'Enable All' : 'Disable All'}
+                </Button>
+              )}
           </Row>
+          {experimentFrozen && freezingExperiment && (
+            <InfoMessage>
+              This flag is part of the experiment{' '}
+              <strong>{freezingExperiment.name}</strong> which is currently{' '}
+              {freezingExperiment.status}. Editing is restricted to prevent
+              skewing experiment results.
+            </InfoMessage>
+          )}
           <div className='text-muted mb-2'>
             <p>
               Segment Overrides apply when the identity traits match the segment
@@ -206,7 +222,7 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               <SegmentOverrides
                 setShowCreateSegment={setShowCreateSegment}
                 onCompareChange={setIsComparing}
-                readOnly={!manageSegmentOverrides}
+                readOnly={!manageSegmentOverrides || !!experimentFrozen}
                 is4Eyes={is4Eyes}
                 showEditSegment
                 showCreateSegment={showCreateSegment}
@@ -229,8 +245,10 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               <Loader />
             </div>
           )}
-          {!isComparing && !showCreateSegment && <ModalHR className='mt-4' />}
-          {!isComparing && !showCreateSegment && (
+          {!isComparing && !showCreateSegment && !experimentFrozen && (
+            <ModalHR className='mt-4' />
+          )}
+          {!isComparing && !showCreateSegment && !experimentFrozen && (
             <div>
               <p className='text-right mt-4 fs-small lh-sm modal-caption'>
                 Re-order overrides to adjust priority.

--- a/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
@@ -250,43 +250,82 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               <Loader />
             </div>
           )}
-          {!isComparing &&
-            !showCreateSegment &&
-            !freeze?.isFrozen &&
-            !freeze?.isLoading && <ModalHR className='mt-4' />}
-          {!isComparing &&
-            !showCreateSegment &&
-            !freeze?.isFrozen &&
-            !freeze?.isLoading && (
-              <div>
-                <p className='text-right mt-4 fs-small lh-sm modal-caption'>
-                  Re-order overrides to adjust priority.
-                </p>
-                <p className='text-right mt-4 fs-small lh-sm modal-caption'>
-                  {is4Eyes && isVersioned
-                    ? 'This will create a change request with any value and segment override changes for the environment'
-                    : 'This will update the segment overrides for the environment'}{' '}
-                  <strong>{environmentName}</strong>
-                </p>
-                {is4Eyes && !isVersioned && (
-                  <InfoMessage>
-                    Enable Feature Versioning to gate segment overrides with
-                    Feature Change Requests.{' '}
-                    <a
-                      href='https://docs.flagsmith.com/managing-flags/feature-versioning'
-                      target='_blank'
-                      rel='noreferrer'
-                    >
-                      Learn more
-                    </a>
-                    .
-                  </InfoMessage>
-                )}
-                <div className='text-right'>
-                  {isVersioned && is4Eyes
-                    ? Utils.renderWithPermission(
-                        savePermission,
-                        Utils.getManageFeaturePermissionDescription(is4Eyes),
+          {!isComparing && !showCreateSegment && !freeze?.isFrozen && (
+            <ModalHR className='mt-4' />
+          )}
+          {!isComparing && !showCreateSegment && !freeze?.isFrozen && (
+            <div>
+              <p className='text-right mt-4 fs-small lh-sm modal-caption'>
+                Re-order overrides to adjust priority.
+              </p>
+              <p className='text-right mt-4 fs-small lh-sm modal-caption'>
+                {is4Eyes && isVersioned
+                  ? 'This will create a change request with any value and segment override changes for the environment'
+                  : 'This will update the segment overrides for the environment'}{' '}
+                <strong>{environmentName}</strong>
+              </p>
+              {is4Eyes && !isVersioned && (
+                <InfoMessage>
+                  Enable Feature Versioning to gate segment overrides with
+                  Feature Change Requests.{' '}
+                  <a
+                    href='https://docs.flagsmith.com/managing-flags/feature-versioning'
+                    target='_blank'
+                    rel='noreferrer'
+                  >
+                    Learn more
+                  </a>
+                  .
+                </InfoMessage>
+              )}
+              <div className='text-right'>
+                {isVersioned && is4Eyes
+                  ? Utils.renderWithPermission(
+                      savePermission,
+                      Utils.getManageFeaturePermissionDescription(is4Eyes),
+                      <Button
+                        onClick={() => saveFeatureSegments(false)}
+                        type='button'
+                        data-test='update-feature-segments-btn'
+                        id='update-feature-segments-btn'
+                        disabled={
+                          isSaving ||
+                          !projectFlag.name ||
+                          invalid ||
+                          !savePermission ||
+                          !!freeze?.isLoading
+                        }
+                      >
+                        {getButtonText()}
+                      </Button>,
+                    )
+                  : Utils.renderWithPermission(
+                      manageSegmentOverrides,
+                      Constants.environmentPermissions(
+                        EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
+                      ),
+                      <>
+                        {!is4Eyes && isVersioned && (
+                          <>
+                            <Button
+                              theme='secondary'
+                              onClick={() => saveFeatureSegments(true)}
+                              className='mr-2'
+                              type='button'
+                              data-test='create-change-request'
+                              id='create-change-request-btn'
+                              disabled={
+                                isSaving ||
+                                !projectFlag.name ||
+                                invalid ||
+                                !savePermission ||
+                                !!freeze?.isLoading
+                              }
+                            >
+                              {getScheduleButtonText()}
+                            </Button>
+                          </>
+                        )}
                         <Button
                           onClick={() => saveFeatureSegments(false)}
                           type='button'
@@ -296,57 +335,17 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
                             isSaving ||
                             !projectFlag.name ||
                             invalid ||
-                            !savePermission
+                            !manageSegmentOverrides ||
+                            !!freeze?.isLoading
                           }
                         >
-                          {getButtonText()}
-                        </Button>,
-                      )
-                    : Utils.renderWithPermission(
-                        manageSegmentOverrides,
-                        Constants.environmentPermissions(
-                          EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
-                        ),
-                        <>
-                          {!is4Eyes && isVersioned && (
-                            <>
-                              <Button
-                                theme='secondary'
-                                onClick={() => saveFeatureSegments(true)}
-                                className='mr-2'
-                                type='button'
-                                data-test='create-change-request'
-                                id='create-change-request-btn'
-                                disabled={
-                                  isSaving ||
-                                  !projectFlag.name ||
-                                  invalid ||
-                                  !savePermission
-                                }
-                              >
-                                {getScheduleButtonText()}
-                              </Button>
-                            </>
-                          )}
-                          <Button
-                            onClick={() => saveFeatureSegments(false)}
-                            type='button'
-                            data-test='update-feature-segments-btn'
-                            id='update-feature-segments-btn'
-                            disabled={
-                              isSaving ||
-                              !projectFlag.name ||
-                              invalid ||
-                              !manageSegmentOverrides
-                            }
-                          >
-                            {isSaving ? 'Updating' : 'Update Segment Overrides'}
-                          </Button>
-                        </>,
-                      )}
-                </div>
+                          {isSaving ? 'Updating' : 'Update Segment Overrides'}
+                        </Button>
+                      </>,
+                    )}
               </div>
-            )}
+            </div>
+          )}
         </div>
       </FeatureInPipelineGuard>
     </FormGroup>

--- a/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
@@ -11,7 +11,9 @@ import WarningMessage from 'components/WarningMessage'
 import ModalHR from 'components/modals/ModalHR'
 import FeatureInPipelineGuard from 'components/release-pipelines/FeatureInPipelineGuard'
 import Utils from 'common/utils/utils'
-import { Experiment, ProjectFlag } from 'common/types/responses'
+import { ProjectFlag } from 'common/types/responses'
+import { FeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
+import ExperimentFreezeNotice from 'components/modals/create-feature/components/ExperimentFreezeNotice'
 import { EnvironmentPermission } from 'common/types/permissions.types'
 
 export type SegmentOverrideValue = {
@@ -34,8 +36,7 @@ type SegmentOverridesTabProps = {
   error: any
   existingChangeRequest?: { id: number }
   noPermissions?: boolean
-  experimentFrozen?: boolean
-  freezingExperiment?: Experiment | null
+  freeze?: FeatureExperimentFreeze
   disableCreate?: boolean
   highlightSegmentId?: number
 }
@@ -47,8 +48,7 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
   environmentId,
   error,
   existingChangeRequest,
-  experimentFrozen,
-  freezingExperiment,
+  freeze,
   highlightSegmentId,
   invalid,
   isSaving,
@@ -164,7 +164,8 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               !showCreateSegment &&
               manageSegmentOverrides &&
               !disableCreate &&
-              !experimentFrozen && (
+              !freeze?.isFrozen &&
+              !freeze?.isLoading && (
                 <div className='text-right'>
                   <Button
                     size='small'
@@ -180,7 +181,8 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
             {!isComparing &&
               !showCreateSegment &&
               !noPermissions &&
-              !experimentFrozen && (
+              !freeze?.isFrozen &&
+              !freeze?.isLoading && (
                 <Button
                   onClick={() => changeSegment(segmentOverrides || [])}
                   type='button'
@@ -191,13 +193,12 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
                 </Button>
               )}
           </Row>
-          {experimentFrozen && freezingExperiment && (
-            <InfoMessage>
-              This flag is part of the experiment{' '}
-              <strong>{freezingExperiment.name}</strong> which is currently{' '}
-              {freezingExperiment.status}. Editing is restricted to prevent
-              skewing experiment results.
-            </InfoMessage>
+          {freeze?.isFrozen && freeze.experiment && (
+            <ExperimentFreezeNotice
+              experiment={freeze.experiment}
+              projectId={projectId}
+              environmentId={environmentId}
+            />
           )}
           <div className='text-muted mb-2'>
             <p>
@@ -222,7 +223,11 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               <SegmentOverrides
                 setShowCreateSegment={setShowCreateSegment}
                 onCompareChange={setIsComparing}
-                readOnly={!manageSegmentOverrides || !!experimentFrozen}
+                readOnly={
+                  !manageSegmentOverrides ||
+                  !!freeze?.isFrozen ||
+                  !!freeze?.isLoading
+                }
                 is4Eyes={is4Eyes}
                 showEditSegment
                 showCreateSegment={showCreateSegment}
@@ -245,80 +250,43 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               <Loader />
             </div>
           )}
-          {!isComparing && !showCreateSegment && !experimentFrozen && (
-            <ModalHR className='mt-4' />
-          )}
-          {!isComparing && !showCreateSegment && !experimentFrozen && (
-            <div>
-              <p className='text-right mt-4 fs-small lh-sm modal-caption'>
-                Re-order overrides to adjust priority.
-              </p>
-              <p className='text-right mt-4 fs-small lh-sm modal-caption'>
-                {is4Eyes && isVersioned
-                  ? 'This will create a change request with any value and segment override changes for the environment'
-                  : 'This will update the segment overrides for the environment'}{' '}
-                <strong>{environmentName}</strong>
-              </p>
-              {is4Eyes && !isVersioned && (
-                <InfoMessage>
-                  Enable Feature Versioning to gate segment overrides with
-                  Feature Change Requests.{' '}
-                  <a
-                    href='https://docs.flagsmith.com/managing-flags/feature-versioning'
-                    target='_blank'
-                    rel='noreferrer'
-                  >
-                    Learn more
-                  </a>
-                  .
-                </InfoMessage>
-              )}
-              <div className='text-right'>
-                {isVersioned && is4Eyes
-                  ? Utils.renderWithPermission(
-                      savePermission,
-                      Utils.getManageFeaturePermissionDescription(is4Eyes),
-                      <Button
-                        onClick={() => saveFeatureSegments(false)}
-                        type='button'
-                        data-test='update-feature-segments-btn'
-                        id='update-feature-segments-btn'
-                        disabled={
-                          isSaving ||
-                          !projectFlag.name ||
-                          invalid ||
-                          !savePermission
-                        }
-                      >
-                        {getButtonText()}
-                      </Button>,
-                    )
-                  : Utils.renderWithPermission(
-                      manageSegmentOverrides,
-                      Constants.environmentPermissions(
-                        EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
-                      ),
-                      <>
-                        {!is4Eyes && isVersioned && (
-                          <>
-                            <Button
-                              theme='secondary'
-                              onClick={() => saveFeatureSegments(true)}
-                              className='mr-2'
-                              type='button'
-                              data-test='create-change-request'
-                              id='create-change-request-btn'
-                              disabled={
-                                isSaving ||
-                                !projectFlag.name ||
-                                invalid ||
-                                !savePermission
-                              }
-                            >
-                              {getScheduleButtonText()}
-                            </Button>
-                          </>
-                        )}
+          {!isComparing &&
+            !showCreateSegment &&
+            !freeze?.isFrozen &&
+            !freeze?.isLoading && <ModalHR className='mt-4' />}
+          {!isComparing &&
+            !showCreateSegment &&
+            !freeze?.isFrozen &&
+            !freeze?.isLoading && (
+              <div>
+                <p className='text-right mt-4 fs-small lh-sm modal-caption'>
+                  Re-order overrides to adjust priority.
+                </p>
+                <p className='text-right mt-4 fs-small lh-sm modal-caption'>
+                  {is4Eyes && isVersioned
+                    ? 'This will create a change request with any value and segment override changes for the environment'
+                    : 'This will update the segment overrides for the environment'}{' '}
+                  <strong>{environmentName}</strong>
+                </p>
+                {is4Eyes && !isVersioned && (
+                  <InfoMessage>
+                    Enable Feature Versioning to gate segment overrides with
+                    Feature Change Requests.{' '}
+                    <a
+                      href='https://docs.flagsmith.com/managing-flags/feature-versioning'
+                      target='_blank'
+                      rel='noreferrer'
+                    >
+                      Learn more
+                    </a>
+                    .
+                  </InfoMessage>
+                )}
+                <div className='text-right'>
+                  {isVersioned && is4Eyes
+                    ? Utils.renderWithPermission(
+                        savePermission,
+                        Utils.getManageFeaturePermissionDescription(is4Eyes),
                         <Button
                           onClick={() => saveFeatureSegments(false)}
                           type='button'
@@ -328,16 +296,57 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
                             isSaving ||
                             !projectFlag.name ||
                             invalid ||
-                            !manageSegmentOverrides
+                            !savePermission
                           }
                         >
-                          {isSaving ? 'Updating' : 'Update Segment Overrides'}
-                        </Button>
-                      </>,
-                    )}
+                          {getButtonText()}
+                        </Button>,
+                      )
+                    : Utils.renderWithPermission(
+                        manageSegmentOverrides,
+                        Constants.environmentPermissions(
+                          EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
+                        ),
+                        <>
+                          {!is4Eyes && isVersioned && (
+                            <>
+                              <Button
+                                theme='secondary'
+                                onClick={() => saveFeatureSegments(true)}
+                                className='mr-2'
+                                type='button'
+                                data-test='create-change-request'
+                                id='create-change-request-btn'
+                                disabled={
+                                  isSaving ||
+                                  !projectFlag.name ||
+                                  invalid ||
+                                  !savePermission
+                                }
+                              >
+                                {getScheduleButtonText()}
+                              </Button>
+                            </>
+                          )}
+                          <Button
+                            onClick={() => saveFeatureSegments(false)}
+                            type='button'
+                            data-test='update-feature-segments-btn'
+                            id='update-feature-segments-btn'
+                            disabled={
+                              isSaving ||
+                              !projectFlag.name ||
+                              invalid ||
+                              !manageSegmentOverrides
+                            }
+                          >
+                            {isSaving ? 'Updating' : 'Update Segment Overrides'}
+                          </Button>
+                        </>,
+                      )}
+                </div>
               </div>
-            </div>
-          )}
+            )}
         </div>
       </FeatureInPipelineGuard>
     </FormGroup>


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

When a flag belongs to a running experiment, the flag editing modal freezes controls to prevent skewing experiment data. Paused experiments allow editing. Frontend-only gate.

**What's frozen:**
- Feature value toggle, remote value, and variation weights
- Segment overrides (read-only, action buttons hidden)
- Server-side only and archive toggles

**What stays editable:**
- Description, tags, owners
- Identity overrides

**Implementation details:**
- `useFeatureExperimentFreeze` hook queries running experiments filtered by status, matches by feature ID
- Controls are disabled during loading to prevent a brief unlocked flash
- Shared `ExperimentFreezeNotice` component with link to the experiment detail page
- Single `freeze` prop object passed to each tab

## How did you test this code?

- 6 unit tests covering: running freeze, no experiments, different feature, loading state, query skipping, status filter verification
- Manual test: opened flag modal for a flag with a running experiment, confirmed value/segment/settings tabs show the freeze banner and controls are disabled
- Verified zero new TypeScript errors (`npm run typecheck`)
- Lint clean across all modified files