### PR TITLE
feat(Flagsmith-on-Flagsmith): Send organisation trait to Flagsmith on identify

### DIFF
--- a/frontend/web/project/api.ts
+++ b/frontend/web/project/api.ts
@@ -134,9 +134,15 @@ const API = {
     const user = AccountStore.model as unknown as AccountModel
     if (!user) return
 
+    const currentOrganisation = AccountStore.getOrganisation()
+
     return flagsmith
       .identify(`${user.id}`, {
         email: user.email,
+        'organisation.id': currentOrganisation
+          ? String(currentOrganisation.id)
+          : null,
+        'organisation.name': currentOrganisation?.name ?? null,
         organisations: user.organisations
           ? user.organisations.map((o) => String(o.id)).join(',')
           : '',


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The dashboard's Flagsmith-on-Flagsmith identify call only sent an `organisations` trait: a comma-joined list of org IDs. That makes single-org targeting awkward — you can't do an exact-equals match on one org, only a `contains` on the list, which risks substring collisions (`12` matches `123`), and there was no way to target by org name at all.

This adds two singular traits to the identify payload so segments can target a single organisation cleanly:

- `organisation.id` — the currently selected organisation's ID (`null` when none is selected)
- `organisation.name` — the currently selected organisation's name (`null` when none is selected)

The keys match the backend's `openfeature_evaluation_context` (`api/organisations/models.py`) so segment rules can be written identically on either side.

`organisations` (plural, list of IDs) is left as-is.

## How did you test this code?

Manually:

1. Log in to the dashboard.
2. In the Flagsmith-on-Flagsmith project, open the identity for your user (identifier is your user ID).
3. Confirm the identity now carries `organisation.id` (current org ID) and `organisation.name` (current org name) traits alongside the existing `organisations` list.
4. Create a segment rule on `organisation.id` equals your org ID and confirm it matches.
