### PR TITLE
feat(experimentation): default to control when rollout segment is created

### DIFF
--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -709,6 +709,8 @@ def _serialize_feature_state_value(
 ) -> tuple[str, FeatureValueType]:
     """Render a stored feature state value as the (string, API type) pair that
     a `FlagChangeSet` expects."""
+    if value.value is None:
+        return "", "string"
     return (
         str(value.value).lower() if value.type == BOOLEAN else str(value.value),
         _ROLLOUT_VALUE_TYPE.get(value.type or STRING, "string"),

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -42,6 +42,7 @@ from experimentation.dataclasses import (
 )
 from experimentation.models import (
     VALID_STATUS_TRANSITIONS,
+    Experiment,
     ExperimentStatus,
     MetricAggregation,
     MetricDirection,
@@ -75,7 +76,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
 
-    from experimentation.models import Experiment, Metric, WarehouseConnection
+    from experimentation.models import Metric, WarehouseConnection
     from experimentation.types import ExposureGranularity
     from features.feature_states.models import FeatureValueType
     from features.models import FeatureStateValue
@@ -678,8 +679,9 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
         )
     validate_rollout_spec(experiment, spec)
     environment_id = experiment.environment_id
-    is_first_rollout = experiment.rollout_segment_id is None
     with transaction.atomic():
+        locked_experiment = Experiment.objects.select_for_update().get(pk=experiment.pk)
+        is_first_rollout = locked_experiment.rollout_segment_id is None
         segment = _sync_rollout_segment(experiment, spec.rollout_percentage)
         if is_first_rollout:
             _reset_default_allocations_to_control(experiment, spec.author)

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -680,8 +680,8 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
     validate_rollout_spec(experiment, spec)
     environment_id = experiment.environment_id
     with transaction.atomic():
-        locked_experiment = Experiment.objects.select_for_update().get(pk=experiment.pk)
-        is_first_rollout = locked_experiment.rollout_segment_id is None
+        experiment.refresh_from_db(from_queryset=Experiment.objects.select_for_update())
+        is_first_rollout = experiment.rollout_segment_id is None
         segment = _sync_rollout_segment(experiment, spec.rollout_percentage)
         if is_first_rollout:
             _reset_default_allocations_to_control(experiment, spec.author)

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -57,7 +57,7 @@ from experimentation.stats import (
 )
 from features.models import FeatureState
 from features.value_types import BOOLEAN, INTEGER, STRING
-from features.versioning.dataclasses import FlagChangeSet
+from features.versioning.dataclasses import FlagChangeSet, MultivariateValueChangeSet
 from features.versioning.versioning_service import (
     update_flag,
     update_multivariate_values,
@@ -65,7 +65,11 @@ from features.versioning.versioning_service import (
 from integrations.flagsmith.client import get_openfeature_client
 from segments.models import Condition, Segment, SegmentRule
 
-_ROLLOUT_VALUE_TYPE = {INTEGER: "integer", STRING: "string", BOOLEAN: "boolean"}
+_ROLLOUT_VALUE_TYPE: dict[str, "FeatureValueType"] = {
+    INTEGER: "integer",
+    STRING: "string",
+    BOOLEAN: "boolean",
+}
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -73,6 +77,8 @@ if typing.TYPE_CHECKING:
 
     from experimentation.models import Experiment, Metric, WarehouseConnection
     from experimentation.types import ExposureGranularity
+    from features.feature_states.models import FeatureValueType
+    from features.models import FeatureStateValue
     from organisations.models import Organisation
     from users.models import FFAdminUser
 
@@ -627,6 +633,47 @@ def _update_rollout_in_place(experiment: Experiment, change_set: FlagChangeSet) 
     update_flag(experiment.environment, experiment.feature, change_set)
 
 
+def _reset_default_allocations_to_control(
+    experiment: Experiment, author: AuthorData
+) -> None:
+    """Zero every variant's allocation on the feature's environment-default
+    feature state, leaving control (the unallocated remainder) at 100%.
+
+    Run once, when the rollout segment is first created: identities outside the
+    rollout cohort should all receive control while the experiment runs.
+    """
+    option_ids = list(
+        experiment.feature.multivariate_options.values_list("id", flat=True)
+    )
+    if not option_ids:
+        return
+    default_state = FeatureState.objects.get_live_feature_states(
+        environment=experiment.environment,
+        additional_filters=Q(feature_segment__isnull=True, identity__isnull=True),
+        feature_id=experiment.feature_id,
+    ).latest("id")
+    str_value, value_type = _serialize_feature_state_value(
+        default_state.feature_state_value
+    )
+    update_flag(
+        experiment.environment,
+        experiment.feature,
+        FlagChangeSet(
+            author=author,
+            enabled=default_state.enabled,
+            feature_state_value=str_value,
+            type_=value_type,
+            multivariate_values=[
+                MultivariateValueChangeSet(
+                    multivariate_feature_option_id=option_id,
+                    percentage_allocation=0,
+                )
+                for option_id in option_ids
+            ],
+        ),
+    )
+
+
 def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
     if experiment.status == ExperimentStatus.COMPLETED:
         raise ValidationError(
@@ -634,8 +681,11 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
         )
     validate_rollout_spec(experiment, spec)
     environment_id = experiment.environment_id
+    is_first_rollout = experiment.rollout_segment_id is None
     with transaction.atomic():
         segment = _sync_rollout_segment(experiment, spec.rollout_percentage)
+        if is_first_rollout:
+            _reset_default_allocations_to_control(experiment, spec.author)
         _update_rollout_in_place(
             experiment,
             FlagChangeSet(
@@ -655,6 +705,17 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
         )
 
 
+def _serialize_feature_state_value(
+    value: FeatureStateValue,
+) -> tuple[str, FeatureValueType]:
+    """Render a stored feature state value as the (string, API type) pair that
+    a `FlagChangeSet` expects."""
+    return (
+        str(value.value).lower() if value.type == BOOLEAN else str(value.value),
+        _ROLLOUT_VALUE_TYPE.get(value.type or STRING, "string"),
+    )
+
+
 def get_experiment_rollout(experiment: Experiment) -> dict[str, typing.Any] | None:
     segment_id = experiment.rollout_segment_id
     if segment_id is None:
@@ -671,16 +732,13 @@ def get_experiment_rollout(experiment: Experiment) -> dict[str, typing.Any] | No
     condition = Condition.objects.get(
         rule__segment_id=segment_id, operator=PERCENTAGE_SPLIT
     )
-    value = feature_state.feature_state_value
+    str_value, value_type = _serialize_feature_state_value(
+        feature_state.feature_state_value
+    )
     return {
         "enabled": feature_state.enabled,
         "rollout_percentage": float(condition.value or 0),
-        "feature_state_value": {
-            "type": _ROLLOUT_VALUE_TYPE.get(value.type or STRING, "string"),
-            "value": (
-                str(value.value).lower() if value.type == BOOLEAN else str(value.value)
-            ),
-        },
+        "feature_state_value": {"type": value_type, "value": str_value},
         "multivariate_feature_state_values": [
             {
                 "multivariate_feature_option": mv.multivariate_feature_option_id,

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -60,6 +60,7 @@ from features.models import FeatureState
 from features.value_types import BOOLEAN, INTEGER, STRING
 from features.versioning.dataclasses import FlagChangeSet, MultivariateValueChangeSet
 from features.versioning.versioning_service import (
+    get_environment_flags_list,
     update_flag,
     update_multivariate_values,
 )
@@ -586,18 +587,15 @@ def _sync_rollout_segment(experiment: Experiment, rollout_percentage: float) -> 
 
 
 def _get_live_rollout_override(experiment: Experiment) -> FeatureState | None:
-    return (
-        FeatureState.objects.get_live_feature_states(
-            environment=experiment.environment,
-            additional_filters=Q(
-                feature_segment__segment_id=experiment.rollout_segment_id,
-                identity__isnull=True,
-            ),
+    flags = get_environment_flags_list(
+        environment=experiment.environment,
+        additional_filters=Q(
             feature_id=experiment.feature_id,
-        )
-        .order_by("-id")
-        .first()
+            feature_segment__segment_id=experiment.rollout_segment_id,
+            identity__isnull=True,
+        ),
     )
+    return flags[0] if flags else None
 
 
 def _update_live_feature_state(
@@ -643,11 +641,14 @@ def _reset_default_allocations_to_control(
     Run once, when the rollout segment is first created: identities outside the
     rollout cohort should all receive control while the experiment runs.
     """
-    default_state = FeatureState.objects.get_live_feature_states(
+    (default_state,) = get_environment_flags_list(
         environment=experiment.environment,
-        additional_filters=Q(feature_segment__isnull=True, identity__isnull=True),
-        feature_id=experiment.feature_id,
-    ).latest("id")
+        additional_filters=Q(
+            feature_id=experiment.feature_id,
+            feature_segment__isnull=True,
+            identity__isnull=True,
+        ),
+    )
     str_value, value_type = _serialize_feature_state_value(
         default_state.feature_state_value
     )

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -642,11 +642,6 @@ def _reset_default_allocations_to_control(
     Run once, when the rollout segment is first created: identities outside the
     rollout cohort should all receive control while the experiment runs.
     """
-    option_ids = list(
-        experiment.feature.multivariate_options.values_list("id", flat=True)
-    )
-    if not option_ids:
-        return
     default_state = FeatureState.objects.get_live_feature_states(
         environment=experiment.environment,
         additional_filters=Q(feature_segment__isnull=True, identity__isnull=True),
@@ -668,7 +663,9 @@ def _reset_default_allocations_to_control(
                     multivariate_feature_option_id=option_id,
                     percentage_allocation=0,
                 )
-                for option_id in option_ids
+                for option_id in experiment.feature.multivariate_options.values_list(
+                    "id", flat=True
+                )
             ],
         ),
     )

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -674,14 +674,14 @@ def _reset_default_allocations_to_control(
 
 
 def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
-    if experiment.status == ExperimentStatus.COMPLETED:
-        raise ValidationError(
-            f"Cannot change the rollout of a {experiment.status} experiment."
-        )
     validate_rollout_spec(experiment, spec)
     environment_id = experiment.environment_id
     with transaction.atomic():
         experiment.refresh_from_db(from_queryset=Experiment.objects.select_for_update())
+        if experiment.status == ExperimentStatus.COMPLETED:
+            raise ValidationError(
+                f"Cannot change the rollout of a {experiment.status} experiment."
+            )
         is_first_rollout = experiment.rollout_segment_id is None
         segment = _sync_rollout_segment(experiment, spec.rollout_percentage)
         if is_first_rollout:

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -56,12 +56,16 @@ from experimentation.stats import (
 )
 from features.models import FeatureState
 from features.value_types import BOOLEAN, INTEGER, STRING
-from features.versioning.dataclasses import FlagChangeSet
+from features.versioning.dataclasses import FlagChangeSet, MultivariateValueChangeSet
 from features.versioning.versioning_service import update_flag
 from integrations.flagsmith.client import get_openfeature_client
 from segments.models import Condition, Segment, SegmentRule
 
-_ROLLOUT_VALUE_TYPE = {INTEGER: "integer", STRING: "string", BOOLEAN: "boolean"}
+_ROLLOUT_VALUE_TYPE: dict[str, "FeatureValueType"] = {
+    INTEGER: "integer",
+    STRING: "string",
+    BOOLEAN: "boolean",
+}
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -69,6 +73,8 @@ if typing.TYPE_CHECKING:
 
     from experimentation.models import Experiment, Metric, WarehouseConnection
     from experimentation.types import ExposureGranularity
+    from features.feature_states.models import FeatureValueType
+    from features.models import FeatureStateValue
     from organisations.models import Organisation
     from users.models import FFAdminUser
 
@@ -574,14 +580,58 @@ def _sync_rollout_segment(experiment: Experiment, rollout_percentage: float) -> 
     return segment
 
 
+def _reset_default_allocations_to_control(
+    experiment: Experiment, author: AuthorData
+) -> None:
+    """Zero every variant's allocation on the feature's environment-default
+    feature state, leaving control (the unallocated remainder) at 100%.
+
+    Run once, when the rollout segment is first created: identities outside the
+    rollout cohort should all receive control while the experiment runs.
+    """
+    option_ids = list(
+        experiment.feature.multivariate_options.values_list("id", flat=True)
+    )
+    if not option_ids:
+        return
+    default_state = FeatureState.objects.get_live_feature_states(
+        environment=experiment.environment,
+        additional_filters=Q(feature_segment__isnull=True, identity__isnull=True),
+        feature_id=experiment.feature_id,
+    ).latest("id")
+    str_value, value_type = _serialize_feature_state_value(
+        default_state.feature_state_value
+    )
+    update_flag(
+        experiment.environment,
+        experiment.feature,
+        FlagChangeSet(
+            author=author,
+            enabled=default_state.enabled,
+            feature_state_value=str_value,
+            type_=value_type,
+            multivariate_values=[
+                MultivariateValueChangeSet(
+                    multivariate_feature_option_id=option_id,
+                    percentage_allocation=0,
+                )
+                for option_id in option_ids
+            ],
+        ),
+    )
+
+
 def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
     if experiment.status == ExperimentStatus.COMPLETED:
         raise ValidationError(
             f"Cannot change the rollout of a {experiment.status} experiment."
         )
     validate_rollout_spec(experiment, spec)
+    is_first_rollout = experiment.rollout_segment_id is None
     with transaction.atomic():
         segment = _sync_rollout_segment(experiment, spec.rollout_percentage)
+        if is_first_rollout:
+            _reset_default_allocations_to_control(experiment, spec.author)
         update_flag(
             experiment.environment,
             experiment.feature,
@@ -594,6 +644,17 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
                 multivariate_values=spec.multivariate_values,
             ),
         )
+
+
+def _serialize_feature_state_value(
+    value: FeatureStateValue,
+) -> tuple[str, FeatureValueType]:
+    """Render a stored feature state value as the (string, API type) pair that
+    a `FlagChangeSet` expects."""
+    return (
+        str(value.value).lower() if value.type == BOOLEAN else str(value.value),
+        _ROLLOUT_VALUE_TYPE.get(value.type or STRING, "string"),
+    )
 
 
 def get_experiment_rollout(experiment: Experiment) -> dict[str, typing.Any] | None:
@@ -612,16 +673,13 @@ def get_experiment_rollout(experiment: Experiment) -> dict[str, typing.Any] | No
     condition = Condition.objects.get(
         rule__segment_id=segment_id, operator=PERCENTAGE_SPLIT
     )
-    value = feature_state.feature_state_value
+    str_value, value_type = _serialize_feature_state_value(
+        feature_state.feature_state_value
+    )
     return {
         "enabled": feature_state.enabled,
         "rollout_percentage": float(condition.value or 0),
-        "feature_state_value": {
-            "type": _ROLLOUT_VALUE_TYPE.get(value.type or STRING, "string"),
-            "value": (
-                str(value.value).lower() if value.type == BOOLEAN else str(value.value)
-            ),
-        },
+        "feature_state_value": {"type": value_type, "value": str_value},
         "multivariate_feature_state_values": [
             {
                 "multivariate_feature_option": mv.multivariate_feature_option_id,

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from django.db import IntegrityError
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -1984,6 +1985,70 @@ def test_post__with_experiment_rollout__zeroes_default_allocations(
         environment=environment,
         feature_segment__segment=experiment.rollout_segment,
     )
+    override_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in override.multivariate_feature_state_values.all()
+    }
+    assert override_allocations == {option_a.id: 60.0, option_b.id: 40.0}
+
+
+def test_post__with_experiment_rollout_v2_versioning__zeroes_default_allocations(
+    admin_client_new: APIClient,
+    environment_v2_versioning: Environment,
+    multivariate_feature: Feature,
+    multivariate_options: list[MultivariateFeatureOption],
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    option_a, option_b, option_c = multivariate_options
+
+    # When
+    response = admin_client_new.post(
+        _list_url(environment_v2_versioning),
+        data={
+            "feature": multivariate_feature.id,
+            "name": "Rollout experiment",
+            "hypothesis": "It will work",
+            "experiment_rollout": {
+                "enabled": True,
+                "rollout_percentage": 30,
+                "feature_state_value": {"type": "string", "value": "control"},
+                "multivariate_feature_state_values": [
+                    {
+                        "multivariate_feature_option": option_a.id,
+                        "percentage_allocation": 60,
+                    },
+                    {
+                        "multivariate_feature_option": option_b.id,
+                        "percentage_allocation": 40,
+                    },
+                ],
+            },
+        },
+        format="json",
+    )
+
+    # Then the live environment default has its allocations zeroed
+    assert response.status_code == status.HTTP_201_CREATED
+    experiment = Experiment.objects.get(id=response.json()["id"])
+    env_default_state = FeatureState.objects.get_live_feature_states(
+        environment=environment_v2_versioning,
+        additional_filters=Q(feature_segment__isnull=True, identity__isnull=True),
+        feature_id=multivariate_feature.id,
+    ).latest("id")
+    default_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in env_default_state.multivariate_feature_state_values.all()
+    }
+    assert default_allocations == {option_a.id: 0, option_b.id: 0, option_c.id: 0}
+
+    # and the live rollout segment override keeps the experiment's own split
+    override = FeatureState.objects.get_live_feature_states(
+        environment=environment_v2_versioning,
+        additional_filters=Q(feature_segment__segment=experiment.rollout_segment),
+        feature_id=multivariate_feature.id,
+    ).latest("id")
     override_allocations = {
         mv.multivariate_feature_option_id: mv.percentage_allocation
         for mv in override.multivariate_feature_state_values.all()

--- a/api/tests/unit/experimentation/test_experiment_views.py
+++ b/api/tests/unit/experimentation/test_experiment_views.py
@@ -1926,6 +1926,71 @@ def test_post__with_experiment_rollout__creates_rollout(
     assert experiment.rollout_segment.is_system_segment is True
 
 
+def test_post__with_experiment_rollout__zeroes_default_allocations(
+    admin_client_new: APIClient,
+    environment: Environment,
+    multivariate_feature: Feature,
+    multivariate_options: list[MultivariateFeatureOption],
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features(EXPERIMENT_FLAG)
+    option_a, option_b, option_c = multivariate_options
+
+    # When
+    response = admin_client_new.post(
+        _list_url(environment),
+        data={
+            "feature": multivariate_feature.id,
+            "name": "Rollout experiment",
+            "hypothesis": "It will work",
+            "experiment_rollout": {
+                "enabled": True,
+                "rollout_percentage": 30,
+                "feature_state_value": {"type": "string", "value": "control"},
+                "multivariate_feature_state_values": [
+                    {
+                        "multivariate_feature_option": option_a.id,
+                        "percentage_allocation": 60,
+                    },
+                    {
+                        "multivariate_feature_option": option_b.id,
+                        "percentage_allocation": 40,
+                    },
+                ],
+            },
+        },
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    experiment = Experiment.objects.get(id=response.json()["id"])
+    env_default_state = FeatureState.objects.get(
+        feature=multivariate_feature,
+        environment=environment,
+        identity__isnull=True,
+        feature_segment__isnull=True,
+    )
+    default_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in env_default_state.multivariate_feature_state_values.all()
+    }
+    assert default_allocations == {option_a.id: 0, option_b.id: 0, option_c.id: 0}
+
+    # The rollout segment override keeps the experiment's own split.
+    override = FeatureState.objects.get(
+        feature=multivariate_feature,
+        environment=environment,
+        feature_segment__segment=experiment.rollout_segment,
+    )
+    override_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in override.multivariate_feature_state_values.all()
+    }
+    assert override_allocations == {option_a.id: 60.0, option_b.id: 40.0}
+
+
 def test_post__rollout_allocations_exceed_100__returns_400(
     admin_client_new: APIClient,
     environment: Environment,

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1445,11 +1445,25 @@ def test_apply_experiment_rollout__existing_segment__leaves_default_allocations(
         ),
     )
 
-    # Then
+    # Then the manual edit to the default allocations survives...
     allocation = default_state.multivariate_feature_state_values.get(
         multivariate_feature_option=option_a
     ).percentage_allocation
     assert allocation == 25.0
+
+    # ...while the rollout update itself is applied
+    condition = Condition.objects.get(rule__segment=experiment.rollout_segment)
+    assert condition.value == "80.0"
+    override = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__segment=experiment.rollout_segment,
+    )
+    override_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in override.multivariate_feature_state_values.all()
+    }
+    assert override_allocations == {option_a.id: 50.0, option_b.id: 50.0}
 
 
 def test_apply_experiment_rollout__existing_segment__updates_percentage_and_enabled(

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1359,6 +1359,99 @@ def test_apply_experiment_rollout__no_segment__creates_segment_and_override(
     assert allocations == {option_a.id: 60.0, option_b.id: 40.0}
 
 
+def test_apply_experiment_rollout__first_rollout__zeroes_default_allocations(
+    experiment: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    option_a, option_b, option_c = multivariate_options
+
+    # When
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=True,
+            rollout_percentage=42.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 60.0),
+                MultivariateValueChangeSet(option_b.id, 40.0),
+            ],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # Then
+    experiment.refresh_from_db()
+    default_state = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__isnull=True,
+        identity__isnull=True,
+    )
+    default_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in default_state.multivariate_feature_state_values.all()
+    }
+    assert default_allocations == {option_a.id: 0, option_b.id: 0, option_c.id: 0}
+
+    # The rollout segment override keeps the experiment's own split.
+    override = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__segment=experiment.rollout_segment,
+    )
+    override_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in override.multivariate_feature_state_values.all()
+    }
+    assert override_allocations == {option_a.id: 60.0, option_b.id: 40.0}
+
+
+def test_apply_experiment_rollout__existing_segment__leaves_default_allocations(
+    experiment_with_rollout: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    experiment = experiment_with_rollout
+    option_a, option_b, _ = multivariate_options
+    default_state = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__isnull=True,
+        identity__isnull=True,
+    )
+    # A later manual edit to the default allocations must survive a rollout update.
+    default_state.multivariate_feature_state_values.filter(
+        multivariate_feature_option=option_a
+    ).update(percentage_allocation=25.0)
+
+    # When
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=True,
+            rollout_percentage=80.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 50.0),
+                MultivariateValueChangeSet(option_b.id, 50.0),
+            ],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # Then
+    allocation = default_state.multivariate_feature_state_values.get(
+        multivariate_feature_option=option_a
+    ).percentage_allocation
+    assert allocation == 25.0
+
+
 def test_apply_experiment_rollout__existing_segment__updates_percentage_and_enabled(
     experiment_with_rollout: Experiment,
     multivariate_options: list[MultivariateFeatureOption],

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1359,6 +1359,43 @@ def test_apply_experiment_rollout__no_segment__creates_segment_and_override(
     assert allocations == {option_a.id: 60.0, option_b.id: 40.0}
 
 
+def test_apply_experiment_rollout__null_default_value__serialised_as_empty_string(
+    experiment: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+) -> None:
+    # Given the environment default has no value stored
+    option_a, option_b, _ = multivariate_options
+    default_state = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__isnull=True,
+        identity__isnull=True,
+    )
+    default_state.feature_state_value.string_value = None
+    default_state.feature_state_value.save()
+
+    # When
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=True,
+            rollout_percentage=42.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 60.0),
+                MultivariateValueChangeSet(option_b.id, 40.0),
+            ],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # Then the default value is not rewritten as the string "None"
+    default_state.refresh_from_db()
+    assert default_state.get_feature_state_value() == ""
+
+
 def test_apply_experiment_rollout__first_rollout__zeroes_default_allocations(
     experiment: Experiment,
     multivariate_options: list[MultivariateFeatureOption],

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1356,6 +1356,99 @@ def test_apply_experiment_rollout__no_segment__creates_segment_and_override(
     assert allocations == {option_a.id: 60.0, option_b.id: 40.0}
 
 
+def test_apply_experiment_rollout__first_rollout__zeroes_default_allocations(
+    experiment: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    option_a, option_b, option_c = multivariate_options
+
+    # When
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=True,
+            rollout_percentage=42.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 60.0),
+                MultivariateValueChangeSet(option_b.id, 40.0),
+            ],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # Then
+    experiment.refresh_from_db()
+    default_state = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__isnull=True,
+        identity__isnull=True,
+    )
+    default_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in default_state.multivariate_feature_state_values.all()
+    }
+    assert default_allocations == {option_a.id: 0, option_b.id: 0, option_c.id: 0}
+
+    # The rollout segment override keeps the experiment's own split.
+    override = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__segment=experiment.rollout_segment,
+    )
+    override_allocations = {
+        mv.multivariate_feature_option_id: mv.percentage_allocation
+        for mv in override.multivariate_feature_state_values.all()
+    }
+    assert override_allocations == {option_a.id: 60.0, option_b.id: 40.0}
+
+
+def test_apply_experiment_rollout__existing_segment__leaves_default_allocations(
+    experiment_with_rollout: Experiment,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    experiment = experiment_with_rollout
+    option_a, option_b, _ = multivariate_options
+    default_state = FeatureState.objects.get(
+        environment=experiment.environment,
+        feature=experiment.feature,
+        feature_segment__isnull=True,
+        identity__isnull=True,
+    )
+    # A later manual edit to the default allocations must survive a rollout update.
+    default_state.multivariate_feature_state_values.filter(
+        multivariate_feature_option=option_a
+    ).update(percentage_allocation=25.0)
+
+    # When
+    services.apply_experiment_rollout(
+        experiment,
+        RolloutSpec(
+            enabled=True,
+            rollout_percentage=80.0,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 50.0),
+                MultivariateValueChangeSet(option_b.id, 50.0),
+            ],
+            author=AuthorData(user=admin_user),
+        ),
+    )
+
+    # Then
+    allocation = default_state.multivariate_feature_state_values.get(
+        multivariate_feature_option=option_a
+    ).percentage_allocation
+    assert allocation == 25.0
+
+
 def test_apply_experiment_rollout__existing_segment__updates_percentage_and_enabled(
     experiment_with_rollout: Experiment,
     multivariate_options: list[MultivariateFeatureOption],

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:801`
+ - `api/experimentation/services.py:799`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:781`
+ - `api/experimentation/services.py:779`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:800`
+ - `api/experimentation/services.py:797`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:780`
+ - `api/experimentation/services.py:777`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:799`
+ - `api/experimentation/services.py:801`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:779`
+ - `api/experimentation/services.py:781`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:797`
+ - `api/experimentation/services.py:799`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:777`
+ - `api/experimentation/services.py:779`
 
 Attributes:
  - `environment.id`
@@ -550,7 +550,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:402`
+ - `api/experimentation/services.py:403`
 
 Attributes:
  - `environment.id`
@@ -560,7 +560,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:388`
+ - `api/experimentation/services.py:389`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:801`
+ - `api/experimentation/services.py:802`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:781`
+ - `api/experimentation/services.py:782`
 
 Attributes:
  - `environment.id`
@@ -550,7 +550,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:403`
+ - `api/experimentation/services.py:404`
 
 Attributes:
  - `environment.id`
@@ -560,7 +560,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:389`
+ - `api/experimentation/services.py:390`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:742`
+ - `api/experimentation/services.py:800`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:722`
+ - `api/experimentation/services.py:780`
 
 Attributes:
  - `environment.id`
@@ -550,7 +550,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:396`
+ - `api/experimentation/services.py:402`
 
 Attributes:
  - `environment.id`
@@ -560,7 +560,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:382`
+ - `api/experimentation/services.py:388`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

When a feature is first added to an experiment's rollout — the moment the rollout system segment is created — zero every variant's allocation on the environment-default feature state, so identities outside the rollout cohort receive control (the unallocated remainder) while the experiment runs.

- The rollout segment override is unchanged: it keeps the experiment's own split.
- Only runs when the rollout segment is first created; later rollout updates leave the default allocations alone, so manual edits to the default survive.
- Goes through the version-aware `update_flag` path, working under both v1 and v2 versioning.

## How did you test this code?

Unit tests (`make test`): service tests covering first-rollout zeroing and later updates leaving the default alone; view tests asserting create-with-rollout zeroes the default and preserves the override split under both v1 and v2 versioning. `mypy`, `ruff`, and `flagsmith-lint-tests` clean.
