### PR TITLE
feat(experimentation): support multi-status filter in frontend

### DIFF
--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -1033,7 +1033,7 @@ export type Req = {
   }
   getExperiments: PagedRequest<{
     environmentId: string
-    status?: ExperimentStatus
+    status?: ExperimentStatus | ExperimentStatus[]
   }>
   createExperiment: {
     environmentId: string

--- a/frontend/common/utils/base/_utils.js
+++ b/frontend/common/utils/base/_utils.js
@@ -504,9 +504,10 @@ emailRegex: /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|
     const target = e.target
 
     if (target.getAttribute) {
-      return target.type === 'checkbox' || target.type === 'radio'
-        ? target.getAttribute('checked')
-        : typeof target.value === 'string'
+      if (target.type === 'checkbox' || target.type === 'radio') {
+        return target.getAttribute('checked')
+      }
+      return typeof target.value === 'string'
         ? target.value
         : target.getAttribute('data-value') || target.getAttribute('value')
     }
@@ -519,9 +520,18 @@ emailRegex: /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|
 
   toParam(obj) {
     // {min:100,max:200} -> min=100&max=200
+    // {status:['running','paused']} -> status=running&status=paused
     return Object.keys(obj)
       .filter((v) => obj[v] !== undefined)
-      .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(obj[k])}`)
+      .flatMap((k) => {
+        const val = obj[k]
+        if (Array.isArray(val)) {
+          return val.map(
+            (v) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`,
+          )
+        }
+        return `${encodeURIComponent(k)}=${encodeURIComponent(val)}`
+      })
       .join('&')
   },
 


### PR DESCRIPTION
## Changes

Contributes to experimentation feature

Frontend support for multi-status experiment filtering (depends on #7893).

- `toParam` utility handles array values by emitting repeated keys (`{status: ['running', 'paused']}` → `status=running&status=paused`)
- `getExperiments` request type accepts `ExperimentStatus | ExperimentStatus[]`
- Fixes pre-existing `no-nested-ternary` lint error in `_utils.js`

## How did you test this code?

- Frontend eslint and typecheck pass
- Existing behaviour unchanged for single-value callers