### PR TITLE
feat(experiments): wizard UX improvements

### DIFF
--- a/frontend/web/components/experiments/CreateExperimentWizard.tsx
+++ b/frontend/web/components/experiments/CreateExperimentWizard.tsx
@@ -4,8 +4,6 @@ import {
   useCreateExperimentMutation,
   useStartExperimentMutation,
 } from 'common/services/useExperiment'
-import { useGetFeatureStatesQuery } from 'common/services/useFeatureState'
-import { useProjectEnvironments } from 'common/hooks/useProjectEnvironments'
 import {
   ENABLE_EXPERIMENT_LIFECYCLE,
   METRIC_DIRECTION_TO_EXPECTED_DIRECTION,
@@ -18,7 +16,7 @@ import RolloutStep from './steps/RolloutStep'
 import {
   VariationSplitEntry,
   getControlPercentage,
-  getVariationSplitDefaults,
+  getEvenSplit,
   toRolloutFeatureValue,
 } from './rollout'
 import isValidPercentage from 'common/utils/isValidPercentage'
@@ -55,32 +53,11 @@ const CreateExperimentWizard: FC<CreateExperimentWizardProps> = ({
   )
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set())
 
-  const { getEnvironmentIdFromKey } = useProjectEnvironments(projectId)
-  const numericEnvId = getEnvironmentIdFromKey(environmentId)
-
-  const { data: featureStatesData } = useGetFeatureStatesQuery(
-    { environment: numericEnvId, feature: selectedFeature?.id },
-    { skip: !selectedFeature || !numericEnvId },
-  )
-
-  const environmentFeatureState = useMemo(
-    () =>
-      featureStatesData?.results?.find(
-        (state) => !state.feature_segment && !state.identity,
-      ),
-    [featureStatesData],
-  )
-
   useEffect(() => {
     setVariationSplit(
-      selectedFeature
-        ? getVariationSplitDefaults(
-            selectedFeature.multivariate_options,
-            environmentFeatureState?.multivariate_feature_state_values,
-          )
-        : [],
+      selectedFeature ? getEvenSplit(selectedFeature.multivariate_options) : [],
     )
-  }, [selectedFeature, environmentFeatureState])
+  }, [selectedFeature])
 
   const [createExperiment, { isLoading: isCreating }] =
     useCreateExperimentMutation()

--- a/frontend/web/components/experiments/results/ExperimentExposuresPanel.tsx
+++ b/frontend/web/components/experiments/results/ExperimentExposuresPanel.tsx
@@ -1,10 +1,9 @@
-import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { FC, useCallback, useMemo } from 'react'
 import moment from 'moment'
 import { LineChart } from 'components/charts'
 import ContentCard from 'components/base/grid/ContentCard'
 import Button from 'components/base/forms/Button'
 import Icon from 'components/icons/Icon'
-import useCountdown from 'common/hooks/useCountdown'
 import { colorIconDanger } from 'common/theme/tokens'
 import {
   useGetExperimentExposuresQuery,
@@ -19,14 +18,9 @@ import {
 } from './derive'
 import type { VariantTotal } from './derive'
 import {
-  DEFAULT_RETRY_AFTER_S,
-  POLL_TIMEOUT_MS,
-  REFRESH_POLL_INTERVAL_MS,
   canRefreshExposures,
   deriveExposuresViewState,
-  getExposuresRefreshLabel,
 } from './exposuresViewState'
-import RefreshControl from './RefreshControl'
 import './results.scss'
 
 const AsOfLabel: FC<{ asOf: string | null }> = ({ asOf }) => (
@@ -45,25 +39,10 @@ const buildLegendLabels = (totals: VariantTotal[]): Record<string, string> => {
   return labels
 }
 
-const parseRetryAfter = (err: unknown): number | null => {
-  const fetchErr = err as {
-    status?: number
-    retryAfter?: number | null
-  }
-  if (fetchErr.status !== 429) return null
-  if (fetchErr.retryAfter) return fetchErr.retryAfter
-  return DEFAULT_RETRY_AFTER_S
-}
-
 type ExperimentExposuresPanelProps = {
   experiment: Experiment
   environmentId: string
   exposuresOverride?: ExperimentExposures
-}
-
-const REFRESH_DISABLED_COPY: Record<string, string> = {
-  final: 'Refresh is disabled because the experiment is complete.',
-  not_started: 'Start the experiment to compute exposures.',
 }
 
 const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
@@ -71,48 +50,19 @@ const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
   experiment,
   exposuresOverride,
 }) => {
-  const [pollInterval, setPollInterval] = useState(0)
-  const [refreshRequested, setRefreshRequested] = useState(false)
-  const [pollStartedAt, setPollStartedAt] = useState<number | null>(null)
-  const [retryAfter, startRetryCountdown] = useCountdown()
   const { data: fetched } = useGetExperimentExposuresQuery(
     { environmentId, experimentId: experiment.id },
     {
-      pollingInterval: pollInterval,
       refetchOnMountOrArgChange: true,
       skip: !!exposuresOverride,
     },
   )
   const exposures = exposuresOverride ?? fetched
-  const [refresh, { isLoading: isSubmitting }] =
-    useRefreshExperimentExposuresMutation()
+  const [refreshExposures] = useRefreshExperimentExposuresMutation()
 
   const viewState = deriveExposuresViewState(exposures)
   const availability = canRefreshExposures(experiment.status, exposures)
   const payload = exposures?.payload ?? null
-
-  const pollTimedOut =
-    pollStartedAt !== null && Date.now() - pollStartedAt > POLL_TIMEOUT_MS
-  const shouldPoll =
-    !pollTimedOut && (viewState.kind === 'refreshing' || refreshRequested)
-  const nextPollInterval = shouldPoll ? REFRESH_POLL_INTERVAL_MS : 0
-  useEffect(() => {
-    setPollInterval(nextPollInterval)
-  }, [nextPollInterval])
-
-  useEffect(() => {
-    if (viewState.kind === 'loaded' || viewState.kind === 'error') {
-      setRefreshRequested(false)
-      setPollStartedAt(null)
-    }
-  }, [viewState.kind])
-
-  useEffect(() => {
-    if (pollTimedOut) {
-      setRefreshRequested(false)
-      setPollStartedAt(null)
-    }
-  }, [pollTimedOut])
 
   const identities = useMemo(
     () => getVariantIdentities(experiment.feature),
@@ -127,61 +77,21 @@ const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
     [payload, identities],
   )
 
-  const isRefreshing =
-    refreshRequested || viewState.kind === 'refreshing' || isSubmitting
+  const isRefreshing = viewState.kind === 'refreshing'
   const headline = payload ? getHeadlineTotal(payload) : 0
   const hasData = !!payload && headline > 0
 
-  const handleRefresh = useCallback(async () => {
-    setRefreshRequested(true)
-    setPollStartedAt(Date.now())
-    const result = await refresh({
+  const handleComputeNow = useCallback(async () => {
+    await refreshExposures({
       environmentId,
       experimentId: experiment.id,
     })
-    if ('error' in result && result.error) {
-      setRefreshRequested(false)
-      setPollStartedAt(null)
-      const seconds = parseRetryAfter(result.error)
-      if (seconds !== null) {
-        startRetryCountdown(seconds)
-      } else {
-        toast('Failed to refresh exposures', 'danger')
-      }
-    }
-  }, [refresh, environmentId, experiment.id, startRetryCountdown])
-
-  const refreshLabel = getExposuresRefreshLabel(retryAfter, isRefreshing)
-
-  const action = (
-    <RefreshControl
-      disabled={!availability.canRefresh || retryAfter !== null}
-      disabledReason={
-        availability.reason
-          ? REFRESH_DISABLED_COPY[availability.reason]
-          : undefined
-      }
-      isRefreshing={isRefreshing}
-      label={
-        refreshLabel && (
-          <span
-            className={
-              refreshLabel.tone === 'danger' ? 'text-danger' : undefined
-            }
-          >
-            {refreshLabel.message}
-          </span>
-        )
-      }
-      onRefresh={handleRefresh}
-    />
-  )
+  }, [refreshExposures, environmentId, experiment.id])
 
   const asOf = exposures?.as_of ?? null
 
   return (
     <ContentCard
-      action={action}
       className='experiment-results__exposures-card'
       title='Enrollment over time'
     >
@@ -262,7 +172,7 @@ const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
             : 'No exposure data computed yet.'}
           {!isRefreshing && availability.canRefresh && (
             <div className='mt-2'>
-              <Button onClick={handleRefresh} size='small' theme='secondary'>
+              <Button onClick={handleComputeNow} size='small' theme='secondary'>
                 Compute now
               </Button>
             </div>

--- a/frontend/web/components/experiments/results/ExperimentExposuresPanel.tsx
+++ b/frontend/web/components/experiments/results/ExperimentExposuresPanel.tsx
@@ -82,10 +82,13 @@ const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
   const hasData = !!payload && headline > 0
 
   const handleComputeNow = useCallback(async () => {
-    await refreshExposures({
+    const result = await refreshExposures({
       environmentId,
       experimentId: experiment.id,
     })
+    if ('error' in result && result.error) {
+      toast('Failed to compute exposures', 'danger')
+    }
   }, [refreshExposures, environmentId, experiment.id])
 
   const asOf = exposures?.as_of ?? null

--- a/frontend/web/components/experiments/results/ExperimentResultsRefreshControl.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsRefreshControl.tsx
@@ -2,7 +2,9 @@ import { FC, useCallback, useEffect, useState } from 'react'
 import useCountdown from 'common/hooks/useCountdown'
 import {
   useGetExperimentBayesianResultsQuery,
+  useGetExperimentExposuresQuery,
   useRefreshExperimentBayesianResultsMutation,
+  useRefreshExperimentExposuresMutation,
 } from 'common/services/useExperiment'
 import { ExperimentStatus } from 'common/types/responses'
 import RefreshControl from './RefreshControl'
@@ -14,6 +16,7 @@ import {
   deriveResultsViewState,
   getResultsRefreshLabel,
 } from './resultsViewState'
+import { deriveExposuresViewState } from './exposuresViewState'
 
 const parseRetryAfter = (err: unknown): number | null => {
   const fetchErr = err as {
@@ -23,6 +26,17 @@ const parseRetryAfter = (err: unknown): number | null => {
   if (fetchErr.status !== 429) return null
   if (fetchErr.retryAfter) return fetchErr.retryAfter
   return DEFAULT_RETRY_AFTER_S
+}
+
+const getMaxRetryAfter = (errors: unknown[]): number | null => {
+  let max: number | null = null
+  for (const err of errors) {
+    const seconds = parseRetryAfter(err)
+    if (seconds !== null && (max === null || seconds > max)) {
+      max = seconds
+    }
+  }
+  return max
 }
 
 type ExperimentResultsRefreshControlProps = {
@@ -48,27 +62,40 @@ const ExperimentResultsRefreshControl: FC<
     { environmentId, experimentId },
     { pollingInterval: pollInterval },
   )
-  const [refresh, { isLoading: isSubmitting }] =
+  const { data: exposures } = useGetExperimentExposuresQuery(
+    { environmentId, experimentId },
+    { pollingInterval: pollInterval },
+  )
+  const [refreshResults, { isLoading: isSubmittingResults }] =
     useRefreshExperimentBayesianResultsMutation()
+  const [refreshExposures, { isLoading: isSubmittingExposures }] =
+    useRefreshExperimentExposuresMutation()
 
-  const viewState = deriveResultsViewState(results)
+  const resultsViewState = deriveResultsViewState(results)
+  const exposuresViewState = deriveExposuresViewState(exposures)
   const availability = canRefreshResults(status, results)
+
+  const eitherRefreshing =
+    resultsViewState.kind === 'refreshing' ||
+    exposuresViewState.kind === 'refreshing'
+  const bothSettled =
+    resultsViewState.kind !== 'refreshing' &&
+    exposuresViewState.kind !== 'refreshing'
 
   const pollTimedOut =
     pollStartedAt !== null && Date.now() - pollStartedAt > POLL_TIMEOUT_MS
-  const shouldPoll =
-    !pollTimedOut && (viewState.kind === 'refreshing' || refreshRequested)
+  const shouldPoll = !pollTimedOut && (eitherRefreshing || refreshRequested)
   const nextPollInterval = shouldPoll ? REFRESH_POLL_INTERVAL_MS : 0
   useEffect(() => {
     setPollInterval(nextPollInterval)
   }, [nextPollInterval])
 
   useEffect(() => {
-    if (viewState.kind === 'loaded' || viewState.kind === 'error') {
+    if (refreshRequested && bothSettled) {
       setRefreshRequested(false)
       setPollStartedAt(null)
     }
-  }, [viewState.kind])
+  }, [refreshRequested, bothSettled])
 
   useEffect(() => {
     if (pollTimedOut) {
@@ -78,25 +105,48 @@ const ExperimentResultsRefreshControl: FC<
   }, [pollTimedOut])
 
   const isRefreshing =
-    refreshRequested || viewState.kind === 'refreshing' || isSubmitting
+    refreshRequested ||
+    eitherRefreshing ||
+    isSubmittingResults ||
+    isSubmittingExposures
 
   const handleRefresh = useCallback(async () => {
     setRefreshRequested(true)
     setPollStartedAt(Date.now())
-    const result = await refresh({ environmentId, experimentId })
-    if ('error' in result && result.error) {
-      setRefreshRequested(false)
-      setPollStartedAt(null)
-      const seconds = parseRetryAfter(result.error)
+    const [resultsResult, exposuresResult] = await Promise.all([
+      refreshResults({ environmentId, experimentId }),
+      refreshExposures({ environmentId, experimentId }),
+    ])
+    const errors: unknown[] = []
+    if ('error' in resultsResult && resultsResult.error) {
+      errors.push(resultsResult.error)
+    }
+    if ('error' in exposuresResult && exposuresResult.error) {
+      errors.push(exposuresResult.error)
+    }
+    if (errors.length > 0) {
+      const seconds = getMaxRetryAfter(errors)
       if (seconds !== null) {
         startRetryCountdown(seconds)
       } else {
-        toast('Failed to refresh results', 'danger')
+        setRefreshRequested(false)
+        setPollStartedAt(null)
+        toast('Failed to refresh experiment data', 'danger')
       }
     }
-  }, [refresh, environmentId, experimentId, startRetryCountdown])
+  }, [
+    refreshResults,
+    refreshExposures,
+    environmentId,
+    experimentId,
+    startRetryCountdown,
+  ])
 
-  const label = getResultsRefreshLabel(retryAfter, isRefreshing, viewState)
+  const label = getResultsRefreshLabel(
+    retryAfter,
+    isRefreshing,
+    resultsViewState,
+  )
 
   return (
     <RefreshControl
@@ -116,7 +166,7 @@ const ExperimentResultsRefreshControl: FC<
       }
       onRefresh={handleRefresh}
     >
-      Refresh results
+      Refresh
     </RefreshControl>
   )
 }

--- a/frontend/web/components/experiments/results/ExperimentResultsRefreshControl.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsRefreshControl.tsx
@@ -126,12 +126,15 @@ const ExperimentResultsRefreshControl: FC<
     }
     if (errors.length > 0) {
       const seconds = getMaxRetryAfter(errors)
+      const hasNonRetryable = errors.some((e) => parseRetryAfter(e) === null)
+      if (hasNonRetryable) {
+        toast('Failed to refresh experiment data', 'danger')
+      }
       if (seconds !== null) {
         startRetryCountdown(seconds)
       } else {
         setRefreshRequested(false)
         setPollStartedAt(null)
-        toast('Failed to refresh experiment data', 'danger')
       }
     }
   }, [

--- a/frontend/web/components/experiments/results/__tests__/exposuresViewState.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/exposuresViewState.test.ts
@@ -80,7 +80,7 @@ describe('canRefreshExposures', () => {
 describe('getExposuresRefreshLabel', () => {
   it('prefers a retry countdown over the in-progress message', () => {
     expect(getExposuresRefreshLabel(90, true)).toEqual({
-      message: 'Computing… retry in 1m 30s',
+      message: 'Refresh available in 1m 30s',
       tone: 'muted',
     })
   })

--- a/frontend/web/components/experiments/results/__tests__/resultsViewState.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/resultsViewState.test.ts
@@ -86,7 +86,7 @@ describe('getResultsRefreshLabel', () => {
   it('prefers a retry countdown over everything else', () => {
     expect(
       getResultsRefreshLabel(90, true, { kind: 'error', staleAvailable: true }),
-    ).toEqual({ message: 'Computing… retry in 1m 30s', tone: 'muted' })
+    ).toEqual({ message: 'Refresh available in 1m 30s', tone: 'muted' })
   })
 
   it('shows an in-progress message while refreshing', () => {

--- a/frontend/web/components/experiments/results/derive.ts
+++ b/frontend/web/components/experiments/results/derive.ts
@@ -110,6 +110,14 @@ export const getHeadlineTotal = (summary: ExposuresSummary): number =>
     0,
   )
 
+export const getResultsTotalUsers = (
+  results: BayesianResultsSummary,
+): number => {
+  const firstMetric = results.metrics[0]
+  if (!firstMetric) return 0
+  return Object.values(firstMetric.variants).reduce((sum, v) => sum + v.n, 0)
+}
+
 export const isLiftFavourable = (
   lift: number,
   direction: ExpectedDirection,

--- a/frontend/web/components/experiments/results/exposuresViewState.ts
+++ b/frontend/web/components/experiments/results/exposuresViewState.ts
@@ -58,7 +58,7 @@ export const getExposuresRefreshLabel = (
 ): RefreshLabel | null => {
   if (retryAfter !== null) {
     return {
-      message: `Computing… retry in ${formatCountdown(retryAfter)}`,
+      message: `Refresh available in ${formatCountdown(retryAfter)}`,
       tone: 'muted',
     }
   }

--- a/frontend/web/components/experiments/results/resultsViewState.ts
+++ b/frontend/web/components/experiments/results/resultsViewState.ts
@@ -60,7 +60,7 @@ export const getResultsRefreshLabel = (
 ): RefreshLabel | null => {
   if (retryAfter !== null) {
     return {
-      message: `Computing… retry in ${formatCountdown(retryAfter)}`,
+      message: `Refresh available in ${formatCountdown(retryAfter)}`,
       tone: 'muted',
     }
   }

--- a/frontend/web/components/pages/ExperimentDetailPage.tsx
+++ b/frontend/web/components/pages/ExperimentDetailPage.tsx
@@ -6,7 +6,10 @@ import {
   useGetExperimentExposuresQuery,
   useGetExperimentQuery,
 } from 'common/services/useExperiment'
-import { getHeadlineTotal } from 'components/experiments/results/derive'
+import {
+  getHeadlineTotal,
+  getResultsTotalUsers,
+} from 'components/experiments/results/derive'
 import ExperimentDetailHeader from 'components/experiments/results/ExperimentDetailHeader'
 import ExperimentConfiguration from 'components/experiments/results/ExperimentConfiguration'
 import ExperimentRecommendation from 'components/experiments/results/ExperimentRecommendation'
@@ -76,9 +79,11 @@ const ExperimentDetailPage: FC = () => {
     )
   }
 
-  const usersEnrolled = exposures?.payload
+  const resultsTotalUsers = results ? getResultsTotalUsers(results) : 0
+  const exposuresTotalUsers = exposures?.payload
     ? getHeadlineTotal(exposures.payload)
-    : null
+    : 0
+  const usersEnrolled = resultsTotalUsers || exposuresTotalUsers || null
 
   return (
     <div className='app-container container mt-4'>

--- a/frontend/web/components/pages/ExperimentDetailPage.tsx
+++ b/frontend/web/components/pages/ExperimentDetailPage.tsx
@@ -79,11 +79,12 @@ const ExperimentDetailPage: FC = () => {
     )
   }
 
-  const resultsTotalUsers = results ? getResultsTotalUsers(results) : 0
+  const resultsTotalUsers =
+    results && results.metrics.length > 0 ? getResultsTotalUsers(results) : null
   const exposuresTotalUsers = exposures?.payload
     ? getHeadlineTotal(exposures.payload)
-    : 0
-  const usersEnrolled = resultsTotalUsers || exposuresTotalUsers || null
+    : null
+  const usersEnrolled = resultsTotalUsers ?? exposuresTotalUsers
 
   return (
     <div className='app-container container mt-4'>


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Experiment creation wizard UX improvements:

- Default variant split to even distribution instead of inheriting current feature weights
- "Users enrolled" card now prefers results total over exposures total (falls back to exposures when results aren't computed yet)
- Merged the two separate refresh buttons (results + exposures) into a single "Refresh" button that fires both in parallel
- Throttle message changed from "Computing… retry in X" to "Refresh available in X"

## How did you test this code?

- Unit tests pass (`resultsViewState`, `exposuresViewState`)
- Typecheck clean
- Lint clean