### PR TITLE
fix(experimentation): rebuild environment document on rollout change

### DIFF
--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -623,8 +623,11 @@ def _update_rollout_in_place(experiment: Experiment, change_set: FlagChangeSet) 
         override := _get_live_rollout_override(experiment)
     ):
         _update_live_feature_state(override, change_set)
-        rebuild_environment_document.delay(
-            kwargs={"environment_id": experiment.environment_id}
+        environment_id = experiment.environment_id
+        transaction.on_commit(
+            lambda env_id=environment_id: rebuild_environment_document.delay(
+                kwargs={"environment_id": env_id}
+            )
         )
         return
     update_flag(experiment.environment, experiment.feature, change_set)

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -612,9 +612,9 @@ def _update_rollout_in_place(experiment: Experiment, change_set: FlagChangeSet) 
     state on every call. Since the multivariate split is salted on the feature
     state id, that would re-randomise control/variant for already-enrolled
     identities on each rollout update. Once the override exists, mutate it in
-    place instead and rebuild the environment document by hand (no version is
-    published). Creating the override, and v1 versioning, still go through
-    ``update_flag``, which already reuses the feature state.
+    place instead (no version is published). Creating the override, and v1
+    versioning, still go through ``update_flag``, which already reuses the
+    feature state.
 
     This is a temporary solution until we find a permanent fix for the
     underlying salting issue: https://github.com/Flagsmith/flagsmith/issues/7913
@@ -623,12 +623,6 @@ def _update_rollout_in_place(experiment: Experiment, change_set: FlagChangeSet) 
         override := _get_live_rollout_override(experiment)
     ):
         _update_live_feature_state(override, change_set)
-        environment_id = experiment.environment_id
-        transaction.on_commit(
-            lambda env_id=environment_id: rebuild_environment_document.delay(
-                kwargs={"environment_id": env_id}
-            )
-        )
         return
     update_flag(experiment.environment, experiment.feature, change_set)
 
@@ -639,6 +633,7 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
             f"Cannot change the rollout of a {experiment.status} experiment."
         )
     validate_rollout_spec(experiment, spec)
+    environment_id = experiment.environment_id
     with transaction.atomic():
         segment = _sync_rollout_segment(experiment, spec.rollout_percentage)
         _update_rollout_in_place(
@@ -651,6 +646,12 @@ def apply_experiment_rollout(experiment: Experiment, spec: RolloutSpec) -> None:
                 segment_id=segment.id,
                 multivariate_values=spec.multivariate_values,
             ),
+        )
+        # Segment condition changes don't trigger a rebuild on their own.
+        transaction.on_commit(
+            lambda: rebuild_environment_document.delay(
+                kwargs={"environment_id": environment_id}
+            )
         )
 
 

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 import pytest
 from django.db.models import Q
@@ -43,6 +44,7 @@ from features.value_types import STRING
 from features.versioning.dataclasses import MultivariateValueChangeSet
 from segments.models import Condition
 from users.models import FFAdminUser
+from util.mappers import map_environment_to_environment_document
 
 
 def test_get_clickhouse_client__configured_url__builds_client_with_timeouts(
@@ -1506,6 +1508,129 @@ def test_apply_experiment_rollout__update_flag_fails__rolls_back(
         rule__segment=experiment.rollout_segment, operator=PERCENTAGE_SPLIT
     )
     assert condition.value == "20.0"
+
+
+def _rollout_percentage_in_written_document(
+    mock_dynamo_env_wrapper: MagicMock,
+) -> str | None:
+    environments = mock_dynamo_env_wrapper.write_environments.call_args[0][0]
+    document = map_environment_to_environment_document(list(environments)[0])
+
+    values: list[str] = []
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            if node.get("operator") == PERCENTAGE_SPLIT:
+                values.append(node.get("value"))  # type: ignore[arg-type]
+            for child in node.values():
+                _walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                _walk(child)
+
+    _walk(document)
+    return values[0] if values else None
+
+
+def test_apply_experiment_rollout__update_under_v2__rebuilds_environment_document(  # type: ignore[no-untyped-def]
+    environment_v2_versioning: Environment,
+    multivariate_feature: Feature,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+    mocker: MockerFixture,
+    django_capture_on_commit_callbacks,
+) -> None:
+    # Given
+    mock_dynamo_env_wrapper = mocker.patch("environments.models.environment_wrapper")
+    environment = environment_v2_versioning
+    environment.project.enable_dynamo_db = True
+    environment.project.save()
+
+    option_a, option_b, _ = multivariate_options
+    experiment = Experiment.objects.create(
+        environment=environment,
+        feature=multivariate_feature,
+        name="exp",
+        hypothesis="h",
+        status=ExperimentStatus.RUNNING,
+    )
+
+    def _spec(rollout_percentage: float) -> RolloutSpec:
+        return RolloutSpec(
+            enabled=True,
+            rollout_percentage=rollout_percentage,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 50.0),
+                MultivariateValueChangeSet(option_b.id, 50.0),
+            ],
+            author=AuthorData(user=admin_user),
+        )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        services.apply_experiment_rollout(experiment, _spec(20.0))
+    experiment.refresh_from_db()
+
+    assert _rollout_percentage_in_written_document(mock_dynamo_env_wrapper) == "20.0"
+
+    # When
+    mock_dynamo_env_wrapper.reset_mock()
+    with django_capture_on_commit_callbacks(execute=True):
+        services.apply_experiment_rollout(experiment, _spec(15.0))
+
+    # Then
+    assert mock_dynamo_env_wrapper.write_environments.called
+    assert _rollout_percentage_in_written_document(mock_dynamo_env_wrapper) == "15.0"
+
+
+def test_apply_experiment_rollout__update_under_v1__rebuilds_environment_document(  # type: ignore[no-untyped-def]
+    environment: Environment,
+    multivariate_feature: Feature,
+    multivariate_options: list[MultivariateFeatureOption],
+    admin_user: FFAdminUser,
+    mocker: MockerFixture,
+    django_capture_on_commit_callbacks,
+) -> None:
+    # Given
+    mock_dynamo_env_wrapper = mocker.patch("environments.models.environment_wrapper")
+    environment.project.enable_dynamo_db = True
+    environment.project.save()
+
+    option_a, option_b, _ = multivariate_options
+    experiment = Experiment.objects.create(
+        environment=environment,
+        feature=multivariate_feature,
+        name="exp",
+        hypothesis="h",
+        status=ExperimentStatus.RUNNING,
+    )
+
+    def _spec(rollout_percentage: float) -> RolloutSpec:
+        return RolloutSpec(
+            enabled=True,
+            rollout_percentage=rollout_percentage,
+            feature_state_value="control",
+            value_type="string",
+            multivariate_values=[
+                MultivariateValueChangeSet(option_a.id, 50.0),
+                MultivariateValueChangeSet(option_b.id, 50.0),
+            ],
+            author=AuthorData(user=admin_user),
+        )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        services.apply_experiment_rollout(experiment, _spec(20.0))
+    experiment.refresh_from_db()
+
+    # When
+    mock_dynamo_env_wrapper.reset_mock()
+    with django_capture_on_commit_callbacks(execute=True):
+        services.apply_experiment_rollout(experiment, _spec(15.0))
+
+    # Then
+    assert mock_dynamo_env_wrapper.write_environments.called
+    assert _rollout_percentage_in_written_document(mock_dynamo_env_wrapper) == "15.0"
 
 
 def test_get_experiment_rollout__rollout_exists__returns_representation(

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -494,7 +494,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:738`
+ - `api/experimentation/services.py:745`
 
 Attributes:
  - `environment.id`
@@ -503,7 +503,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:718`
+ - `api/experimentation/services.py:725`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -494,7 +494,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:745`
+ - `api/experimentation/services.py:742`
 
 Attributes:
  - `environment.id`
@@ -503,7 +503,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:725`
+ - `api/experimentation/services.py:722`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION
- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Experiment rollout updates were not refreshing the Edge/DynamoDB environment document. Postgres got the new percentage; Edge kept serving the stale one until a manual backoffice rebuild.

**Root cause:** The rollout percentage lives on the segment `Condition` (`PERCENTAGE_SPLIT`), which skips audit log creation. On v1 environments, a percentage-only update re-saves an unchanged feature state — no audit log, no `process_environment_update`, no rebuild.

**Fix:** Dispatch `rebuild_environment_document` unconditionally in `apply_experiment_rollout` via `transaction.on_commit`.

## How did you test this code?

- Added v1 and v2 regression tests for the rebuild dispatch — test failing on main confirming the root cause.
- All 10 `apply_experiment_rollout` tests pass.