### PR TITLE
Handle non-mapping request data in update_traits

### DIFF
--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import typing
-from collections.abc import Mapping
+
 import pydantic
 from common.environments.permissions import (
     MANAGE_IDENTITIES,
@@ -177,9 +177,7 @@ class EdgeIdentityViewSet(
             raise TraitPersistenceError()
         edge_identity = self.get_object()
         if not isinstance(request.data, dict):
-         raise ValidationError(
-        "Expected a JSON object (dictionary) for trait data."
-    )
+            raise ValidationError("Expected a JSON object (dictionary) for trait data.")
         try:
             trait = TraitModel(**request.data)
         except pydantic.ValidationError as validation_error:

--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import typing
-
+from collections.abc import Mapping
 import pydantic
 from common.environments.permissions import (
     MANAGE_IDENTITIES,
@@ -176,6 +176,10 @@ class EdgeIdentityViewSet(
         if not environment.project.organisation.persist_trait_data:
             raise TraitPersistenceError()
         edge_identity = self.get_object()
+        if not isinstance(request.data, dict):
+         raise ValidationError(
+        "Expected a JSON object (dictionary) for trait data."
+    )
         try:
             trait = TraitModel(**request.data)
         except pydantic.ValidationError as validation_error:


### PR DESCRIPTION
## Description

This change prevents a crash when `request.data` is not a mapping before unpacking it with `**request.data` in `update_traits()`.

Instead of raising a `TypeError`, the endpoint now returns a proper `ValidationError` for invalid request payloads.

Fixes #7951