### PR TITLE
fix(organisations): Enforce seat limit against licence-derived metadata

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -134,14 +134,9 @@ class Organisation(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
             },
         )
 
-    def over_plan_seats_limit(self, additional_seats: int = 0):  # type: ignore[no-untyped-def]
-        if self.has_paid_subscription():
-            susbcription_metadata = self.subscription.get_subscription_metadata()
-            return self.num_seats + additional_seats > susbcription_metadata.seats
-
-        return self.num_seats + additional_seats > getattr(
-            self.subscription, "max_seats", MAX_SEATS_IN_FREE_PLAN
-        )
+    def over_plan_seats_limit(self, additional_seats: int = 0) -> bool:
+        subscription_metadata = self.subscription.get_subscription_metadata()
+        return self.num_seats + additional_seats > subscription_metadata.seats
 
     def reset_alert_status(self):  # type: ignore[no-untyped-def]
         self.alerted_over_plan_limit = False
@@ -434,9 +429,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         return cb_metadata
 
     def _get_subscription_metadata_for_self_hosted(self) -> BaseSubscriptionMetadata:
-        if is_enterprise() and hasattr(
-            self.organisation, "licence"
-        ):  # pragma: no cover
+        if is_enterprise() and hasattr(self.organisation, "licence"):
             licence_information = self.organisation.licence.get_licence_information()
             return BaseSubscriptionMetadata(
                 seats=licence_information.num_seats,

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -98,6 +98,7 @@ def test_delete_invite_link__valid_invite__returns_204(
     settings: SettingsWrapper,
     organisation: Organisation,
     admin_client: APIClient,
+    mocker: MockerFixture,
 ) -> None:
     # Given
     settings.ENABLE_CHARGEBEE = True
@@ -107,9 +108,10 @@ def test_delete_invite_link__valid_invite__returns_204(
         args=[organisation.pk, invite.pk],
     )
 
-    # update subscription to add another seat
-    organisation.subscription.max_seats = 3
-    organisation.subscription.save()
+    mocker.patch(
+        "organisations.models.Organisation.over_plan_seats_limit",
+        return_value=False,
+    )
 
     # When
     response = admin_client.delete(url)

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -215,7 +215,13 @@ def test_over_plan_seats_limit__licence_seats_exceeded__returns_true(
         num_seats=1,
         num_projects=None,
     )
-    organisation.licence = licence
+    mocker.patch.object(
+        Organisation,
+        "licence",
+        new_callable=mocker.PropertyMock,
+        return_value=licence,
+        create=True,
+    )
     mocker.patch("organisations.models.is_enterprise", return_value=True)
     mocker.patch("organisations.models.is_saas", return_value=False)
 
@@ -236,7 +242,13 @@ def test_over_plan_seats_limit__licence_seats_available__returns_false(
         num_seats=5,
         num_projects=None,
     )
-    organisation.licence = licence
+    mocker.patch.object(
+        Organisation,
+        "licence",
+        new_callable=mocker.PropertyMock,
+        return_value=licence,
+        create=True,
+    )
     mocker.patch("organisations.models.is_enterprise", return_value=True)
     mocker.patch("organisations.models.is_saas", return_value=False)
 

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -191,21 +191,57 @@ def test_over_plan_seats_limit__over_limit__returns_true(  # type: ignore[no-unt
     mocked_get_subscription_metadata.assert_called_once_with(chargebee_subscription)
 
 
-def test_over_plan_seats_limit__no_subscription_metadata__returns_true(  # type: ignore[no-untyped-def]
-    organisation, mocker, admin_user
-):  # noqa: E501
+def test_over_plan_seats_limit__free_plan_default__returns_true(
+    organisation: Organisation,
+) -> None:
     # Given
-    organisation.subscription.max_seats = 0
-    organisation.subscription.save()
-
-    mocked_get_subscription_metadata = mocker.patch(
-        "organisations.models.Subscription.get_subscription_metadata",
-        autospec=True,
-    )
+    # The `organisation` fixture links an admin and a staff user, so num_seats
+    # is 2 while the default free plan grants a single seat.
 
     # When / Then
     assert organisation.over_plan_seats_limit() is True
-    mocked_get_subscription_metadata.assert_not_called()
+
+
+def test_over_plan_seats_limit__licence_seats_exceeded__returns_true(
+    organisation: Organisation,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    organisation.subscription.plan = "enterprise"
+    organisation.subscription.save()
+
+    licence = mocker.Mock()
+    licence.get_licence_information.return_value = mocker.Mock(
+        num_seats=1,
+        num_projects=None,
+    )
+    organisation.licence = licence
+    mocker.patch("organisations.models.is_enterprise", return_value=True)
+    mocker.patch("organisations.models.is_saas", return_value=False)
+
+    # When / Then
+    assert organisation.over_plan_seats_limit() is True
+
+
+def test_over_plan_seats_limit__licence_seats_available__returns_false(
+    organisation: Organisation,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    organisation.subscription.plan = "enterprise"
+    organisation.subscription.save()
+
+    licence = mocker.Mock()
+    licence.get_licence_information.return_value = mocker.Mock(
+        num_seats=5,
+        num_projects=None,
+    )
+    organisation.licence = licence
+    mocker.patch("organisations.models.is_enterprise", return_value=True)
+    mocker.patch("organisations.models.is_saas", return_value=False)
+
+    # When / Then
+    assert organisation.over_plan_seats_limit() is False
 
 
 @pytest.mark.saas_mode


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7862

Route `Organisation.over_plan_seats_limit` through `get_subscription_metadata` unconditionally so licence-only Enterprise orgs enforce the licence's seat count, not the unpopulated `Subscription.max_seats` default of 1.

## How did you test this code?

New unit tests cover both branches of the licence path; `make test opts="tests/unit/organisations/ tests/unit/users/"` and `make typecheck` are clean.