### PR TITLE
fix(dark mode): move colour and shadow utilities from Bootstrap to tokens

### DIFF
--- a/frontend/web/components/Breadcrumb.tsx
+++ b/frontend/web/components/Breadcrumb.tsx
@@ -16,7 +16,7 @@ const Breadcrumb: FC<BreadcrumbType> = ({
     <div className='d-flex align-items-center my-2 py-1'>
       {items?.map((item) => (
         <>
-          <Link className='text-primary h6 mb-0' to={item.url}>
+          <Link className='text-action h6 mb-0' to={item.url}>
             {item.title}
           </Link>
           <div className='text-muted mx-2 h6 mb-0'>/</div>

--- a/frontend/web/components/BreadcrumbSeparator.tsx
+++ b/frontend/web/components/BreadcrumbSeparator.tsx
@@ -125,7 +125,7 @@ const ItemList: FC<ItemListType> = ({
               </span>
             </div>
             {isActive && (
-              <IonIcon className='text-primary' icon={checkmarkCircle} />
+              <IonIcon className='icon-action' icon={checkmarkCircle} />
             )}
           </a>
         )

--- a/frontend/web/components/ClearFilters.tsx
+++ b/frontend/web/components/ClearFilters.tsx
@@ -10,7 +10,7 @@ const ClearFilters: FC<ClearFiltersType> = ({ onClick }) => {
   return (
     <div
       onClick={onClick}
-      className='fw-semibold cursor-pointer text-primary  d-flex align-items-center mx-3 gap-1'
+      className='fw-semibold cursor-pointer text-action  d-flex align-items-center mx-3 gap-1'
     >
       <IonIcon className='h6 mb-0' color='#6837fc' icon={closeCircle} />
       Clear all

--- a/frontend/web/components/EditIdentity.tsx
+++ b/frontend/web/components/EditIdentity.tsx
@@ -64,7 +64,7 @@ const EditIdentity: FC<EditIdentityType> = ({ data, environmentId }) => {
       <Button
         disabled={!data}
         theme='text'
-        className='text-primary'
+        className='text-action'
         onClick={handleFocus}
       >
         Edit

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -825,7 +825,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
               <div className='mb-2'>
                 <Row className={role ? 'py-2' : ''}>
                   <Flex>
-                    <div className='font-weight-medium text-dark mb-1'>
+                    <div className='font-weight-medium text-default mb-1'>
                       Administrator
                     </div>
                   </Flex>
@@ -898,7 +898,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
               )}
             />
 
-            <p className='text-right mt-5 text-dark'>
+            <p className='text-right mt-5 text-default'>
               This will edit the permissions for{' '}
               <strong>{getEditText()}</strong>.
             </p>

--- a/frontend/web/components/EnvironmentDocumentCodeHelp.tsx
+++ b/frontend/web/components/EnvironmentDocumentCodeHelp.tsx
@@ -57,7 +57,7 @@ const EnvironmentDocumentCodeHelp: FC<EnvironmentDocumentCodeHelpType> = ({
           <div className='mb-2'>
             Providing flag defaults is recommended for{' '}
             <a
-              className='text-primary'
+              className='text-action'
               target='_blank'
               href='https://docs.flagsmith.com/guides-and-examples/defensive-coding'
               rel='noreferrer'

--- a/frontend/web/components/FeatureHistory.tsx
+++ b/frontend/web/components/FeatureHistory.tsx
@@ -114,7 +114,7 @@ const FeatureHistory: FC<FeatureHistoryPageType> = ({
                       >
                         <Button
                           theme='text'
-                          className='px-0 text-primary'
+                          className='px-0 text-action'
                           size='xSmall'
                         >
                           View Details
@@ -131,7 +131,7 @@ const FeatureHistory: FC<FeatureHistoryPageType> = ({
                                 setSelected(null)
                                 setDiff(diff === v.uuid ? null : v.uuid)
                               }}
-                              className='px-0 text-primary'
+                              className='px-0 text-action'
                               theme='text'
                               size='xSmall'
                             >
@@ -151,7 +151,7 @@ const FeatureHistory: FC<FeatureHistoryPageType> = ({
                                     setOpen(true)
                                   }
                                 }}
-                                className='px-0 text-primary'
+                                className='px-0 text-action'
                                 theme='text'
                                 size='xSmall'
                               >

--- a/frontend/web/components/GithubStar.tsx
+++ b/frontend/web/components/GithubStar.tsx
@@ -40,7 +40,7 @@ const GithubStar: FC<GithubStarType> = ({}) => {
     <a
       target='_blank'
       href='https://github.com/flagsmith/flagsmith'
-      className='d-flex text-body'
+      className='d-flex text-default'
       rel='noreferrer'
     >
       <div

--- a/frontend/web/components/Highlight.js
+++ b/frontend/web/components/Highlight.js
@@ -182,7 +182,7 @@ class Highlight extends React.Component {
             >
               {this.state.expanded ? 'Hide' : 'Show More'}
               <span
-                className={`icon ml-2 ion text-primary ${
+                className={`icon ml-2 ion icon-action ${
                   this.state.expanded
                     ? 'ion-ios-arrow-up'
                     : 'ion-ios-arrow-down'

--- a/frontend/web/components/IntegrationList.tsx
+++ b/frontend/web/components/IntegrationList.tsx
@@ -306,7 +306,7 @@ const Integration: FC<IntegrationProps> = (props) => {
             <Link
               to={`/project/${props.lastSaved.projectId}/integrations`}
               data-test='view-project-integrations-link'
-              className='text-primary'
+              className='text-action'
             >
               Manage in project integrations
             </Link>

--- a/frontend/web/components/PermissionsTabs.tsx
+++ b/frontend/web/components/PermissionsTabs.tsx
@@ -177,7 +177,7 @@ const PermissionsTabs: FC<PermissionsTabsType> = ({
               />
             )}
           </div>
-          <p className='text-right mt-5 text-dark'>
+          <p className='text-right mt-5 text-default'>
             This will edit the permissions for{' '}
             <strong>the {group?.name} group</strong>.
           </p>

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -133,7 +133,7 @@ const SegmentOverrideInner = class Override extends React.Component {
           >
             {this.props.id ? (
               <>
-                <Row className='font-weight-medium text-dark mb-1'>
+                <Row className='font-weight-medium text-default mb-1'>
                   {projectFlag.description ? (
                     <Tooltip
                       title={
@@ -173,7 +173,7 @@ const SegmentOverrideInner = class Override extends React.Component {
                   width={16}
                   height={16}
                 />
-                <span className='ms-2 fw-bold text-body mb-0'>
+                <span className='ms-2 fw-bold text-default mb-0'>
                   {name || v.segment_name}
                 </span>
                 {v.is_feature_specific && (

--- a/frontend/web/components/feature-health/components/EventTextBlocks.tsx
+++ b/frontend/web/components/feature-health/components/EventTextBlocks.tsx
@@ -48,11 +48,11 @@ const EventTextBlocks: React.FC<EventTextBlocksProps> = ({ textBlocks }) => {
 
   return (
     <div className='d-flex flex-column m-0 gap-2 flex-1'>
-      <strong className='text-body'>Incident Insights</strong>
+      <strong className='text-default'>Incident Insights</strong>
       {textBlocks.map((textBlock, index) => (
         <div key={`${textBlock.text}-${index}`}>
           {textBlock.title && (
-            <div className='mb-2 text-body'>
+            <div className='mb-2 text-default'>
               <strong style={{ color }}>{textBlock.title ?? 'Event'}</strong>
               {!!textBlock.text && (
                 <IonIcon

--- a/frontend/web/components/feature-health/components/EventUrlsBlock.tsx
+++ b/frontend/web/components/feature-health/components/EventUrlsBlock.tsx
@@ -14,7 +14,7 @@ const EventURLBlocks: React.FC<EventURLBlocksProps> = ({ urlBlocks }) => {
   return (
     <div className='d-flex flex-column m-0 gap-2 align-items-start'>
       <div>
-        <strong className='text-body'>Provider Links</strong>
+        <strong className='text-default'>Provider Links</strong>
       </div>
       {urlBlocks.map((urlBlock, index) => (
         <Button

--- a/frontend/web/components/feature-override/IdentityOverrideDescription.tsx
+++ b/frontend/web/components/feature-override/IdentityOverrideDescription.tsx
@@ -7,7 +7,7 @@ const IdentityOverrideDescription: FC<
   IdentityOverrideDescriptionType
 > = ({}) => {
   return (
-    <div className='list-item-subtitle text-primary d-flex align-items-center'>
+    <div className='list-item-subtitle text-action d-flex align-items-center'>
       <UsersIcon fill='#6837fc' width={16} className='me-1' />
       This feature is being overridden for this identity
     </div>

--- a/frontend/web/components/feature-override/SegmentOverrideDescription.tsx
+++ b/frontend/web/components/feature-override/SegmentOverrideDescription.tsx
@@ -21,7 +21,7 @@ const SegmentOverrideDescription: FC<SegmentOverrideDescriptionType> = ({
   // If neither enabled nor value override is shown, show a generic message
   if (!showEnabledOverride && !showValueOverride) {
     return (
-      <span className='d-flex list-item-subtitle text-primary align-items-center'>
+      <span className='d-flex list-item-subtitle text-action align-items-center'>
         <SegmentsIcon className='me-1' width={16} fill='#6837fc' />
         {`This feature is being overridden by ${
           level === 'segment' ? 'this segment' : 'a segment'
@@ -36,7 +36,7 @@ const SegmentOverrideDescription: FC<SegmentOverrideDescriptionType> = ({
         <div className='list-item-subtitle'>
           <Row>
             <Flex>
-              <span className='list-item-subtitle d-flex text-primary align-items-center'>
+              <span className='list-item-subtitle d-flex text-action align-items-center'>
                 <SegmentsIcon className='me-1' width={16} fill='#6837fc' />
                 {`This feature is being overridden by ${
                   level === 'segment' ? 'this segment' : 'a segment'
@@ -51,7 +51,7 @@ const SegmentOverrideDescription: FC<SegmentOverrideDescriptionType> = ({
         </div>
       )}
       {showValueOverride && (
-        <span className='d-flex list-item-subtitle text-primary align-items-center'>
+        <span className='d-flex list-item-subtitle text-action align-items-center'>
           <SegmentsIcon className='me-1' width={16} fill='#6837fc' />
           {`This feature is being overridden by ${
             level === 'segment' ? 'this segment' : 'a segment'

--- a/frontend/web/components/inspect-permissions/Permissions.tsx
+++ b/frontend/web/components/inspect-permissions/Permissions.tsx
@@ -70,7 +70,7 @@ const Permissions = ({
         <div className='my-2'>
           <Row>
             <Flex>
-              <div className='font-weight-medium text-dark mb-1'>
+              <div className='font-weight-medium text-default mb-1'>
                 Administrator
               </div>
               {isDerivedAdmin && (

--- a/frontend/web/components/modals/CreateAuditLogWebhook.tsx
+++ b/frontend/web/components/modals/CreateAuditLogWebhook.tsx
@@ -131,7 +131,7 @@ const CreateAuditLogWebhook: React.FC<Props> = ({
           )}
           <div className={isEdit ? 'footer' : ''}>
             <div className='mb-3'>
-              <p className='text-dark fw-bold'>
+              <p className='text-default fw-bold'>
                 This will {isEdit ? 'update' : 'create'} a webhook for the
                 Organisation{' '}
                 <strong>{AccountStore.getOrganisation().name}</strong>

--- a/frontend/web/components/modals/CreateAuditLogWebhook.tsx
+++ b/frontend/web/components/modals/CreateAuditLogWebhook.tsx
@@ -104,7 +104,7 @@ const CreateAuditLogWebhook: React.FC<Props> = ({
             <label>
               Secret (Optional) -{' '}
               <a
-                className='text-info'
+                className='text-action'
                 target='_blank'
                 href='https://docs.flagsmith.com/system-administration/webhooks#web-hook-signature'
                 rel='noreferrer'

--- a/frontend/web/components/modals/CreateRole.tsx
+++ b/frontend/web/components/modals/CreateRole.tsx
@@ -509,7 +509,7 @@ const CreateRole: FC<CreateRoleType> = ({
                 ))}
               </div>
             </div>
-            <p className='text-right mt-5 text-dark'>
+            <p className='text-right mt-5 text-default'>
               This will edit the members for <strong>{role?.name}</strong>.
             </p>
           </div>

--- a/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
+++ b/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
@@ -184,7 +184,7 @@ const CreateSegmentRulesTabForm: React.FC<CreateSegmentRulesTabFormProps> = ({
           />
           <span
             style={{ fontWeight: 'normal', marginLeft: '12px' }}
-            className='mb-0 fs-small text-dark'
+            className='mb-0 fs-small text-default'
           >
             Show condition descriptions
           </span>

--- a/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
+++ b/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
@@ -66,7 +66,7 @@ const UserRow: FC<UserRowType> = ({
         <div className='font-weight-medium'>{identifier}</div>
         <Row
           className={`font-weight-medium fs-small lh-sm ${
-            inSegment ? 'text-primary' : 'faint'
+            inSegment ? 'text-action' : 'faint'
           }`}
         >
           {inSegment ? (

--- a/frontend/web/components/modals/CreateUser.tsx
+++ b/frontend/web/components/modals/CreateUser.tsx
@@ -28,7 +28,7 @@ const CreateUser: FC<CreateUserType> = ({ environmentId }) => {
   return (
     <div>
       <div className='modal-body px-4'>
-        <div className='fw-bold text-dark mt-4 mb-3'>
+        <div className='fw-bold text-default mt-4 mb-3'>
           Enter a comma or space separate list of user IDs.
         </div>
         <label>User IDs</label>

--- a/frontend/web/components/modals/CreateWebhook.tsx
+++ b/frontend/web/components/modals/CreateWebhook.tsx
@@ -128,7 +128,7 @@ const CreateWebhook: FC<CreateWebhookProps> = ({
           )}
           <div className={isEdit ? 'footer' : ''}>
             <div className='mb-3'>
-              <p className='text-dark fw-bold'>
+              <p className='text-default fw-bold'>
                 This will {isEdit ? 'update' : 'create'} a webhook for the
                 environment <strong>{environment?.name}</strong>
               </p>
@@ -163,7 +163,7 @@ const CreateWebhook: FC<CreateWebhookProps> = ({
         <FormGroup className='ml-1'>
           <div>
             <Row className='mb-3' space>
-              <div className='font-weight-medium text-dark'>
+              <div className='font-weight-medium text-default'>
                 Example Payload
               </div>
               <ViewDocs href='https://docs.flagsmith.com/system-administration/webhooks#environment-web-hooks' />

--- a/frontend/web/components/modals/CreateWebhook.tsx
+++ b/frontend/web/components/modals/CreateWebhook.tsx
@@ -102,7 +102,7 @@ const CreateWebhook: FC<CreateWebhookProps> = ({
             <label>
               Secret (Optional) -{' '}
               <a
-                className='text-info'
+                className='text-action'
                 target='_blank'
                 href='https://docs.flagsmith.com/system-administration/webhooks#audit-log-web-hooks'
                 rel='noreferrer'

--- a/frontend/web/components/modals/payment/Payment.tsx
+++ b/frontend/web/components/modals/payment/Payment.tsx
@@ -139,7 +139,7 @@ export const Payment: FC<PaymentProps> = ({
               <>
                 Optional{' '}
                 <a
-                  className='text-primary fw-bold'
+                  className='text-action fw-bold'
                   target='_blank'
                   href={ON_PREMISE_HOSTING_URL}
                   rel='noreferrer'
@@ -148,7 +148,7 @@ export const Payment: FC<PaymentProps> = ({
                 </a>{' '}
                 or{' '}
                 <a
-                  className='text-primary fw-bold'
+                  className='text-action fw-bold'
                   target='_blank'
                   href={ON_PREMISE_HOSTING_URL}
                   rel='noreferrer'

--- a/frontend/web/components/modals/payment/PricingPanel.tsx
+++ b/frontend/web/components/modals/payment/PricingPanel.tsx
@@ -51,7 +51,7 @@ export const PricingPanel = ({
               {headerContent && (
                 <span
                   className={classNames('featured', {
-                    'text-body': !isEnterprise,
+                    'text-default': !isEnterprise,
                     'text-white': isEnterprise,
                   })}
                 >
@@ -127,7 +127,7 @@ export const PricingPanel = ({
             })}
           >
             All from{' '}
-            <span className={isEnterprise ? 'pricing-accent' : 'text-primary'}>
+            <span className={isEnterprise ? 'pricing-accent' : 'text-action'}>
               {includesFrom},
             </span>{' '}
             plus

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
@@ -155,7 +155,7 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
       {canEdit && (
         <Button
           theme='text'
-          className='text-primary ml-2'
+          className='text-action ml-2'
           onClick={startEditing}
           data-test={`featureVariationKeyEdit${index}`}
           aria-label='Edit label'

--- a/frontend/web/components/navigation/EnvironmentAside.tsx
+++ b/frontend/web/components/navigation/EnvironmentAside.tsx
@@ -72,7 +72,7 @@ const CustomOption = ({ hasWarning, ...rest }: CustomOptionProps) => {
           )}
           <div className='flex ml-auto'>
             {rest.isSelected && (
-              <IonIcon icon={checkmarkCircle} className='text-primary' />
+              <IonIcon icon={checkmarkCircle} className='icon-action' />
             )}
           </div>
         </div>

--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -183,7 +183,7 @@ const Tabs: React.FC<TabsProps> = ({
                 return {
                   className: classNames('', [
                     active
-                      ? 'text-primary fw-semibold bg-primary-opacity-5 fill-primary'
+                      ? 'text-action fw-semibold bg-primary-opacity-5 fill-primary'
                       : 'hover-color-primary',
                   ]),
                   label: (
@@ -193,7 +193,7 @@ const Tabs: React.FC<TabsProps> = ({
                         isSelected={false}
                         className={classNames(
                           'full-width btn-no-focus width-100',
-                          active && 'text-primary fw-semibold fill-primary',
+                          active && 'text-action fw-semibold fill-primary',
                         )}
                         noFocus={noFocus}
                         child={child}

--- a/frontend/web/components/onboarding/GettingStartedItem.tsx
+++ b/frontend/web/components/onboarding/GettingStartedItem.tsx
@@ -76,7 +76,7 @@ const GettingStartedItem: FC<GettingStartedItemType> = (data) => {
                   ) : (
                     <Icon
                       name={data.icon || 'file-text'}
-                      className='text-body'
+                      className='text-default'
                     />
                   )}
                 </div>

--- a/frontend/web/components/onboarding/OnboardingStep.tsx
+++ b/frontend/web/components/onboarding/OnboardingStep.tsx
@@ -57,7 +57,7 @@ const Step: FC<StepProps> = ({
     >
       <div
         className={classNames(numberClassName, {
-          'bg-white bg-body text-primary fw-semibold': !isComplete && isActive,
+          'bg-white bg-body text-action fw-semibold': !isComplete && isActive,
           'bg-white bg-light200': !isComplete && !isActive,
         })}
         style={{
@@ -74,7 +74,7 @@ const Step: FC<StepProps> = ({
         )}
       </div>
       <div className='d-flex align-items-center gap-1'>
-        <h5 className={`mb-0 ${isComplete ? 'text-success' : 'text-primary'}`}>
+        <h5 className={`mb-0 ${isComplete ? 'text-success' : 'text-action'}`}>
           {isComplete ? completedTitle : title}
         </h5>
       </div>

--- a/frontend/web/components/pages/AccountSettingsPage.tsx
+++ b/frontend/web/components/pages/AccountSettingsPage.tsx
@@ -107,7 +107,7 @@ const AccountSettingsPage: FC = () => {
       body: (
         <div>
           Invalidating your token will generate a new token to use with our API,{' '}
-          <span className='text-dark font-weight-medium'>
+          <span className='text-default font-weight-medium'>
             your current token will no longer work
           </span>
           . Performing this action will also log you out, are you sure you wish

--- a/frontend/web/components/pages/CreateOrganisationPage.tsx
+++ b/frontend/web/components/pages/CreateOrganisationPage.tsx
@@ -133,7 +133,7 @@ const CreateOrganisationPage: React.FC = () => {
                 <div>
                   What is your company's desired hosting option?{' '}
                   <a
-                    className='text-primary'
+                    className='text-action'
                     href='https://docs.flagsmith.com/version-comparison'
                     target='_blank'
                     rel='noreferrer'

--- a/frontend/web/components/pages/GettingStartedPage.tsx
+++ b/frontend/web/components/pages/GettingStartedPage.tsx
@@ -166,7 +166,7 @@ const GettingStartedPage: FC = () => {
           <Button
             theme='text'
             onClick={onChatClick}
-            className='text-primary gap-2'
+            className='text-action gap-2'
             href=''
           >
             let us know

--- a/frontend/web/components/pages/OnboardingPage.tsx
+++ b/frontend/web/components/pages/OnboardingPage.tsx
@@ -120,7 +120,7 @@ const OnboardingPage: FC<OnboardingPageProps> = () => {
               <br />
               View our{' '}
               <a
-                className='text-primary'
+                className='text-action'
                 href='https://docs.flagsmith.com/deployment'
                 target={'_blank'}
                 rel='noreferrer'
@@ -129,7 +129,7 @@ const OnboardingPage: FC<OnboardingPageProps> = () => {
               </a>{' '}
               or{' '}
               <a
-                className='text-primary'
+                className='text-action'
                 target='_blank'
                 href='https://www.flagsmith.com/contact-us'
                 rel='noreferrer'

--- a/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
@@ -169,7 +169,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
                 <Tooltip
                   title={
                     <IonIcon
-                      className='text-primary'
+                      className='text-action'
                       icon={cloudDownloadOutline}
                       style={{ fontSize: '18px' }}
                     />

--- a/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
@@ -169,7 +169,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
                 <Tooltip
                   title={
                     <IonIcon
-                      className='text-action'
+                      className='icon-action'
                       icon={cloudDownloadOutline}
                       style={{ fontSize: '18px' }}
                     />

--- a/frontend/web/components/pages/sdk-keys/SDKKeysPage.tsx
+++ b/frontend/web/components/pages/sdk-keys/SDKKeysPage.tsx
@@ -57,7 +57,10 @@ const SDKKeysPage: FC = () => {
               placeholder='Client-side Environment Key'
             />
           </Flex>
-          <Button onClick={handleCopy} className='ml-2 btn-with-icon text-body'>
+          <Button
+            onClick={handleCopy}
+            className='ml-2 btn-with-icon icon-default'
+          >
             <Icon name='copy' width={20} />
           </Button>
         </Row>

--- a/frontend/web/components/pages/sdk-keys/components/ServerSideKeyRow.tsx
+++ b/frontend/web/components/pages/sdk-keys/components/ServerSideKeyRow.tsx
@@ -34,7 +34,7 @@ const ServerSideKeyRow: FC<ServerSideKeyRowProps> = ({
         onClick={() => {
           Utils.copyToClipboard(keyValue)
         }}
-        className='ml-2 btn-with-icon text-body'
+        className='ml-2 btn-with-icon icon-default'
       >
         <Icon name='copy' width={20} />
       </Button>
@@ -42,7 +42,7 @@ const ServerSideKeyRow: FC<ServerSideKeyRowProps> = ({
         <Button
           onClick={() => onRemove(id, name)}
           id='remove-sdk-key'
-          className='btn btn-with-icon text-body'
+          className='btn btn-with-icon icon-default'
         >
           <Icon name='trash-2' width={20} />
         </Button>

--- a/frontend/web/components/segments/AssociatedSegmentOverrides.tsx
+++ b/frontend/web/components/segments/AssociatedSegmentOverrides.tsx
@@ -101,7 +101,7 @@ const AssociatedSegmentOverrides: FC<AssociatedSegmentOverridesType> = ({
             }
           >
             This feature is specifically associated with the segment{' '}
-            <strong className='text-primary'>{segment?.name}</strong>.
+            <strong className='text-action'>{segment?.name}</strong>.
           </PageTitle>
         </div>
         <div className='panel panel-without-heading no-pad overflow-visible'>
@@ -143,8 +143,8 @@ const AssociatedSegmentOverrides: FC<AssociatedSegmentOverridesType> = ({
           }
         >
           This will highlight any feature overridden by the segment{' '}
-          <strong className='text-primary'>{segment?.name}</strong> in the
-          chosen environment.
+          <strong className='text-action'>{segment?.name}</strong> in the chosen
+          environment.
         </PageTitle>
       </div>
       {projectFlagsLoading ? (

--- a/frontend/web/components/tables/TableFilterItem.tsx
+++ b/frontend/web/components/tables/TableFilterItem.tsx
@@ -34,7 +34,7 @@ const TableFilterItem: FC<TableFilterItemType> = ({
         </div>
         <div>
           <Icon
-            className={classNames('text-body', { 'opacity-0': !isActive })}
+            className={classNames('text-default', { 'opacity-0': !isActive })}
             name={'checkmark'}
           />
         </div>

--- a/frontend/web/components/tables/TableSortFilter.tsx
+++ b/frontend/web/components/tables/TableSortFilter.tsx
@@ -59,7 +59,7 @@ const TableSortFilter: FC<TableFilterType> = ({
                 <div>{sortOption.label}</div>
                 <div>
                   <Icon
-                    className={classNames('text-body', {
+                    className={classNames('text-default', {
                       'opacity-0': !isActive,
                     })}
                     name={

--- a/frontend/web/components/tags/AddEditTags.tsx
+++ b/frontend/web/components/tags/AddEditTags.tsx
@@ -254,7 +254,7 @@ const AddEditTags: FC<AddEditTagsType> = ({
               {!!filter && !exactTag ? (
                 <div
                   onClick={submit}
-                  className='text-center flex-row text-dark justify-content-center'
+                  className='text-center flex-row text-default justify-content-center'
                 >
                   <div className='me-2'>Create</div>
                   <Tag
@@ -267,7 +267,7 @@ const AddEditTags: FC<AddEditTagsType> = ({
                 </div>
               ) : null}
               {noTags && (
-                <div className='text-center text-dark mt-4'>
+                <div className='text-center text-default mt-4'>
                   You have no tags yet
                 </div>
               )}

--- a/frontend/web/project/project-components.js
+++ b/frontend/web/project/project-components.js
@@ -110,7 +110,7 @@ const Option = (props) => {
       >
         <div>{labelContent}</div>
         {props.isSelected && (
-          <IonIcon icon={checkmarkCircle} className='text-primary' />
+          <IonIcon icon={checkmarkCircle} className='icon-action' />
         )}
       </div>
     </components.Option>

--- a/frontend/web/project/toast.tsx
+++ b/frontend/web/project/toast.tsx
@@ -85,10 +85,10 @@ const Message: FC<MessageProps> = ({
 
   return (
     <div className={className}>
-      <div className='my-2 w-100 d-flex flex-nowrap  text-body gap-2'>
+      <div className='my-2 w-100 d-flex flex-nowrap  text-default gap-2'>
         <ToastIcon theme={theme} />
         <div className='flex-1 flex-column'>
-          <div className='text-body mb-1 fw-semibold'>
+          <div className='text-default mb-1 fw-semibold'>
             {theme === 'success' ? 'Success' : 'Error'}
           </div>
           <div className='fw-normal mb-1'>{children} </div>

--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -21,12 +21,10 @@
 // Drop the overlapping keys from Bootstrap's text-colour utility so `.text-*`
 // resolve to the tokens, not Bootstrap's `$theme-colors`. Otherwise Bootstrap's
 // `!important` copy wins the cascade and the token utility is dead.
-//
 // - secondary/success/danger/warning/info: token utilities take over. Values are
 //   identical to Bootstrap (secondary excepted, that is the intended yellow->grey
 //   fix), so this is a no-op for the others.
 // - light/black/white-50/black-50: unused, no token equivalent, dropped.
-//
 // Not touched here (see DARK_MODE_TEXT_COLOUR_PLAN_6606.md): primary, dark, body,
 // muted, white, reset.
 $_color-util: map-get($utilities, "color");

--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -50,6 +50,26 @@ $_color-util: map-merge(
 );
 $utilities: map-merge($utilities, ("color": $_color-util));
 
+// Border colour: token border utilities take over. Values are identical to
+// Bootstrap's, so a no-op; it just moves ownership to the token layer.
+$_border-util: map-get($utilities, "border-color");
+$_border-util: map-merge(
+  $_border-util,
+  (values: map-remove(map-get($_border-util, "values"), "danger", "info", "success", "warning"))
+);
+$utilities: map-merge($utilities, ("border-color": $_border-util));
+
+// Shadow scale is owned by the token utilities (--shadow-*). Drop sm/lg/none so
+// `.shadow-sm` / `.shadow-lg` / `.shadow-none` use the DS tokens, consistent with
+// the token-only `.shadow-md` / `.shadow-xl`. Bootstrap's suffixless `.shadow`
+// (the `null` key) is left in place.
+$_shadow-util: map-get($utilities, "shadow");
+$_shadow-util: map-merge(
+  $_shadow-util,
+  (values: map-remove(map-get($_shadow-util, "values"), "sm", "lg", "none"))
+);
+$utilities: map-merge($utilities, ("shadow": $_shadow-util));
+
 @import "~bootstrap/scss/utilities/api";
 
 // 5. Include any optional Bootstrap CSS as needed

--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -25,8 +25,8 @@
 //   identical to Bootstrap (secondary excepted, that is the intended yellow->grey
 //   fix), so this is a no-op for the others.
 // - light/black/white-50/black-50: unused, no token equivalent, dropped.
-// Not touched here (see DARK_MODE_TEXT_COLOUR_PLAN_6606.md): primary, dark, body,
-// muted, white, reset.
+// Not removed: primary, dark, body, muted, white, reset. Bootstrap still
+// generates these; muted resolves to the token via $text-muted (_variables.scss).
 $_color-util: map-get($utilities, "color");
 $_color-util: map-merge(
   $_color-util,

--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -18,14 +18,35 @@
 @import "../project/spacing-utils";
 
 // Colour is owned by the design-system token utilities (_token-utilities.scss).
-// Drop `secondary` from Bootstrap's text-colour utility so `.text-secondary`
-// resolves to `--color-text-secondary` (the token) instead of `$secondary`
-// (the brand yellow). Without this, Bootstrap's `!important` copy wins the
-// cascade and the token utility is dead.
+// Drop the overlapping keys from Bootstrap's text-colour utility so `.text-*`
+// resolve to the tokens, not Bootstrap's `$theme-colors`. Otherwise Bootstrap's
+// `!important` copy wins the cascade and the token utility is dead.
+//
+// - secondary/success/danger/warning/info: token utilities take over. Values are
+//   identical to Bootstrap (secondary excepted, that is the intended yellow->grey
+//   fix), so this is a no-op for the others.
+// - light/black/white-50/black-50: unused, no token equivalent, dropped.
+//
+// Not touched here (see DARK_MODE_TEXT_COLOUR_PLAN_6606.md): primary, dark, body,
+// muted, white, reset.
 $_color-util: map-get($utilities, "color");
 $_color-util: map-merge(
   $_color-util,
-  (values: map-remove(map-get($_color-util, "values"), "secondary"))
+  (
+    values:
+      map-remove(
+        map-get($_color-util, "values"),
+        "secondary",
+        "success",
+        "danger",
+        "warning",
+        "info",
+        "light",
+        "black",
+        "white-50",
+        "black-50"
+      )
+  )
 );
 $utilities: map-merge($utilities, ("color": $_color-util));
 

--- a/frontend/web/styles/_variables.scss
+++ b/frontend/web/styles/_variables.scss
@@ -31,7 +31,7 @@ $body-color: #1a2634;
 $text-icon-light: #ffffff;
 $text-icon-grey: #656d7b;
 $text-icon-light-grey: rgba(157, 164, 174, 1);
-$text-muted: $text-icon-grey;
+$text-muted: var(--color-text-secondary);
 
 // Header
 $header-color: #1e0d26; // for headers and labels

--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -88,6 +88,3 @@
     background-color: $danger-solid-dark-alert
   }
 }
-.text-info {
-  color: $primary !important;
-}


### PR DESCRIPTION
## Changes

Contributes to #6606. Consolidates the dark-mode colour work into one PR (supersedes #7985, #7986, #7987) so it can be reviewed and QA'd in a single pass.

Moves ownership of colour and shadow **utilities** from Bootstrap to the design-system token layer. Bootstrap's utilities load later and carry `!important`, so wherever a token utility shared a name it was silently dead and Bootstrap's value won. Commit-by-commit:

- **Reclaim semantic text colours** — drop `success` / `danger` / `warning` / `info` from Bootstrap's text-colour utility (values identical, no-op) + the unused `light` / `black` / `white-50` / `black-50`. (`secondary` already landed in #7981.)
- **Migrate `text-primary` / `text-dark` / `text-body`** to token classes: `text-action` / `icon-action` for the purple, `text-default` / `icon-default` for body text (~43 files).
- **`text-muted` theme-aware** — point `$text-muted` at `--color-text-secondary` (one line): `#656d7b` light unchanged, `#9da4ae` dark (3.45:1 → 7.16:1, fixes AA). No usage churn.
- **Reclaim border-colour + shadow** — `border-*` danger/info/success/warning (identical, no-op); `shadow-sm`/`shadow-lg` now use the DS `--shadow-*` tokens (were silently using Bootstrap's heavier shadows).
- **Remove the global `.text-info` purple override** — an unscoped `!important` rule forced all `.text-info` to purple; moved the two webhook doc links to `.text-action` and restored `.text-info` to info-blue.

## How did you test this code?

Compiled the full stylesheet and confirmed every previously-colliding utility now resolves to a single token rule: `text-secondary/success/danger/warning/info`, `border-success/warning`, `shadow-sm/lg` → `var(--...)`; `text-muted` → `var(--color-text-secondary)`; `text-info` → info-blue. No stray `text-primary/dark/body/muted/info` classNames remain.

**Single dark-mode QA pass** covers everything that actually changes appearance:
- purple `text-action` elements (tabs, breadcrumbs, links, segment names) — near-black → readable purple in dark
- muted text (tables, forms, labels) — lighter grey in dark
- the one `shadow-sm` element — subtler DS shadow
- the two webhook "Secret" doc links — still purple
