### PR TITLE
fix(experimentation): poll warehouse status for created connections

### DIFF
--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehousePolling.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehousePolling.test.ts
@@ -9,8 +9,8 @@ describe('getWarehousePollingInterval', () => {
     expect(getWarehousePollingInterval('connected')).toBe(0)
   })
 
-  it('does not poll for created', () => {
-    expect(getWarehousePollingInterval('created')).toBe(0)
+  it('polls every minute while created', () => {
+    expect(getWarehousePollingInterval('created')).toBe(60000)
   })
 
   it('does not poll for errored', () => {

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehousePolling.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehousePolling.ts
@@ -2,8 +2,12 @@ import { WarehouseConnectionStatus } from 'common/types/responses'
 
 export const WAREHOUSE_POLL_INTERVAL_MS = 60000
 
-// RTK Query treats a pollingInterval of 0 as "do not poll". We only poll while
-// the backend is waiting for the first event to land in the warehouse.
+// RTK Query treats a pollingInterval of 0 as "do not poll". We poll until the
+// warehouse has received its first event, whether the connection is freshly
+// created or a test event is on its way.
 export const getWarehousePollingInterval = (
   status: WarehouseConnectionStatus | undefined,
-): number => (status === 'pending_connection' ? WAREHOUSE_POLL_INTERVAL_MS : 0)
+): number =>
+  status === 'created' || status === 'pending_connection'
+    ? WAREHOUSE_POLL_INTERVAL_MS
+    : 0

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehousePolling.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehousePolling.ts
@@ -2,9 +2,7 @@ import { WarehouseConnectionStatus } from 'common/types/responses'
 
 export const WAREHOUSE_POLL_INTERVAL_MS = 60000
 
-// RTK Query treats a pollingInterval of 0 as "do not poll". We poll until the
-// warehouse has received its first event, whether the connection is freshly
-// created or a test event is on its way.
+// Poll until the warehouse has received its first event.
 export const getWarehousePollingInterval = (
   status: WarehouseConnectionStatus | undefined,
 ): number =>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

A warehouse connection's status is only evaluated by the test-connection endpoint, and the Warehouse tab only
polled it while a connection was `pending_connection`. A connection in `created` status therefore never advanced
to `connected`, even with application events already flowing, until someone clicked "Send your first event".

The Warehouse tab now polls the test-connection endpoint for `created` connections too, so a warehouse that is
already receiving application events connects by simply opening the tab. No backend changes: GET endpoints stay
read-only, and the existing POST endpoint handles the status transitions.

## How did you test this code?

- Unit tests for the polling interval (`warehousePolling.test.ts`).
- `npx eslint` clean on the changed files.
