### PR TITLE
Fix (Billing): API usage notification evaluates against actual plan limit instead of cache

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -125,7 +125,7 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
         month_delta = _get_total_months(relativedelta(now, billing_starts_at))
         period_starts_at = relativedelta(months=month_delta) + billing_starts_at
 
-        allowed_api_calls = subscription_cache.allowed_30d_api_calls
+        allowed_api_calls = organisation.subscription.max_api_calls
 
     openfeature_client = get_openfeature_client()
     # TODO: Default to get_total_events_count — https://github.com/Flagsmith/flagsmith/issues/6985

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -131,7 +131,7 @@ def handle_api_usage_notifications() -> None:
         # threshold in the last 30d, it must be below it for the current billing period
         # (which by definition is <30d).
         subscription_information_cache__api_calls_30d__gte=F(
-            "subscription_information_cache__allowed_30d_api_calls"
+            "subscription__max_api_calls"
         )
         * threshold_percentage,
     ).select_related("subscription", "subscription_information_cache"):

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -575,6 +575,7 @@ def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_lim
     # Then
     # Because usage (95) is evaluated against the true allowance (50,000),
     # it is < 1%, so no notification should be sent.
+    mock_api_usage.assert_not_called()
     assert len(mailoutbox) == 0
 
     assert (

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -498,6 +498,38 @@ def test_handle_api_usage_notifications__usage_below_100_percent__sends_90_perce
         },
     )
 
+    assert email.from_email == "noreply@flagsmith.com"
+    # Only admin because threshold is under 100.
+    assert email.to == ["admin@example.com"]
+
+    assert (
+        OrganisationAPIUsageNotification.objects.filter(
+            organisation=organisation,
+        ).count()
+        == 1
+    )
+    api_usage_notification = OrganisationAPIUsageNotification.objects.filter(
+        organisation=organisation,
+    ).first()
+
+    assert api_usage_notification.percent_usage == 90  # type: ignore[union-attr]
+
+    # Now re-run the usage to make sure the notification isn't resent.
+    handle_api_usage_notifications()
+
+    assert (
+        OrganisationAPIUsageNotification.objects.filter(
+            organisation=organisation,
+        ).count()
+        == 1
+    )
+    assert (
+        OrganisationAPIUsageNotification.objects.filter(
+            organisation=organisation
+        ).first()
+        == api_usage_notification
+    )
+
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_limit__sends_no_email(
@@ -615,6 +647,7 @@ def test_handle_api_usage_notifications__usage_above_100_percent__sends_limit_no
     now = timezone.now()
     organisation.subscription.plan = SCALE_UP
     organisation.subscription.subscription_id = "fancy_id"
+    organisation.subscription.max_api_calls = allowance
     organisation.subscription.save()
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
@@ -758,6 +791,8 @@ def test_handle_api_usage_notifications__free_account_over_limit__sends_limit_no
     assert organisation.is_paid is False
     assert organisation.subscription.is_free_plan is True
     assert organisation.subscription.max_api_calls == MAX_API_CALLS_IN_FREE_PLAN
+    organisation.subscription.max_api_calls = MAX_API_CALLS_IN_FREE_PLAN
+    organisation.subscription.save()
 
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -431,6 +431,7 @@ def test_handle_api_usage_notifications__usage_below_100_percent__sends_90_perce
     now = timezone.now()
     organisation.subscription.plan = SCALE_UP
     organisation.subscription.subscription_id = "fancy_id"
+    organisation.subscription.max_api_calls = 100
     organisation.subscription.save()
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
@@ -496,7 +497,58 @@ def test_handle_api_usage_notifications__usage_below_100_percent__sends_90_perce
             "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
+def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_limit__sends_no_email(
+    mocker: MockerFixture,
+    organisation: Organisation,
+    mailoutbox: list[EmailMultiAlternatives],
+    enable_features: EnableFeaturesFixture,
+) -> None:
+    # Given
+    now = timezone.now()
+    usage = 95
+    stale_cache_allowance = 100
+    true_subscription_allowance = 50_000
 
+    # 1. Set the TRUE subscription limit to 50,000
+    organisation.subscription.plan = SCALE_UP
+    organisation.subscription.subscription_id = "fancy_id"
+    organisation.subscription.max_api_calls = true_subscription_allowance
+    organisation.subscription.save()
+
+    # 2. Set the STALE cache limit to 100
+    OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        allowed_30d_api_calls=stale_cache_allowance,
+        current_billing_term_starts_at=now - timedelta(days=45),
+        current_billing_term_ends_at=now + timedelta(days=320),
+        api_calls_30d=usage,
+    )
+    
+    mock_api_usage = mocker.patch(
+        "organisations.task_helpers.get_current_api_usage",
+    )
+    mock_api_usage.return_value = usage
+    enable_features("api_usage_alerting")
+
+    assert not OrganisationAPIUsageNotification.objects.filter(
+        organisation=organisation,
+    ).exists()
+
+    # When
+    handle_api_usage_notifications()
+
+    # Then
+    # Because usage (95) is evaluated against the true allowance (50,000), 
+    # it is < 1%, so no notification should be sent.
+    assert len(mailoutbox) == 0
+
+    assert (
+        OrganisationAPIUsageNotification.objects.filter(
+            organisation=organisation,
+        ).count()
+        == 0
+    )
     assert email.from_email == "noreply@flagsmith.com"
     # Only admin because threshold is under 100.
     assert email.to == ["admin@example.com"]

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -737,6 +737,7 @@ def test_handle_api_usage_notifications__processing_error__logs_error_message(
     now = timezone.now()
     organisation.subscription.plan = SCALE_UP
     organisation.subscription.subscription_id = "fancy_id"
+    organisation.subscription.max_api_calls = 100
     organisation.subscription.save()
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -431,7 +431,7 @@ def test_handle_api_usage_notifications__usage_below_100_percent__sends_90_perce
     now = timezone.now()
     organisation.subscription.plan = SCALE_UP
     organisation.subscription.subscription_id = "fancy_id"
-    organisation.subscription.max_api_calls = 100  # Updated to fix broken test
+    organisation.subscription.max_api_calls = 100
     organisation.subscription.save()
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -431,7 +431,7 @@ def test_handle_api_usage_notifications__usage_below_100_percent__sends_90_perce
     now = timezone.now()
     organisation.subscription.plan = SCALE_UP
     organisation.subscription.subscription_id = "fancy_id"
-    organisation.subscription.max_api_calls = 100
+    organisation.subscription.max_api_calls = 100  # Updated to fix broken test
     organisation.subscription.save()
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
@@ -497,6 +497,8 @@ def test_handle_api_usage_notifications__usage_below_100_percent__sends_90_perce
             "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
+
+
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_limit__sends_no_email(
     mocker: MockerFixture,
@@ -524,7 +526,7 @@ def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_lim
         current_billing_term_ends_at=now + timedelta(days=320),
         api_calls_30d=usage,
     )
-    
+
     mock_api_usage = mocker.patch(
         "organisations.task_helpers.get_current_api_usage",
     )
@@ -539,7 +541,7 @@ def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_lim
     handle_api_usage_notifications()
 
     # Then
-    # Because usage (95) is evaluated against the true allowance (50,000), 
+    # Because usage (95) is evaluated against the true allowance (50,000),
     # it is < 1%, so no notification should be sent.
     assert len(mailoutbox) == 0
 
@@ -548,37 +550,6 @@ def test_handle_api_usage_notifications__stale_cache_lower_than_subscription_lim
             organisation=organisation,
         ).count()
         == 0
-    )
-    assert email.from_email == "noreply@flagsmith.com"
-    # Only admin because threshold is under 100.
-    assert email.to == ["admin@example.com"]
-
-    assert (
-        OrganisationAPIUsageNotification.objects.filter(
-            organisation=organisation,
-        ).count()
-        == 1
-    )
-    api_usage_notification = OrganisationAPIUsageNotification.objects.filter(
-        organisation=organisation,
-    ).first()
-
-    assert api_usage_notification.percent_usage == 90  # type: ignore[union-attr]
-
-    # Now re-run the usage to make sure the notification isn't resent.
-    handle_api_usage_notifications()
-
-    assert (
-        OrganisationAPIUsageNotification.objects.filter(
-            organisation=organisation,
-        ).count()
-        == 1
-    )
-    assert (
-        OrganisationAPIUsageNotification.objects.filter(
-            organisation=organisation
-        ).first()
-        == api_usage_notification
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/7976

Organisations on paid plans were receiving API usage warning emails prematurely. The `handle_api_usage_notifications` task was evaluating usage against the `subscription_information_cache` rather than the true plan limit. Because the cache can become stale, the percentage evaluated artificially high. 

- Updated the task filter in `handle_api_usage_notifications` to use `subscription__max_api_calls`.
- Updated the denominator in the `else` block of `handle_api_usage_notification_for_organisation` to bypass the cache and use `organisation.subscription.max_api_calls` directly.

Review effort: 1/5

## How did you test this code?

- Ran `make format` to ensure code style compliance.
- Verified the logic path tracing back to the core database models.
- Relying on the automated GitHub Actions CI/CD pipeline to execute the `tests/unit/organisations/` test suite, as my local Docker test-database permissions are currently restricted.