### PR TITLE
perf(Segment Membership): Members list improvements

### DIFF
--- a/api/segment_membership/services.py
+++ b/api/segment_membership/services.py
@@ -129,7 +129,8 @@ def compute_segment_counts_for_project(
             f"SELECT {seg.id} AS segment_id, "
             f"i.environment_id AS env_key, count() AS c "
             f"FROM IDENTITIES AS i FINAL "
-            f"WHERE i.environment_id IN %(env_keys)s AND ({predicate}) "
+            f"WHERE i.environment_id IN %(env_keys)s "
+            f"AND i.is_deleted = false AND ({predicate}) "
             f"GROUP BY i.environment_id"
         )
 
@@ -186,7 +187,10 @@ def get_segment_members_page(
         )
         return []
 
-    conditions = ["i.environment_id = %(env_key)s"]
+    conditions = [
+        "i.environment_id = %(env_key)s",
+        "i.is_deleted = false",
+    ]
     params: dict[str, Any] = {"env_key": environment.api_key, "limit": limit}
     if cursor:
         conditions.append("i.identifier > %(cursor)s")
@@ -196,12 +200,28 @@ def get_segment_members_page(
         params["q"] = q
     conditions.append(f"({predicate})")
 
-    sql = (
-        "SELECT i.identifier, i.identity_key, i.traits "
-        "FROM IDENTITIES AS i FINAL "
+    # Why two queries? `traits` is a wide JSON column split over many per-path files.
+    # That fans out into thousands of object-storage requests, which is what
+    # makes a cold read slow. Delegating the `traits` read to an outer query
+    # limits them to the page.
+    #
+    # Besides that, bypass FINAL, which is heavy, in favour of LIMIT 1 BY i.identifier,
+    # which is (tolerably) less correct but substantially faster.
+    inner_sql = (
+        "SELECT i.identifier "
+        "FROM IDENTITIES AS i "
         f"WHERE {' AND '.join(conditions)} "
-        "ORDER BY i.identifier ASC "
+        "ORDER BY i.identifier ASC, i.inserted_at DESC "
+        "LIMIT 1 BY i.identifier "
         "LIMIT %(limit)s"
+    )
+    sql = (
+        "SELECT m.identifier, m.identity_key, m.traits "
+        "FROM IDENTITIES AS m "
+        "WHERE m.environment_id = %(env_key)s AND m.is_deleted = false "
+        f"AND m.identifier IN ({inner_sql}) "
+        "ORDER BY m.identifier ASC, m.inserted_at DESC "
+        "LIMIT 1 BY m.identifier"
     )
     log_comment = (
         "flagsmith:segment_membership:read"

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
 from common.test_tools import RunTasksFixture
+from django.db import connections
 from flag_engine.segments.constants import EQUAL
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
@@ -184,6 +186,96 @@ def matching_segment(segment: Segment) -> Segment:
     rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
     Condition.objects.create(rule=rule, property="foo", operator=EQUAL, value="bar")
     return segment
+
+
+@pytest.mark.clickhouse
+def test_get_segment_members_page__deleted_identity__excluded(
+    segment_membership_identities: None,
+    matching_segment: Segment,
+    environment: Environment,
+    environment_api_key_str: str,
+) -> None:
+    # Given
+    with connections["clickhouse"].cursor() as cursor:
+        cursor.executemany(
+            "INSERT INTO IDENTITIES "
+            "(environment_id, identifier, identity_key, traits, is_deleted) VALUES",
+            [(environment_api_key_str, "aaron", "aaron_key", {"foo": "bar"}, True)],  # type: ignore[list-item]
+        )
+
+    # When
+    members = get_segment_members_page(
+        matching_segment, environment, cursor=None, limit=100
+    )
+
+    # Then
+    assert [member["identifier"] for member in members] == ["alice", "bob"]
+
+
+@pytest.mark.clickhouse
+def test_get_segment_members_page__duplicate_versions__returns_latest_once(
+    segment_membership_identities: None,
+    matching_segment: Segment,
+    environment: Environment,
+    environment_api_key_str: str,
+) -> None:
+    # Given
+    # a newer version of alice that still matches the segment
+    with connections["clickhouse"].cursor() as cursor:
+        cursor.executemany(
+            "INSERT INTO IDENTITIES "
+            "(environment_id, identifier, identity_key, traits, inserted_at) VALUES",
+            [
+                (  # type: ignore[list-item]
+                    environment_api_key_str,
+                    "alice",
+                    "alice_key",
+                    {"foo": "bar", "version": "new"},
+                    datetime(2099, 1, 1),
+                )
+            ],
+        )
+
+    # When
+    members = get_segment_members_page(
+        matching_segment, environment, cursor=None, limit=100
+    )
+
+    # Then
+    # alice appears once, with the latest version's traits
+    assert members == [
+        SegmentMember(
+            identifier="alice",
+            identity_key="alice_key",
+            traits={"foo": "bar", "version": "new"},
+        ),
+        SegmentMember(identifier="bob", identity_key="bob_key", traits={"foo": "bar"}),
+    ]
+
+
+@pytest.mark.clickhouse
+def test_compute_segment_counts_for_project__deleted_identity__excluded_from_count(
+    segment_membership_identities: None,
+    matching_segment: Segment,
+    project: Project,
+    environment_api_key_str: str,
+) -> None:
+    # Given
+    with connections["clickhouse"].cursor() as cursor:
+        cursor.executemany(
+            "INSERT INTO IDENTITIES "
+            "(environment_id, identifier, identity_key, traits, is_deleted) VALUES",
+            [(environment_api_key_str, "aaron", "aaron_key", {"foo": "bar"}, True)],  # type: ignore[list-item]
+        )
+
+    # When
+    with connections["clickhouse"].cursor() as cursor:
+        counts = compute_segment_counts_for_project(project, cursor)
+
+    # Then
+    assert len(counts) == 1
+    assert counts[0].segment_id == matching_segment.id
+    assert counts[0].count == 2
 
 
 @pytest.mark.clickhouse

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -379,7 +379,7 @@ Attributes:
 ### `segment_membership.members.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:182`
+ - `api/segment_membership/services.py:183`
 
 Attributes:
  - `reason`


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7593.

In this PR, we make two changes to the Segment Membership read path:

1. Drop `FINAL` in the list query. Adopt a two-stage `LIMIT 1 BY identifier` dedup and limit trait reads to a page.
2. Filter `is_deleted = false` in both read queries. Neither excluded soft-deleted identities before, so deleted identities appeared in the members list and were counted. 

## How did you test this code?

Added new unit tests.

Verified the queries against production. A 52k-identity environment, default first page (no search term), `LIMIT 11`, returning 11 rows:

| Query shape | Warm latency | Warm bytes | Cold | Cold S3 GETs |
| --- | --- | --- | --- | --- |
| `FINAL` (before) | 2.7–4.2s | ~370 MB | 7.3s | 6,211 |
| No `FINAL` | 0.12s | 22 MB | 1.5s | 816 |
| Single-stage `LIMIT 1 BY` | 0.13–0.22s | 160 MB | 1.8s | 1,601 |
| Two-stage `LIMIT 1 BY` (this PR) | ~0.10s | 43 MB | 1.9s | 1,602 |
