### PR TITLE
fix: add navigation to identity page from segment members list

### DIFF
--- a/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
+++ b/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
@@ -176,6 +176,7 @@ const CreateSegmentUsersTabContent: React.FC<
               projectId={projectId}
               segmentId={segmentId}
               environmentId={selectedEnv.id}
+              environmentApiKey={selectedEnv.api_key}
               count={selectedMembership?.count}
             />
           ) : (

--- a/frontend/web/components/modals/SegmentMembersList.tsx
+++ b/frontend/web/components/modals/SegmentMembersList.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import PanelSearch from 'components/PanelSearch'
 import Utils from 'common/utils/utils'
 import useDebouncedSearch from 'common/useDebouncedSearch'
@@ -11,6 +12,7 @@ type SegmentMembersListProps = {
   projectId: string | number
   segmentId: number
   environmentId: number
+  environmentApiKey: string
   // Total members for the selected environment, from the segment's
   // membership_counts. The list endpoint is cursor-paginated and returns no
   // count, so this drives the title total rather than the pager.
@@ -24,6 +26,7 @@ type SegmentMembersListProps = {
 // response carries the `next`/`previous` flags (via `transformCursorPaging`).
 const SegmentMembersList: FC<SegmentMembersListProps> = ({
   count,
+  environmentApiKey,
   environmentId,
   projectId,
   segmentId,
@@ -74,14 +77,15 @@ const SegmentMembersList: FC<SegmentMembersListProps> = ({
         // Cursor pagination cannot jump to an arbitrary page.
       }}
       renderRow={({ identifier }: SegmentMember, index: number) => (
-        <Row
-          className='list-item list-item-sm clickable'
+        <Link
+          to={`/project/${projectId}/environment/${environmentApiKey}/identities/${encodeURIComponent(
+            identifier,
+          )}`}
+          className='list-item list-item-sm clickable d-flex align-items-center px-3'
           data-test={`segment-member-${index}`}
         >
-          <Row space className='px-3'>
-            <div className='font-weight-medium'>{identifier}</div>
-          </Row>
-        </Row>
+          <div className='font-weight-medium'>{identifier}</div>
+        </Link>
       )}
       filterRow={() => true}
       search={searchInput}


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes a url link in the segment identities page.

## How did you test this code?

Visit a segment and click on the identities tab, click one of the rows