### PR TITLE
fix(dark mode): reclaim border-colour and shadow utilities for tokens

### DIFF
--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -29,6 +29,26 @@ $_color-util: map-merge(
 );
 $utilities: map-merge($utilities, ("color": $_color-util));
 
+// Border colour: token border utilities take over. Values are identical to
+// Bootstrap's, so a no-op; it just moves ownership to the token layer.
+$_border-util: map-get($utilities, "border-color");
+$_border-util: map-merge(
+  $_border-util,
+  (values: map-remove(map-get($_border-util, "values"), "danger", "info", "success", "warning"))
+);
+$utilities: map-merge($utilities, ("border-color": $_border-util));
+
+// Shadow scale is owned by the token utilities (--shadow-*). Drop sm/lg/none so
+// `.shadow-sm` / `.shadow-lg` / `.shadow-none` use the DS tokens, consistent with
+// the token-only `.shadow-md` / `.shadow-xl`. Bootstrap's suffixless `.shadow`
+// (the `null` key) is left in place.
+$_shadow-util: map-get($utilities, "shadow");
+$_shadow-util: map-merge(
+  $_shadow-util,
+  (values: map-remove(map-get($_shadow-util, "values"), "sm", "lg", "none"))
+);
+$utilities: map-merge($utilities, ("shadow": $_shadow-util));
+
 @import "~bootstrap/scss/utilities/api";
 
 // 5. Include any optional Bootstrap CSS as needed


### PR DESCRIPTION
## Changes

Contributes to #6606. Same `map-remove` pattern as the text-colour reclaim, extended to two more utility families found by auditing token-vs-Bootstrap collisions.

- **border-colour** (`danger`/`info`/`success`/`warning`): token `.border-*` was shadowed by Bootstrap. Values are **identical**, so this is a no-op; it just moves ownership to the token layer.
- **shadow** (`sm`/`lg`/`none`): `.shadow-sm` and `.shadow-lg` were silently using **Bootstrap's** shadows, while `.shadow-md`/`.shadow-xl` (token-only) used the DS tokens, so the scale was half-and-half. Now all of sm/md/lg/xl use `--shadow-*`. Suffixless `.shadow` stays Bootstrap.

## How did you test this code?

Compiled the stylesheet: `.border-*` now resolve to `var(--color-border-*)`, and `.shadow-sm`/`.shadow-lg` to `var(--shadow-*)`. Border is a no-op (identical values). Shadow is a real change but tiny footprint (`shadow-sm`: 1 usage, `shadow-lg`: 0) — the DS shadows are subtler; worth a quick eyeball on that one `shadow-sm` element.