### PR TITLE
fix(mypy): narrow compressed feature_states to bytes in dynamodb mapper test

### DIFF
--- a/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
@@ -277,8 +277,10 @@ def test_map_environment_to_compressed_environment_document__mv_option_with_key_
     result = dynamodb.map_environment_to_compressed_environment_document(environment)
 
     # Then
+    compressed_feature_states = result.document["feature_states"]
+    assert isinstance(compressed_feature_states, bytes)
     feature_states = json.loads(
-        gzip.decompress(result.document["feature_states"]).decode("utf-8")
+        gzip.decompress(compressed_feature_states).decode("utf-8")
     )
     mv_options = [
         mv_value["multivariate_feature_option"]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #7915. The new test `test_map_environment_to_compressed_environment_document__mv_option_with_key__key_preserved` passed `result.document["feature_states"]` — a `DocumentValue` union — directly to `gzip.decompress`, which mypy rejects:

```
error: Argument 1 to "decompress" has incompatible type
"dict[str, DocumentValue] | list[DocumentValue] | str | bytes | bool | Decimal | None"; expected "Buffer"  [arg-type]
```

Narrow the value to `bytes` with an `isinstance` assert before decompressing, matching the sibling `*_returns_compressed_fields` tests.

## How did you test this code?

- `mypy tests/unit/util/mappers/test_unit_mappers_dynamodb.py` → `Success: no issues found`.
- `test_map_environment_to_compressed_environment_document__mv_option_with_key__key_preserved` still passes.