### PR TITLE
Fix: Preserve /api/v1 prefix in frontend proxy (Fixes #7974)

### DIFF
--- a/frontend/api/dev-routes.js
+++ b/frontend/api/dev-routes.js
@@ -65,17 +65,17 @@ module.exports = function setupRoutes(app) {
   })
 
   // Optionally proxy the API
-  if (process.env.FLAGSMITH_PROXY_API_URL) {
-      const { createProxyMiddleware } = require('http-proxy-middleware')
-      app.use(
-        createProxyMiddleware({
-          pathFilter: '/api/v1/',
-          changeOrigin: true,
-          target: process.env.FLAGSMITH_PROXY_API_URL,
-          xfwd: true,
-        })
-      )
-    }
+ if (process.env.FLAGSMITH_PROXY_API_URL) {
+    const { createProxyMiddleware } = require('http-proxy-middleware')
+    app.use(
+      createProxyMiddleware({
+        pathFilter: (pathname) => pathname === '/api/v1' || pathname.startsWith('/api/v1/'),
+        changeOrigin: true,
+        target: process.env.FLAGSMITH_PROXY_API_URL,
+        xfwd: true,
+      })
+    )
+  }
 
   app.use(bodyParser.json())
 

--- a/frontend/api/dev-routes.js
+++ b/frontend/api/dev-routes.js
@@ -66,17 +66,16 @@ module.exports = function setupRoutes(app) {
 
   // Optionally proxy the API
   if (process.env.FLAGSMITH_PROXY_API_URL) {
-    const { createProxyMiddleware } = require('http-proxy-middleware')
-    app.use(
-      
-createProxyMiddleware({
-        pathFilter: '/api/v1/', 
-        changeOrigin: true,
-        target: process.env.FLAGSMITH_PROXY_API_URL,
-        xfwd: true,
-      }),
-        )
-  }
+      const { createProxyMiddleware } = require('http-proxy-middleware')
+      app.use(
+        createProxyMiddleware({
+          pathFilter: '/api/v1/',
+          changeOrigin: true,
+          target: process.env.FLAGSMITH_PROXY_API_URL,
+          xfwd: true,
+        })
+      )
+    }
 
   app.use(bodyParser.json())
 

--- a/frontend/api/dev-routes.js
+++ b/frontend/api/dev-routes.js
@@ -65,7 +65,7 @@ module.exports = function setupRoutes(app) {
   })
 
   // Optionally proxy the API
- if (process.env.FLAGSMITH_PROXY_API_URL) {
+  if (process.env.FLAGSMITH_PROXY_API_URL) {
     const { createProxyMiddleware } = require('http-proxy-middleware')
     app.use(
       createProxyMiddleware({

--- a/frontend/api/dev-routes.js
+++ b/frontend/api/dev-routes.js
@@ -68,13 +68,14 @@ module.exports = function setupRoutes(app) {
   if (process.env.FLAGSMITH_PROXY_API_URL) {
     const { createProxyMiddleware } = require('http-proxy-middleware')
     app.use(
-      '/api/v1/',
-      createProxyMiddleware({
+      
+createProxyMiddleware({
+        pathFilter: '/api/v1/', 
         changeOrigin: true,
         target: process.env.FLAGSMITH_PROXY_API_URL,
         xfwd: true,
       }),
-    )
+        )
   }
 
   app.use(bodyParser.json())

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -138,15 +138,15 @@ app.get('/config/project-overrides', (req, res) => {
 // FLAGSMITH_PROXY_API_URL should end with the hostname and not /api/v1/
 // e.g. FLAGSMITH_PROXY_API_URL=http://api.flagsmith.com/
 if (process.env.FLAGSMITH_PROXY_API_URL) {
-  const { createProxyMiddleware } = require('http-proxy-middleware')
-  app.use(
-    '/api/v1/',
-    createProxyMiddleware({
-      changeOrigin: true,
-      target: process.env.FLAGSMITH_PROXY_API_URL,
-      xfwd: true,
-    }),
-  )
+    const { createProxyMiddleware } = require('http-proxy-middleware')
+    app.use(
+      createProxyMiddleware({
+        pathFilter: '/api/v1/',
+        changeOrigin: true,
+        target: process.env.FLAGSMITH_PROXY_API_URL,
+        xfwd: true,
+      })
+    )
 }
 
 if (isDev) {

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -141,7 +141,7 @@ if (process.env.FLAGSMITH_PROXY_API_URL) {
     const { createProxyMiddleware } = require('http-proxy-middleware')
     app.use(
       createProxyMiddleware({
-        pathFilter: '/api/v1/',
+        pathFilter: (pathname) => pathname === '/api/v1' || pathname.startsWith('/api/v1/'),
         changeOrigin: true,
         target: process.env.FLAGSMITH_PROXY_API_URL,
         xfwd: true,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7974

**Fix frontend API proxy stripping `/api/v1` prefix**

This PR fixes a bug introduced in v2.246.0 where the frontend API proxy strips the mandatory `/api/v1` prefix, causing 404/405 errors on SAML SSO logins and all other proxied API calls.

The issue was caused by an upgrade to `http-proxy-middleware` v3, which removed the automatic `req.url` patching when mounting a proxy to a specific path via Express. 

To resolve this, the middleware configuration in `frontend/api/dev-routes.js` has been updated to align with the v3 migration guide:
* Removed the explicit path mount from `app.use('/api/v1/')`.
* Utilized the `pathFilter: '/api/v1/'` property inside `createProxyMiddleware` to ensure the prefix is preserved and forwarded correctly to the backend.

## How did you test this code?

I tested this manually by replicating the proxy environment and verifying the routed paths in the backend logs:

1. Started the Django backend using `make serve` (listening on port 8000).
2. Started the frontend dev server with the proxy enabled: `FLAGSMITH_PROXY_API_URL=http://localhost:8000 npm run dev`
3. Sent a test POST request to the SAML login endpoint via the frontend proxy: 
   `curl -X POST http://localhost:8080/api/v1/auth/saml/login/`
4. Verified in the Django backend logs that the request correctly arrived at the full path `[django.request] ... request=<WSGIRequest: POST '/api/v1/auth/saml/login/'>` instead of the stripped `/auth/saml/login/` path.