### PR TITLE
docs: restrict string's length for openAPI SDK to prevent API rejection

### DIFF
--- a/api/api/openapi.py
+++ b/api/api/openapi.py
@@ -15,7 +15,6 @@ from typing_extensions import is_typeddict
 from environments.identities.traits.constants import (
     TRAIT_STRING_VALUE_MAX_LENGTH,
 )
-from oauth2_metadata.dataclasses import OAuthConfig
 
 
 def append_meta(schema: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:

--- a/api/api/openapi.py
+++ b/api/api/openapi.py
@@ -12,6 +12,11 @@ from pydantic import TypeAdapter
 from rest_framework.request import Request
 from typing_extensions import is_typeddict
 
+from environments.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
+from oauth2_metadata.dataclasses import OAuthConfig
+
 
 def append_meta(schema: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
     """
@@ -309,4 +314,27 @@ def postprocessing_assign_tags(
                 operation["tags"] = ["Other"]
 
     result["tags"] = TAGS
+    return result
+
+
+def postprocessing_add_trait_value_max_length(
+    result: dict[str, Any], generator: Any, **kwargs: Any
+) -> dict[str, Any]:
+    """Document the `trait_value` string length limit enforced by the API.
+
+    `trait_value` schemas are generated from `flagsmith_schemas`, which
+    types the field as `flag_engine.segments.types.ContextValue` — a plain
+    `str | int | float | bool | None` union with no length constraint. The
+    API enforces `TRAIT_STRING_VALUE_MAX_LENGTH` at runtime (see
+    `environments.identities.traits.fields.TraitValueField`), so patch the
+    generated schema here to keep the two in sync.
+    """
+    for schema in result.get("components", {}).get("schemas", {}).values():
+        trait_value_schema = schema.get("properties", {}).get("trait_value")
+        if not isinstance(trait_value_schema, dict):
+            continue
+        for variant in trait_value_schema.get("anyOf", []):
+            if variant.get("type") == "string":
+                variant["maxLength"] = TRAIT_STRING_VALUE_MAX_LENGTH
+
     return result

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -588,6 +588,7 @@ SPECTACULAR_SETTINGS = {
     "POSTPROCESSING_HOOKS": [
         "drf_spectacular.hooks.postprocess_schema_enums",
         "api.openapi.postprocessing_assign_tags",
+        "api.openapi.postprocessing_add_trait_value_max_length",
     ],
     "ENUM_NAME_OVERRIDES": {
         # Overrides to use specific schema names for fields named "type".

--- a/api/tests/unit/api/test_unit_openapi.py
+++ b/api/tests/unit/api/test_unit_openapi.py
@@ -8,9 +8,11 @@ from typing_extensions import TypedDict
 from api.openapi import (
     TAGS,
     TypedDictSchemaExtension,
+    postprocessing_add_trait_value_max_length,
     postprocessing_assign_tags,
     preprocessing_filter_spec,
 )
+from environments.identities.traits.constants import TRAIT_STRING_VALUE_MAX_LENGTH
 
 
 def test_typeddict_schema_extension__nested_typed_dict__renders_expected_schema() -> (
@@ -266,3 +268,83 @@ def test_typeddict_schema_extension__simple_model__returns_correct_name() -> Non
 
     # Then
     assert name == "MyModel"
+
+
+def test_postprocessing_add_trait_value_max_length__string_variant__adds_max_length() -> (
+    None
+):
+    # Given
+    result: dict[str, Any] = {
+        "components": {
+            "schemas": {
+                "TraitInput": {
+                    "properties": {
+                        "trait_value": {
+                            "anyOf": [
+                                {"type": "integer"},
+                                {"type": "number"},
+                                {"type": "boolean"},
+                                {"type": "string"},
+                                {"type": "null"},
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    # When
+    postprocessing_add_trait_value_max_length(result, generator=None)
+
+    # Then
+    trait_value_schema = result["components"]["schemas"]["TraitInput"]["properties"][
+        "trait_value"
+    ]
+    assert trait_value_schema["anyOf"] == [
+        {"type": "integer"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "string", "maxLength": TRAIT_STRING_VALUE_MAX_LENGTH},
+        {"type": "null"},
+    ]
+
+
+def test_postprocessing_add_trait_value_max_length__no_trait_value_property__left_unchanged() -> (
+    None
+):
+    # Given
+    result: dict[str, Any] = {
+        "components": {
+            "schemas": {
+                "Organisation": {
+                    "properties": {
+                        "name": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+    # When
+    postprocessing_add_trait_value_max_length(result, generator=None)
+
+    # Then
+    assert result["components"]["schemas"]["Organisation"] == {
+        "properties": {
+            "name": {"type": "string"},
+        },
+    }
+
+
+def test_postprocessing_add_trait_value_max_length__no_components__returns_result_unchanged() -> (
+    None
+):
+    # Given
+    result: dict[str, Any] = {"paths": {}}
+
+    # When
+    output = postprocessing_add_trait_value_max_length(result, generator=None)
+
+    # Then
+    assert output == {"paths": {}}

--- a/sdk/openapi.yaml
+++ b/sdk/openapi.yaml
@@ -449,6 +449,7 @@ components:
             - type: number
             - type: boolean
             - type: string
+              maxLength: 2000
             - type: 'null'
           title: Trait Value
         transient:
@@ -517,6 +518,7 @@ components:
             - type: number
             - type: boolean
             - type: string
+              maxLength: 2000
             - type: 'null'
           title: Trait Value
       required:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have filled in the "Changes" section below.
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "How did you test this code" section below.


## Changes

Closes #7995 

1. Use existing constant TRAIT_STRING_VALUE_MAX_LENGTH to restrict the string's length.
2. Build a function for post-processing the hook and detecting `trait_value` to return the desired result
3. Call the function during API calling
4. Update yaml file with `maxLength`

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. Build unit tests with various schemas to ensure reliable results
