### PR TITLE
fix: return 400 when environment is null in featurestate update

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -728,6 +728,10 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
         return feature
 
     def validate_environment(self, environment):  # type: ignore[no-untyped-def]
+        if environment is None:
+            raise serializers.ValidationError(
+                "Environment may not be null."
+            )
         if self.instance and self.instance.environment_id != environment.id:  # type: ignore[union-attr]
             raise serializers.ValidationError(
                 "Cannot change the environment of a feature state"

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -729,9 +729,7 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
 
     def validate_environment(self, environment):  # type: ignore[no-untyped-def]
         if environment is None:
-            raise serializers.ValidationError(
-                "Environment may not be null."
-            )
+            raise serializers.ValidationError("Environment may not be null.")
         if self.instance and self.instance.environment_id != environment.id:  # type: ignore[union-attr]
             raise serializers.ValidationError(
                 "Cannot change the environment of a feature state"

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3246,6 +3246,30 @@ def test_update_feature_state__change_feature__returns_400(
     )
 
 
+def test_update_feature_state__null_environment__returns_400(
+    admin_client_new: APIClient,
+    environment: Environment,
+    feature: Feature,
+    feature_state: FeatureState,
+) -> None:
+    # Given
+    url = reverse("api-v1:features:featurestates-detail", args=[feature_state.id])
+    data = {
+        "enabled": True,
+        "environment": None,
+        "feature": feature.id,
+    }
+
+    # When
+    response = admin_client_new.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "environment" in response.json()
+
+
 @pytest.mark.parametrize(
     "client",
     [lazy_fixture("admin_master_api_key_client"), lazy_fixture("admin_client")],


### PR DESCRIPTION
## Description

Fixes a 500 crash in `/api/v1/features/featurestates/{pk}/` when the `environment` field is `null` in the request payload.

**Root cause:** `validate_environment` in `FeatureStateSerializerBasic` calls `environment.id` without checking if `environment` is `None` first, causing an `AttributeError: 'NoneType' object has no attribute 'id'`.

**Fix:** Added a null check at the beginning of `validate_environment` that returns a 400 validation error with the message `"Environment may not be null."` when the environment field is null.

## Changes

- `api/features/serializers.py`: Added null check in `validate_environment` method
- `api/tests/unit/features/test_unit_features_views.py`: Added regression test `test_update_feature_state__null_environment__returns_400`

## Related

- Fixes #6597
- Sentry: FLAGSMITH-API-5GQ
