### PR TITLE
fix: make Headway bell icon clickable

### DIFF
--- a/frontend/web/components/Headway.js
+++ b/frontend/web/components/Headway.js
@@ -34,13 +34,15 @@ class _Headway extends React.Component {
       <Tooltip
         place='bottom'
         title={
-          <Row
-            onClick={() => {
-              Headway.show()
-            }}
-            className={this.props.className}
-          >
-            <Icon name='bell' width={20} fill='#9DA4AE' />
+          <Row onClick={() => Headway.show()} className={this.props.className}>
+            <span
+              onClick={(e) => {
+                e.stopPropagation()
+                Headway.show()
+              }}
+            >
+              <Icon name='bell' width={20} fill='#9DA4AE' />
+            </span>
             <span id='headway'>
               <span />
             </span>


### PR DESCRIPTION
The bell icon wasn't triggering Headway.show() because clicks weren't being captured. Added onClick handler to the icon wrapper span with stopPropagation to prevent double-firing from event bubbling.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes headway click target 

## How did you test this code?

Clicked bell icon