### PR TITLE
fix(dark mode): migrate text-muted usages to the text-secondary token

### DIFF
--- a/frontend/web/components/Breadcrumb.tsx
+++ b/frontend/web/components/Breadcrumb.tsx
@@ -19,12 +19,12 @@ const Breadcrumb: FC<BreadcrumbType> = ({
           <Link className='text-primary h6 mb-0' to={item.url}>
             {item.title}
           </Link>
-          <div className='text-muted mx-2 h6 mb-0'>/</div>
+          <div className='text-secondary mx-2 h6 mb-0'>/</div>
         </>
       ))}
       {isCurrentPageMuted ? (
         <div
-          className='active h6 text-muted mb-0'
+          className='active h6 text-secondary mb-0'
           aria-current='page'
           style={{ opacity: 0.6 }}
         >

--- a/frontend/web/components/BreadcrumbSeparator.tsx
+++ b/frontend/web/components/BreadcrumbSeparator.tsx
@@ -87,7 +87,7 @@ const ItemList: FC<ItemListType> = ({
       className={classNames('overflow-auto custom-scroll', className)}
       style={{ maxHeight: 400 }}
     >
-      <div className='mb-2 text-muted'>{title}</div>
+      <div className='mb-2 text-secondary'>{title}</div>
       {isLoading && (
         <div className='text-center'>
           <Loader />
@@ -281,12 +281,12 @@ const BreadcrumbSeparator: FC<BreadcrumbSeparatorType> = ({
           <IonIcon
             style={{ marginBottom: -2 }}
             icon={chevronUp}
-            className='text-muted'
+            className='text-secondary'
           />
           <IonIcon
             style={{ marginTop: -2 }}
             icon={chevronDown}
-            className='text-muted'
+            className='text-secondary'
           />
         </span>
       )}

--- a/frontend/web/components/DateList.tsx
+++ b/frontend/web/components/DateList.tsx
@@ -64,7 +64,7 @@ const DateList = <T extends { [key: string]: any }>({
               <Icon name='clock' fill='#9DA4AE' />
               <div style={{ height: 15, width: 1 }} className='border-1' />
             </div>
-            <div className='text-muted py-1 fs-caption'>{formatDate(date)}</div>
+            <div className='text-secondary py-1 fs-caption'>{formatDate(date)}</div>
           </div>
 
           <div className='border-1 rounded'>

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -133,7 +133,7 @@ const withAdminPermissions = (InnerComponent: any) => {
     if (!permission) {
       return (
         <div
-          className='my-4 text-center text-muted'
+          className='my-4 text-center text-secondary'
           data-test='no-organisation-permissions'
         >
           To manage permissions you need to be admin of this {level}.
@@ -1315,7 +1315,7 @@ const EditPermissions: FC<EditPermissionsType> = (props) => {
                 renderNoResults={
                   <Panel title={'Roles'} className='no-pad'>
                     <div className='search-list'>
-                      <Row className='list-item p-3 text-muted'>
+                      <Row className='list-item p-3 text-secondary'>
                         {`You currently have no roles.`}
                       </Row>
                     </div>

--- a/frontend/web/components/EmptyState.tsx
+++ b/frontend/web/components/EmptyState.tsx
@@ -31,7 +31,7 @@ const EmptyState: FC<EmptyStateProps> = ({
       )}
       <h5 className='empty-state__title'>{title}</h5>
       {description && (
-        <div className='empty-state__description text-muted'>{description}</div>
+        <div className='empty-state__description text-secondary'>{description}</div>
       )}
       {docsUrl && (
         <a

--- a/frontend/web/components/FeatureHistory.tsx
+++ b/frontend/web/components/FeatureHistory.tsx
@@ -100,7 +100,7 @@ const FeatureHistory: FC<FeatureHistoryPageType> = ({
                     >
                       <div className='font-weight-medium d-flex gap-2 align-items-center mb-1'>
                         {moment(v.live_from).format('HH:mma')}
-                        <div className='text-muted fw-normal text-small'>
+                        <div className='text-secondary fw-normal text-small'>
                           {user ? `${getUserDisplayName(user)} ` : 'System '}
                         </div>
                         {!i && <span className='chip chip--xs px-2'>Live</span>}

--- a/frontend/web/components/IdentityTraits.tsx
+++ b/frontend/web/components/IdentityTraits.tsx
@@ -224,7 +224,7 @@ const IdentityTraits: FC<IdentityTraitsType> = ({
             }
           >
             <div className='search-list'>
-              <Row className='list-item text-muted px-3'>
+              <Row className='list-item text-secondary px-3'>
                 This user has no traits.
               </Row>
             </div>

--- a/frontend/web/components/JSONUpload.tsx
+++ b/frontend/web/components/JSONUpload.tsx
@@ -85,7 +85,7 @@ const JSONUpload: FC<DropAreaType> = ({ onChange, value }) => {
             <div className='mb-2'>
               <strong>Select a file or drag and drop here</strong>
             </div>
-            <div className='text-muted fs-small mb-4'>JSON File</div>
+            <div className='text-secondary fs-small mb-4'>JSON File</div>
             <Button>Select File</Button>
           </div>
         </div>

--- a/frontend/web/components/Paging.js
+++ b/frontend/web/components/Paging.js
@@ -47,7 +47,7 @@ export default class Paging extends PureComponent {
         style={isLoading ? { opacity: 0.5 } : {}}
       >
         {!!paging.count && (
-          <span className='fs-caption text-muted'>
+          <span className='fs-caption text-secondary'>
             {currentIndex * paging.pageSize + 1}-
             {Math.min((currentIndex + 1) * paging.pageSize, paging.count)} of{' '}
             {paging.count}

--- a/frontend/web/components/RolesTable.tsx
+++ b/frontend/web/components/RolesTable.tsx
@@ -174,7 +174,7 @@ const RolesTable: FC<RolesTableType> = ({ organisationId, users }) => {
         renderNoResults={
           <Panel title={'Organisation roles'} className='no-pad'>
             <div className='search-list'>
-              <Row className='list-item p-3 text-muted'>
+              <Row className='list-item p-3 text-secondary'>
                 You currently have no organisation roles
               </Row>
             </div>

--- a/frontend/web/components/StatItem.tsx
+++ b/frontend/web/components/StatItem.tsx
@@ -51,7 +51,7 @@ const StatItem: FC<StatItemProps> = ({
         <h4 className='mb-0'>
           {formattedValue}
           {limit !== null && limit !== undefined && (
-            <span className='text-muted fs-small fw-normal'>
+            <span className='text-secondary fs-small fw-normal'>
               {' '}
               / {formatNumber(limit)}
             </span>
@@ -75,7 +75,7 @@ const StatItem: FC<StatItemProps> = ({
                 <Icon name='checkmark' width={10} fill='white' />
               )}
             </div>
-            <span className='text-muted fs-small'>Visible</span>
+            <span className='text-secondary fs-small'>Visible</span>
           </div>
         )}
       </div>

--- a/frontend/web/components/UserGroupList.tsx
+++ b/frontend/web/components/UserGroupList.tsx
@@ -265,7 +265,7 @@ const UserGroupList: FC<UserGroupListType> = ({
         renderNoResults={
           <Panel title={noTitle ? '' : 'Groups'} className='no-pad'>
             <div className='search-list'>
-              <Row className='list-item p-3 text-muted'>
+              <Row className='list-item p-3 text-secondary'>
                 You have no groups in your organisation.
               </Row>
             </div>

--- a/frontend/web/components/UserSelect.tsx
+++ b/frontend/web/components/UserSelect.tsx
@@ -96,7 +96,7 @@ const UserSelect: React.FC<UserSelectProps> = ({
                   )}
                 >
                   {v.first_name} {v.last_name}
-                  <div className='text-muted text-small'>{v.email}</div>
+                  <div className='text-secondary text-small'>{v.email}</div>
                 </div>
                 {selectedValue.includes(v.id) && (
                   <span className='mr-1'>

--- a/frontend/web/components/UsersGroups.tsx
+++ b/frontend/web/components/UsersGroups.tsx
@@ -77,7 +77,7 @@ const UsersGroups: FC<UsersGroupsType> = ({ orgId, user }) => {
             <Row className='list-item' key={id}>
               <Flex className='table-column px-3'>
                 <div className='font-weight-medium'>{name}</div>
-                <div className='text-muted'>{external_id}</div>
+                <div className='text-secondary'>{external_id}</div>
               </Flex>
               <div className='table-column' style={{ width: widths[0] }}>
                 <Switch

--- a/frontend/web/components/XMLUpload.tsx
+++ b/frontend/web/components/XMLUpload.tsx
@@ -58,7 +58,7 @@ const XMLUpload: FC<DropAreaType> = ({ onChange, value }) => {
             <div className='mb-2'>
               <strong>Drag a file or click to select a file</strong>
             </div>
-            <div className='text-muted fs-small mb-4'>XML File</div>
+            <div className='text-secondary fs-small mb-4'>XML File</div>
           </div>
         </div>
       )}

--- a/frontend/web/components/base/forms/GhostInput/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput/GhostInput.tsx
@@ -54,7 +54,7 @@ const GhostInput = ({
         className={classNames(
           'ghost-input__field fw-normal m-0 p-0 border-0 bg-transparent',
           className,
-          { 'text-muted': !value },
+          { 'text-secondary': !value },
         )}
         value={value}
         placeholder={placeholder}

--- a/frontend/web/components/diff/DiffString.tsx
+++ b/frontend/web/components/diff/DiffString.tsx
@@ -35,7 +35,7 @@ const DiffString: FC<DiffType> = ({
 
   if (oldValue === newValue) {
     if (oldValue === null || oldValue === '') {
-      return <div className='text-muted'>No Value.</div>
+      return <div className='text-secondary'>No Value.</div>
     }
     return (
       <div className='react-diff react-diff-same overflow-auto react-diff-line d-flex align-items-center'>

--- a/frontend/web/components/experiments/CreateMetricForm/CreateMetricForm.tsx
+++ b/frontend/web/components/experiments/CreateMetricForm/CreateMetricForm.tsx
@@ -137,7 +137,7 @@ const CreateMetricForm: FC<CreateMetricFormProps> = ({
 
       <div className='create-metric-form__field'>
         <label className='create-metric-form__label'>Data Source</label>
-        <span className='create-metric-form__hint text-muted fs-small'>
+        <span className='create-metric-form__hint text-secondary fs-small'>
           Where this metric is collected from. Reads from your connected
           warehouse.
         </span>

--- a/frontend/web/components/experiments/ExperimentsTable/ExperimentsTable.tsx
+++ b/frontend/web/components/experiments/ExperimentsTable/ExperimentsTable.tsx
@@ -57,10 +57,10 @@ const ExperimentsTable: FC<ExperimentsTableProps> = ({
                 <StatusBadge status={exp.status} />
               </td>
               <td>{(exp.feature?.multivariate_options?.length ?? 0) + 1}</td>
-              <td className='text-muted'>
+              <td className='text-secondary'>
                 {primaryMetric?.metric_name ?? <>&mdash;</>}
               </td>
-              <td className='text-muted'>{moment(exp.updated_at).fromNow()}</td>
+              <td className='text-secondary'>{moment(exp.updated_at).fromNow()}</td>
               <td
                 className='experiments-table__actions'
                 onClick={(e) => e.stopPropagation()}

--- a/frontend/web/components/experiments/LivePreviewPanel.tsx
+++ b/frontend/web/components/experiments/LivePreviewPanel.tsx
@@ -5,7 +5,7 @@ const LivePreviewPanel: FC = () => {
   return (
     <div className='d-none d-xl-block' style={{ flexShrink: 0, width: 320 }}>
       <ContentCard title='Live Preview'>
-        <p className='text-muted fs-small mb-0'>Coming soon</p>
+        <p className='text-secondary fs-small mb-0'>Coming soon</p>
       </ContentCard>
     </div>
   )

--- a/frontend/web/components/experiments/MetricsTable/MetricsTable.tsx
+++ b/frontend/web/components/experiments/MetricsTable/MetricsTable.tsx
@@ -41,11 +41,11 @@ const MetricsTable: FC<MetricsTableProps> = ({ metrics, onDelete, onEdit }) => {
                 {getMetricSubline(metric)}
               </span>
             </td>
-            <td className='text-muted'>{metric.description || '—'}</td>
-            <td className='text-muted'>
+            <td className='text-secondary'>{metric.description || '—'}</td>
+            <td className='text-secondary'>
               {getMetricUsageLabel(metric.experiments?.length ?? 0)}
             </td>
-            <td className='text-muted'>
+            <td className='text-secondary'>
               {moment(metric.updated_at).fromNow()}
             </td>
             <td className='metrics-table__actions'>

--- a/frontend/web/components/experiments/RolloutSplitEditor/RolloutSplitEditor.tsx
+++ b/frontend/web/components/experiments/RolloutSplitEditor/RolloutSplitEditor.tsx
@@ -64,7 +64,7 @@ const RolloutSplitEditor: FC<RolloutSplitEditorProps> = ({
               readOnly
               value={Math.max(0, controlPercentage)}
             />
-            <span className='text-muted'>%</span>
+            <span className='text-secondary'>%</span>
           </span>
         </div>
 
@@ -92,13 +92,13 @@ const RolloutSplitEditor: FC<RolloutSplitEditorProps> = ({
                   setPercentage(option.id, val ? parseFloat(val) : 0)
                 }}
               />
-              <span className='text-muted'>%</span>
+              <span className='text-secondary'>%</span>
             </span>
           </div>
         ))}
       </div>
 
-      <p className='rollout-split__hint text-muted mb-0'>
+      <p className='rollout-split__hint text-secondary mb-0'>
         Bucketing is deterministic on the SDK identifier. The same identity
         always lands in the same variation.
       </p>

--- a/frontend/web/components/experiments/results/ExperimentConfiguration.tsx
+++ b/frontend/web/components/experiments/results/ExperimentConfiguration.tsx
@@ -46,7 +46,7 @@ const ExperimentConfiguration: FC<ExperimentConfigurationProps> = ({
               </div>
             </div>
           ) : (
-            <span className='text-muted'>—</span>
+            <span className='text-secondary'>—</span>
           )}
         </ContentCard>
       </div>

--- a/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
+++ b/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
@@ -200,7 +200,7 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
     if (isEditingHypothesis) {
       return (
         <div className='mt-3' style={{ maxWidth: 640 }}>
-          <span className='fs-caption text-muted fw-bold'>Hypothesis</span>
+          <span className='fs-caption text-secondary fw-bold'>Hypothesis</span>
           <div className='d-flex align-items-start gap-2 mt-1'>
             <textarea
               autoFocus
@@ -252,9 +252,9 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
 
     return (
       <div className='mt-3' style={{ maxWidth: 640 }}>
-        <span className='fs-caption text-muted fw-bold'>Hypothesis</span>
+        <span className='fs-caption text-secondary fw-bold'>Hypothesis</span>
         <div className='d-flex align-items-start gap-1'>
-          <p className='text-muted mb-0'>
+          <p className='text-secondary mb-0'>
             {experiment.hypothesis || (
               <span className='fst-italic'>No hypothesis</span>
             )}
@@ -286,7 +286,7 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
         <div className='d-flex align-items-center gap-2 fs-caption mt-2'>
           {metricName && <strong>{metricName}</strong>}
           {[startedFact, endedFact].filter(Boolean).length > 0 && (
-            <span className='text-muted'>
+            <span className='text-secondary'>
               {metricName ? '· ' : ''}
               {[startedFact, endedFact].filter(Boolean).join(' · ')}
             </span>

--- a/frontend/web/components/experiments/results/ExperimentExposuresPanel.tsx
+++ b/frontend/web/components/experiments/results/ExperimentExposuresPanel.tsx
@@ -30,7 +30,7 @@ import RefreshControl from './RefreshControl'
 import './results.scss'
 
 const AsOfLabel: FC<{ asOf: string | null }> = ({ asOf }) => (
-  <span className='text-muted fs-caption'>
+  <span className='text-secondary fs-caption'>
     {asOf ? `As of ${moment.utc(asOf).format('D MMM YYYY, HH:mm')} UTC` : ''}
   </span>
 )
@@ -213,7 +213,7 @@ const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
 
       {payload && !hasData && (
         <>
-          <div className='text-muted text-center py-5'>
+          <div className='text-secondary text-center py-5'>
             No exposures collected yet.
           </div>
           <div className='d-flex justify-content-center gap-3 fs-caption mb-2'>
@@ -256,7 +256,7 @@ const ExperimentExposuresPanel: FC<ExperimentExposuresPanelProps> = ({
       )}
 
       {!payload && viewState.kind !== 'error' && (
-        <div className='text-muted text-center py-4'>
+        <div className='text-secondary text-center py-4'>
           {isRefreshing
             ? 'Computing exposures…'
             : 'No exposure data computed yet.'}

--- a/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
@@ -52,10 +52,10 @@ const renderLift = (
   liftRange: number,
 ): ReactNode => {
   if (identity.isControl) {
-    return <span className='text-muted fs-caption'>Baseline</span>
+    return <span className='text-secondary fs-caption'>Baseline</span>
   }
   if (!inference) {
-    return <span className='text-muted fs-caption'>Collecting data…</span>
+    return <span className='text-secondary fs-caption'>Collecting data…</span>
   }
   const colour = getLiftColour(inference.lift, direction)
   const left = liftToPercent(inference.ci_low, liftRange)
@@ -94,7 +94,7 @@ const renderCI = (
   inference: Inference | null,
 ): ReactNode => {
   if (identity.isControl) {
-    return <span className='text-muted fs-caption'>Baseline</span>
+    return <span className='text-secondary fs-caption'>Baseline</span>
   }
   if (!inference) return '—'
   return (

--- a/frontend/web/components/experiments/results/ExperimentRolloutCard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentRolloutCard.tsx
@@ -146,10 +146,10 @@ const ExperimentRolloutCard: FC<ExperimentRolloutCardProps> = ({
                   setDraftRollout(val ? parseFloat(val) : 0)
                 }}
               />
-              <span className='text-muted'>%</span>
+              <span className='text-secondary'>%</span>
             </span>
           ) : (
-            <span className='text-muted'>
+            <span className='text-secondary'>
               {rollout?.rollout_percentage ?? 100}%
             </span>
           )}
@@ -209,10 +209,10 @@ const ExperimentRolloutCard: FC<ExperimentRolloutCardProps> = ({
                       )
                     }}
                   />
-                  <span className='text-muted'>%</span>
+                  <span className='text-secondary'>%</span>
                 </span>
               ) : (
-                <span className='text-muted'>{Math.round(currentPct)}%</span>
+                <span className='text-secondary'>{Math.round(currentPct)}%</span>
               )}
             </div>
           )

--- a/frontend/web/components/experiments/results/RefreshControl.tsx
+++ b/frontend/web/components/experiments/results/RefreshControl.tsx
@@ -32,7 +32,7 @@ const RefreshControl: FC<RefreshControlProps> = ({
       {children ?? 'Refresh'}
     </Button>
     {label ? (
-      <div className='text-muted fs-caption mt-1 text-end'>{label}</div>
+      <div className='text-secondary fs-caption mt-1 text-end'>{label}</div>
     ) : null}
   </div>
 )

--- a/frontend/web/components/experiments/results/StatCard.tsx
+++ b/frontend/web/components/experiments/results/StatCard.tsx
@@ -9,9 +9,9 @@ type StatCardProps = {
 
 const StatCard: FC<StatCardProps> = ({ label, loading, value }) => (
   <ContentCard compact>
-    <div className='text-muted fs-caption'>{label}</div>
+    <div className='text-secondary fs-caption'>{label}</div>
     <div className='fs-3 mt-1'>
-      {loading ? <span className='text-muted'>—</span> : value ?? '—'}
+      {loading ? <span className='text-secondary'>—</span> : value ?? '—'}
     </div>
   </ContentCard>
 )

--- a/frontend/web/components/experiments/steps/ReviewStep.tsx
+++ b/frontend/web/components/experiments/steps/ReviewStep.tsx
@@ -48,19 +48,19 @@ const ReviewStep: FC<ReviewStepProps> = ({
         }
       >
         <div className='review-row review-row--block'>
-          <span className='text-muted'>Name</span>
+          <span className='text-secondary'>Name</span>
           <span className='review-row__value'>{name}</span>
         </div>
         {hypothesis && (
           <div className='review-row review-row--block'>
-            <span className='text-muted'>Hypothesis</span>
+            <span className='text-secondary'>Hypothesis</span>
             <span className='review-row__hypothesis'>{hypothesis}</span>
           </div>
         )}
         {selectedFeature && (
           <>
             <div className='review-row review-row--block'>
-              <span className='text-muted'>Feature Flag</span>
+              <span className='text-secondary'>Feature Flag</span>
               <span className='review-row__value review-row__value--flag'>
                 {selectedFeature.name}
               </span>
@@ -124,7 +124,7 @@ const ReviewStep: FC<ReviewStepProps> = ({
             <span className='review-metric-card__badge'>Primary</span>
           </div>
         ) : (
-          <p className='text-muted mb-0'>No metric selected.</p>
+          <p className='text-secondary mb-0'>No metric selected.</p>
         )}
       </ContentCard>
     </div>

--- a/frontend/web/components/experiments/steps/RolloutStep.tsx
+++ b/frontend/web/components/experiments/steps/RolloutStep.tsx
@@ -28,7 +28,7 @@ const RolloutStep: FC<RolloutStepProps> = ({
   if (!selectedFeature) {
     return (
       <ContentCard background='white' title='Rollout configuration'>
-        <p className='text-muted mb-0'>
+        <p className='text-secondary mb-0'>
           Select a feature flag in the Setup step to configure the rollout.
         </p>
       </ContentCard>

--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/FeatureCodeReferencesContainer.tsx
@@ -70,7 +70,7 @@ const FeatureCodeReferencesContainer: React.FC<
   if (!data || data.length === 0) {
     if (!hasGithubIntegration && !hasGitlabIntegration) {
       return (
-        <div className='text-center text-muted'>
+        <div className='text-center text-secondary'>
           Set up{' '}
           <a href={`/organisation/${organisationId}/integrations`}>GitHub</a> or{' '}
           <a href={`/project/${projectId}/integrations`}>GitLab</a> integration
@@ -79,7 +79,7 @@ const FeatureCodeReferencesContainer: React.FC<
       )
     }
     return (
-      <div className='text-center text-muted'>
+      <div className='text-center text-secondary'>
         No code references found for this feature.
       </div>
     )

--- a/frontend/web/components/integrations/MCPIntegration.tsx
+++ b/frontend/web/components/integrations/MCPIntegration.tsx
@@ -99,12 +99,12 @@ const MCPIntegration: FC = () => {
                   </div>
                 )}
                 {tab.configHint && (
-                  <div className='text-muted mb-1'>{tab.configHint}</div>
+                  <div className='text-secondary mb-1'>{tab.configHint}</div>
                 )}
                 <MCPSnippet code={tab.snippet} language={tab.language} />
                 {!isSaas && (
                   <>
-                    <p className='text-muted mt-2 mb-0'>
+                    <p className='text-secondary mt-2 mb-0'>
                       Replace{' '}
                       <InlineCode>
                         <span className='fw-bold'>
@@ -113,7 +113,7 @@ const MCPIntegration: FC = () => {
                       </InlineCode>{' '}
                       with your MCP server&apos;s base URL.
                     </p>
-                    <p className='text-muted mt-1 mb-0'>
+                    <p className='text-secondary mt-1 mb-0'>
                       See{' '}
                       <a
                         href={SELF_HOSTING_DOCS_URL}
@@ -127,12 +127,12 @@ const MCPIntegration: FC = () => {
                   </>
                 )}
                 {effectiveConnection === 'apiKey' ? (
-                  <p className='text-muted mt-2 mb-0'>
+                  <p className='text-secondary mt-2 mb-0'>
                     Generate an API key in {apiKeysLink} and use it in place of{' '}
                     <InlineCode>&lt;your-api-key&gt;</InlineCode>.
                   </p>
                 ) : (
-                  <p className='text-muted mt-2 mb-0'>
+                  <p className='text-secondary mt-2 mb-0'>
                     The first time you connect, your editor opens an OAuth flow
                     to authorise Flagsmith.
                   </p>

--- a/frontend/web/components/metadata/MetadataPage.tsx
+++ b/frontend/web/components/metadata/MetadataPage.tsx
@@ -203,7 +203,7 @@ const MetadataPage: FC<MetadataPageType> = ({ organisationId, projectId }) => {
             goToPage={(p: number) => setOrgPage(p)}
             renderNoResults={
               <div className='search-list'>
-                <Row className='list-item p-3 text-muted'>
+                <Row className='list-item p-3 text-secondary'>
                   <RedirectCreateCustomFields
                     organisationId={organisationId}
                     organisationOnly
@@ -229,7 +229,7 @@ const MetadataPage: FC<MetadataPageType> = ({ organisationId, projectId }) => {
             goToPage={(p: number) => setProjectPage(p)}
             renderNoResults={
               <div className='search-list'>
-                <Row className='list-item p-3 text-muted'>
+                <Row className='list-item p-3 text-secondary'>
                   No project-level custom fields configured.
                 </Row>
               </div>
@@ -276,7 +276,7 @@ const MetadataPage: FC<MetadataPageType> = ({ organisationId, projectId }) => {
           renderNoResults={
             <Panel className='no-pad' title={'Custom Fields'}>
               <div className='search-list'>
-                <Row className='list-item p-3 text-muted'>
+                <Row className='list-item p-3 text-secondary'>
                   You currently have no custom fields configured.
                 </Row>
               </div>

--- a/frontend/web/components/modals/AuditLogWebhooks.tsx
+++ b/frontend/web/components/modals/AuditLogWebhooks.tsx
@@ -146,7 +146,7 @@ const AuditLogWebhooks: FC<AuditLogWebhooksType> = ({ organisationId }) => {
               }
             >
               <div className='search-list'>
-                <Row className='list-item p-3 text-muted'>
+                <Row className='list-item p-3 text-secondary'>
                   You currently have no webhooks configured for this
                   organisation.
                 </Row>

--- a/frontend/web/components/modals/CreateProject.tsx
+++ b/frontend/web/components/modals/CreateProject.tsx
@@ -208,7 +208,7 @@ const CreateProject: FC<CreateProjectProps> = ({ history, onSave }) => {
                   <label className='form-label mb-1'>
                     Project administrators
                   </label>
-                  <div className='text-muted text-small mb-3'>
+                  <div className='text-secondary text-small mb-3'>
                     Optionally grant other users or roles administrator access
                     to this project. Organisation administrators already have
                     full access to all projects.
@@ -250,7 +250,7 @@ const CreateProject: FC<CreateProjectProps> = ({ history, onSave }) => {
                               </Row>
                             ))}
                             {!selectedAdmins.length && (
-                              <div className='text-muted'>
+                              <div className='text-secondary'>
                                 No users assigned
                               </div>
                             )}
@@ -300,7 +300,7 @@ const CreateProject: FC<CreateProjectProps> = ({ history, onSave }) => {
                               </Row>
                             ))}
                             {!selectedRoles.length && (
-                              <div className='text-muted'>
+                              <div className='text-secondary'>
                                 No roles assigned
                               </div>
                             )}

--- a/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
+++ b/frontend/web/components/modals/CreateSegmentRulesTabForm.tsx
@@ -221,7 +221,7 @@ const CreateSegmentRulesTabForm: React.FC<CreateSegmentRulesTabFormProps> = ({
             </Row>
             {topLevelRuleType === 'ANY' &&
               Utils.getFlagsmithValue('segment_any_rule_type') && (
-                <div className='fs-small fst-italic text-muted mb-3'>
+                <div className='fs-small fst-italic text-secondary mb-3'>
                   {Utils.getFlagsmithValue('segment_any_rule_type')}
                 </div>
               )}

--- a/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
+++ b/frontend/web/components/modals/CreateSegmentUsersTabContent.tsx
@@ -160,7 +160,7 @@ const CreateSegmentUsersTabContent: React.FC<
                   }}
                   formatOptionLabel={renderEnvOption}
                 />
-                <div className='text-muted fs-small mt-2'>
+                <div className='text-secondary fs-small mt-2'>
                   Last synced:{' '}
                   {selectedMembership
                     ? moment(selectedMembership.last_synced_at).format(

--- a/frontend/web/components/modals/CreateTrait.tsx
+++ b/frontend/web/components/modals/CreateTrait.tsx
@@ -171,7 +171,7 @@ const CreateTrait: FC<CreateTraitProps> = ({
               </strong>
             </p>
 
-            <FormGroup className='text-muted'>
+            <FormGroup className='text-secondary'>
               <label>Example SDK response:</label>
               <Highlight forceExpanded className='json no-pad'>
                 {JSON.stringify({

--- a/frontend/web/components/modals/create-feature/tabs/IdentityOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/IdentityOverridesTab.tsx
@@ -183,7 +183,7 @@ const IdentityOverridesTab: FC<IdentityOverridesTabProps> = ({
             </Button>
           )}
         </Row>
-        <div className='text-muted mb-2'>
+        <div className='text-secondary mb-2'>
           Identity Overrides apply to all individual identities listed here.{' '}
           <a
             target='_blank'

--- a/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/SegmentOverridesTab.tsx
@@ -198,7 +198,7 @@ const SegmentOverridesTab: FC<SegmentOverridesTabProps> = ({
               environmentId={environmentId}
             />
           )}
-          <div className='text-muted mb-2'>
+          <div className='text-secondary mb-2'>
             <p>
               Segment Overrides apply when the identity traits match the segment
               rules.

--- a/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/UsageTab.tsx
@@ -39,7 +39,7 @@ const UsageTab: FC<UsageTabProps> = ({
             New
           </span>
         </div>
-        <div className='text-muted mb-2'>
+        <div className='text-secondary mb-2'>
           Code references allow you to track where feature flags are being used
           within your code.{' '}
           <a

--- a/frontend/web/components/modals/payment/PricingToggle.tsx
+++ b/frontend/web/components/modals/payment/PricingToggle.tsx
@@ -11,7 +11,7 @@ export const PricingToggle = ({ isYearly, onChange }: PricingToggleProps) => {
     <div className='d-flex mb-4 font-weight-medium justify-content-center align-items-center gap-2'>
       <h5
         className={classNames('mb-0', {
-          'text-muted': !isYearly,
+          'text-secondary': !isYearly,
         })}
       >
         Pay Yearly & Save
@@ -24,7 +24,7 @@ export const PricingToggle = ({ isYearly, onChange }: PricingToggleProps) => {
       />
       <h5
         className={classNames('mb-0', {
-          'text-muted': isYearly,
+          'text-secondary': isYearly,
         })}
       >
         Pay Monthly

--- a/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
+++ b/frontend/web/components/mv/VariationValueInput/VariationValueInput.tsx
@@ -138,7 +138,7 @@ export const VariationValueInput: React.FC<VariationValueProps> = ({
               step='any'
             />
           </div>
-          <span className='text-muted'>%</span>
+          <span className='text-secondary'>%</span>
         </div>
       </Row>
       {!!apiError && (

--- a/frontend/web/components/navigation/EnvironmentAside.tsx
+++ b/frontend/web/components/navigation/EnvironmentAside.tsx
@@ -258,7 +258,7 @@ const EnvironmentAside: FC<HomeAsideType> = ({ environmentId, projectId }) => {
                   </div>
                   <div
                     style={{ width: 260 }}
-                    className='d-none d-lg-block text-muted position-fixed bottom-0 p-2 fs-caption d-flex flex-column gap-4'
+                    className='d-none d-lg-block text-secondary position-fixed bottom-0 p-2 fs-caption d-flex flex-column gap-4'
                   >
                     <BuildVersion />
                   </div>

--- a/frontend/web/components/onboarding/GettingStartedItem.tsx
+++ b/frontend/web/components/onboarding/GettingStartedItem.tsx
@@ -87,7 +87,7 @@ const GettingStartedItem: FC<GettingStartedItemType> = (data) => {
                     {title}
                   </span>
 
-                  <h6 className='fw-normal d-flex fs-small text-muted flex-1 mb-0'>
+                  <h6 className='fw-normal d-flex fs-small text-secondary flex-1 mb-0'>
                     {description}
                   </h6>
                 </div>

--- a/frontend/web/components/onboarding/GettingStartedResource.tsx
+++ b/frontend/web/components/onboarding/GettingStartedResource.tsx
@@ -26,7 +26,7 @@ const GettingStartedResource: FC<Resource> = ({
           <div className='h-100 d-flex flex-column justify-content-center p-3'>
             <h6 className={`d-flex align-items-center gap-1`}>{title}</h6>
 
-            <span className='fw-normal fs-small  text-muted '>
+            <span className='fw-normal fs-small  text-secondary '>
               {description}
             </span>
           </div>

--- a/frontend/web/components/onboarding/OnboardingStep.tsx
+++ b/frontend/web/components/onboarding/OnboardingStep.tsx
@@ -79,7 +79,7 @@ const Step: FC<StepProps> = ({
         </h5>
       </div>
 
-      {isActive && description && <p className='text-muted'>{description}</p>}
+      {isActive && description && <p className='text-secondary'>{description}</p>}
       {isActive && (
         <>
           <hr />

--- a/frontend/web/components/pages/CreateEnvironmentPage.tsx
+++ b/frontend/web/components/pages/CreateEnvironmentPage.tsx
@@ -296,7 +296,7 @@ const CreateEnvironmentPage: React.FC = () => {
                             <label className='form-label mb-1'>
                               Environment administrators
                             </label>
-                            <div className='text-muted text-small mb-3'>
+                            <div className='text-secondary text-small mb-3'>
                               Optionally grant other users or roles
                               administrator access to this environment.
                               Organisation administrators already have full
@@ -343,7 +343,7 @@ const CreateEnvironmentPage: React.FC = () => {
                                         </Row>
                                       ))}
                                       {!selectedAdmins.length && (
-                                        <div className='text-muted'>
+                                        <div className='text-secondary'>
                                           No users assigned
                                         </div>
                                       )}
@@ -395,7 +395,7 @@ const CreateEnvironmentPage: React.FC = () => {
                                         </Row>
                                       ))}
                                       {!selectedRoles.length && (
-                                        <div className='text-muted'>
+                                        <div className='text-secondary'>
                                           No roles assigned
                                         </div>
                                       )}

--- a/frontend/web/components/pages/DevViewPage.tsx
+++ b/frontend/web/components/pages/DevViewPage.tsx
@@ -9,8 +9,8 @@ const DevViewPage: FC = () => {
       </PageTitle>
 
       <div className='text-center py-5'>
-        <h2 className='text-muted'>Coming Soon</h2>
-        <p className='text-muted mt-3'>
+        <h2 className='text-secondary'>Coming Soon</h2>
+        <p className='text-secondary mt-3'>
           This view will provide developer-focused tools and workflows.
         </p>
       </div>

--- a/frontend/web/components/pages/ExecutiveViewPage.tsx
+++ b/frontend/web/components/pages/ExecutiveViewPage.tsx
@@ -9,8 +9,8 @@ const ExecutiveViewPage: FC = () => {
       </PageTitle>
 
       <div className='text-center py-5'>
-        <h2 className='text-muted'>Coming Soon</h2>
-        <p className='text-muted mt-3'>
+        <h2 className='text-secondary'>Coming Soon</h2>
+        <p className='text-secondary mt-3'>
           This view will provide executive-level insights and analytics.
         </p>
       </div>

--- a/frontend/web/components/pages/ExperimentsPage.tsx
+++ b/frontend/web/components/pages/ExperimentsPage.tsx
@@ -137,10 +137,10 @@ const ExperimentsPage: FC = () => {
           <Icon
             name='setting'
             width={48}
-            className='text-muted mb-3 d-block mx-auto'
+            className='text-secondary mb-3 d-block mx-auto'
           />
           <h5>Data warehouse not configured</h5>
-          <p className='text-muted mb-4'>
+          <p className='text-secondary mb-4'>
             Experiments require a data warehouse connection to collect and
             analyse results. Configure one in your environment settings to get
             started.
@@ -157,10 +157,10 @@ const ExperimentsPage: FC = () => {
           <Icon
             name='flask'
             width={48}
-            className='text-muted mb-3 d-block mx-auto'
+            className='text-secondary mb-3 d-block mx-auto'
           />
           <h5>No experiments yet</h5>
-          <p className='text-muted mb-4'>
+          <p className='text-secondary mb-4'>
             Create your first experiment to start testing hypotheses with your
             feature flags.
           </p>
@@ -193,7 +193,7 @@ const ExperimentsPage: FC = () => {
           />
         ) : (
           <div className='text-center py-5'>
-            <p className='text-muted'>
+            <p className='text-secondary'>
               No experiments match your {search ? 'search' : 'filter'}.
             </p>
           </div>

--- a/frontend/web/components/pages/FlagEnvironmentsPage.tsx
+++ b/frontend/web/components/pages/FlagEnvironmentsPage.tsx
@@ -97,7 +97,7 @@ const EnvironmentRow: FC<EnvironmentRowProps> = ({
       </td>
       <td className='text-center'>
         {isLoading ? (
-          <small className='text-muted'>...</small>
+          <small className='text-secondary'>...</small>
         ) : (
           <Switch checked={enabled} disabled className='switch-sm' />
         )}
@@ -237,7 +237,7 @@ const FlagEnvironmentsPage: FC = () => {
   if (!flag) {
     return (
       <div className='app-container container'>
-        <div className='text-center text-muted py-5'>Flag not found</div>
+        <div className='text-center text-secondary py-5'>Flag not found</div>
       </div>
     )
   }
@@ -264,7 +264,7 @@ const FlagEnvironmentsPage: FC = () => {
 
       <PageTitle title={flag.name}>
         {flag.description && (
-          <div className='text-muted mt-2'>{flag.description}</div>
+          <div className='text-secondary mt-2'>{flag.description}</div>
         )}
       </PageTitle>
 
@@ -416,7 +416,7 @@ const FlagEnvironmentsPage: FC = () => {
               {(!environments?.results ||
                 environments.results.length === 0) && (
                 <tr>
-                  <td colSpan={6} className='text-center text-muted py-4'>
+                  <td colSpan={6} className='text-center text-secondary py-4'>
                     No environments found
                   </td>
                 </tr>

--- a/frontend/web/components/pages/GitHubSetupPage.tsx
+++ b/frontend/web/components/pages/GitHubSetupPage.tsx
@@ -285,7 +285,7 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
       ) : (
         <div className='text-center py-5'>
           <h1 className='mb-3'>GitHub installation completed!</h1>
-          <p className='text-muted'>You can close this window.</p>
+          <p className='text-secondary'>You can close this window.</p>
         </div>
       )}
     </div>

--- a/frontend/web/components/pages/HomePage.tsx
+++ b/frontend/web/components/pages/HomePage.tsx
@@ -680,7 +680,7 @@ const HomePage: React.FC = () => {
                   </div>
                 )}
               </div>
-              <div className='mt-4 text-center text-small text-muted'>
+              <div className='mt-4 text-center text-small text-secondary'>
                 By signing up you agree to our{' '}
                 <a
                   style={{ opacity: 0.8 }}

--- a/frontend/web/components/pages/IdentitiesPage.tsx
+++ b/frontend/web/components/pages/IdentitiesPage.tsx
@@ -333,7 +333,7 @@ const IdentitiesPage: FC<{ props: any }> = (props) => {
           />
         </FormGroup>
         <FormGroup>
-          <p className='text-muted col-md-8 fs-small lh-sm mt-4'>
+          <p className='text-secondary col-md-8 fs-small lh-sm mt-4'>
             Identities are created for your environment automatically when
             calling identify/get flags from any of the SDKs. We've created{' '}
             <strong>user_123456</strong> for you so you always have an example

--- a/frontend/web/components/pages/IdentityPage.tsx
+++ b/frontend/web/components/pages/IdentityPage.tsx
@@ -392,7 +392,7 @@ const IdentityPage: FC = () => {
                             renderNoResults={
                               <Panel title='Segments' className='no-pad'>
                                 <div className='search-list'>
-                                  <Row className='list-item text-muted px-3'>
+                                  <Row className='list-item text-secondary px-3'>
                                     This user is not a member of any segments.
                                   </Row>
                                 </div>

--- a/frontend/web/components/pages/MetricsPage.tsx
+++ b/frontend/web/components/pages/MetricsPage.tsx
@@ -217,10 +217,10 @@ const MetricsPage: FC = () => {
           <Icon
             name='bar-chart'
             width={48}
-            className='text-muted mb-3 d-block mx-auto'
+            className='text-secondary mb-3 d-block mx-auto'
           />
           <h5>No metrics yet</h5>
-          <p className='text-muted mb-4'>
+          <p className='text-secondary mb-4'>
             Create your first metric to measure experiment outcomes.
           </p>
           <Button onClick={() => history.push(`${metricsPath}?create=true`)}>
@@ -291,7 +291,7 @@ const MetricsPage: FC = () => {
           </>
         ) : (
           <div className='text-center py-5'>
-            <p className='text-muted'>No metrics match your search.</p>
+            <p className='text-secondary'>No metrics match your search.</p>
           </div>
         )}
       </>

--- a/frontend/web/components/pages/OAuthAuthorizePage.tsx
+++ b/frontend/web/components/pages/OAuthAuthorizePage.tsx
@@ -81,7 +81,7 @@ const OAuthAuthorizePage = () => {
       return (
         <div className='oauth-authorize__card card shadow p-4'>
           <h3>Invalid authorisation request</h3>
-          <p className='text-muted'>
+          <p className='text-secondary'>
             Required OAuth parameters are missing. Please return to the
             application and try again.
           </p>
@@ -103,7 +103,7 @@ const OAuthAuthorizePage = () => {
       return (
         <div className='oauth-authorize__card card shadow p-4'>
           <h3>Authorisation error</h3>
-          <p className='text-muted'>
+          <p className='text-secondary'>
             The authorisation request is invalid. The application may have
             provided incorrect parameters.
           </p>
@@ -158,7 +158,7 @@ const OAuthAuthorizePage = () => {
           </div>
         </div>
 
-        <p className='oauth-authorize__redirect-text text-muted text-center mb-4'>
+        <p className='oauth-authorize__redirect-text text-secondary text-center mb-4'>
           You will be redirected to:
           <br />
           <code className='oauth-authorize__redirect-uri'>

--- a/frontend/web/components/pages/OnboardingPage.tsx
+++ b/frontend/web/components/pages/OnboardingPage.tsx
@@ -103,7 +103,7 @@ const OnboardingPage: FC<OnboardingPageProps> = () => {
                 <div className='text-center'>
                   <Logo size={100} />
                   <h3 className='fw-semibold mt-2'>Welcome to Flagsmith</h3>
-                  <h5 className='fw-normal text-muted'>
+                  <h5 className='fw-normal text-secondary'>
                     You've successfully installed Flagsmith v{version?.tag},
                     let's get started!
                   </h5>

--- a/frontend/web/components/pages/ReleaseManagerPage.tsx
+++ b/frontend/web/components/pages/ReleaseManagerPage.tsx
@@ -101,7 +101,7 @@ const ReleaseManagerPage: FC = () => {
       </div>
 
       {!hasSearched && (
-        <div className='text-center text-muted py-5'>
+        <div className='text-center text-secondary py-5'>
           Enter a search query and click Search to find flags across all
           projects
         </div>
@@ -252,7 +252,7 @@ const FlagsTable: FC<FlagsTableProps> = ({ projects, searchQuery }) => {
       }
     >
       {filteredFlags.length === 0 ? (
-        <div className='text-center text-muted py-4'>
+        <div className='text-center text-secondary py-4'>
           No flags found matching "{searchQuery}"
         </div>
       ) : (
@@ -272,7 +272,7 @@ const FlagsTable: FC<FlagsTableProps> = ({ projects, searchQuery }) => {
                     className='text-center'
                     style={{ minWidth: '80px' }}
                   >
-                    <small className='text-muted'>{envName}</small>
+                    <small className='text-secondary'>{envName}</small>
                   </th>
                 ))}
                 <th className='text-center' style={{ minWidth: '100px' }}>
@@ -330,7 +330,7 @@ const EnvironmentCell: FC<EnvironmentCellProps> = ({
   return (
     <td className='text-center'>
       {isLoading ? (
-        <small className='text-muted'>...</small>
+        <small className='text-secondary'>...</small>
       ) : (
         <Switch checked={enabled} disabled className='switch-sm' />
       )}
@@ -371,20 +371,20 @@ const FlagRow: FC<FlagRowProps> = ({
             <strong>{flag.name}</strong>
           </div>
           {flag.description && (
-            <small className='text-muted d-block mt-1'>
+            <small className='text-secondary d-block mt-1'>
               {flag.description}
             </small>
           )}
         </Link>
       </td>
       <td>
-        <small className='text-muted'>{flag.projectName}</small>
+        <small className='text-secondary'>{flag.projectName}</small>
       </td>
       <td>
         {flag.tags && flag.tags.length > 0 ? (
           <TagValues projectId={String(flag.projectId)} value={flag.tags} />
         ) : (
-          <span className='text-muted'>-</span>
+          <span className='text-secondary'>-</span>
         )}
       </td>
       {uniqueEnvNames.map((envName) => {
@@ -395,7 +395,7 @@ const FlagRow: FC<FlagRowProps> = ({
           // This environment doesn't exist in this flag's project
           return (
             <td key={envName} className='text-center'>
-              <span className='text-muted'>-</span>
+              <span className='text-secondary'>-</span>
             </td>
           )
         }
@@ -410,7 +410,7 @@ const FlagRow: FC<FlagRowProps> = ({
         )
       })}
       <td className='text-center'>
-        <small className='text-muted'>
+        <small className='text-secondary'>
           {new Date(flag.created_date).toLocaleDateString('en-GB')}
         </small>
       </td>

--- a/frontend/web/components/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/web/components/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -39,7 +39,7 @@ const AdminDashboardPage: FC = () => {
     return (
       <div className='app-container text-center py-5'>
         <h3>Access Denied</h3>
-        <p className='text-muted'>
+        <p className='text-secondary'>
           This page is only accessible to instance administrators.
         </p>
       </div>
@@ -50,7 +50,7 @@ const AdminDashboardPage: FC = () => {
     <div className='app-container container'>
       <div className='py-2' style={{ marginBottom: -48 }}>
         <h2 className='mb-0'>Platform Hub</h2>
-        <p className='text-muted mb-0'>
+        <p className='text-secondary mb-0'>
           Centralised view of platform-wide usage, lifecycle, and adoption data
         </p>
       </div>

--- a/frontend/web/components/pages/admin-dashboard/components/InstanceMetricsCards.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/InstanceMetricsCards.tsx
@@ -31,7 +31,7 @@ const InstanceMetricsCards: FC<InstanceMetricsCardsProps> = ({
           label='Organisations'
           value={summary.total_organisations}
         />
-        <small className='text-muted d-block mt-1'>
+        <small className='text-secondary d-block mt-1'>
           {summary.active_organisations} active in last {days} days
         </small>
       </div>
@@ -42,14 +42,14 @@ const InstanceMetricsCards: FC<InstanceMetricsCardsProps> = ({
           label='Total Flags'
           value={summary.total_flags}
         />
-        <small className='text-muted d-block mt-1'>
+        <small className='text-secondary d-block mt-1'>
           Across {summary.total_projects} projects
         </small>
       </div>
 
       <div className='flex-fill'>
         <StatItem icon='people' label='Seats' value={summary.total_users} />
-        <small className='text-muted d-block mt-1'>
+        <small className='text-secondary d-block mt-1'>
           {summary.active_users} active of {summary.total_users}
         </small>
       </div>
@@ -60,7 +60,7 @@ const InstanceMetricsCards: FC<InstanceMetricsCardsProps> = ({
           label='API Calls'
           value={summary.total_api_calls_30d}
         />
-        <small className='text-muted d-block mt-1'>
+        <small className='text-secondary d-block mt-1'>
           Across {summary.total_environments} environments
         </small>
       </div>
@@ -71,7 +71,7 @@ const InstanceMetricsCards: FC<InstanceMetricsCardsProps> = ({
           label='Integrations'
           value={summary.total_integrations}
         />
-        <small className='text-muted d-block mt-1'>
+        <small className='text-secondary d-block mt-1'>
           Across {summary.total_organisations} organisations
         </small>
       </div>

--- a/frontend/web/components/pages/admin-dashboard/components/IntegrationAdoptionTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/IntegrationAdoptionTable.tsx
@@ -241,7 +241,7 @@ const IntegrationAdoptionTable: FC<IntegrationAdoptionTableProps> = ({
                   style={{ gap: 8, width: '100%' }}
                 >
                   <span
-                    className='text-muted'
+                    className='text-secondary'
                     style={{ fontSize: 11, minWidth: 90, textAlign: 'right' }}
                   >
                     {SCOPE_LABELS[detail.scope]}
@@ -268,7 +268,7 @@ const IntegrationAdoptionTable: FC<IntegrationAdoptionTableProps> = ({
                     />
                   </div>
                   <span
-                    className='text-muted'
+                    className='text-secondary'
                     style={{ fontSize: 11, minWidth: 120, textAlign: 'right' }}
                   >
                     {renderScopeLabel(detail)}
@@ -276,7 +276,7 @@ const IntegrationAdoptionTable: FC<IntegrationAdoptionTableProps> = ({
                 </div>
               ))}
               {org.scope_details.length === 0 && (
-                <span className='text-muted' style={{ fontSize: 12 }}>
+                <span className='text-secondary' style={{ fontSize: 12 }}>
                   Not installed
                 </span>
               )}
@@ -407,7 +407,7 @@ const IntegrationAdoptionTable: FC<IntegrationAdoptionTableProps> = ({
                 </span>
               </div>
               <div
-                className='table-column text-muted'
+                className='table-column text-secondary'
                 style={{ fontSize: 13, width: 200 }}
               >
                 {renderBreakdownSummary(row)}

--- a/frontend/web/components/pages/admin-dashboard/components/OrganisationUsageTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/OrganisationUsageTable.tsx
@@ -12,7 +12,7 @@ interface OrganisationUsageTableProps {
 
 const overageCell = (apiCalls: number, allowed: number) => {
   if (allowed === 0) {
-    return <span className='text-muted'>—</span>
+    return <span className='text-secondary'>—</span>
   }
   const diff = apiCalls - allowed
   const pct = Math.round((diff / allowed) * 100)
@@ -63,20 +63,20 @@ const OrganisationUsageTable: FC<OrganisationUsageTableProps> = ({
             style={{ paddingBottom: 8, paddingLeft: 80, paddingTop: 8 }}
           >
             <div className='flex-fill'>
-              <span className='text-muted' style={{ fontSize: 13 }}>
+              <span className='text-secondary' style={{ fontSize: 13 }}>
                 {env.name}
               </span>
             </div>
             <div style={{ width: 120 }} />
             <div style={{ width: 120 }} />
             <div
-              className='table-column text-muted'
+              className='table-column text-secondary'
               style={{ fontSize: 13, width: 160 }}
             >
               {Utils.numberWithCommas(env.api_calls_30d)}
             </div>
             <div
-              className='table-column text-muted'
+              className='table-column text-secondary'
               style={{ fontSize: 13, width: 140 }}
             >
               {envPct}% of org usage
@@ -118,25 +118,25 @@ const OrganisationUsageTable: FC<OrganisationUsageTableProps> = ({
                   <span className='font-weight-medium' style={{ fontSize: 13 }}>
                     {project.name}
                   </span>
-                  <span className='text-muted' style={{ fontSize: 12 }}>
+                  <span className='text-secondary' style={{ fontSize: 12 }}>
                     ({project.environments.length} environments)
                   </span>
                 </div>
                 <div
-                  className='table-column text-muted'
+                  className='table-column text-secondary'
                   style={{ fontSize: 13, width: 120 }}
                 >
                   {project.flags}
                 </div>
                 <div style={{ width: 120 }} />
                 <div
-                  className='table-column text-muted'
+                  className='table-column text-secondary'
                   style={{ fontSize: 13, width: 160 }}
                 >
                   {Utils.numberWithCommas(project.api_calls_30d)}
                 </div>
                 <div
-                  className='table-column text-muted'
+                  className='table-column text-secondary'
                   style={{ fontSize: 13, width: 140 }}
                 >
                   {projectPct}% of org usage
@@ -202,7 +202,7 @@ const OrganisationUsageTable: FC<OrganisationUsageTableProps> = ({
               />
               <div>
                 <div className='font-weight-medium mb-1'>{org.name}</div>
-                <div className='text-muted' style={{ fontSize: 13 }}>
+                <div className='text-secondary' style={{ fontSize: 13 }}>
                   {Utils.numberWithCommas(org.active_users_30d)} active users
                 </div>
               </div>
@@ -215,7 +215,7 @@ const OrganisationUsageTable: FC<OrganisationUsageTableProps> = ({
                 {Utils.numberWithCommas(org.total_flags)}
               </div>
               {org.stale_flags > 0 && (
-                <div className='text-muted' style={{ fontSize: 12 }}>
+                <div className='text-secondary' style={{ fontSize: 12 }}>
                   {Utils.numberWithCommas(org.stale_flags)} stale
                 </div>
               )}
@@ -227,7 +227,7 @@ const OrganisationUsageTable: FC<OrganisationUsageTableProps> = ({
               <div className='font-weight-medium'>
                 {Utils.numberWithCommas(org.total_users)}
               </div>
-              <div className='text-muted' style={{ fontSize: 12 }}>
+              <div className='text-secondary' style={{ fontSize: 12 }}>
                 {Utils.numberWithCommas(org.active_users_30d)} active
               </div>
             </div>

--- a/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/ReleasePipelineStatsTable.tsx
@@ -142,7 +142,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
               />
             </div>
           ) : (
-            <div className='text-muted fs-captionSmall'>No features yet</div>
+            <div className='text-secondary fs-captionSmall'>No features yet</div>
           )}
         </div>
 
@@ -160,7 +160,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   {stage.stage_name}
                 </span>
                 <div
-                  className='text-muted fs-captionXSmall'
+                  className='text-secondary fs-captionXSmall'
                   style={{ marginTop: 1 }}
                 >
                   {stage.trigger_description} · {stage.action_description}
@@ -189,7 +189,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                 Released
               </span>
               <div
-                className='text-muted fs-captionXSmall'
+                className='text-secondary fs-captionXSmall'
                 style={{ marginTop: 1 }}
               >
                 Features that completed this pipeline
@@ -257,13 +257,13 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                 </span>
               </div>
               <div
-                className='table-column text-muted fs-caption'
+                className='table-column text-secondary fs-caption'
                 style={{ width: 100 }}
               >
                 {pipeline.stages.length} stages
               </div>
               <div
-                className='table-column text-muted fs-caption'
+                className='table-column text-secondary fs-caption'
                 style={{ width: 100 }}
               >
                 {pipeline.total_features} features
@@ -356,13 +356,13 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                 <span className='font-weight-medium fs-caption'>
                   {project.project_name}
                 </span>
-                <span className='text-muted fs-captionSmall'>
+                <span className='text-secondary fs-captionSmall'>
                   ({projectPipelineCount}{' '}
                   {projectPipelineCount === 1 ? 'pipeline' : 'pipelines'})
                 </span>
               </div>
               <div
-                className='table-column text-muted fs-caption'
+                className='table-column text-secondary fs-caption'
                 style={{ width: 120 }}
               >
                 {projectFeatures} features
@@ -383,7 +383,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
 
   return (
     <div>
-      <div className='text-muted mb-3 fs-caption' style={{ paddingLeft: 4 }}>
+      <div className='text-secondary mb-3 fs-caption' style={{ paddingLeft: 4 }}>
         {projectsWithPipelines} of {totalProjects} projects use release
         pipelines ({adoptionPct}%)
       </div>
@@ -467,7 +467,7 @@ const ReleasePipelineStatsTable: FC<ReleasePipelineStatsTableProps> = ({
                   <span className='font-weight-medium text-success fs-caption'>
                     {org.total_released}
                   </span>
-                  <span className='text-muted fs-captionSmall'>
+                  <span className='text-secondary fs-captionSmall'>
                     ({releasedPct}%)
                   </span>
                 </div>

--- a/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
+++ b/frontend/web/components/pages/admin-dashboard/components/StaleFlagsTable.tsx
@@ -41,7 +41,7 @@ const StaleFlagsTable: FC<StaleFlagsTableProps> = ({ data }) => {
         >
           <div className='flex-fill' style={{ paddingLeft: 20 }}>
             <div className='font-weight-medium'>{row.project_name}</div>
-            <div className='text-muted' style={{ fontSize: 12 }}>
+            <div className='text-secondary' style={{ fontSize: 12 }}>
               {row.organisation_name}
             </div>
           </div>

--- a/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
@@ -893,7 +893,7 @@ const EnvironmentSettingsPage: React.FC = () => {
                               }
                             >
                               <div className='search-list'>
-                                <Row className='list-item p-3 text-muted'>
+                                <Row className='list-item p-3 text-secondary'>
                                   You currently have no Feature Webhooks
                                   configured for this Environment.
                                 </Row>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -84,7 +84,7 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
             </Tooltip>
           </div>
           {typeLabel && (
-            <span className='fst-italic text-muted' style={{ fontSize: 13 }}>
+            <span className='fst-italic text-secondary' style={{ fontSize: 13 }}>
               {typeLabel}
               {connection.config &&
                 'account_identifier' in connection.config &&
@@ -122,7 +122,7 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
       />
       <hr className='my-4' />
       {connection.status === 'pending_connection' && (
-        <div className='d-flex flex-row flex-nowrap align-items-center gap-2 text-muted mb-2'>
+        <div className='d-flex flex-row flex-nowrap align-items-center gap-2 text-secondary mb-2'>
           <Icon name='info' width={14} fill='#656D7B' />
           <span>
             Your test event is on its way. It can take up to a few hours to

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseEventCodeHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseEventCodeHelp.tsx
@@ -118,7 +118,7 @@ const enabledSnippets = Object.fromEntries(
 
 const WarehouseEventCodeHelp: FC = () => (
   <div>
-    <p className='text-muted fw-bold'>
+    <p className='text-secondary fw-bold'>
       Use our SDKs to send your first experimentation events.
     </p>
     <CodeHelp

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseStats.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseStats.tsx
@@ -40,15 +40,15 @@ const WarehouseStats: FC<WarehouseStatsProps> = ({
       </div>
     )}
     <div className='d-flex flex-row gap-2'>
-      <span className='text-muted'>Last event received:</span>
+      <span className='text-secondary'>Last event received:</span>
       <span className='font-weight-medium'>{lastEventReceived}</span>
     </div>
     <div className='d-flex flex-row align-items-center gap-2'>
-      <span className='text-muted'>Total events received:</span>
+      <span className='text-secondary'>Total events received:</span>
       <StatValue loading={loading} value={totalEventsReceived} />
     </div>
     <div className='d-flex flex-row align-items-center gap-2'>
-      <span className='text-muted'>Number of unique events:</span>
+      <span className='text-secondary'>Number of unique events:</span>
       <StatValue loading={loading} value={uniqueEventsCount} />
     </div>
   </div>

--- a/frontend/web/components/pages/feature-lifecycle/components/LifecycleSidebar.tsx
+++ b/frontend/web/components/pages/feature-lifecycle/components/LifecycleSidebar.tsx
@@ -31,7 +31,7 @@ const LifecycleSidebar: FC<LifecycleSidebarProps> = ({
     <div className='border-md-right home-aside d-flex flex-column pe-0 me-0'>
       <div className='flex-1 flex-column ms-0 me-2'>
         <div className='px-2 pt-2'>
-          <div className='text-muted fs-captionXSmall mb-1 d-flex align-items-center gap-1'>
+          <div className='text-secondary fs-captionXSmall mb-1 d-flex align-items-center gap-1'>
             Measure evaluations from
             <Tooltip
               title={<Icon name='info-outlined' width={12} />}
@@ -62,7 +62,7 @@ const LifecycleSidebar: FC<LifecycleSidebarProps> = ({
                 {s.label}
                 <span
                   className={classNames('ms-1 px-2 unread rounded d-inline', {
-                    'bg-light300 text-muted': activeSection !== s.key,
+                    'bg-light300 text-secondary': activeSection !== s.key,
                   })}
                 >
                   {isLoading ? '...' : counts[s.key] ?? 0}

--- a/frontend/web/components/pages/feature-lifecycle/components/SectionShell.tsx
+++ b/frontend/web/components/pages/feature-lifecycle/components/SectionShell.tsx
@@ -81,7 +81,7 @@ const SectionShell: FC<SectionShellProps> = ({
     return (
       <div className='text-center'>
         <h4 className='mb-3'>Unable to Load Features</h4>
-        <p className='text-muted mb-3'>
+        <p className='text-secondary mb-3'>
           We couldn&apos;t load your feature flags. This might be due to a
           network issue or a temporary server problem.
         </p>
@@ -95,7 +95,7 @@ const SectionShell: FC<SectionShellProps> = ({
   if (hasNoResults) {
     return (
       <div className='text-center py-5'>
-        <p className='text-muted'>{emptyLabel}</p>
+        <p className='text-secondary'>{emptyLabel}</p>
       </div>
     )
   }

--- a/frontend/web/components/pages/features/FeaturesPage.tsx
+++ b/frontend/web/components/pages/features/FeaturesPage.tsx
@@ -382,7 +382,7 @@ const FeaturesPage: FC<FeaturesPageProps> = ({
         {error || projectEnvError ? (
           <div className='text-center'>
             <h4 className='mb-3'>Unable to Load Features</h4>
-            <p className='text-muted mb-3'>
+            <p className='text-secondary mb-3'>
               We couldn't load your feature flags. This might be due to a
               network issue or a temporary server problem.
             </p>

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/ConnectWithAiPanel.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/ConnectWithAiPanel.tsx
@@ -51,7 +51,7 @@ Detect my stack, install the SDK, and wire ${featureName} into one place. Then r
       </div>
       <div>
         <span className='text-default fw-semibold'>What happens next</span>
-        <ul className='onboarding-connect__steps text-muted mt-2 mb-0'>
+        <ul className='onboarding-connect__steps text-secondary mt-2 mb-0'>
           <li>Detects your stack: language, framework and package manager.</li>
           <li>Installs the Flagsmith SDK and wires it into your code.</li>
           <li>Uses your flag {featureName} and verifies it’s working.</li>

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -130,7 +130,7 @@ const OnboardingFlow: FC = () => {
     return (
       <div className='onboarding-flow mx-auto text-center'>
         <h2 className='mb-2'>We couldn’t set up your workspace</h2>
-        <p className='text-muted mb-3'>
+        <p className='text-secondary mb-3'>
           Something went wrong creating your starter project. Please try again.
         </p>
         <Button onClick={() => window.location.reload()}>Try again</Button>

--- a/frontend/web/components/pages/onboarding/OnboardingHeader/OnboardingHeader.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingHeader/OnboardingHeader.tsx
@@ -25,13 +25,13 @@ const OnboardingHeader: FC<OnboardingHeaderProps> = ({
   projectName,
 }) => (
   <header className='onboarding-header'>
-    <div className='onboarding-header__crumb text-muted'>
+    <div className='onboarding-header__crumb text-secondary'>
       Onboarding / Connect your app
     </div>
     <h1 className='onboarding-header__title mb-0'>
       Welcome, let’s get you live 👋
     </h1>
-    <p className='onboarding-header__subtitle text-muted mb-0'>
+    <p className='onboarding-header__subtitle text-secondary mb-0'>
       We created your organisation{' '}
       <InlineInput
         label='Organisation'

--- a/frontend/web/components/pages/organisation-settings/tabs/sso/scim/index.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/scim/index.tsx
@@ -172,13 +172,13 @@ const ScimSection: FC<ScimSectionProps> = ({ organisationId }) => {
       <PageTitle title='SCIM Configuration' />
       <Row className='gap-4 mb-3'>
         <div>
-          <div className='text-muted text-uppercase'>Created</div>
+          <div className='text-secondary text-uppercase'>Created</div>
           <div className='font-weight-medium'>
             {moment(data.created_at).format(DATE_FORMAT)}
           </div>
         </div>
         <div>
-          <div className='text-muted text-uppercase'>Token last rotated</div>
+          <div className='text-secondary text-uppercase'>Token last rotated</div>
           <div className='font-weight-medium'>
             {moment(data.token_rotated_at).format(DATE_FORMAT)}
           </div>
@@ -186,7 +186,7 @@ const ScimSection: FC<ScimSectionProps> = ({ organisationId }) => {
       </Row>
 
       <div className='mb-3'>
-        <div className='text-muted text-uppercase mb-1'>SCIM base URL</div>
+        <div className='text-secondary text-uppercase mb-1'>SCIM base URL</div>
         <CopyField value={data.base_url} data-test='scim-base-url' />
       </div>
 

--- a/frontend/web/components/pages/organisation-settings/tabs/sso/scim/modals/ScimTokenModal.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/scim/modals/ScimTokenModal.tsx
@@ -32,7 +32,7 @@ const ScimTokenModal: FC<ScimTokenModalProps> = ({ token }) => {
       />
       {isConfirming ? (
         <div className='mt-4 d-flex align-items-center justify-content-end gap-2'>
-          <span className='me-auto text-muted'>
+          <span className='me-auto text-secondary'>
             Have you saved the token? It cannot be retrieved later.
           </span>
           <Button

--- a/frontend/web/components/release-pipelines/FlagActionDetail.tsx
+++ b/frontend/web/components/release-pipelines/FlagActionDetail.tsx
@@ -53,7 +53,7 @@ export const renderActionDetail = (
             </div>
           )}
           {currentSplit && (
-            <div className='mb-1 fs-caption text-muted'>
+            <div className='mb-1 fs-caption text-secondary'>
               Current rollout:{' '}
               <b className={currentSplit ? 'text-success' : ''}>
                 {currentSplit}%

--- a/frontend/web/components/release-pipelines/ReleasePipelineDetail.tsx
+++ b/frontend/web/components/release-pipelines/ReleasePipelineDetail.tsx
@@ -27,7 +27,7 @@ const LaunchedCard = ({
         <Icon name='checkmark-circle' width={30} fill='#27AB95' />
         <h5 className='mb-0'>Launched</h5>
       </Row>
-      <p className='text-muted'>
+      <p className='text-secondary'>
         Features that completed this pipeline in the last 30 days
       </p>
       <StageFeatureDetail features={completedFeatures} projectId={projectId} />

--- a/frontend/web/components/release-pipelines/StageFeatureDetail.tsx
+++ b/frontend/web/components/release-pipelines/StageFeatureDetail.tsx
@@ -54,7 +54,7 @@ const StageFeatureDetail = ({
     return (
       <>
         <h6>Features (0)</h6>
-        <p className='text-muted'>No features at this stage.</p>
+        <p className='text-secondary'>No features at this stage.</p>
       </>
     )
   }
@@ -83,10 +83,10 @@ const StageFeatureDetail = ({
     const part = moment.duration(duration.asMilliseconds() * partsRemaining)
     return (
       <div className='mt-1'>
-        <div className='text-muted text-small'>
+        <div className='text-secondary text-small'>
           Rollout currently at {feature.phased_rollout_state.current_split}%
         </div>
-        <div className='text-muted text-small'>
+        <div className='text-secondary text-small'>
           {part.humanize()} remaining for complete rollout
         </div>
       </div>
@@ -99,7 +99,7 @@ const StageFeatureDetail = ({
       {projectFlags?.map((flag) => (
         <div key={flag.id}>
           <b
-            className={classNames('text-muted', {
+            className={classNames('text-secondary', {
               'cursor-pointer': !!environmentKey,
             })}
             onClick={() => handleFeatureClick(flag)}

--- a/frontend/web/components/release-pipelines/StageInfo.tsx
+++ b/frontend/web/components/release-pipelines/StageInfo.tsx
@@ -49,7 +49,7 @@ const StageInfo = ({
           <div>
             <h5>{stageData?.name}</h5>
             <p>{environmentData?.name}</p>
-            <p className='text-muted'>
+            <p className='text-secondary'>
               {getTriggerText(
                 stageData?.trigger?.trigger_type,
                 stageData?.trigger?.trigger_body,

--- a/frontend/web/components/release-pipelines/StageStatus.tsx
+++ b/frontend/web/components/release-pipelines/StageStatus.tsx
@@ -108,7 +108,7 @@ const StageStatus = ({
       <span>
         <b>{stageName}</b>
       </span>
-      {envName && <p className='text-muted'>{envName}</p>}
+      {envName && <p className='text-secondary'>{envName}</p>}
     </div>
   )
 }

--- a/frontend/web/components/release-pipelines/StageSummaryData.tsx
+++ b/frontend/web/components/release-pipelines/StageSummaryData.tsx
@@ -62,7 +62,7 @@ const StageSummaryData = ({
             </div>
           </Row>
           {isTimeLeft && (
-            <div className='text-muted ml-4 mt-1'>
+            <div className='text-secondary ml-4 mt-1'>
               {moment.duration(timeRemainingDuration).humanize()} remaining
             </div>
           )}

--- a/frontend/web/components/tables/TableFilterItem.tsx
+++ b/frontend/web/components/tables/TableFilterItem.tsx
@@ -30,7 +30,7 @@ const TableFilterItem: FC<TableFilterItemType> = ({
       <Row space className='px-3 no-wrap overflow-hidden py-2'>
         <div className={'overflow-ellipsis'}>
           {title}
-          {subtitle && <div className='text-muted fw-normal'>{subtitle}</div>}
+          {subtitle && <div className='text-secondary fw-normal'>{subtitle}</div>}
         </div>
         <div>
           <Icon

--- a/frontend/web/project/project-components.js
+++ b/frontend/web/project/project-components.js
@@ -105,7 +105,7 @@ const Option = (props) => {
     <components.Option {...props}>
       <div
         className={`d-flex justify-content-between align-items-center ${
-          props.data.isDisabled ? 'text-muted cursor-not-allowed' : ''
+          props.data.isDisabled ? 'text-secondary cursor-not-allowed' : ''
         }`}
       >
         <div>{labelContent}</div>

--- a/frontend/web/styles/project/_lists.scss
+++ b/frontend/web/styles/project/_lists.scss
@@ -18,7 +18,7 @@
   color: $panel-table-header-color;
   border-top-right-radius: $border-radius+2;
   border-top-left-radius: $border-radius+2;
-  .text-muted {
+  .text-secondary {
     color: $panel-table-header-color-muted !important;
   }
   font-weight: 500;


### PR DESCRIPTION
## Changes

Contributes to #6606.

Migrates all 173 `text-muted` classNames to `text-secondary`. They are all text
(no icon usages), so it is a straight swap onto the design-system token.

`text-muted` was a static `#656d7b` with no dark variant (3.45:1 on the dark
surface, fails WCAG AA). `--color-text-secondary` is `#656d7b` in light (unchanged)
and `#9da4ae` in dark (7.16:1, passes AA/AAA). So: **light is a visual no-op, dark
mode gets the contrast fix.**

Also updates the one scoped override (`.table-header .text-muted` in `_lists.scss`)
to key on `.text-secondary`, preserving the table-header muted colour exactly.

## How did you test this code?

Compiled the full stylesheet (no errors). Verified no `text-muted` classNames
remain and all `text-muted` usages were text (no icons needing `icon-secondary`).
CI lints only changed lines.

Recommend a **dark-mode QA sweep**: muted/secondary text is used widely (tables,
forms, labels, empty states), and this is the change that lightens it from
`#656d7b` to `#9da4ae` in dark. Worth eyeballing a few dense screens.
