### PR TITLE
feat: Adopt the flagsmith entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ ARG ACCESS_LOG_LOCATION="/dev/null"
 ENV ACCESS_LOG_LOCATION=${ACCESS_LOG_LOCATION} \
   PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR} \
   DJANGO_SETTINGS_MODULE=app.settings.production \
-  APPLICATION_LOGGERS="app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,mcp,oauth2_metadata,organisations,projects,segments,task_processor,users,webhooks,workflows"
+  APPLICATION_LOGGERS="app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,mcp,oauth2_metadata,organisations,projects,segment_membership,segments,task_processor,users,webhooks,workflows"
 
 ARG CI_COMMIT_SHA
 RUN echo ${CI_COMMIT_SHA} > /app/CI_COMMIT_SHA && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,8 @@ ARG ACCESS_LOG_LOCATION="/dev/null"
 ENV ACCESS_LOG_LOCATION=${ACCESS_LOG_LOCATION} \
   PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR} \
   DJANGO_SETTINGS_MODULE=app.settings.production \
+  GUNICORN_WORKERS=3 \
+  GUNICORN_THREADS=2 \
   APPLICATION_LOGGERS="app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,mcp,oauth2_metadata,organisations,projects,segment_membership,segments,task_processor,users,webhooks,workflows"
 
 ARG CI_COMMIT_SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,8 @@ ARG PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus"
 ARG ACCESS_LOG_LOCATION="/dev/null"
 ENV ACCESS_LOG_LOCATION=${ACCESS_LOG_LOCATION} \
   PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR} \
-  DJANGO_SETTINGS_MODULE=app.settings.production
+  DJANGO_SETTINGS_MODULE=app.settings.production \
+  APPLICATION_LOGGERS="app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,mcp,oauth2_metadata,organisations,projects,segments,task_processor,users,webhooks,workflows"
 
 ARG CI_COMMIT_SHA
 RUN echo ${CI_COMMIT_SHA} > /app/CI_COMMIT_SHA && \
@@ -144,7 +145,7 @@ RUN echo ${CI_COMMIT_SHA} > /app/CI_COMMIT_SHA && \
 
 EXPOSE 8000
 
-ENTRYPOINT ["/app/scripts/run-docker.sh"]
+ENTRYPOINT ["flagsmith"]
 
 CMD ["migrate-and-serve"]
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1525,3 +1525,20 @@ if CLICKHOUSE_ENABLED:
         },
     }
     DATABASES["clickhouse"] = _clickhouse_db  # type: ignore[assignment]
+
+# Startup verbs (flagsmith-common `flagsmith` entrypoint): which databases each
+# role migrates and waits on. Mirrors the per-role gating run-docker.sh applied —
+# only databases actually configured are included. `DATABASES` is undefined when
+# no `DATABASE_URL` is set (e.g. build-time collectstatic), so guard for that.
+_configured_databases = globals().get("DATABASES", {})
+FLAGSMITH_MIGRATE_DATABASES = [
+    alias
+    for alias in ("default", "analytics", "task_processor", "clickhouse")
+    if alias in _configured_databases
+]
+FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES = [
+    alias
+    for alias in ("default", "analytics", "task_processor")
+    if alias in _configured_databases
+]
+FLAGSMITH_STARTUP_COMMANDS = ["bootstrap"]

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -183,6 +183,11 @@ DJANGO_DB_CONN_MAX_AGE = 0 if db_conn_max_age == -1 else db_conn_max_age
 DJANGO_DB_CONN_HEALTH_CHECKS = env.bool("DJANGO_DB_CONN_HEALTH_CHECKS", False)
 
 DATABASE_ROUTERS: list[str] = []
+
+FLAGSMITH_MIGRATE_DATABASES: list[str] = []
+FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES: list[str] = []
+FLAGSMITH_STARTUP_COMMANDS = ["bootstrap"]
+
 # Allows collectstatic to run without a database, mainly for Docker builds to collectstatic at build time
 if "DATABASE_URL" in os.environ:
     DATABASES = {
@@ -192,6 +197,8 @@ if "DATABASE_URL" in os.environ:
             conn_health_checks=DJANGO_DB_CONN_HEALTH_CHECKS,
         ),
     }
+    FLAGSMITH_MIGRATE_DATABASES.append("default")
+    FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES.append("default")
     REPLICA_DATABASE_URLS_DELIMITER = env("REPLICA_DATABASE_URLS_DELIMITER", ",")
     REPLICA_DATABASE_URLS = (
         env.list(
@@ -249,6 +256,8 @@ if "DATABASE_URL" in os.environ:
             conn_health_checks=DJANGO_DB_CONN_HEALTH_CHECKS,
         )
         DATABASE_ROUTERS.insert(0, "app.routers.AnalyticsRouter")
+        FLAGSMITH_MIGRATE_DATABASES.append("analytics")
+        FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES.append("analytics")
 elif "DJANGO_DB_NAME" in os.environ:
     # If there is no DATABASE_URL configured, check for old style DB config parameters
     DATABASES = {
@@ -263,6 +272,8 @@ elif "DJANGO_DB_NAME" in os.environ:
             "CONN_HEALTH_CHECKS": DJANGO_DB_CONN_HEALTH_CHECKS,
         },
     }
+    FLAGSMITH_MIGRATE_DATABASES.append("default")
+    FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES.append("default")
     if "DJANGO_DB_NAME_ANALYTICS" in os.environ:
         DATABASES["analytics"] = {
             "ENGINE": "django.db.backends.postgresql",
@@ -276,6 +287,8 @@ elif "DJANGO_DB_NAME" in os.environ:
         }
 
         DATABASE_ROUTERS.insert(0, "app.routers.AnalyticsRouter")
+        FLAGSMITH_MIGRATE_DATABASES.append("analytics")
+        FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES.append("analytics")
 
 # Task processor database — OPTIONALLY SEPARATED
 TASK_PROCESSOR_DATABASE_URL = env("TASK_PROCESSOR_DATABASE_URL", default=None)
@@ -305,6 +318,8 @@ if TASK_PROCESSOR_DATABASE_URL or TASK_PROCESSOR_DATABASE_NAME:
             "CONN_MAX_AGE": DJANGO_DB_CONN_MAX_AGE,
         }
     DATABASE_ROUTERS.insert(0, "task_processor.routers.TaskProcessorRouter")
+    FLAGSMITH_MIGRATE_DATABASES.append("task_processor")
+    FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES.append("task_processor")
 
     # Consume any remaining tasks from 'default' when opting in to 'task_processor' database
     _task_processor_databases = ["default", "task_processor"]
@@ -1525,20 +1540,4 @@ if CLICKHOUSE_ENABLED:
         },
     }
     DATABASES["clickhouse"] = _clickhouse_db  # type: ignore[assignment]
-
-# Startup verbs (flagsmith-common `flagsmith` entrypoint): which databases each
-# role migrates and waits on. Mirrors the per-role gating run-docker.sh applied —
-# only databases actually configured are included. `DATABASES` is undefined when
-# no `DATABASE_URL` is set (e.g. build-time collectstatic), so guard for that.
-_configured_databases = globals().get("DATABASES", {})
-FLAGSMITH_MIGRATE_DATABASES = [
-    alias
-    for alias in ("default", "analytics", "task_processor", "clickhouse")
-    if alias in _configured_databases
-]
-FLAGSMITH_WAIT_FOR_MIGRATIONS_DATABASES = [
-    alias
-    for alias in ("default", "analytics", "task_processor")
-    if alias in _configured_databases
-]
-FLAGSMITH_STARTUP_COMMANDS = ["bootstrap"]
+    FLAGSMITH_MIGRATE_DATABASES.append("clickhouse")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "hubspot-api-client>=12.0.0,<13.0.0",
     "djangorestframework-dataclasses>=1.3.1,<2.0.0",
     "pyotp>=2.9.0,<3.0.0",
-    "flagsmith-common[common-core,flagsmith-schemas,task-processor]>=3.10.1,<4",
+    "flagsmith-common[common-core,flagsmith-schemas,task-processor]>=3.11.0,<4",
     "django-stubs>=5.1.3,<6.0.0",
     "tzdata>=2024.1,<2025.0.0",
     "djangorestframework-simplejwt>=5.5.1,<6.0.0",
@@ -155,9 +155,6 @@ explicit = true
 
 [tool.uv.sources]
 flagsmith-private = { index = "flagsmith-pypi-production" }
-# TEMPORARY: track the composite startup verbs branch until flagsmith-common ships them.
-# TODO: revert to the PyPI release once the entrypoint verbs are released.
-flagsmith-common = { git = "https://github.com/Flagsmith/flagsmith-common", branch = "feat/composite-startup-verbs" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 # TODO: Revert to the PyPI release once a version closing
 # https://github.com/jayvynl/django-clickhouse-backend/issues/154 is published.

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -155,6 +155,9 @@ explicit = true
 
 [tool.uv.sources]
 flagsmith-private = { index = "flagsmith-pypi-production" }
+# TEMPORARY: track the composite startup verbs branch until flagsmith-common ships them.
+# TODO: revert to the PyPI release once the entrypoint verbs are released.
+flagsmith-common = { git = "https://github.com/Flagsmith/flagsmith-common", branch = "feat/composite-startup-verbs" }
 clickhouse-driver = { git = "https://github.com/Flagsmith/clickhouse-driver", branch = "newjson" }
 # TODO: Revert to the PyPI release once a version closing
 # https://github.com/jayvynl/django-clickhouse-backend/issues/154 is published.

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -1,12 +1,4 @@
 #!/bin/sh
 set -e
 
-# Container startup is handled by the `flagsmith` entrypoint (flagsmith-common),
-# which provides the serve / migrate / run-task-processor / migrate-and-serve
-# verbs this script used to implement in shell.
-#
-# This shim stays for backwards compatibility: anything invoking the script
-# path directly (Helm charts, compose files, task definitions) keeps working.
-# Prefer calling `flagsmith <verb>` directly; this file can be removed once all
-# consumers have migrated.
 exec flagsmith "$@"

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -1,108 +1,12 @@
 #!/bin/sh
 set -e
 
-# common environment variables
-ACCESS_LOG_FORMAT=${ACCESS_LOG_FORMAT:-'%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({origin}i)s %({access-control-allow-origin}o)s'}
-APPLICATION_LOGGERS=${APPLICATION_LOGGERS:-"app_analytics,audit,code_references,common,core,dynamodb,edge_api,environments,features,import_export,integrations,mcp,oauth2_metadata,organisations,projects,segment_membership,segments,task_processor,users,webhooks,workflows"}
-
-waitfordb() {
-  if [ -z "${SKIP_WAIT_FOR_DB}" ]; then
-     python manage.py waitfordb "$@"
-  fi
-}
-
-migrate () {
-    waitfordb \
-      && python manage.py showmigrations --verbosity 2 \
-      && python manage.py migrate --verbosity 2 \
-      && python manage.py createcachetable
-}
-serve() {
-    # configuration parameters for statsd. Docs can be found here:
-    # https://docs.gunicorn.org/en/stable/instrumentation.html
-    export STATSD_PORT=${STATSD_PORT:-8125}
-    export STATSD_PREFIX=${STATSD_PREFIX:-flagsmith.api}
-
-    waitfordb
-
-    exec flagsmith start \
-             --worker-tmp-dir /dev/shm \
-             --timeout ${GUNICORN_TIMEOUT:-30} \
-             --workers ${GUNICORN_WORKERS:-3} \
-             --threads ${GUNICORN_THREADS:-2} \
-             --access-logfile $ACCESS_LOG_LOCATION \
-             --access-logformat "$ACCESS_LOG_FORMAT" \
-             --keep-alive ${GUNICORN_KEEP_ALIVE:-2} \
-             ${STATSD_HOST:+--statsd-host $STATSD_HOST:$STATSD_PORT} \
-             ${STATSD_HOST:+--statsd-prefix $STATSD_PREFIX} \
-             api
-}
-run_task_processor() {
-    waitfordb --waitfor 30 --migrations
-    if [ -n "$ANALYTICS_DATABASE_URL" ] || [ -n "$DJANGO_DB_NAME_ANALYTICS" ]; then
-        waitfordb --waitfor 30 --migrations --database analytics
-    fi
-    if [ -n "$TASK_PROCESSOR_DATABASE_URL" ] || [ -n "$TASK_PROCESSOR_DATABASE_NAME" ]; then
-        waitfordb --waitfor 30 --migrations --database task_processor
-    fi
-    exec flagsmith start \
-             --bind 0.0.0.0:8000 \
-             --access-logfile $ACCESS_LOG_LOCATION \
-             --access-logformat "$ACCESS_LOG_FORMAT" \
-             task-processor \
-             --sleepintervalms ${TASK_PROCESSOR_SLEEP_INTERVAL_MS:-${TASK_PROCESSOR_SLEEP_INTERVAL:-500}} \
-             --graceperiodms ${TASK_PROCESSOR_GRACE_PERIOD_MS:-20000} \
-             --numthreads ${TASK_PROCESSOR_NUM_THREADS:-5} \
-             --queuepopsize ${TASK_PROCESSOR_QUEUE_POP_SIZE:-10}
-
-}
-migrate_analytics_db(){
-    if [ -z "$ANALYTICS_DATABASE_URL" ] && [ -z "$DJANGO_DB_NAME_ANALYTICS" ]; then
-        return 0
-    fi
-    python manage.py migrate --database analytics
-}
-migrate_task_processor_db(){
-    if [ -z "$TASK_PROCESSOR_DATABASE_URL" ] && [ -z "$TASK_PROCESSOR_DATABASE_NAME" ]; then
-        return 0
-    fi
-    python manage.py migrate --database task_processor
-}
-migrate_clickhouse_db(){
-    if [ -z "$CLICKHOUSE_URL" ] && [ -z "$CLICKHOUSE_HOST" ]; then
-        return 0
-    fi
-    python manage.py migrate --database clickhouse
-}
-bootstrap(){
-    python manage.py bootstrap
-}
-default(){
-    python manage.py "$@"
-}
-
-set -x
-
-if [ "$1" = "migrate" ]; then
-    migrate
-    migrate_analytics_db
-    migrate_task_processor_db
-    migrate_clickhouse_db
-elif [ "$1" = "serve" ]; then
-    serve
-elif [ "$1" = "run-task-processor" ]; then
-    migrate
-    migrate_analytics_db
-    migrate_task_processor_db
-    migrate_clickhouse_db
-    run_task_processor
-elif [ "$1" = "migrate-and-serve" ]; then
-    migrate
-    migrate_analytics_db
-    migrate_task_processor_db
-    migrate_clickhouse_db
-    bootstrap
-    serve
-else
-   default "$@"
-fi
+# Container startup is handled by the `flagsmith` entrypoint (flagsmith-common),
+# which provides the serve / migrate / run-task-processor / migrate-and-serve
+# verbs this script used to implement in shell.
+#
+# This shim stays for backwards compatibility: anything invoking the script
+# path directly (Helm charts, compose files, task definitions) keeps working.
+# Prefer calling `flagsmith <verb>` directly; this file can be removed once all
+# consumers have migrated.
+exec flagsmith "$@"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1552,7 +1552,7 @@ requires-dist = [
     { name = "email-validator", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "environs", specifier = ">=14.1.1,<15.0.0" },
     { name = "flagsmith", specifier = ">=5.3.0,<6.0.0" },
-    { name = "flagsmith-common", extras = ["common-core", "flagsmith-schemas", "task-processor"], specifier = ">=3.10.1,<4" },
+    { name = "flagsmith-common", extras = ["common-core", "flagsmith-schemas", "task-processor"], specifier = ">=3.11.0,<4" },
     { name = "flagsmith-common", extras = ["test-tools"], marker = "extra == 'dev'" },
     { name = "flagsmith-flag-engine", specifier = ">=10.1.0,<11.0.0" },
     { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.10.1,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
@@ -1623,11 +1623,11 @@ provides-extras = ["private", "dev"]
 
 [[package]]
 name = "flagsmith-common"
-version = "3.10.1"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/88/69b64381dd5c27eab67da364b5163bc40fc500fb45804d9ba6824a2e3d1d/flagsmith_common-3.10.1.tar.gz", hash = "sha256:d07b8bdac4e2b7913daed2538c5fec7512a08f10e6f64fc5a2bb1016f9493a7b", size = 59260, upload-time = "2026-06-30T10:06:07.926Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/10/5bcec25cfa4e86ad25fa0c97269b74633bf0305abc181c1d439a26bd9864/flagsmith_common-3.11.0.tar.gz", hash = "sha256:178f908c5355e41ad5bed8839943de28b37fcf69131fac464751a8e3d6bf3301", size = 61027, upload-time = "2026-07-06T11:51:10.344Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b1/0527d883b246b4b600d5595a1648d5bda34110747962c88377d5c2301eb0/flagsmith_common-3.10.1-py3-none-any.whl", hash = "sha256:ea03bd41c7842d00bfbf65546f371b9e3d602b1e772cb33e9e86d9bcfd732236", size = 96851, upload-time = "2026-06-30T10:06:06.324Z" },
+    { url = "https://files.pythonhosted.org/packages/af/60/83c432cd1368281a483eb94a13ba789180c48d576e57222fce8e289004be/flagsmith_common-3.11.0-py3-none-any.whl", hash = "sha256:c4b637887cb22a89cc8fe7083342cc32ad8ccc5e7f8d050bd0bb1e4155a73651", size = 99115, upload-time = "2026-07-06T11:51:08.932Z" },
 ]
 
 [package.optional-dependencies]
@@ -1665,6 +1665,7 @@ task-processor = [
     { name = "backoff" },
     { name = "django" },
     { name = "django-health-check" },
+    { name = "environs" },
     { name = "opentelemetry-api" },
     { name = "prometheus-client" },
 ]

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -7,7 +7,8 @@
         {
             "name": "flagsmith-task-processor",
             "command": [
-                "run-task-processor"
+                "start",
+                "task-processor"
             ],
             "portMappings": [
                 {
@@ -29,7 +30,7 @@
                 "interval": 10,
                 "timeout": 2,
                 "retries": 5,
-                "startPeriod": 120
+                "startPeriod": 30
             },
             "essential": true,
             "environment": [

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -6,7 +6,7 @@
     "containerDefinitions": [
         {
             "name": "flagsmith-task-processor",
-            "command": ["run-task-processor"],
+            "command": ["start", "task-processor"],
             "portMappings": [
                 {
                     "containerPort": 9100,
@@ -24,7 +24,7 @@
                 "interval": 10,
                 "timeout": 2,
                 "retries": 5,
-                "startPeriod": 120
+                "startPeriod": 30
             },
             "essential": true,
             "environment": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7891. 

Adopts the `flagsmith` CLI entrypoint (from flagsmith-common) for container startup, replacing the bespoke sequencing in `api/scripts/run-docker.sh`.

- `run-docker.sh` is reduced to a backwards-compatible shim (`exec flagsmith "$@"`), so anything invoking the script path or its verbs keeps working.
- The image `ENTRYPOINT` is now `flagsmith`; `APPLICATION_LOGGERS` (previously defaulted in the shell script) moves to a Dockerfile `ENV` so logging is unchanged.
- The startup verbs are driven by settings, set in `app/settings/common.py` from the databases actually configured.
- The task processor in SaaS no longer migrates on every task start. Its task definition command becomes `start task-processor`.
- The temporary `startPeriod` raised to 120s in #7887 is lowered to 30s in both the prod and staging task-processor definitions, which comfortably covers the new single-boot startup.

## How did you test this code?

End-to-end against a local environment, exercising each verb via the `flagsmith` entrypoint:

- `flagsmith migrate` — waits for the DB, migrates the configured databases, creates the cache table.
- `flagsmith serve` — waits for the DB, starts the API; `/health/liveness` served on `:8000`.
- `flagsmith start task-processor` — the new task-definition command; binds `:8000` and starts the worker threads.
- `flagsmith migrate-and-serve` — runs migrate, then `bootstrap` (via `FLAGSMITH_STARTUP_COMMANDS`), then serves.
