### PR TITLE
perf(Segment Membership): Count all segments in one scan per environment

### DIFF
--- a/api/segment_membership/services.py
+++ b/api/segment_membership/services.py
@@ -159,8 +159,6 @@ def compute_segment_counts_for_project(
     if not count_columns:
         return []
 
-    # One scan per environment: dedupe with FINAL once, then count every segment
-    # in the same pass via `countIf`, rather than re-scanning per segment.
     sql = (
         f"SELECT i.environment_id AS env_key, {', '.join(count_columns)} "
         f"FROM IDENTITIES AS i FINAL "

--- a/api/segment_membership/services.py
+++ b/api/segment_membership/services.py
@@ -113,8 +113,7 @@ def compute_segment_counts_for_project(
     `project`, scanning each environment once.
 
     A single `GROUP BY environment_id` over `IDENTITIES FINAL` counts every
-    segment in one pass via `countIf(<predicate>)` per segment, instead of
-    re-scanning (and re-deduping) the environment once per segment.
+    segment in one pass via `countIf(<predicate>)` per segment.
 
     Returns unsaved `SegmentMembershipCount` instances with `count` and
     keys populated; the caller stamps `last_synced_at` consistently

--- a/api/segment_membership/services.py
+++ b/api/segment_membership/services.py
@@ -110,7 +110,11 @@ def compute_segment_counts_for_project(
     project: Project, cursor: CursorWrapper
 ) -> list[SegmentMembershipCount]:
     """Count identity matches per (canonical-segment, environment) for
-    `project` in one `UNION ALL` query.
+    `project`, scanning each environment once.
+
+    A single `GROUP BY environment_id` over `IDENTITIES FINAL` counts every
+    segment in one pass via `countIf(<predicate>)` per segment, instead of
+    re-scanning (and re-deduping) the environment once per segment.
 
     Returns unsaved `SegmentMembershipCount` instances with `count` and
     keys populated; the caller stamps `last_synced_at` consistently
@@ -128,7 +132,8 @@ def compute_segment_counts_for_project(
 
     dialect = ClickHouseDialect()
     binder = Binder(PyformatParamStyle())
-    select_clauses: list[str] = []
+    count_columns: list[str] = []
+    counted_segment_ids: list[int] = []
     for seg in segments:
         translate_ctx = TranslateContext(
             evaluation_context=EvaluationContext(
@@ -149,33 +154,37 @@ def compute_segment_counts_for_project(
                 reason="untranslatable",
             )
             continue
-        select_clauses.append(
-            f"SELECT {seg.id} AS segment_id, "
-            f"i.environment_id AS env_key, count() AS c "
-            f"FROM IDENTITIES AS i FINAL "
-            f"WHERE i.environment_id IN %(env_keys)s "
-            f"AND i.is_deleted = false AND ({predicate}) "
-            f"GROUP BY i.environment_id"
-        )
+        count_columns.append(f"countIf({predicate}) AS c{seg.id}")
+        counted_segment_ids.append(seg.id)
 
-    if not select_clauses:
+    if not count_columns:
         return []
 
-    sql = "\nUNION ALL\n".join(select_clauses)
+    # One scan per environment: dedupe with FINAL once, then count every segment
+    # in the same pass via `countIf`, rather than re-scanning per segment.
+    sql = (
+        f"SELECT i.environment_id AS env_key, {', '.join(count_columns)} "
+        f"FROM IDENTITIES AS i FINAL "
+        f"WHERE i.environment_id IN %(env_keys)s AND i.is_deleted = false "
+        f"GROUP BY i.environment_id"
+    )
     cursor.execute(sql, {"env_keys": tuple(env_id_by_key), **binder.params})
     rows: list[tuple[Any, ...]] = cursor.fetchall()
     membership_counts: list[SegmentMembershipCount] = []
     for row in rows:
-        env_id = env_id_by_key.get(str(row[1]))
+        env_id = env_id_by_key.get(str(row[0]))
         if env_id is None:
             continue
-        membership_counts.append(
-            SegmentMembershipCount(
-                segment_id=int(row[0]),
-                environment_id=env_id,
-                count=int(row[2]),
-            )
-        )
+        # Columns line up with counted_segment_ids; a zero-match pair is absent.
+        for segment_id, count in zip(counted_segment_ids, row[1:]):
+            if count:
+                membership_counts.append(
+                    SegmentMembershipCount(
+                        segment_id=segment_id,
+                        environment_id=env_id,
+                        count=int(count),
+                    )
+                )
     return membership_counts
 
 

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -131,7 +131,8 @@ def test_compute_segment_counts_for_project__unknown_env_key_in_row__skips(
         return_value="TRUE",
     )
     cursor = MagicMock()
-    cursor.fetchall.return_value = [(segment.id, "ghost-env", 99)]
+    # New row shape: (env_key, count-per-segment...); env_key is unknown here
+    cursor.fetchall.return_value = [("ghost-env", 99)]
 
     # When
     result = compute_segment_counts_for_project(project, cursor)
@@ -286,6 +287,40 @@ def test_compute_segment_counts_for_project__deleted_identity__excluded_from_cou
     assert len(counts) == 1
     assert counts[0].segment_id == matching_segment.id
     assert counts[0].count == 2
+
+
+@pytest.mark.clickhouse
+def test_compute_segment_counts_for_project__multiple_segments__maps_each_count_drops_zeros(
+    segment_membership_identities: None,
+    matching_segment: Segment,
+    project: Project,
+    environment: Environment,
+) -> None:
+    # Given, alongside matching_segment (foo == bar -> alice, bob), a segment
+    # matching a different value and one matching nobody
+    seg_baz = Segment.objects.create(name="baz", project=project)
+    Condition.objects.create(
+        rule=SegmentRule.objects.create(segment=seg_baz, type=SegmentRule.ALL_RULE),
+        property="foo",
+        operator=EQUAL,
+        value="baz",
+    )
+    seg_none = Segment.objects.create(name="none", project=project)
+    Condition.objects.create(
+        rule=SegmentRule.objects.create(segment=seg_none, type=SegmentRule.ALL_RULE),
+        property="foo",
+        operator=EQUAL,
+        value="zzz",
+    )
+
+    # When one scan counts all three segments
+    with connections["clickhouse"].cursor() as cursor:
+        counts = compute_segment_counts_for_project(project, cursor)
+
+    # Then each column maps to its own segment and the zero-match one is absent
+    by_segment = {c.segment_id: c.count for c in counts}
+    assert by_segment == {matching_segment.id: 2, seg_baz.id: 1}
+    assert seg_none.id not in by_segment
 
 
 @pytest.mark.clickhouse

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -131,7 +131,6 @@ def test_compute_segment_counts_for_project__unknown_env_key_in_row__skips(
         return_value="TRUE",
     )
     cursor = MagicMock()
-    # New row shape: (env_key, count-per-segment...); env_key is unknown here
     cursor.fetchall.return_value = [("ghost-env", 99)]
 
     # When
@@ -321,7 +320,6 @@ def test_compute_segment_counts_for_project__multiple_segments__maps_each_count_
         counts = compute_segment_counts_for_project(project, cursor)
 
     # Then
-    # each column maps to its own segment and the zero-match one is absent
     by_segment = {c.segment_id: c.count for c in counts}
     assert by_segment == {
         three_segments["bar"].id: 2,

--- a/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
+++ b/api/tests/unit/segment_membership/test_unit_segment_membership_services.py
@@ -6,7 +6,7 @@ from common.test_tools import RunTasksFixture
 from django.db import connections
 from django.utils import timezone
 from flag_engine.segments.constants import EQUAL, REGEX
-from pytest_django.fixtures import SettingsWrapper
+from pytest_django.fixtures import DjangoAssertNumQueries, SettingsWrapper
 from pytest_mock import MockerFixture
 from task_processor.models import Task
 from task_processor.task_run_method import TaskRunMethod
@@ -199,6 +199,27 @@ def percent_regex_segment(segment: Segment) -> Segment:
     return segment
 
 
+@pytest.fixture
+def three_segments(matching_segment: Segment, project: Project) -> dict[str, Segment]:
+    """`matching_segment` matches foo == bar (alice, bob); add one matching a
+    different value (carol) and one matching nobody."""
+    seg_baz = Segment.objects.create(name="baz", project=project)
+    Condition.objects.create(
+        rule=SegmentRule.objects.create(segment=seg_baz, type=SegmentRule.ALL_RULE),
+        property="foo",
+        operator=EQUAL,
+        value="baz",
+    )
+    seg_none = Segment.objects.create(name="none", project=project)
+    Condition.objects.create(
+        rule=SegmentRule.objects.create(segment=seg_none, type=SegmentRule.ALL_RULE),
+        property="foo",
+        operator=EQUAL,
+        value="zzz",
+    )
+    return {"bar": matching_segment, "baz": seg_baz, "none": seg_none}
+
+
 @pytest.mark.clickhouse
 def test_get_segment_members_page__deleted_identity__excluded(
     segment_membership_identities: None,
@@ -292,35 +313,39 @@ def test_compute_segment_counts_for_project__deleted_identity__excluded_from_cou
 @pytest.mark.clickhouse
 def test_compute_segment_counts_for_project__multiple_segments__maps_each_count_drops_zeros(
     segment_membership_identities: None,
-    matching_segment: Segment,
+    three_segments: dict[str, Segment],
     project: Project,
-    environment: Environment,
 ) -> None:
-    # Given, alongside matching_segment (foo == bar -> alice, bob), a segment
-    # matching a different value and one matching nobody
-    seg_baz = Segment.objects.create(name="baz", project=project)
-    Condition.objects.create(
-        rule=SegmentRule.objects.create(segment=seg_baz, type=SegmentRule.ALL_RULE),
-        property="foo",
-        operator=EQUAL,
-        value="baz",
-    )
-    seg_none = Segment.objects.create(name="none", project=project)
-    Condition.objects.create(
-        rule=SegmentRule.objects.create(segment=seg_none, type=SegmentRule.ALL_RULE),
-        property="foo",
-        operator=EQUAL,
-        value="zzz",
-    )
-
-    # When one scan counts all three segments
+    # Given / When
     with connections["clickhouse"].cursor() as cursor:
         counts = compute_segment_counts_for_project(project, cursor)
 
-    # Then each column maps to its own segment and the zero-match one is absent
+    # Then
+    # each column maps to its own segment and the zero-match one is absent
     by_segment = {c.segment_id: c.count for c in counts}
-    assert by_segment == {matching_segment.id: 2, seg_baz.id: 1}
-    assert seg_none.id not in by_segment
+    assert by_segment == {
+        three_segments["bar"].id: 2,
+        three_segments["baz"].id: 1,
+    }
+    assert three_segments["none"].id not in by_segment
+
+
+@pytest.mark.clickhouse
+def test_compute_segment_counts_for_project__multiple_segments__uses_single_query(
+    segment_membership_identities: None,
+    three_segments: dict[str, Segment],
+    project: Project,
+    django_assert_num_queries: DjangoAssertNumQueries,
+) -> None:
+    # Given
+    # three_segments + identities are set up by fixtures
+
+    # When / Then
+    with (
+        django_assert_num_queries(1, connection=connections["clickhouse"]),
+        connections["clickhouse"].cursor() as cursor,
+    ):
+        compute_segment_counts_for_project(project, cursor)
 
 
 @pytest.mark.clickhouse

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -369,7 +369,7 @@ Attributes:
 ### `segment_membership.compute.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:150`
+ - `api/segment_membership/services.py:149`
 
 Attributes:
  - `project.id`
@@ -379,7 +379,7 @@ Attributes:
 ### `segment_membership.members.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:218`
+ - `api/segment_membership/services.py:217`
 
 Attributes:
  - `reason`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -379,7 +379,7 @@ Attributes:
 ### `segment_membership.members.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:217`
+ - `api/segment_membership/services.py:215`
 
 Attributes:
  - `reason`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -369,7 +369,7 @@ Attributes:
 ### `segment_membership.compute.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:145`
+ - `api/segment_membership/services.py:150`
 
 Attributes:
  - `project.id`
@@ -379,7 +379,7 @@ Attributes:
 ### `segment_membership.members.segment.skipped`
 
 Logged at `error` from:
- - `api/segment_membership/services.py:209`
+ - `api/segment_membership/services.py:218`
 
 Attributes:
  - `reason`


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8015.

In this PR, we optimise the segment membership count calculation by compressing querying all relevant segments for a given environment into a single query, as opposed to scanning an environment once per each segment.

We replace the fan-out with a single `GROUP BY environment_id` scan that counts every segment in one pass via `countIf(<predicate>)` per segment, then maps the columns back to per-segment counts. Each environment is scanned and de-duplicated once regardless of segment count.

## How did you test this code?

Added a test asserting that three segments counted in one query map to the right counts and that a zero-match segment is absent; updated the existing mock-based test for the new row shape. Existing single-segment count tests (including the deleted-identity and percent-regex cases) still pass.

Measured the query shapes against a production environment with 20 segments/~16M-identities:

| Shape | rows read | data | elapsed |
| --- | --- | --- | --- |
| `UNION ALL` (before) | 331M | 25.7 GB | 8.65s |
| single-scan `countIf` (this PR) | 16.6M | 1.29 GB | 0.49s |

The heaviest production projects run 80–159 segments, so the reduction there is proportionally larger, and peak memory falls too.
