### PR TITLE
fix(LaunchDarkly): Import processing not idempotent for completed requests

### DIFF
--- a/api/integrations/launch_darkly/services.py
+++ b/api/integrations/launch_darkly/services.py
@@ -1106,6 +1106,17 @@ def create_import_request(
 def process_import_request(
     import_request: LaunchDarklyImportRequest,
 ) -> None:
+    if import_request.completed_at is not None:
+        # `_complete_import_request` clears `ld_token` once an import request is
+        # completed, so re-running this (e.g. a stale/duplicate task delivery)
+        # would otherwise crash trying to unsign an empty value instead of being
+        # a harmless no-op.
+        logger.warning(
+            "Ignoring already-completed LaunchDarkly import request %d.",
+            import_request.id,
+        )
+        return
+
     with _complete_import_request(import_request):
         ld_token = _unsign_ld_value(
             import_request.ld_token,

--- a/api/integrations/launch_darkly/services.py
+++ b/api/integrations/launch_darkly/services.py
@@ -1107,10 +1107,6 @@ def process_import_request(
     import_request: LaunchDarklyImportRequest,
 ) -> None:
     if import_request.completed_at is not None:
-        # `_complete_import_request` clears `ld_token` once an import request is
-        # completed, so re-running this (e.g. a stale/duplicate task delivery)
-        # would otherwise crash trying to unsign an empty value instead of being
-        # a harmless no-op.
         logger.warning(
             "Ignoring already-completed LaunchDarkly import request %d.",
             import_request.id,

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -270,8 +270,6 @@ def test_process_import_request__already_completed__does_not_reprocess(
     import_request: LaunchDarklyImportRequest,
 ) -> None:
     # Given
-    # Simulate a request that has already finished (and had its token wiped),
-    # e.g. because of a duplicate/stale task delivery.
     import_request.status["result"] = "success"
     import_request.completed_at = timezone.now()
     import_request.ld_token = ""
@@ -282,8 +280,6 @@ def test_process_import_request__already_completed__does_not_reprocess(
     process_import_request(import_request)
 
     # Then
-    # The request wasn't reprocessed: the LD client was never (re)instantiated,
-    # and trying to unsign the (already blank) token didn't raise.
     ld_client_class_mock.assert_not_called()
     ld_client_mock.get_environments.assert_not_called()
 

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -8,6 +8,7 @@ import pytest
 from common.test_tools import SnapshotFixture
 from django.conf import settings
 from django.core import signing
+from django.utils import timezone
 from flag_engine.segments import constants as segment_constants
 from pytest_mock import MockerFixture
 from requests.exceptions import HTTPError, RequestException, Timeout
@@ -260,6 +261,31 @@ def test_process_import_request__success__expected_status(  # type: ignore[no-un
     # Tags are imported correctly.
     tagged_feature = Feature.objects.get(project=project, name="flag5")
     [tag.label for tag in tagged_feature.tags.all()] == ["testtag", "testtag2"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_process_import_request__already_completed__does_not_reprocess(
+    ld_client_class_mock: MagicMock,
+    ld_client_mock: MagicMock,
+    import_request: LaunchDarklyImportRequest,
+) -> None:
+    # Given
+    # Simulate a request that has already finished (and had its token wiped),
+    # e.g. because of a duplicate/stale task delivery.
+    import_request.status["result"] = "success"
+    import_request.completed_at = timezone.now()
+    import_request.ld_token = ""
+    import_request.save()
+    ld_client_class_mock.reset_mock()
+
+    # When
+    process_import_request(import_request)
+
+    # Then
+    # The request wasn't reprocessed: the LD client was never (re)instantiated,
+    # and trying to unsign the (already blank) token didn't raise.
+    ld_client_class_mock.assert_not_called()
+    ld_client_mock.get_environments.assert_not_called()
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
- [x] I have read the Contributing Guide.
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7950

The Sentry trace attached to the issue shows `process_import_request` crashing with:

```
django.core.signing.BadSignature: No ":" found in value
```

while unsigning `import_request.ld_token`. This isn't actually about the create endpoint accepting an empty token: `CreateLaunchDarklyImportRequestSerializer.token` is a plain `CharField`, and `allow_blank` defaults to `False`, so the create endpoint already rejects a blank token with a 400 (verified locally, see test plan below).

The real issue is in `process_import_request` itself: `_complete_import_request` clears `import_request.ld_token` to `""` once the request finishes (success or failure), by design, so the token isn't kept around longer than needed. If `process_import_request` runs again for that same, already-completed request (for example a stale/duplicate task-processor delivery, which the task's `timeout` and failure-retry behavior make possible), it tries to unsign that now-blank token and blows up with the exact `BadSignature` error from the Sentry trace, rather than being a harmless no-op.

This adds a guard at the top of `process_import_request` that returns early (with a log message) if `import_request.completed_at` is already set, making reprocessing idempotent instead of crashing.

## How did you test this code?

Added `test_process_import_request__already_completed__does_not_reprocess`, which marks an import request as completed with a blank `ld_token` (mirroring what `_complete_import_request` leaves behind) and asserts that calling `process_import_request` on it again is a no-op (the LaunchDarkly client is never re-instantiated). I confirmed this test reproduces the exact `BadSignature: No ":" found in value` crash from the Sentry trace when the guard is removed, and passes with the fix.

Also ran the full `tests/unit/integrations/launch_darkly/` suite (47 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed files.