### PR TITLE
fix:  gate experiment freeze behind feature flag and unblock inputs during loading

### DIFF
--- a/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
+++ b/frontend/common/hooks/__tests__/useFeatureExperimentFreeze.test.ts
@@ -7,12 +7,24 @@ jest.mock('react', () => ({
   useMemo: (fn: () => any) => fn(),
 }))
 
+jest.mock('common/utils/utils', () => ({
+  __esModule: true,
+  default: {
+    getFlagsmithHasFeature: jest.fn(),
+  },
+}))
+
 import { useFeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
 import { useGetExperimentsQuery } from 'common/services/useExperiment'
+import Utils from 'common/utils/utils'
 import { Experiment } from 'common/types/responses'
 
 const mockUseGetExperimentsQuery =
   useGetExperimentsQuery as jest.MockedFunction<typeof useGetExperimentsQuery>
+const mockGetFlagsmithHasFeature =
+  Utils.getFlagsmithHasFeature as jest.MockedFunction<
+    typeof Utils.getFlagsmithHasFeature
+  >
 
 const makeExperiment = (
   overrides: Partial<Experiment> & { featureId: number },
@@ -37,7 +49,6 @@ const makeExperiment = (
 })
 
 const empty = { data: { results: [] }, isLoading: false } as any
-const loading = { data: undefined, isLoading: true } as any
 
 const withResults = (experiments: Experiment[]) =>
   ({ data: { results: experiments }, isLoading: false } as any)
@@ -45,6 +56,7 @@ const withResults = (experiments: Experiment[]) =>
 describe('useFeatureExperimentFreeze', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGetFlagsmithHasFeature.mockReturnValue(true)
   })
 
   it('returns isFrozen true when a running experiment exists for the feature', () => {
@@ -56,7 +68,6 @@ describe('useFeatureExperimentFreeze', () => {
 
     expect(result.isFrozen).toBe(true)
     expect(result.experiment?.id).toBe(1)
-    expect(result.isLoading).toBe(false)
   })
 
   it('returns isFrozen false when no experiments exist', () => {
@@ -79,7 +90,10 @@ describe('useFeatureExperimentFreeze', () => {
   })
 
   it('returns isLoading true while the query is loading', () => {
-    mockUseGetExperimentsQuery.mockReturnValue(loading)
+    mockUseGetExperimentsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as any)
 
     const result = useFeatureExperimentFreeze(42, 'env-123')
 
@@ -111,7 +125,20 @@ describe('useFeatureExperimentFreeze', () => {
     )
   })
 
-  it('queries only running experiments', () => {
+  it('skips query when experimental_flags feature is disabled', () => {
+    mockGetFlagsmithHasFeature.mockReturnValue(false)
+    mockUseGetExperimentsQuery.mockReturnValue(empty)
+
+    const result = useFeatureExperimentFreeze(42, 'env-123')
+
+    expect(result.isFrozen).toBe(false)
+    expect(mockUseGetExperimentsQuery).toHaveBeenCalledWith(
+      { environmentId: 'env-123', status: 'running' },
+      { skip: true },
+    )
+  })
+
+  it('queries only running experiments when feature is enabled', () => {
     mockUseGetExperimentsQuery.mockReturnValue(empty)
 
     useFeatureExperimentFreeze(42, 'env-123')

--- a/frontend/common/hooks/useFeatureExperimentFreeze.ts
+++ b/frontend/common/hooks/useFeatureExperimentFreeze.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { useGetExperimentsQuery } from 'common/services/useExperiment'
 import type { Experiment } from 'common/types/responses'
+import Utils from 'common/utils/utils'
 
 export type FeatureExperimentFreeze = {
   isFrozen: boolean
@@ -12,7 +13,8 @@ export function useFeatureExperimentFreeze(
   featureId: number | undefined,
   environmentId: string,
 ): FeatureExperimentFreeze {
-  const skip = !featureId || !environmentId
+  const hasExperiments = Utils.getFlagsmithHasFeature('experimental_flags')
+  const skip = !hasExperiments || !featureId || !environmentId
   const { data, isLoading } = useGetExperimentsQuery(
     { environmentId, status: 'running' },
     { skip },

--- a/frontend/common/hooks/useFeatureExperimentFreeze.ts
+++ b/frontend/common/hooks/useFeatureExperimentFreeze.ts
@@ -13,8 +13,8 @@ export function useFeatureExperimentFreeze(
   featureId: number | undefined,
   environmentId: string,
 ): FeatureExperimentFreeze {
-  const hasExperiments = Utils.getFlagsmithHasFeature('experimental_flags')
-  const skip = !hasExperiments || !featureId || !environmentId
+  const isExperimentEnabled = Utils.getFlagsmithHasFeature('experimental_flags')
+  const skip = !isExperimentEnabled || !featureId || !environmentId
   const { data, isLoading } = useGetExperimentsQuery(
     { environmentId, status: 'running' },
     { skip },

--- a/frontend/web/components/modals/create-feature/tabs/FeatureSettingsTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureSettingsTab.tsx
@@ -292,7 +292,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
               onChange={(is_server_key_only) =>
                 onChange({ ...projectFlag, is_server_key_only })
               }
-              disabled={!!freeze?.isFrozen || !!freeze?.isLoading}
+              disabled={!!freeze?.isFrozen}
               className='ml-0'
             />
             <Tooltip
@@ -316,7 +316,7 @@ const FeatureSettingsTab: FC<FeatureSettingsTabProps> = ({
               onChange={(is_archived) =>
                 onChange({ ...projectFlag, is_archived })
               }
-              disabled={!!freeze?.isFrozen || !!freeze?.isLoading}
+              disabled={!!freeze?.isFrozen}
               className='ml-0'
             />
             <Tooltip

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -81,8 +81,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   projectId,
 }) => {
   const isEdit = !!projectFlag?.id
-  const isDisabled =
-    !!noPermissions || !!freeze?.isFrozen || !!freeze?.isLoading
+  const isDisabled = !!noPermissions || !!freeze?.isFrozen
 
   const { permission: createFeature } = useHasPermission({
     id: projectId,
@@ -506,38 +505,41 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
         </div>
       )}
 
-      {environmentId && onSaveFeatureValue && !freeze?.isFrozen && (
-        <>
-          <JSONReference
-            className='mb-3'
-            showNamesButton
-            title={'Feature'}
-            json={projectFlag}
-          />
-          <JSONReference
-            className='mb-3'
-            title={'Feature state'}
-            json={environmentFlag}
-          />
-          <FlagValueFooter
-            is4Eyes={!!is4Eyes}
-            isVersioned={!!isVersioned}
-            projectId={
-              typeof projectId === 'string'
-                ? parseInt(projectId, 10)
-                : projectId
-            }
-            projectFlag={projectFlag}
-            environmentId={environmentId}
-            environmentName={environmentName || ''}
-            isSaving={!!isSaving || !!freeze?.isLoading}
-            featureName={projectFlag.name}
-            isInvalid={!!invalid}
-            existingChangeRequest={!!existingChangeRequest}
-            onSaveFeatureValue={onSaveFeatureValue}
-          />
-        </>
-      )}
+      {environmentId &&
+        onSaveFeatureValue &&
+        !freeze?.isFrozen &&
+        !freeze?.isLoading && (
+          <>
+            <JSONReference
+              className='mb-3'
+              showNamesButton
+              title={'Feature'}
+              json={projectFlag}
+            />
+            <JSONReference
+              className='mb-3'
+              title={'Feature state'}
+              json={environmentFlag}
+            />
+            <FlagValueFooter
+              is4Eyes={!!is4Eyes}
+              isVersioned={!!isVersioned}
+              projectId={
+                typeof projectId === 'string'
+                  ? parseInt(projectId, 10)
+                  : projectId
+              }
+              projectFlag={projectFlag}
+              environmentId={environmentId}
+              environmentName={environmentName || ''}
+              isSaving={!!isSaving}
+              featureName={projectFlag.name}
+              isInvalid={!!invalid}
+              existingChangeRequest={!!existingChangeRequest}
+              onSaveFeatureValue={onSaveFeatureValue}
+            />
+          </>
+        )}
     </div>
   )
 }

--- a/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
@@ -164,8 +164,7 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               !showCreateSegment &&
               manageSegmentOverrides &&
               !disableCreate &&
-              !freeze?.isFrozen &&
-              !freeze?.isLoading && (
+              !freeze?.isFrozen && (
                 <div className='text-right'>
                   <Button
                     size='small'
@@ -181,8 +180,7 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
             {!isComparing &&
               !showCreateSegment &&
               !noPermissions &&
-              !freeze?.isFrozen &&
-              !freeze?.isLoading && (
+              !freeze?.isFrozen && (
                 <Button
                   onClick={() => changeSegment(segmentOverrides || [])}
                   type='button'
@@ -223,11 +221,7 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               <SegmentOverrides
                 setShowCreateSegment={setShowCreateSegment}
                 onCompareChange={setIsComparing}
-                readOnly={
-                  !manageSegmentOverrides ||
-                  !!freeze?.isFrozen ||
-                  !!freeze?.isLoading
-                }
+                readOnly={!manageSegmentOverrides || !!freeze?.isFrozen}
                 is4Eyes={is4Eyes}
                 showEditSegment
                 showCreateSegment={showCreateSegment}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
- Inputs were frozen on experiment loading first load (even without flag)
- Skip entirely freeze hook if `experimental_flags` is disabled
- Removed `isLoading` from inputs

## How did you test this code?
- Added tests
- Tested in parallel prod and local against prod