### PR TITLE
docs(integrations): Split Grafana and Prometheus integration pages

### DIFF
--- a/docs/docs/third-party-integrations/index.mdx
+++ b/docs/docs/third-party-integrations/index.mdx
@@ -81,7 +81,14 @@ Monitor flag performance and get alerts with APM tools to ensure proper operatio
 
 <Card>
     <h3>
-        <Link to="/third-party-integrations/observability-and-monitoring/grafana">Grafana & Prometheus Integration</Link>
+        <Link to="/third-party-integrations/observability-and-monitoring/grafana">Grafana Integration</Link>
+    </h3>
+    <p>Open-source monitoring and analytics</p>
+</Card>
+
+<Card>
+    <h3>
+        <Link to="/third-party-integrations/observability-and-monitoring/prometheus">Prometheus Integration</Link>
     </h3>
     <p>Open-source monitoring and analytics</p>
 </Card>

--- a/docs/docs/third-party-integrations/observability-and-monitoring/grafana.md
+++ b/docs/docs/third-party-integrations/observability-and-monitoring/grafana.md
@@ -61,8 +61,6 @@ Annotations for feature-specific events include project tags, user-defined tags,
 
 You can create multiple alert rules pointing to the Feature Health Provider webhook. Ensure they include the `flagsmith_feature` label with a feature flag name from the project you created the Feature Health Provider for, to see Feature Health status changes for your feature flags.
 
-You can integrate Grafana Feature Health with Prometheus Alertmanager. For detailed instructions on adding Flagsmith labels to your alerts in Prometheus, refer to the [Prometheus Alertmanager webhook configuration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [Alerting rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/#defining-alerting-rules) documentation.
-
 The Feature Health UI will display the following information:
 - Alert name
 - Link to the alert instance in your Alertmanager

--- a/docs/docs/third-party-integrations/observability-and-monitoring/grafana.md
+++ b/docs/docs/third-party-integrations/observability-and-monitoring/grafana.md
@@ -1,7 +1,7 @@
 ---
-title: Grafana & Prometheus Integration
-description: Integrate Flagsmith with Grafana & Prometheus
-sidebar_label: Grafana & Prometheus
+title: Grafana Integration
+description: Integrate Flagsmith with Grafana
+sidebar_label: Grafana
 hide_title: true
 ---
 

--- a/docs/docs/third-party-integrations/observability-and-monitoring/prometheus.md
+++ b/docs/docs/third-party-integrations/observability-and-monitoring/prometheus.md
@@ -5,7 +5,7 @@ sidebar_label: Prometheus
 hide_title: true
 ---
 
-Integrate Flagsmith with Prometheus Alertmanager to drive [Feature Health](/advanced-use/feature-health) status from your existing alerts.
+Integrate Flagsmith with Prometheus Alertmanager to drive [Feature Health](/managing-flags/feature-health-metrics) status from your existing alerts.
 
 ## Feature Health Provider Setup
 

--- a/docs/docs/third-party-integrations/observability-and-monitoring/prometheus.md
+++ b/docs/docs/third-party-integrations/observability-and-monitoring/prometheus.md
@@ -1,0 +1,61 @@
+---
+title: Prometheus Integration
+description: Integrate Flagsmith with Prometheus Alertmanager
+sidebar_label: Prometheus
+hide_title: true
+---
+
+Integrate Flagsmith with Prometheus Alertmanager to drive [Feature Health](/advanced-use/feature-health) status from your existing alerts.
+
+## Feature Health Provider Setup
+
+### In Flagsmith
+
+1. Go to Project Settings > Feature Health.
+2. Select "Grafana" from the Provider Name drop-down menu.
+3. Click Create and copy the Webhook URL.
+
+:::note
+
+The Feature Health webhook accepts the Alertmanager payload format, so "Grafana" is the right choice here whether you're sending alerts via Grafana or directly from Prometheus Alertmanager.
+
+:::
+
+### In Alertmanager
+
+Add a webhook receiver pointing at the Flagsmith Webhook URL, and ensure your alert rules carry the `flagsmith_feature` label (and optionally `flagsmith_environment`).
+
+```yaml
+# alertmanager.yml
+receivers:
+  - name: flagsmith-feature-health
+    webhook_configs:
+      - url: <FLAGSMITH_WEBHOOK_URL>
+        send_resolved: true
+```
+
+```yaml
+# example alert rule
+groups:
+  - name: flagsmith-feature-health
+    rules:
+      - alert: HighErrorRate
+        expr: ...
+        labels:
+          flagsmith_feature: my_feature_name
+          flagsmith_environment: production
+        annotations:
+          summary: ...
+          description: ...
+          runbook_url: ...
+```
+
+Refer to the [Alertmanager webhook configuration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [Alerting rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/#defining-alerting-rules) documentation for full details.
+
+## What the Feature Health UI displays
+
+- Alert name
+- Link to the alert instance in Alertmanager
+- Alert description (if provided in annotations)
+- Alert summary (if provided in annotations)
+- Runbook URL (if provided in annotations)


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Resolves #7608

Splits the combined Grafana & Prometheus integration page into two sibling pages so that users searching for a Flagsmith Prometheus integration land on a page dedicated to that workflow.

No backend or frontend code changes; the webhook handler is already format-compatible with Alertmanager payloads.

## How did you test this code?

Reviewed Vercel preview deploy from this PR to verify.