### PR TITLE
fix(Experiments): Dark mode visibility in results page

### DIFF
--- a/frontend/web/components/experiments/results/ExperimentConfiguration.tsx
+++ b/frontend/web/components/experiments/results/ExperimentConfiguration.tsx
@@ -28,7 +28,7 @@ const ExperimentConfiguration: FC<ExperimentConfigurationProps> = ({
       <div className='col-md-4'>
         <ContentCard compact title='Feature flag'>
           <div>
-            <span className='selectable-card__tag'>
+            <span className='experiment-results__tag'>
               {experiment.feature.name}
             </span>
           </div>
@@ -40,7 +40,7 @@ const ExperimentConfiguration: FC<ExperimentConfigurationProps> = ({
             <div>
               <div>{metric.metric_name}</div>
               <div className='mt-3'>
-                <span className='selectable-card__tag'>
+                <span className='experiment-results__tag'>
                   {EXPECTED_DIRECTION_CHIP[metric.expected_direction]}
                 </span>
               </div>

--- a/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
+++ b/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
@@ -200,7 +200,7 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
     if (isEditingHypothesis) {
       return (
         <div className='mt-3' style={{ maxWidth: 640 }}>
-          <span className='fs-caption text-muted fw-bold'>Hypothesis</span>
+          <span className='fs-caption text-secondary fw-bold'>Hypothesis</span>
           <div className='d-flex align-items-start gap-2 mt-1'>
             <textarea
               autoFocus
@@ -252,9 +252,9 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
 
     return (
       <div className='mt-3' style={{ maxWidth: 640 }}>
-        <span className='fs-caption text-muted fw-bold'>Hypothesis</span>
+        <span className='fs-caption text-secondary fw-bold'>Hypothesis</span>
         <div className='d-flex align-items-start gap-1'>
-          <p className='text-muted mb-0'>
+          <p className='text-secondary mb-0'>
             {experiment.hypothesis || (
               <span className='fst-italic'>No hypothesis</span>
             )}

--- a/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
@@ -52,10 +52,10 @@ const renderLift = (
   liftRange: number,
 ): ReactNode => {
   if (identity.isControl) {
-    return <span className='text-muted fs-caption'>Baseline</span>
+    return <span className='text-secondary fs-caption'>Baseline</span>
   }
   if (!inference) {
-    return <span className='text-muted fs-caption'>Collecting data…</span>
+    return <span className='text-secondary fs-caption'>Collecting data…</span>
   }
   const colour = getLiftColour(inference.lift, direction)
   const left = liftToPercent(inference.ci_low, liftRange)
@@ -94,7 +94,7 @@ const renderCI = (
   inference: Inference | null,
 ): ReactNode => {
   if (identity.isControl) {
-    return <span className='text-muted fs-caption'>Baseline</span>
+    return <span className='text-secondary fs-caption'>Baseline</span>
   }
   if (!inference) return '—'
   return (

--- a/frontend/web/components/experiments/results/StatCard.tsx
+++ b/frontend/web/components/experiments/results/StatCard.tsx
@@ -9,9 +9,9 @@ type StatCardProps = {
 
 const StatCard: FC<StatCardProps> = ({ label, loading, value }) => (
   <ContentCard compact>
-    <div className='text-muted fs-caption'>{label}</div>
+    <div className='text-secondary fs-caption'>{label}</div>
     <div className='fs-3 mt-1'>
-      {loading ? <span className='text-muted'>—</span> : value ?? '—'}
+      {loading ? <span className='text-secondary'>—</span> : value ?? '—'}
     </div>
   </ContentCard>
 )

--- a/frontend/web/components/experiments/results/results.scss
+++ b/frontend/web/components/experiments/results/results.scss
@@ -4,6 +4,17 @@
 
 .experiment-recommendation {
   font-size: 16px;
+  color: var(--color-text-default);
+}
+
+.experiment-results__tag {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: var(--font-weight-regular);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-secondary);
 }
 
 .experiment-results {


### PR DESCRIPTION
## Changes

Fix dark mode visibility issues on the experiment results page:
- Variant names invisible in recommendation card
- Hypothesis text too faint
- Stat card titles barely visible
- Chip/tag backgrounds blending into background
- "Baseline" text invisible in scorecard table

## How did you test this code?

Toggled dark mode and verified all affected elements are visible.