### PR TITLE
refactor(components): migrate Highlight to TypeScript

### DIFF
--- a/frontend/web/components/Highlight.tsx
+++ b/frontend/web/components/Highlight.tsx
@@ -1,7 +1,39 @@
 import React from 'react'
 import hljs from 'highlight.js'
+import Button from './base/forms/Button'
 
-function escapeHtml(unsafe) {
+type HtmlValue = { __html?: string }
+
+export type HighlightProps = {
+  // The code/value to render (via dangerouslySetInnerHTML, so a string), and
+  // the initial value in editor mode.
+  children?: string
+  className?: string
+  style?: React.CSSProperties
+  'data-test'?: string
+  // Display
+  forceExpanded?: boolean // skip the collapse / "Show more" measurement
+  preventEscape?: boolean // render children as-is (don't HTML-escape)
+  innerHTML?: boolean // render children as raw HTML into `element`/div
+  element?: React.ElementType // wrapper element for the innerHTML branch
+  // Editor mode (contentEditable), active when onChange is provided
+  onChange?: (value: string) => void
+  onBlur?: () => void
+  disabled?: boolean
+}
+
+type HighlightState = {
+  value: HtmlValue
+  focus?: boolean
+  expandable?: boolean
+  expanded?: boolean
+  key?: number
+  // Never assigned; the value-sync comparison below relies on it always being
+  // undefined so the draft re-syncs to children on update. Kept as-is.
+  prevValue?: string
+}
+
+function escapeHtml(unsafe: HtmlValue | undefined): HtmlValue | undefined {
   if (!unsafe || !unsafe.__html) return unsafe
   return {
     __html: `${unsafe.__html}`
@@ -12,15 +44,20 @@ function escapeHtml(unsafe) {
       .replace(/'/g, '&#039;'),
   }
 }
-const defaultValue = { __html: 'Enter a value...' }
-const defaultDisabledValue = { __html: ' ' }
+
+const defaultValue: HtmlValue = { __html: 'Enter a value...' }
+const defaultDisabledValue: HtmlValue = { __html: ' ' }
 const collapsedHeight = 110
-class Highlight extends React.Component {
-  state = {
+
+class Highlight extends React.Component<HighlightProps, HighlightState> {
+  el: HTMLElement | null = null
+  measure: (force?: boolean) => void = () => {}
+
+  state: HighlightState = {
     value: { __html: this.props.children },
   }
 
-  constructor(props) {
+  constructor(props: HighlightProps) {
     super(props)
     this.setEl = this.setEl.bind(this)
   }
@@ -29,36 +66,27 @@ class Highlight extends React.Component {
     this.highlightCode()
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: HighlightProps) {
     this.highlightCode()
     if (this.props.className !== prevProps.className) {
-      setTimeout(() => {
-        this.highlightCode()
-      }, 100)
+      setTimeout(() => this.highlightCode(), 100)
     }
     if (this.state.prevValue !== this.props.children) {
       this.setState({
         key: Date.now(),
-        value: {
-          ...this.state.value,
-          __html: this.props.children,
-        },
+        value: { ...this.state.value, __html: this.props.children },
       })
     }
   }
 
   highlightCode = () => {
-    const nodes = this.el.querySelectorAll('pre code')
-    if (typeof hljs !== 'undefined') {
-      for (let i = 0; i < nodes.length; i++) {
-        hljs.highlightBlock(nodes[i])
-      }
-    }
+    const nodes = this.el?.querySelectorAll('pre code')
+    nodes?.forEach((node) => hljs.highlightElement(node as HTMLElement))
   }
 
-  setEl(el) {
+  setEl(el: HTMLElement | null) {
     this.el = el
-    this.measure = (force) => {
+    this.measure = (force?: boolean) => {
       if (this.props.forceExpanded) return
       if (!this.el) return
       const height = this.el.clientHeight
@@ -69,9 +97,7 @@ class Highlight extends React.Component {
         if (height > collapsedHeight) {
           this.setState({ expandable: true, expanded: false })
         } else if (!height) {
-          setTimeout(() => {
-            this.measure()
-          }, 50)
+          setTimeout(() => this.measure(), 50)
         } else {
           this.setState({ expandable: false })
         }
@@ -79,7 +105,8 @@ class Highlight extends React.Component {
     }
     this.measure()
   }
-  shouldComponentUpdate(nextProps, nextState) {
+
+  shouldComponentUpdate(nextProps: HighlightProps, nextState: HighlightState) {
     if (nextState.focus !== this.state.focus) return true
     if (nextProps.className !== this.props.className) return true
     if (nextState.expandable !== this.state.expandable) return true
@@ -88,60 +115,52 @@ class Highlight extends React.Component {
     return this.state.value.__html !== `${nextProps.children}`
   }
 
-  _handleInput = (event) => {
-    const value = event.target.innerText
+  handleInput = (event: React.FormEvent<HTMLElement>) => {
+    const value = event.currentTarget.innerText
     this.state.value.__html = value
-    this.props.onChange(value)
+    this.props.onChange?.(value)
   }
 
-  onFocus = () => {
-    this.setState({ focus: true })
-  }
+  onFocus = () => this.setState({ focus: true })
 
   onBlur = () => {
     this.setState({ focus: false })
     this.props.onBlur?.()
   }
 
+  // The value to render before escaping: the live edit while focused, the
+  // current value when there's content, otherwise a disabled/empty placeholder.
+  getRawHtml(): HtmlValue | undefined {
+    if (this.state.focus) return this.state.value
+    if (this.props.children) return { ...this.state.value }
+    return this.props.disabled ? defaultDisabledValue : defaultValue
+  }
+
   render() {
-    const {
-      children,
-      className,
-      disabled,
-      element: Element,
-      innerHTML,
-    } = this.props
-    const props = { className, ref: this.setEl }
+    const { children, className, element: Element, innerHTML } = this.props
 
     if (innerHTML) {
-      props.dangerouslySetInnerHTML = { __html: children }
-      if (Element) {
-        return <Element {...props} />
+      const htmlProps = {
+        className,
+        dangerouslySetInnerHTML: { __html: children ?? '' },
+        ref: this.setEl,
       }
-      return <div {...props} />
+      if (Element) {
+        return <Element {...htmlProps} />
+      }
+      return <div {...htmlProps} />
     }
 
     if (Element) {
-      return <Element {...props}>{children}</Element>
+      return (
+        <Element className={className} ref={this.setEl}>
+          {children}
+        </Element>
+      )
     }
 
-    const html = this.props.preventEscape
-      ? this.state.focus
-        ? this.state.value
-        : this.props.children
-        ? { ...this.state.value }
-        : disabled
-        ? defaultDisabledValue
-        : defaultValue
-      : escapeHtml(
-          this.state.focus
-            ? this.state.value
-            : this.props.children
-            ? { ...this.state.value }
-            : disabled
-            ? defaultDisabledValue
-            : defaultValue,
-        )
+    const raw = this.getRawHtml()
+    const html = this.props.preventEscape ? raw : escapeHtml(raw)
     return (
       <div className={this.state.expandable ? 'expandable' : ''}>
         <pre
@@ -166,11 +185,11 @@ class Highlight extends React.Component {
             contentEditable={!!this.props.onChange}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
-            onInput={this._handleInput}
-            className={`${className} ${
+            onInput={this.handleInput}
+            className={`${className ?? ''} ${
               !this.state.value || !this.state.value.__html ? 'empty' : ''
             }`}
-            dangerouslySetInnerHTML={html}
+            dangerouslySetInnerHTML={{ __html: html?.__html ?? '' }}
           />
         </pre>
         {this.state.expandable && (
@@ -194,12 +213,6 @@ class Highlight extends React.Component {
       </div>
     )
   }
-}
-
-Highlight.defaultProps = {
-  className: null,
-  element: null,
-  innerHTML: false,
 }
 
 export default Highlight


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Part of the ongoing TypeScript migration (after CodeHelp #7170 and Input #7758).

Migrates `web/components/Highlight` from `.js` to `.tsx`:

- Adds `HighlightProps` + `HighlightState`, covering both the display and the editor (contentEditable) modes.
- `children` is typed as `string` (it renders via `dangerouslySetInnerHTML`), so non-string children now surface as type errors.
- Imports `Button` instead of relying on the runtime global, and de-nests the html ternary into a small helper.

Behaviour-preserving. Follow-up: `ValueEditor` (the main editor-mode consumer) will be migrated on top of this so the editor path is type-checked end to end.

## How did you test this code?

`typecheck` and `lint` pass; the 7 `.tsx` consumers type-check against the new props with no changes. Manually: open a code block (SDK setup / CodeHelp) and confirm highlighting renders, and edit a flag value / trait to confirm the contentEditable editor still works.
