### PR TITLE
fix(Segment Membership): Enabled for different organisations in backend and frontend

### DIFF
--- a/api/segment_membership/tasks.py
+++ b/api/segment_membership/tasks.py
@@ -212,10 +212,14 @@ def refresh_project_segment_counts(project_id: int) -> None:
 
     project = Project.objects.select_related("organisation").get(pk=project_id)
     if not is_membership_enabled(project.organisation):
+        deleted, _ = SegmentMembershipCount.objects.filter(
+            segment__project=project
+        ).delete()
         logger.info(
             "refresh.project.skipped",
             project__id=project_id,
             reason="ff_disabled",
+            stale_counts__count=deleted,
         )
         return
 

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
@@ -449,23 +449,37 @@ def test_refresh_project_segment_counts__no_clickhouse_creds__skips(
     )
 
 
-def test_refresh_project_segment_counts__ff_disabled__skips(
+def test_refresh_project_segment_counts__ff_disabled__skips_and_purges_stale_counts(
     mocker: MockerFixture,
     settings: SettingsWrapper,
     project: Project,
+    environment: Environment,
+    segment: Segment,
     log: StructuredLogCapture,
 ) -> None:
-    # Given
+    # Given a count left over from when the org was still enabled
     settings.CLICKHOUSE_ENABLED = True
     spy = mocker.patch.object(tasks, "open_clickhouse_cursor")
+    SegmentMembershipCount.objects.create(
+        segment=segment,
+        environment=environment,
+        count=15,
+        last_synced_at=timezone.now(),
+    )
 
     # When
     refresh_project_segment_counts(project.id)
 
-    # Then
+    # Then the compute path is skipped and the stale row is purged, so the
+    # dashboard stops showing the feature for the now-disabled org
     spy.assert_not_called()
+    assert not SegmentMembershipCount.objects.filter(
+        segment=segment, environment=environment
+    ).exists()
     assert any(
-        e["event"] == "refresh.project.skipped" and e["reason"] == "ff_disabled"
+        e["event"] == "refresh.project.skipped"
+        and e["reason"] == "ff_disabled"
+        and e["stale_counts__count"] == 1
         for e in log.events
     )
 

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
@@ -457,7 +457,7 @@ def test_refresh_project_segment_counts__ff_disabled__skips_and_purges_stale_cou
     segment: Segment,
     log: StructuredLogCapture,
 ) -> None:
-    # Given a count left over from when the org was still enabled
+    # Given
     settings.CLICKHOUSE_ENABLED = True
     spy = mocker.patch.object(tasks, "open_clickhouse_cursor")
     SegmentMembershipCount.objects.create(

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_tasks.py
@@ -470,8 +470,7 @@ def test_refresh_project_segment_counts__ff_disabled__skips_and_purges_stale_cou
     # When
     refresh_project_segment_counts(project.id)
 
-    # Then the compute path is skipped and the stale row is purged, so the
-    # dashboard stops showing the feature for the now-disabled org
+    # Then
     spy.assert_not_called()
     assert not SegmentMembershipCount.objects.filter(
         segment=segment, environment=environment

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -388,7 +388,7 @@ Attributes:
 ### `segment_membership.refresh.project.completed`
 
 Logged at `info` from:
- - `api/segment_membership/tasks.py:262`
+ - `api/segment_membership/tasks.py:266`
 
 Attributes:
  - `membership_counts.count`
@@ -398,7 +398,7 @@ Attributes:
 ### `segment_membership.refresh.project.failed`
 
 Logged at `exception` from:
- - `api/segment_membership/tasks.py:235`
+ - `api/segment_membership/tasks.py:239`
 
 Attributes:
  - `project.id`
@@ -407,11 +407,12 @@ Attributes:
 
 Logged at `info` from:
  - `api/segment_membership/tasks.py:206`
- - `api/segment_membership/tasks.py:215`
+ - `api/segment_membership/tasks.py:218`
 
 Attributes:
  - `project.id`
  - `reason`
+ - `stale_counts.count`
 
 ### `segment_membership.seed.environment.completed`
 

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -757,11 +757,14 @@ const LoadingCreateSegment: FC<LoadingCreateSegmentType> = (props) => {
 
   const isEdge = Utils.getIsEdge()
 
-  // When membership inspection is enabled and the project uses edge, the
-  // Identities tab uses the dedicated segment members endpoint, so the legacy
-  // identities list (and its request) is not needed.
+  // Availability is derived strictly from the backend: membership counts are
+  // only present for membership-enabled orgs (see `is_membership_enabled`), so
+  // their presence gates the UI without a separate frontend flag. When enabled
+  // and the project uses edge, the Identities tab uses the dedicated segment
+  // members endpoint, so the legacy identities list (and its request) is not
+  // needed.
   const membersEnabled =
-    Utils.getFlagsmithHasFeature('segment_membership_inspection') && isEdge
+    (segmentData?.membership_counts?.length ?? 0) > 0 && isEdge
 
   const { data: identities, isLoading: identitiesLoading } =
     useGetIdentitiesQuery(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The dashboard decided whether to show the segment membership UI by evaluating its own Flagsmith flag in the Flagsmith Website project, separately from the backend's `is_membership_enabled` check. The two evaluations target different projects, and their `PERCENTAGE_SPLIT` rules are salted by segment id, so an org falls into one segment's 10% bucket but not the other's. The result is that the frontend and backend disagree about whether the feature is on for a given org.

In this PR, we drop the separate frontend flag and derive availability strictly from backend output.

## How did you test this code?

- Manual: with an org membership-enabled and counts present, the Identities tab uses the members endpoint; disabling the org (removing it from `membership-enabled-orgs`) clears the counts on the next refresh, and the tab falls back to the legacy identities list.
