### PR TITLE
feat(experimentation): support multi-status filter on experiments list

### DIFF
--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -391,6 +391,13 @@ class ExperimentFeatureSerializer(serializers.ModelSerializer):  # type: ignore[
         return options  # type: ignore[return-value]
 
 
+class ExperimentQueryParamSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    status = serializers.ListField(
+        child=serializers.ChoiceField(choices=ExperimentStatus.choices),
+        required=False,
+    )
+
+
 class ExperimentListSerializer(ExperimentSerializer):
     feature = ExperimentFeatureSerializer(read_only=True)
     metrics = ExperimentMetricSerializer(

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -43,6 +43,7 @@ from experimentation.serializers import (
     ExperimentExposuresSerializer,
     ExperimentListSerializer,
     ExperimentMetricSerializer,
+    ExperimentQueryParamSerializer,
     ExperimentResultsSerializer,
     ExperimentRolloutSerializer,
     ExperimentSerializer,
@@ -195,13 +196,9 @@ class ExperimentViewSet(
                 "feature__feature_states__multivariate_feature_state_values",
                 "experiment_metrics__metric",
             )
-        status_filter = self.request.query_params.getlist("status")
-        if status_filter:
-            invalid = [s for s in status_filter if s not in ExperimentStatus.values]
-            if invalid:
-                raise serializers.ValidationError(
-                    {"status": f"Invalid status value(s): {', '.join(invalid)}."}
-                )
+        query_params = ExperimentQueryParamSerializer(data=self.request.GET)
+        query_params.is_valid(raise_exception=True)
+        if status_filter := query_params.validated_data.get("status"):
             qs = qs.filter(status__in=status_filter)
 
         q = self.request.query_params.get("q")

--- a/api/experimentation/views.py
+++ b/api/experimentation/views.py
@@ -195,13 +195,14 @@ class ExperimentViewSet(
                 "feature__feature_states__multivariate_feature_state_values",
                 "experiment_metrics__metric",
             )
-        status_filter = self.request.query_params.get("status")
+        status_filter = self.request.query_params.getlist("status")
         if status_filter:
-            if status_filter not in ExperimentStatus.values:
+            invalid = [s for s in status_filter if s not in ExperimentStatus.values]
+            if invalid:
                 raise serializers.ValidationError(
-                    {"status": f"Invalid status '{status_filter}'."}
+                    {"status": f"Invalid status value(s): {', '.join(invalid)}."}
                 )
-            qs = qs.filter(status=status_filter)
+            qs = qs.filter(status__in=status_filter)
 
         q = self.request.query_params.get("q")
         if q:

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -1156,6 +1156,48 @@ def test_delete__valid_delete__creates_audit_log(
     assert "deleted" in audit.log
 
 
+def test_get_list__filter_by_multiple_statuses__returns_matching(
+    admin_client_new: APIClient,
+    environment: Environment,
+    experiment: Experiment,
+    project: "Project",
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    second_feature = Feature.objects.create(
+        name="mv_feature_2",
+        project=project,
+        type=MULTIVARIATE,
+        initial_value="control",
+    )
+    for pct in (50, 50):
+        MultivariateFeatureOption.objects.create(
+            feature=second_feature,
+            default_percentage_allocation=pct,
+            type="unicode",
+            string_value=f"option_{pct}",
+        )
+    running_experiment = Experiment.objects.create(
+        environment=environment,
+        feature=second_feature,
+        name="Running Experiment",
+        hypothesis="hypothesis",
+        status=ExperimentStatus.RUNNING,
+    )
+
+    # When — filter for both created and running
+    response = admin_client_new.get(
+        _list_url(environment),
+        {"status": ["created", "running"]},
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    result_ids = {r["id"] for r in response.json()["results"]}
+    assert result_ids == {experiment.id, running_experiment.id}
+
+
 def test_get_list__invalid_status__returns_400(
     admin_client_new: APIClient,
     environment: Environment,
@@ -1166,6 +1208,24 @@ def test_get_list__invalid_status__returns_400(
 
     # When
     response = admin_client_new.get(_list_url(environment), {"status": "garbage"})
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_get_list__mixed_valid_and_invalid_status__returns_400(
+    admin_client_new: APIClient,
+    environment: Environment,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+
+    # When
+    response = admin_client_new.get(
+        _list_url(environment),
+        {"status": ["running", "garbage"]},
+    )
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Changes

Contributes to experimentation feature

The experiments list endpoint now accepts multiple `status` values as repeated query params (`?status=running&status=paused`). Previously only a single status string was accepted.

- `get_queryset` uses `getlist("status")` and `filter(status__in=...)` — fully backwards compatible with single-value usage
- Validation reports all invalid values at once

## How did you test this code?

- Existing parametrised single-status filter tests pass unchanged (backwards compatible)
- Added `test_get_list__filter_by_multiple_statuses__returns_matching`
- Added `test_get_list__mixed_valid_and_invalid_status__returns_400`
- Backend mypy passes