### PR TITLE
fix(dark mode): make text-muted theme-aware via the secondary token

### DIFF
--- a/frontend/web/styles/_variables.scss
+++ b/frontend/web/styles/_variables.scss
@@ -31,7 +31,7 @@ $body-color: #1a2634;
 $text-icon-light: #ffffff;
 $text-icon-grey: #656d7b;
 $text-icon-light-grey: rgba(157, 164, 174, 1);
-$text-muted: $text-icon-grey;
+$text-muted: var(--color-text-secondary);
 
 // Header
 $header-color: #1e0d26; // for headers and labels


### PR DESCRIPTION
## Changes

Contributes to #6606.

`.text-muted` is a static `#656d7b` with no dark variant, so muted text is 3.45:1 on the dark surface (fails WCAG AA). Point `$text-muted` at the `--color-text-secondary` token so the utility becomes theme-aware: `#656d7b` in light (unchanged, 5.22:1) and `#9da4ae` in dark (7.16:1).

One line, no usage churn. Unlike `text-secondary`, `.text-muted` doesn't collide with the token utilities, so its ~170 usages don't need migrating; fixing the value is enough. Full removal of Bootstrap's `.text-muted` can come with the later cleanup.

## How did you test this code?

Compiled the stylesheet: `.text-muted` now emits `color: var(--color-text-secondary) !important`. Light mode unchanged; recommend a dark-mode eyeball on muted text (tables, forms, labels).