### PR TITLE
ci(Renovate): Eagerly bump flagsmith-common and flagsmith-private

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,12 @@
       "matchFileNames": [".github/**"],
       "addLabels": ["ci", "dependencies"],
       "semanticCommitScope": "CI"
+    },
+    {
+      "description": "Eagerly bump internal Flagsmith packages on every release",
+      "matchPackageNames": ["flagsmith-common", "flagsmith-private"],
+      "enabled": true,
+      "rangeStrategy": "bump"
     }
   ],
   "semanticCommitScope": ""


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In this PR, we add a Renovate package rule that opens an update PR for every `flagsmith-common` and `flagsmith-private` release.
