### PR TITLE
fix(webhooks): accept 2xx status codes in webhook test endpoint

### DIFF
--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -365,7 +365,7 @@ def test_send_test_webhook__200_response_from_webhook__returns_correct_response(
 ) -> None:
     # Given
     webhook_url = "http://test.webhook.com"
-    mock_post = mocker.patch("requests.post")
+    mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.text = "success"
@@ -408,7 +408,7 @@ def test_send_test_webhook__various_2xx_status_codes__returns_success(
 ) -> None:
     # Given
     webhook_url = "http://test.webhook.com"
-    mock_post = mocker.patch("requests.post")
+    mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = external_api_response_status
     mock_response.text = "success"
@@ -453,7 +453,7 @@ def test_send_test_webhook__various_error_status_codes__returns_correct_response
 ) -> None:
     # Given
     webhook_url = "http://test.webhook.com"
-    mock_post = mocker.patch("requests.post")
+    mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = external_api_response_status
     mock_response.text = external_api_error_text
@@ -518,7 +518,7 @@ def test_send_test_webhook__various_secrets__sends_correct_payload(
 ) -> None:
     # Given
     webhook_url = "http://test.webhook.com"
-    mock_post = mocker.patch("requests.post")
+    mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_post.return_value = mock_response
@@ -557,7 +557,7 @@ def test_send_test_webhook__request_exception__returns_error_response(
 ) -> None:
     # Given
     webhook_url = "http://test.webhook.com"
-    mock_post = mocker.patch("requests.post")
+    mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_post.side_effect = requests.exceptions.RequestException(
         "Some internal exception details that should not be exposed!"
     )

--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -369,6 +369,7 @@ def test_send_test_webhook__200_response_from_webhook__returns_correct_response(
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.ok = True
     mock_response.text = "success"
     mock_post.return_value = mock_response
     mocker.patch(
@@ -416,6 +417,7 @@ def test_send_test_webhook__various_2xx_status_codes__returns_success(
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = external_api_response_status
+    mock_response.ok = external_api_response_status < 400
     mock_response.text = "success"
     mock_post.return_value = mock_response
     mocker.patch(
@@ -465,6 +467,7 @@ def test_send_test_webhook__various_error_status_codes__returns_correct_response
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = external_api_response_status
+    mock_response.ok = external_api_response_status < 400
     mock_response.text = external_api_error_text
     mock_post.return_value = mock_response
     mocker.patch(
@@ -534,6 +537,7 @@ def test_send_test_webhook__various_secrets__sends_correct_payload(
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.ok = True
     mock_post.return_value = mock_response
     mocker.patch(
         "webhooks.fields.socket.getaddrinfo",

--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -364,7 +364,7 @@ def test_send_test_webhook__200_response_from_webhook__returns_correct_response(
     organisation: Organisation,
 ) -> None:
     # Given
-    webhook_url = "http://test.webhook.com"
+    webhook_url = "https://example.com"
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -407,7 +407,7 @@ def test_send_test_webhook__various_2xx_status_codes__returns_success(
     organisation: Organisation,
 ) -> None:
     # Given
-    webhook_url = "http://test.webhook.com"
+    webhook_url = "https://example.com"
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = external_api_response_status
@@ -452,7 +452,7 @@ def test_send_test_webhook__various_error_status_codes__returns_correct_response
     organisation: Organisation,
 ) -> None:
     # Given
-    webhook_url = "http://test.webhook.com"
+    webhook_url = "https://example.com"
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = external_api_response_status
@@ -517,7 +517,7 @@ def test_send_test_webhook__various_secrets__sends_correct_payload(
     secret: str,
 ) -> None:
     # Given
-    webhook_url = "http://test.webhook.com"
+    webhook_url = "https://example.com"
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -556,7 +556,7 @@ def test_send_test_webhook__request_exception__returns_error_response(
     organisation: Organisation,
 ) -> None:
     # Given
-    webhook_url = "http://test.webhook.com"
+    webhook_url = "https://example.com"
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_post.side_effect = requests.exceptions.RequestException(
         "Some internal exception details that should not be exposed!"

--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import socket
 from typing import Callable, Type
 from unittest import mock
 from unittest.mock import MagicMock
@@ -370,6 +371,10 @@ def test_send_test_webhook__200_response_from_webhook__returns_correct_response(
     mock_response.status_code = 200
     mock_response.text = "success"
     mock_post.return_value = mock_response
+    mocker.patch(
+        "webhooks.fields.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, None, ("93.184.216.34", 0))],
+    )
 
     url = reverse("api-v1:webhooks:webhooks-test")
 
@@ -413,6 +418,10 @@ def test_send_test_webhook__various_2xx_status_codes__returns_success(
     mock_response.status_code = external_api_response_status
     mock_response.text = "success"
     mock_post.return_value = mock_response
+    mocker.patch(
+        "webhooks.fields.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, None, ("93.184.216.34", 0))],
+    )
 
     url = reverse("api-v1:webhooks:webhooks-test")
 
@@ -458,6 +467,10 @@ def test_send_test_webhook__various_error_status_codes__returns_correct_response
     mock_response.status_code = external_api_response_status
     mock_response.text = external_api_error_text
     mock_post.return_value = mock_response
+    mocker.patch(
+        "webhooks.fields.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, None, ("93.184.216.34", 0))],
+    )
 
     url = reverse("api-v1:webhooks:webhooks-test")
 
@@ -522,6 +535,10 @@ def test_send_test_webhook__various_secrets__sends_correct_payload(
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_post.return_value = mock_response
+    mocker.patch(
+        "webhooks.fields.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, None, ("93.184.216.34", 0))],
+    )
 
     url = reverse("api-v1:webhooks:webhooks-test")
 
@@ -560,6 +577,10 @@ def test_send_test_webhook__request_exception__returns_error_response(
     mock_post = mocker.patch("webhooks.webhooks.requests.post")
     mock_post.side_effect = requests.exceptions.RequestException(
         "Some internal exception details that should not be exposed!"
+    )
+    mocker.patch(
+        "webhooks.fields.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, None, ("93.184.216.34", 0))],
     )
 
     url = reverse("api-v1:webhooks:webhooks-test")

--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -434,10 +434,10 @@ def test_send_test_webhook__various_error_status_codes__returns_correct_response
     mock_post.assert_called_once()
     response_json = response.json()
     assert response_json["status"] == external_api_response_status
-    assert response_json["detail"] == "Webhook returned invalid status"
+    assert response_json["detail"] == "Webhook returned error status"
     assert (
         response_json["body"]
-        == "Please check the webhook endpoint to validate it returns a 200 OK."
+        == f"Webhook returned HTTP {external_api_response_status}."
     )
 
 

--- a/api/tests/unit/webhooks/test_unit_webhooks.py
+++ b/api/tests/unit/webhooks/test_unit_webhooks.py
@@ -393,6 +393,49 @@ def test_send_test_webhook__200_response_from_webhook__returns_correct_response(
 
 
 @pytest.mark.parametrize(
+    "external_api_response_status",
+    [
+        201,
+        202,
+        204,
+    ],
+)
+def test_send_test_webhook__various_2xx_status_codes__returns_success(
+    mocker: MockerFixture,
+    admin_client: APIClient,
+    external_api_response_status: int,
+    organisation: Organisation,
+) -> None:
+    # Given
+    webhook_url = "http://test.webhook.com"
+    mock_post = mocker.patch("requests.post")
+    mock_response = MagicMock()
+    mock_response.status_code = external_api_response_status
+    mock_response.text = "success"
+    mock_post.return_value = mock_response
+
+    url = reverse("api-v1:webhooks:webhooks-test")
+
+    data = {
+        "webhook_url": webhook_url,
+        "secret": "some-secret",
+        "scope": {"type": "organisation", "id": organisation.id},
+    }
+
+    # When
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == 200
+    mock_post.assert_called_once()
+    response_json = response.json()
+    assert response_json["status"] == external_api_response_status
+    assert response_json["detail"] == "Webhook test successful"
+
+
+@pytest.mark.parametrize(
     "external_api_response_status, external_api_error_text, expected_final_status",
     [
         (400, "wrong-payload", 400),

--- a/api/webhooks/views.py
+++ b/api/webhooks/views.py
@@ -47,11 +47,11 @@ class WebhookViewSet(viewsets.ViewSet):
                 else WebhookType.ENVIRONMENT
             )
             response = send_test_request_to_webhook(webhook_url, secret, webhook_type)
-            if response.status_code != 200:
+            if response.status_code >= 400:
                 return Response(
                     {
-                        "detail": "Webhook returned invalid status",
-                        "body": "Please check the webhook endpoint to validate it returns a 200 OK.",
+                        "detail": "Webhook returned error status",
+                        "body": f"Webhook returned HTTP {response.status_code}.",
                         "status": response.status_code,
                     },
                     status=status.HTTP_400_BAD_REQUEST,

--- a/api/webhooks/views.py
+++ b/api/webhooks/views.py
@@ -47,7 +47,7 @@ class WebhookViewSet(viewsets.ViewSet):
                 else WebhookType.ENVIRONMENT
             )
             response = send_test_request_to_webhook(webhook_url, secret, webhook_type)
-            if response.status_code >= 400:
+            if not response.ok:
                 return Response(
                     {
                         "detail": "Webhook returned error status",


### PR DESCRIPTION
## Changes

The webhook test endpoint (`POST /api/v1/webhooks/test/`) previously treated any non-200 response as a failure. This is incorrect - HTTP 201 (Created), 202 (Accepted), and 204 (No Content) are all valid and common webhook responses.

**Before:** Users testing a webhook that returns 201 or 204 would see `Webhook returned invalid status - Please check the webhook endpoint to validate it returns a 200 OK.` even though their webhook is working correctly.

**After:** Any 2xx response (200-299) is treated as successful. Only 4xx/5xx responses are reported as failures, with the actual status code included in the error message.

## How did you test this code?

- Verified the change only affects the condition check (`!= 200` -> `>= 400`)
- No other code paths depend on this specific status code check
- The success response still includes the actual status code for debugging
- Updated test assertions in `test_unit_webhooks.py` to match the new error messages