### PR TITLE
fix(dark mode): resolve .text-secondary to the token, not Bootstrap

### DIFF
--- a/frontend/web/components/modals/payment/PricingPanel.tsx
+++ b/frontend/web/components/modals/payment/PricingPanel.tsx
@@ -85,7 +85,7 @@ export const PricingPanel = ({
 
               {isEnterprise && (
                 <Row className='pt-3 justify-content-center'>
-                  <div className='pricing-type text-secondary'>
+                  <div className='pricing-type pricing-accent'>
                     Maximum security and control
                   </div>
                 </Row>
@@ -127,14 +127,14 @@ export const PricingPanel = ({
             })}
           >
             All from{' '}
-            <span className={isEnterprise ? 'text-secondary' : 'text-primary'}>
+            <span className={isEnterprise ? 'pricing-accent' : 'text-primary'}>
               {includesFrom},
             </span>{' '}
             plus
           </h5>
           <PricingFeaturesList
             features={features}
-            iconClass={isEnterprise ? 'text-secondary' : undefined}
+            iconClass={isEnterprise ? 'pricing-accent' : undefined}
           />
         </div>
       </div>

--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -16,6 +16,19 @@
 // 4. Optionally include utilities API last to generate classes based on the Sass map in `_utilities.scss`
 
 @import "../project/spacing-utils";
+
+// Colour is owned by the design-system token utilities (_token-utilities.scss).
+// Drop `secondary` from Bootstrap's text-colour utility so `.text-secondary`
+// resolves to `--color-text-secondary` (the token) instead of `$secondary`
+// (the brand yellow). Without this, Bootstrap's `!important` copy wins the
+// cascade and the token utility is dead.
+$_color-util: map-get($utilities, "color");
+$_color-util: map-merge(
+  $_color-util,
+  (values: map-remove(map-get($_color-util, "values"), "secondary"))
+);
+$utilities: map-merge($utilities, ("color": $_color-util));
+
 @import "~bootstrap/scss/utilities/api";
 
 // 5. Include any optional Bootstrap CSS as needed

--- a/frontend/web/styles/project/_PricingPage.scss
+++ b/frontend/web/styles/project/_PricingPage.scss
@@ -2,6 +2,12 @@
   border-radius: 4px;
 }
 
+// Enterprise brand accent, previously Bootstrap's `.text-secondary` ($secondary).
+// Kept local so `.text-secondary` can be reclaimed for the design-system token.
+.pricing-accent {
+  color: $secondary;
+}
+
 .pricing-panel-content {
   background-color: rgba(39, 171, 149, 0.08);
   min-height: 320px;


### PR DESCRIPTION
## Changes

Contributes to #6606

`.text-secondary` was generated twice: by our token utilities
(`--color-text-secondary`) and by Bootstrap's colour utility (`$secondary`, the
brand yellow, with `!important`). Bootstrap won the cascade, so muted text rendered
yellow, fine on dark but ~1.3:1 on white (fails WCAG AA).

This drops the `secondary` key from Bootstrap's text-colour utility map so
`.text-secondary` resolves to the design-system token (`#656d7b` light / `#9da4ae`
dark, AA in both). The one intentional brand-yellow usage (`PricingPanel`) moves to
a local `.pricing-accent` class so it keeps `$secondary`.

## How did you test this code?

Compiled the full stylesheet and confirmed the only `.text-secondary` rule in the
output now resolves to `var(--color-text-secondary)` (Bootstrap's yellow copy is
gone). `PricingPanel` is the sole component that used `.text-secondary`, migrated to
`.pricing-accent`; its enterprise panel (subtitle, "All from" text, feature icons)
should stay yellow, worth a quick visual confirm on review.
