### PR TITLE
fix(tags): Duplicate system tags wedge GitHub tagging with MultipleObjectsReturned

### DIFF
--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -79,12 +79,16 @@ def tag_feature_per_github_event(
             action = "merged"
         # Get or create the corresponding project Tag to tag the feature
         github_tag, _ = Tag.objects.get_or_create(
-            color=GITHUB_TAG_COLOR,
-            description=github_tag_description[tag_by_event_type[event_type][action]],
             label=tag_by_event_type[event_type][action],
             project=feature.project,
             is_system_tag=True,
             type=TagType.GITHUB,
+            defaults={
+                "color": GITHUB_TAG_COLOR,
+                "description": github_tag_description[
+                    tag_by_event_type[event_type][action]
+                ],
+            },
         )
         tag_label_pattern = "Issue" if event_type == "issues" else "PR"
         # Remove all GITHUB tags from the feature which label starts with issue or pr depending on event_type

--- a/api/integrations/github/models.py
+++ b/api/integrations/github/models.py
@@ -105,11 +105,13 @@ class GitHubRepository(LifecycleModelMixin, SoftDeleteExportableModel):  # type:
         from projects.tags.models import Tag, TagType
 
         for tag_label in GitHubTag:
-            tag, created = Tag.objects.get_or_create(
-                color=GITHUB_TAG_COLOR,
-                description=github_tag_description[tag_label.value],
+            Tag.objects.get_or_create(
                 label=tag_label.value,
                 project=self.project,
                 is_system_tag=True,
                 type=TagType.GITHUB,
+                defaults={
+                    "color": GITHUB_TAG_COLOR,
+                    "description": github_tag_description[tag_label.value],
+                },
             )

--- a/api/projects/tags/migrations/0010_unique_system_tags.py
+++ b/api/projects/tags/migrations/0010_unique_system_tags.py
@@ -3,6 +3,8 @@ from django.db import migrations, models
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models import Count
 
+from core.migration_helpers import PostgresOnlyRunSQL
+
 
 def deduplicate_system_tags(
     apps: Apps,
@@ -13,11 +15,14 @@ def deduplicate_system_tags(
 
     # Block concurrent writes until the transaction commits, so no duplicate
     # can be inserted between this cleanup and the constraint creation below.
-    # Reads are unaffected.
-    schema_editor.execute(
-        "LOCK TABLE %s IN EXCLUSIVE MODE"
-        % schema_editor.quote_name(Tag._meta.db_table)
-    )
+    # Reads are unaffected. Downstream forks may run other database vendors,
+    # where the partial unique constraint is not supported and not created,
+    # so the lock is only taken where the constraint exists to protect.
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute(
+            "LOCK TABLE %s IN EXCLUSIVE MODE"
+            % schema_editor.quote_name(Tag._meta.db_table)
+        )
 
     duplicate_groups = (
         Tag.objects.filter(is_system_tag=True)
@@ -70,7 +75,7 @@ class Migration(migrations.Migration):
         ),
         # Fire the deferred foreign key triggers queued by the deletes above,
         # so the unique index can be created in the same transaction.
-        migrations.RunSQL(
+        PostgresOnlyRunSQL(
             sql="SET CONSTRAINTS ALL IMMEDIATE",
             reverse_sql=migrations.RunSQL.noop,
         ),

--- a/api/projects/tags/migrations/0010_unique_system_tags.py
+++ b/api/projects/tags/migrations/0010_unique_system_tags.py
@@ -11,6 +11,14 @@ def deduplicate_system_tags(
     Tag = apps.get_model("tags", "Tag")
     FeatureTag = apps.get_model("features", "Feature").tags.through
 
+    # Block concurrent writes until the transaction commits, so no duplicate
+    # can be inserted between this cleanup and the constraint creation below.
+    # Reads are unaffected.
+    schema_editor.execute(
+        "LOCK TABLE %s IN EXCLUSIVE MODE"
+        % schema_editor.quote_name(Tag._meta.db_table)
+    )
+
     duplicate_groups = (
         Tag.objects.filter(is_system_tag=True)
         .values("project_id", "label", "type")

--- a/api/projects/tags/migrations/0010_unique_system_tags.py
+++ b/api/projects/tags/migrations/0010_unique_system_tags.py
@@ -1,0 +1,77 @@
+from django.apps.registry import Apps
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.models import Count
+
+
+def deduplicate_system_tags(
+    apps: Apps,
+    schema_editor: BaseDatabaseSchemaEditor,
+) -> None:
+    Tag = apps.get_model("tags", "Tag")
+    FeatureTag = apps.get_model("features", "Feature").tags.through
+
+    duplicate_groups = (
+        Tag.objects.filter(is_system_tag=True)
+        .values("project_id", "label", "type")
+        .annotate(count=Count("id"))
+        .filter(count__gt=1)
+    )
+    for group in duplicate_groups:
+        canonical_id, *duplicate_ids = (
+            Tag.objects.filter(
+                is_system_tag=True,
+                project_id=group["project_id"],
+                label=group["label"],
+                type=group["type"],
+            )
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+        # Re-point features tagged with a duplicate to the canonical tag,
+        # skipping features already tagged with it to avoid violating the
+        # M2M (feature, tag) uniqueness.
+        feature_ids = set(
+            FeatureTag.objects.filter(tag_id__in=duplicate_ids).values_list(
+                "feature_id", flat=True
+            )
+        )
+        already_tagged_feature_ids = set(
+            FeatureTag.objects.filter(
+                tag_id=canonical_id,
+                feature_id__in=feature_ids,
+            ).values_list("feature_id", flat=True)
+        )
+        FeatureTag.objects.bulk_create(
+            FeatureTag(feature_id=feature_id, tag_id=canonical_id)
+            for feature_id in feature_ids - already_tagged_feature_ids
+        )
+        Tag.objects.filter(id__in=duplicate_ids).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tags", "0009_add_gitlab_tag_type"),
+        ("features", "0023_auto_20200717_1515"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            deduplicate_system_tags,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        # Fire the deferred foreign key triggers queued by the deletes above,
+        # so the unique index can be created in the same transaction.
+        migrations.RunSQL(
+            sql="SET CONSTRAINTS ALL IMMEDIATE",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="tag",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("is_system_tag", True)),
+                fields=("project", "label", "type"),
+                name="unique_project_label_type_system_tag",
+            ),
+        ),
+    ]

--- a/api/projects/tags/models.py
+++ b/api/projects/tags/models.py
@@ -37,6 +37,13 @@ class Tag(AbstractBaseExportableModel):
 
     class Meta:
         ordering = ("id",)  # explicit ordering to prevent pagination warnings
+        constraints = [
+            models.UniqueConstraint(
+                fields=["project", "label", "type"],
+                condition=models.Q(is_system_tag=True),
+                name="unique_project_label_type_system_tag",
+            )
+        ]
 
     def __str__(self):  # type: ignore[no-untyped-def]
         return "Tag %s" % self.label

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
 
 [project.optional-dependencies]
 private = [
-    "flagsmith-private>=0.11.0,<1",
+    "flagsmith-private>=0.11.1,<1",
 ]
 dev = [
     "django-test-migrations>=1.2.0,<2.0.0",

--- a/api/tests/unit/integrations/github/test_unit_github_models.py
+++ b/api/tests/unit/integrations/github/test_unit_github_models.py
@@ -1,0 +1,35 @@
+from integrations.github.constants import GitHubTag
+from integrations.github.models import GithubConfiguration, GitHubRepository
+from projects.models import Project
+from projects.tags.models import Tag, TagType
+
+
+def test_create_github_tags__existing_tag_with_drifted_attributes__reuses_existing_tag(
+    github_configuration: GithubConfiguration,
+    project: Project,
+) -> None:
+    # Given
+    # a pre-existing system tag whose colour and description differ
+    # from the current defaults
+    existing_tag = Tag.objects.create(
+        label=GitHubTag.PR_OPEN.value,
+        project=project,
+        is_system_tag=True,
+        type=TagType.GITHUB,
+        color="#123456",
+        description="A drifted description",
+    )
+
+    # When
+    GitHubRepository.objects.create(
+        github_configuration=github_configuration,
+        repository_owner="repositoryownertest",
+        repository_name="repositorynametest",
+        project=project,
+        tagging_enabled=True,
+    )
+
+    # Then - the hook reuses the existing tag instead of creating a duplicate
+    github_tags = Tag.objects.filter(project=project, type=TagType.GITHUB)
+    assert github_tags.count() == len(GitHubTag)
+    assert github_tags.get(label=GitHubTag.PR_OPEN.value).id == existing_tag.id

--- a/api/tests/unit/projects/tags/test_migrations.py
+++ b/api/tests/unit/projects/tags/test_migrations.py
@@ -61,7 +61,7 @@ def test_unique_system_tags__duplicate_system_tags__deduplicated_and_features_re
     NewFeature = new_state.apps.get_model("features", "Feature")
 
     surviving_tag = NewTag.objects.get(
-        project_id=project.id, label="PR Open", type="GITHUB"
+        project_id=project.id, label="PR Open", type="GITHUB", is_system_tag=True
     )
     assert surviving_tag.id == canonical_tag.id
 

--- a/api/tests/unit/projects/tags/test_migrations.py
+++ b/api/tests/unit/projects/tags/test_migrations.py
@@ -1,0 +1,82 @@
+import pytest
+from django.conf import settings as test_settings
+from django_test_migrations.migrator import Migrator
+
+
+@pytest.mark.skipif(
+    test_settings.SKIP_MIGRATION_TESTS is True,
+    reason="Skip migration tests to speed up tests where necessary",
+)
+def test_unique_system_tags__duplicate_system_tags__deduplicated_and_features_repointed(
+    migrator: Migrator,
+) -> None:
+    # Given
+    old_state = migrator.apply_initial_migration(("tags", "0009_add_gitlab_tag_type"))
+    Organisation = old_state.apps.get_model("organisations", "Organisation")
+    Project = old_state.apps.get_model("projects", "Project")
+    Tag = old_state.apps.get_model("tags", "Tag")
+    Feature = old_state.apps.get_model("features", "Feature")
+
+    organisation = Organisation.objects.create(name="Test Organisation")
+    project = Project.objects.create(name="Test Project", organisation=organisation)
+
+    # A system tag duplicated twice
+    canonical_tag = Tag.objects.create(
+        project=project, label="PR Open", type="GITHUB", is_system_tag=True
+    )
+    first_duplicate_tag = Tag.objects.create(
+        project=project, label="PR Open", type="GITHUB", is_system_tag=True
+    )
+    second_duplicate_tag = Tag.objects.create(
+        project=project, label="PR Open", type="GITHUB", is_system_tag=True
+    )
+
+    # A non-duplicated system tag
+    unique_system_tag = Tag.objects.create(
+        project=project, label="Unhealthy", type="UNHEALTHY", is_system_tag=True
+    )
+
+    # Duplicate user tags, which are allowed to collide
+    Tag.objects.create(project=project, label="user tag")
+    Tag.objects.create(project=project, label="user tag")
+
+    # A feature tagged with a duplicate only
+    feature_with_duplicate = Feature.objects.create(
+        name="feature_with_duplicate", project=project
+    )
+    feature_with_duplicate.tags.add(first_duplicate_tag)
+
+    # A feature tagged with both the canonical tag and a duplicate
+    feature_with_both = Feature.objects.create(
+        name="feature_with_both", project=project
+    )
+    feature_with_both.tags.add(canonical_tag, second_duplicate_tag)
+
+    # When
+    new_state = migrator.apply_tested_migration(("tags", "0010_unique_system_tags"))
+
+    # Then
+    # only the oldest duplicate survives
+    NewTag = new_state.apps.get_model("tags", "Tag")
+    NewFeature = new_state.apps.get_model("features", "Feature")
+
+    surviving_tag = NewTag.objects.get(
+        project_id=project.id, label="PR Open", type="GITHUB"
+    )
+    assert surviving_tag.id == canonical_tag.id
+
+    # and features previously tagged with a duplicate point at the surviving tag
+    assert list(
+        NewFeature.objects.get(id=feature_with_duplicate.id).tags.values_list(
+            "id", flat=True
+        )
+    ) == [canonical_tag.id]
+    assert list(
+        NewFeature.objects.get(id=feature_with_both.id).tags.values_list(
+            "id", flat=True
+        )
+    ) == [canonical_tag.id]
+
+    # and unrelated tags are left alone
+    assert NewTag.objects.filter(id=unique_system_tag.id).exists()
+    assert NewTag.objects.filter(project_id=project.id, label="user tag").count() == 2

--- a/api/tests/unit/projects/tags/test_unit_projects_tags_models.py
+++ b/api/tests/unit/projects/tags/test_unit_projects_tags_models.py
@@ -1,0 +1,39 @@
+import pytest
+from django.db import IntegrityError
+
+from projects.models import Project
+from projects.tags.models import Tag, TagType
+
+
+def test_tag__duplicate_system_tag__raises_integrity_error(
+    project: Project,
+) -> None:
+    # Given
+    Tag.objects.create(
+        label="Unhealthy",
+        project=project,
+        is_system_tag=True,
+        type=TagType.UNHEALTHY,
+    )
+
+    # When / Then
+    with pytest.raises(IntegrityError):
+        Tag.objects.create(
+            label="Unhealthy",
+            project=project,
+            is_system_tag=True,
+            type=TagType.UNHEALTHY,
+        )
+
+
+def test_tag__duplicate_user_tag__created(
+    project: Project,
+) -> None:
+    # Given
+    Tag.objects.create(label="my tag", project=project)
+
+    # When
+    duplicate_tag = Tag.objects.create(label="my tag", project=project)
+
+    # Then
+    assert duplicate_tag.id is not None

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1555,7 +1555,7 @@ requires-dist = [
     { name = "flagsmith-common", extras = ["common-core", "flagsmith-schemas", "task-processor"], specifier = ">=3.11.0,<4" },
     { name = "flagsmith-common", extras = ["test-tools"], marker = "extra == 'dev'" },
     { name = "flagsmith-flag-engine", specifier = ">=10.1.0,<11.0.0" },
-    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.11.0,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
+    { name = "flagsmith-private", marker = "extra == 'private'", specifier = ">=0.11.1,<1", index = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" },
     { name = "flagsmith-sql-flag-engine", specifier = ">=0.2.0,<0.3.0" },
     { name = "google-api-python-client", specifier = ">=1.12.5,<1.13.0" },
     { name = "google-re2", specifier = ">=1.0,<2.0.0" },
@@ -1690,7 +1690,7 @@ wheels = [
 
 [[package]]
 name = "flagsmith-private"
-version = "0.11.0"
+version = "0.11.1"
 source = { registry = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/" }
 dependencies = [
     { name = "cryptography" },
@@ -1700,9 +1700,9 @@ dependencies = [
     { name = "pysaml2" },
     { name = "scim2-filter-parser" },
 ]
-sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.11.0/flagsmith_private-0.11.0.tar.gz", hash = "sha256:98a54d3b01d7f1731b8070521d4f342cbfcba608565b88789d3683e7fe227452", upload-time = "2026-07-14T17:31:17.917Z" }
+sdist = { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.11.1/flagsmith_private-0.11.1.tar.gz", hash = "sha512:a0dfdc48083fb9ea69a05760e870bce19e26d5e672c2a22ea985d8893ea7d032ba712d96559bebd4e96d7039b8088341c65ce9976e78f9b6a69fdd978743d314", size = 54192, upload-time = "2026-07-15T11:30:06.267Z" }
 wheels = [
-    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.11.0/flagsmith_private-0.11.0-py3-none-any.whl", hash = "sha256:68c15d3d39b2c7736573bcf3ea89d3f798396ca8cca3659c9b1c3edcde8dd1b5", upload-time = "2026-07-14T17:31:17.442Z" },
+    { url = "https://flagsmith-production-084060095745.d.codeartifact.eu-west-2.amazonaws.com/pypi/flagsmith-pypi-production/simple/flagsmith-private/0.11.1/flagsmith_private-0.11.1-py3-none-any.whl", hash = "sha512:e3216c6bcac962db52a9d7f33d785ae7b63253f6a1c3b4856d210acc9c4b0507ebad66fbb2ec73f2afa3737f3ea2a54f7186d4cdebe2418a30becd17f7653e01", size = 91726, upload-time = "2026-07-15T11:30:05.765Z" },
 ]
 
 [[package]]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24569,6 +24569,7 @@ components:
             * `GITHUB` - Github
             * `UNHEALTHY` - Unhealthy
             * `GITLAB` - Gitlab
+          default: NONE
           allOf:
             - $ref: '#/components/schemas/TagTypeEnum'
           readOnly: true
@@ -26575,6 +26576,7 @@ components:
             * `GITHUB` - Github
             * `UNHEALTHY` - Unhealthy
             * `GITLAB` - Gitlab
+          default: NONE
           allOf:
             - $ref: '#/components/schemas/TagTypeEnum'
           readOnly: true


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7326.

In this PR, we add a partial unique constraint on `Tag(project, label, type)` where `is_system_tag=True`. This fixes a situation where two concurrent callers could both miss the existing row check and both insert, which caused `Tag.MultipleObjectsReturned` later.

The migration first deduplicates existing system tags by keeping the oldest row, re-points `Feature.tags` assignments to it, deletes the rest. A `SET CONSTRAINTS ALL IMMEDIATE` between the data migration and `AddConstraint` fires the deferred FK triggers queued by the deletes, without which Postgres/Oracle refuses to build the unique index in the same transaction.

## How did you test this code?

Added a migration test, model tests to verify the constraint works as expected, and a GitHub integration test making sure that the correct system tag is reused.
