### PR TITLE
fix(api): handle non-object payloads in edge identity update-traits

### DIFF
--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -176,8 +176,20 @@ class EdgeIdentityViewSet(
         if not environment.project.organisation.persist_trait_data:
             raise TraitPersistenceError()
         edge_identity = self.get_object()
+        # `pyngo.drf_error_details` assumes every pydantic error has a non-empty
+        # `loc`, which isn't true when the payload itself isn't an object (e.g. a
+        # JSON array), so that case is rejected here before it ever reaches
+        # `TraitModel.model_validate`/`drf_error_details`.
+        if not isinstance(request.data, typing.Mapping):
+            raise ValidationError(
+                {
+                    "non_field_errors": [
+                        "Expected an object with trait_key and trait_value."
+                    ]
+                }
+            )
         try:
-            trait = TraitModel(**request.data)
+            trait = TraitModel.model_validate(request.data)
         except pydantic.ValidationError as validation_error:
             raise ValidationError(
                 drf_error_details(validation_error)

--- a/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
@@ -696,3 +696,32 @@ def test_edge_identities_update_trait__persist_trait_data_disabled__returns_400(
     )
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_edge_identities_update_trait__malformed_traits_payload__returns_400(  # type: ignore[no-untyped-def]
+    admin_client,
+    dynamo_enabled_environment,
+    environment_api_key,
+    identity_document,
+    edge_identity_dynamo_wrapper_mock,
+):
+    # Given
+    edge_identity_dynamo_wrapper_mock.get_item_from_uuid_or_404.return_value = (
+        identity_document
+    )
+    identity_uuid = identity_document["identity_uuid"]
+    url = reverse(
+        "api-v1:environments:environment-edge-identities-update-traits",
+        args=[environment_api_key, identity_uuid],
+    )
+    # A JSON array instead of the expected object.
+    data = [{"trait_key": "some_key", "trait_value": "some_value"}]
+
+    # When
+    response = admin_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    edge_identity_dynamo_wrapper_mock.put_item.assert_not_called()


### PR DESCRIPTION
- [x] I have read the Contributing Guide.
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7951

The edge identity `update-traits` endpoint raised an unhandled 500 error when the request body was a JSON array instead of an object, because `TraitModel(**request.data)` raises a bare `TypeError` for non-mapping input, which was not caught by the existing `pydantic.ValidationError` handler.

Switching to `TraitModel.model_validate(request.data)` correctly turns that into a `pydantic.ValidationError`, but doing so uncovers a second issue: `pyngo.drf_error_details()` assumes every error in `ValidationError.errors()` has a non-empty `loc`, which isn't true for a top-level `model_type` error (the `loc` is `()` when the payload itself isn't an object). That call then raises an `IndexError`, so the 500 doesn't go away, it just changes shape.

This PR rejects non-mapping payloads up front with a normal DRF `ValidationError` (400), before either of those code paths is reached, and switches the remaining case over to `model_validate` for more consistent validation behavior.

## How did you test this code?

Added a regression test (`test_edge_identities_update_trait__malformed_traits_payload__returns_400`) that PUTs a JSON array to the `update-traits` endpoint and asserts a 400 response, with no DynamoDB write attempted. Verified it fails against the old code (500) and passes with the fix. Also ran the full `tests/integration/edge_api/identities/test_edge_identity_viewset.py` suite (22 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed file.