### PR TITLE
feat(Segment Membership): Recount after identity delete

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1484,6 +1484,12 @@ SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS = env.int(
     "SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS", default=6
 )
 
+# Edge CDC writes the `is_deleted` tombstone to ClickHouse asynchronously; delay
+# the post-delete recount by this long so it reads state after the tombstone lands.
+SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS = env.int(
+    "SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS", default=120
+)
+
 # Always installed: the router fences the `clickhouse` app's migrations off
 # the default Postgres database whether or not a CH alias is configured.
 DATABASE_ROUTERS.append("app.routers.ClickHouseRouter")

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1483,9 +1483,6 @@ CLICKHOUSE_ENABLED = bool(CLICKHOUSE_URL or CLICKHOUSE_HOST)
 SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS = env.int(
     "SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS", default=6
 )
-
-# Edge CDC writes the `is_deleted` tombstone to ClickHouse asynchronously; delay
-# the post-delete recount by this long so it reads state after the tombstone lands.
 SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS = env.int(
     "SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS", default=120
 )

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1484,7 +1484,8 @@ SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS = env.int(
     "SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS", default=6
 )
 SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS = env.int(
-    "SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS", default=120
+    "SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS",
+    default=120,  # We can expect the identity deletion to propagate by T+120 seconds based on Edge CDC SLO.
 )
 
 # Always installed: the router fences the `clickhouse` app's migrations off

--- a/api/edge_api/identities/models.py
+++ b/api/edge_api/identities/models.py
@@ -1,8 +1,11 @@
 import copy
 import typing
 from contextlib import suppress
+from datetime import timedelta
 
+from django.conf import settings
 from django.db.models import Prefetch, Q
+from django.utils import timezone
 
 from api_keys.user import APIKeyUser
 from edge_api.identities.tasks import (
@@ -194,6 +197,19 @@ class EdgeIdentity:
             user=user,
         )
         self._reset_initial_state()  # type: ignore[no-untyped-call]
+
+        if settings.CLICKHOUSE_ENABLED:
+            from segment_membership.services import enqueue_membership_refresh
+
+            enqueue_membership_refresh(
+                self.environment.project,
+                delay_until=(
+                    timezone.now()
+                    + timedelta(
+                        seconds=settings.SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS
+                    )
+                ),
+            )
 
     def synchronise_features(self, valid_feature_names: typing.Collection[str]) -> None:
         identity_feature_names = {

--- a/api/segment_membership/services.py
+++ b/api/segment_membership/services.py
@@ -5,6 +5,7 @@ from typing import Any, Iterator
 import structlog
 from django.db import connections
 from django.db.backends.utils import CursorWrapper
+from django.db.models import Q
 from flag_engine.context.types import EvaluationContext
 from flagsmith_sql_flag_engine import TranslateContext, translate_segment
 from flagsmith_sql_flag_engine.dialects import ClickHouseDialect
@@ -39,22 +40,29 @@ def enqueue_membership_refresh(
 ) -> None:
     """Queue a per-project segment membership count refresh.
 
-    Pass `delay_until` to schedule the refresh for a future time.
+    Pass `delay_until` to schedule the refresh for a future time, e.g. to let an
+    Edge CDC tombstone land in ClickHouse before recounting.
 
-    No-op when the org has the feature off, or when a refresh for the project
-    is already pending or running.
+    No-op when the org has the feature off, or when a refresh for the project is
+    already pending. A pending refresh scheduled sooner than `delay_until` is
+    pushed out to it.
     """
     if not is_membership_enabled(project.organisation):
         return
 
     from segment_membership.tasks import refresh_project_segment_counts
 
-    if Task.objects.filter(
+    pending = Task.objects.filter(
         task_identifier=refresh_project_segment_counts.task_identifier,
         completed=False,
         num_failures__lt=3,
         serialized_args=Task.serialize_data((project.id,)),
-    ).exists():
+    )
+    if pending.exists():
+        if delay_until is not None:
+            pending.filter(
+                Q(scheduled_for__isnull=True) | Q(scheduled_for__lt=delay_until),
+            ).update(scheduled_for=delay_until)
         return
 
     refresh_project_segment_counts.delay(

--- a/api/segment_membership/services.py
+++ b/api/segment_membership/services.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime
 from typing import Any, Iterator
 
 import structlog
@@ -31,9 +32,14 @@ def is_membership_enabled(organisation: Organisation) -> bool:
     )
 
 
-def enqueue_membership_refresh(project: Project) -> None:
-    """Queue a per-project segment membership count refresh after a canonical
-    segment is created or edited.
+def enqueue_membership_refresh(
+    project: Project,
+    *,
+    delay_until: datetime | None = None,
+) -> None:
+    """Queue a per-project segment membership count refresh.
+
+    Pass `delay_until` to schedule the refresh for a future time.
 
     No-op when the org has the feature off, or when a refresh for the project
     is already pending or running.
@@ -51,7 +57,10 @@ def enqueue_membership_refresh(project: Project) -> None:
     ).exists():
         return
 
-    refresh_project_segment_counts.delay(args=(project.id,))
+    refresh_project_segment_counts.delay(
+        args=(project.id,),
+        delay_until=delay_until,
+    )
 
 
 @contextmanager

--- a/api/tests/integration/segment_membership/test_segment_membership_clickhouse.py
+++ b/api/tests/integration/segment_membership/test_segment_membership_clickhouse.py
@@ -119,7 +119,7 @@ def test_seed_organisation_identities__happy_path__rows_land_in_clickhouse(
         rows = cursor.fetchall()
     assert [(row[0], row[1]) for row in rows] == [("a", "k1"), ("b", "k2")]
     # and the project's count refresh is dispatched
-    refresh_dispatch.delay.assert_called_once_with(args=(project,))
+    refresh_dispatch.delay.assert_called_once_with(args=(project,), delay_until=None)
     assert any(
         e["event"] == "seed.environment.completed" and e["rows__count"] == 2
         for e in log.events

--- a/api/tests/unit/edge_api/identities/test_edge_identity_models.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_models.py
@@ -6,8 +6,10 @@ import shortuuid
 from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django import DjangoAssertNumQueries
+from pytest_django.fixtures import SettingsWrapper
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
+from task_processor.task_run_method import TaskRunMethod
 
 from api_keys.user import APIKeyUser
 from edge_api.identities.models import EdgeIdentity
@@ -15,7 +17,9 @@ from environments.models import Environment
 from features.models import Feature, FeatureSegment, FeatureState
 from features.versioning.tasks import enable_v2_versioning
 from features.workflows.core.models import ChangeRequest
+from projects.models import Project
 from segments.models import Segment
+from tests.types import EnableFeaturesFixture
 from users.models import FFAdminUser
 from util.engine_models.features.models import FeatureModel, FeatureStateModel
 
@@ -549,3 +553,72 @@ def test_get_all_feature_states__post_v2_versioning_migration__returns_latest_ov
     # Then
     assert len(feature_states) == 1
     assert feature_states[0] == v2_segment_override
+
+
+def test_delete__clickhouse_enabled__schedules_delayed_recount(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    project: Project,
+    environment: Environment,
+    edge_identity_model: EdgeIdentity,
+    edge_identity_dynamo_wrapper_mock: MagicMock,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
+    settings.SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS = 120
+    enqueue_membership_refresh_mock = mocker.patch(
+        "segment_membership.services.enqueue_membership_refresh"
+    )
+
+    # When
+    with freeze_time("2099-01-01T00:00:00Z"):
+        edge_identity_model.delete(user=mocker.MagicMock())
+        expected_delay_until = timezone.now() + timedelta(seconds=120)
+
+    # Then
+    enqueue_membership_refresh_mock.assert_called_once_with(
+        project, delay_until=expected_delay_until
+    )
+
+
+def test_delete__clickhouse_disabled__does_not_schedule_recount(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    edge_identity_model: EdgeIdentity,
+    edge_identity_dynamo_wrapper_mock: MagicMock,
+) -> None:
+    # Given
+    settings.CLICKHOUSE_ENABLED = False
+    enqueue_membership_refresh_mock = mocker.patch(
+        "segment_membership.services.enqueue_membership_refresh"
+    )
+
+    # When
+    edge_identity_model.delete(user=mocker.MagicMock())
+
+    # Then
+    enqueue_membership_refresh_mock.assert_not_called()
+
+
+def test_delete__membership_flag_off__does_not_enqueue_refresh(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    edge_identity_model: EdgeIdentity,
+    edge_identity_dynamo_wrapper_mock: MagicMock,
+) -> None:
+    # Given
+    settings.CLICKHOUSE_ENABLED = True
+    settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
+    refresh_mock = mocker.patch(
+        "segment_membership.tasks.refresh_project_segment_counts"
+    )
+    refresh_mock.task_identifier = "segment_membership.refresh_project_segment_counts"
+
+    # When
+    edge_identity_model.delete(user=mocker.MagicMock())
+
+    # Then
+    refresh_mock.delay.assert_not_called()

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -1,12 +1,15 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
 from common.test_tools import RunTasksFixture
 from django.db import connections
+from django.utils import timezone
 from flag_engine.segments.constants import EQUAL
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
+from task_processor.models import Task
+from task_processor.task_run_method import TaskRunMethod
 
 from environments.models import Environment
 from organisations.models import Organisation
@@ -544,3 +547,76 @@ def test_enqueue_membership_refresh__delay_until__forwards_delay_to_task(
     refresh_mock.delay.assert_called_once_with(
         args=(project.id,), delay_until=delay_until
     )
+
+
+def test_enqueue_membership_refresh__pending_scheduled_sooner__reschedules_to_delay_until(
+    settings: SettingsWrapper,
+    project: Project,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
+    sooner = timezone.now()
+    later = sooner + timedelta(seconds=120)
+    refresh_project_segment_counts.delay(args=(project.id,), delay_until=sooner)
+
+    # When
+    enqueue_membership_refresh(project, delay_until=later)
+
+    # Then
+    # the pending task is pushed out rather than a second one being enqueued
+    task = Task.objects.get(
+        task_identifier=refresh_project_segment_counts.task_identifier,
+        serialized_args=Task.serialize_data((project.id,)),
+    )
+    assert task.scheduled_for == later
+
+
+def test_enqueue_membership_refresh__pending_scheduled_later__leaves_schedule(
+    settings: SettingsWrapper,
+    project: Project,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
+    later = timezone.now() + timedelta(hours=1)
+    refresh_project_segment_counts.delay(args=(project.id,), delay_until=later)
+
+    # When
+    enqueue_membership_refresh(
+        project, delay_until=timezone.now() + timedelta(seconds=120)
+    )
+
+    # Then
+    task = Task.objects.get(
+        task_identifier=refresh_project_segment_counts.task_identifier,
+        serialized_args=Task.serialize_data((project.id,)),
+    )
+    assert task.scheduled_for == later
+
+
+def test_enqueue_membership_refresh__pending_and_no_delay__leaves_schedule(
+    settings: SettingsWrapper,
+    project: Project,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
+    scheduled = timezone.now() + timedelta(seconds=120)
+    refresh_project_segment_counts.delay(args=(project.id,), delay_until=scheduled)
+
+    # When
+    enqueue_membership_refresh(project, delay_until=None)
+
+    # Then
+    task = Task.objects.get(
+        task_identifier=refresh_project_segment_counts.task_identifier,
+        serialized_args=Task.serialize_data((project.id,)),
+    )
+    assert task.scheduled_for == scheduled

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -520,3 +520,27 @@ def test_enqueue_membership_refresh__pending_for_other_project__still_enqueues(
         [mocker.call(project, mocker.ANY), mocker.call(project_b, mocker.ANY)],
         any_order=True,
     )
+
+
+def test_enqueue_membership_refresh__delay_until__forwards_delay_to_task(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    project: Project,
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    enable_features("segment_membership_inspection")
+    settings.CLICKHOUSE_ENABLED = True
+    refresh_mock = mocker.patch(
+        "segment_membership.tasks.refresh_project_segment_counts"
+    )
+    refresh_mock.task_identifier = "segment_membership.refresh_project_segment_counts"
+    delay_until = datetime(2099, 1, 1)
+
+    # When
+    enqueue_membership_refresh(project, delay_until=delay_until)
+
+    # Then
+    refresh_mock.delay.assert_called_once_with(
+        args=(project.id,), delay_until=delay_until
+    )

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -369,7 +369,7 @@ Attributes:
 ### `segment_membership.compute.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:130`
+ - `api/segment_membership/services.py:138`
 
 Attributes:
  - `project.id`
@@ -379,7 +379,7 @@ Attributes:
 ### `segment_membership.members.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:192`
+ - `api/segment_membership/services.py:200`
 
 Attributes:
  - `reason`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -369,7 +369,7 @@ Attributes:
 ### `segment_membership.compute.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:121`
+ - `api/segment_membership/services.py:130`
 
 Attributes:
  - `project.id`
@@ -379,7 +379,7 @@ Attributes:
 ### `segment_membership.members.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:183`
+ - `api/segment_membership/services.py:192`
 
 Attributes:
  - `reason`


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7593.

In this PR, we trigger segment count refresh when an identity is deleted in UI.

## How did you test this code?

Added unit tests. Will test E2E in staging.
