### PR TITLE
feat(auth): surface is_new_user in OAuth login responses

### DIFF
--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -22,6 +22,11 @@ GOOGLE_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json&"
 UserModel = get_user_model()
 
 
+class OAuthTokenSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    key = serializers.CharField(read_only=True)
+    is_new_user = serializers.BooleanField(read_only=True)
+
+
 class OAuthLoginSerializer(InviteLinkValidationMixin, serializers.Serializer):  # type: ignore[type-arg]
     access_token = serializers.CharField(
         required=True,
@@ -42,6 +47,7 @@ class OAuthLoginSerializer(InviteLinkValidationMixin, serializers.Serializer):  
     utm_data = UTMDataSerializer(required=False, allow_null=True)
     auth_type: AuthType | None = None
     user_model_id_attribute: str = "id"
+    is_new_user: bool = False
 
     class Meta:
         abstract = True
@@ -98,6 +104,7 @@ class OAuthLoginSerializer(InviteLinkValidationMixin, serializers.Serializer):  
             user = FFAdminUser.objects.create(
                 **user_data, email=email.lower(), sign_up_type=sign_up_type
             )
+            self.is_new_user = True
 
             # On first OAuth signup, we register the hubspot cookies and utms before creating the hubspot contact
             if request := self.context.get("request"):

--- a/api/custom_auth/oauth/views.py
+++ b/api/custom_auth/oauth/views.py
@@ -14,8 +14,8 @@ from custom_auth.oauth.exceptions import GithubError, GoogleError
 from custom_auth.oauth.serializers import (
     GithubLoginSerializer,
     GoogleLoginSerializer,
+    OAuthTokenSerializer,
 )
-from custom_auth.serializers import CustomTokenSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ GOOGLE_AUTH_ERROR_MESSAGE = AUTH_ERROR_MESSAGE.format("GOOGLE")
 
 @extend_schema(
     request=GoogleLoginSerializer,
-    responses={200: CustomTokenSerializer, 502: ErrorSerializer},
+    responses={200: OAuthTokenSerializer, 502: ErrorSerializer},
 )
 @api_view(["POST"])
 @permission_classes([AllowAny])
@@ -39,7 +39,7 @@ def login_with_google(request):  # type: ignore[no-untyped-def]
         token = serializer.save()
         if settings.COOKIE_AUTH_ENABLED:
             return authorise_response(token.user, Response(status=HTTP_204_NO_CONTENT))
-        return Response(data=CustomTokenSerializer(instance=token).data)
+        return Response(data={"key": token.key, "is_new_user": serializer.is_new_user})
     except GoogleError as e:
         logger.warning("%s: %s" % (GOOGLE_AUTH_ERROR_MESSAGE, str(e)))
         return Response(
@@ -50,7 +50,7 @@ def login_with_google(request):  # type: ignore[no-untyped-def]
 
 @extend_schema(
     request=GithubLoginSerializer,
-    responses={200: CustomTokenSerializer, 502: ErrorSerializer},
+    responses={200: OAuthTokenSerializer, 502: ErrorSerializer},
 )
 @api_view(["POST"])
 @permission_classes([AllowAny])
@@ -63,7 +63,7 @@ def login_with_github(request):  # type: ignore[no-untyped-def]
         token = serializer.save()
         if settings.COOKIE_AUTH_ENABLED:
             return authorise_response(token.user, Response(status=HTTP_204_NO_CONTENT))
-        return Response(data=CustomTokenSerializer(instance=token).data)
+        return Response(data={"key": token.key, "is_new_user": serializer.is_new_user})
     except GithubError as e:
         logger.warning("%s: %s" % (GITHUB_AUTH_ERROR_MESSAGE, str(e)))
         return Response(

--- a/api/custom_auth/oauth/views.py
+++ b/api/custom_auth/oauth/views.py
@@ -39,7 +39,11 @@ def login_with_google(request):  # type: ignore[no-untyped-def]
         token = serializer.save()
         if settings.COOKIE_AUTH_ENABLED:
             return authorise_response(token.user, Response(status=HTTP_204_NO_CONTENT))
-        return Response(data={"key": token.key, "is_new_user": serializer.is_new_user})
+        return Response(
+            data=OAuthTokenSerializer(
+                {"key": token.key, "is_new_user": serializer.is_new_user}
+            ).data
+        )
     except GoogleError as e:
         logger.warning("%s: %s" % (GOOGLE_AUTH_ERROR_MESSAGE, str(e)))
         return Response(
@@ -63,7 +67,11 @@ def login_with_github(request):  # type: ignore[no-untyped-def]
         token = serializer.save()
         if settings.COOKIE_AUTH_ENABLED:
             return authorise_response(token.user, Response(status=HTTP_204_NO_CONTENT))
-        return Response(data={"key": token.key, "is_new_user": serializer.is_new_user})
+        return Response(
+            data=OAuthTokenSerializer(
+                {"key": token.key, "is_new_user": serializer.is_new_user}
+            ).data
+        )
     except GithubError as e:
         logger.warning("%s: %s" % (GITHUB_AUTH_ERROR_MESSAGE, str(e)))
         return Response(

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -78,6 +78,7 @@ def test_google_oauth_login__invite_exists_and_registration_disabled__returns_20
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+    assert response.json()["is_new_user"] is True
 
 
 @mock.patch("custom_auth.oauth.serializers.GithubUser")
@@ -107,6 +108,7 @@ def test_github_oauth_login__invite_exists_and_registration_disabled__returns_20
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+    assert response.json()["is_new_user"] is True
 
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
@@ -133,6 +135,7 @@ def test_google_oauth_login__existing_user_and_registration_disabled__returns_20
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert "key" in response.json()
+    assert response.json()["is_new_user"] is False
 
 
 @mock.patch("custom_auth.oauth.serializers.GithubUser")
@@ -161,6 +164,7 @@ def test_github_oauth_login__existing_user_and_registration_disabled__returns_20
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert "key" in response.json()
+    assert response.json()["is_new_user"] is False
 
 
 def test_google_oauth_login__case_insensitive_email__updates_existing_user(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19140,14 +19140,6 @@ components:
             $ref: '#/components/schemas/MultivariateFeatureStateValue'
       required:
         - feature_state_value
-    CustomToken:
-      type: object
-      properties:
-        key:
-          type: string
-          maxLength: 40
-      required:
-        - key
     CustomUserCreate:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -497,7 +497,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomToken'
+                $ref: '#/components/schemas/OAuthToken'
         '502':
           description: ''
           content:
@@ -531,7 +531,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomToken'
+                $ref: '#/components/schemas/OAuthToken'
         '502':
           description: ''
           content:
@@ -22049,6 +22049,15 @@ components:
         - app_id
     NullEnum:
       type: 'null'
+    OAuthToken:
+      type: object
+      properties:
+        key:
+          type: string
+          readOnly: true
+        is_new_user:
+          type: boolean
+          readOnly: true
     OrganisationAPIUsageNotification:
       type: object
       properties:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Google and GitHub OAuth login responses now include `is_new_user`, true when the login created the account. This lets the frontend distinguish OAuth signups from logins, so signup conversion events (see #7979) can also be emitted for OAuth-based signups. No model changes.

## How did you test this code?

Unit tests: existing OAuth view tests extended to assert `is_new_user` is `true` for newly created users and `false` for existing ones.