### PR TITLE
fix(dark mode): stop .text-info being hijacked to purple

### DIFF
--- a/frontend/web/components/modals/CreateAuditLogWebhook.tsx
+++ b/frontend/web/components/modals/CreateAuditLogWebhook.tsx
@@ -104,7 +104,7 @@ const CreateAuditLogWebhook: React.FC<Props> = ({
             <label>
               Secret (Optional) -{' '}
               <a
-                className='text-info'
+                className='text-action'
                 target='_blank'
                 href='https://docs.flagsmith.com/system-administration/webhooks#web-hook-signature'
                 rel='noreferrer'

--- a/frontend/web/components/modals/CreateWebhook.tsx
+++ b/frontend/web/components/modals/CreateWebhook.tsx
@@ -102,7 +102,7 @@ const CreateWebhook: FC<CreateWebhookProps> = ({
             <label>
               Secret (Optional) -{' '}
               <a
-                className='text-info'
+                className='text-action'
                 target='_blank'
                 href='https://docs.flagsmith.com/system-administration/webhooks#audit-log-web-hooks'
                 rel='noreferrer'

--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -88,6 +88,3 @@
     background-color: $danger-solid-dark-alert
   }
 }
-.text-info {
-  color: $primary !important;
-}


### PR DESCRIPTION
## Changes

Contributes to #6606.

`_alert.scss` had an unscoped `.text-info { color: $primary !important }` (added in 2022 for two webhook secret-field doc links). It forced **every** `.text-info` to purple globally, overriding the info-blue token, and `!important` meant it survived the text-colour reclaim too.

- Move the two webhook doc links (`CreateWebhook`, `CreateAuditLogWebhook`) to `.text-action` — they're links, so the interactive/purple colour is the correct semantic, and appearance is preserved.
- Remove the global override, so `.text-info` resolves to `--color-text-info` (info-blue) again.

## How did you test this code?

Compiled the stylesheet: the purple `.text-info` rule is gone; `.text-info` now resolves to the info-blue token. No `text-info` classNames remain (both moved to `text-action`). The two links keep their purple.