### PR TITLE
fix(e2e): staging E2E failures from shared-project pollution and onboarding flag race

### DIFF
--- a/frontend/e2e/tests/deep-link-test.pw.ts
+++ b/frontend/e2e/tests/deep-link-test.pw.ts
@@ -20,10 +20,6 @@ test.describe('Deep link to feature slideout', () => {
     const { login } = createHelpers(page)
     const api = Project.api
 
-    // Given - an authenticated API session and a dedicated per-run project
-    // with > PAGE_SIZE features. Seeding a shared project would push other
-    // tests' features off page 1 of the list; the e2etests teardown deletes
-    // the E2E user's organisations, so no cleanup is needed here.
     log('Authenticate against the API')
     const loginRes = await request.post(`${api}auth/login/`, {
       data: { email: E2E_USER, password: PASSWORD },

--- a/frontend/e2e/tests/deep-link-test.pw.ts
+++ b/frontend/e2e/tests/deep-link-test.pw.ts
@@ -20,12 +20,10 @@ test.describe('Deep link to feature slideout', () => {
     const { login } = createHelpers(page)
     const api = Project.api
 
-    // Given - an authenticated API session and a dedicated project with
-    // > PAGE_SIZE features. The project is created per run: seeding the shared
-    // "My Test Project" fills page 1 of its feature list with e2e_deeplink_*
-    // rows, which hides features that concurrently running tests create (they
-    // sort after "e" and land on page 2). The e2etests teardown deletes all of
-    // the E2E user's organisations, so nothing here needs explicit cleanup.
+    // Given - an authenticated API session and a dedicated per-run project
+    // with > PAGE_SIZE features. Seeding a shared project would push other
+    // tests' features off page 1 of the list; the e2etests teardown deletes
+    // the E2E user's organisations, so no cleanup is needed here.
     log('Authenticate against the API')
     const loginRes = await request.post(`${api}auth/login/`, {
       data: { email: E2E_USER, password: PASSWORD },

--- a/frontend/e2e/tests/deep-link-test.pw.ts
+++ b/frontend/e2e/tests/deep-link-test.pw.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../test-setup'
 import { createHelpers, LONG_TIMEOUT, log } from '../helpers'
-import { E2E_USER, PASSWORD, E2E_TEST_PROJECT } from '../config'
+import { E2E_USER, PASSWORD } from '../config'
 import Project from '../../common/project'
 
 const PAGE_SIZE = 50
@@ -20,7 +20,12 @@ test.describe('Deep link to feature slideout', () => {
     const { login } = createHelpers(page)
     const api = Project.api
 
-    // Given - an authenticated API session and a project with > PAGE_SIZE features
+    // Given - an authenticated API session and a dedicated project with
+    // > PAGE_SIZE features. The project is created per run: seeding the shared
+    // "My Test Project" fills page 1 of its feature list with e2e_deeplink_*
+    // rows, which hides features that concurrently running tests create (they
+    // sort after "e" and land on page 2). The e2etests teardown deletes all of
+    // the E2E user's organisations, so nothing here needs explicit cleanup.
     log('Authenticate against the API')
     const loginRes = await request.post(`${api}auth/login/`, {
       data: { email: E2E_USER, password: PASSWORD },
@@ -29,86 +34,93 @@ test.describe('Deep link to feature slideout', () => {
     const { key } = await loginRes.json()
     const headers = { Authorization: `Token ${key}` }
 
-    const project = unwrap<{ id: number; name: string }>(
-      await (await request.get(`${api}projects/`, { headers })).json(),
-    ).find((p) => p.name === E2E_TEST_PROJECT)!
-    expect(project).toBeTruthy()
+    // Unique names per run so the flakiness check (`E2E_REPEAT` / `/e2e N`) does
+    // not collide with entities created by a previous iteration.
+    const runId = Date.now()
 
-    const environment = unwrap<{ id: number; name: string; api_key: string }>(
-      await (
-        await request.get(`${api}environments/?project=${project.id}`, {
-          headers,
-        })
-      ).json(),
-    ).find((e) => e.name === 'Development')!
-    expect(environment).toBeTruthy()
+    log('Create a dedicated project and environment')
+    // The seeded organisation from e2e_seed_data.py; other orgs may appear
+    // concurrently (e.g. the versioning test creates one), so match by name.
+    const organisation = unwrap<{ id: number; name: string }>(
+      await (await request.get(`${api}organisations/`, { headers })).json(),
+    ).find((o) => o.name === 'Bullet Train Ltd')!
+    expect(organisation).toBeTruthy()
+
+    // The seeded org is at its subscription's project cap; the E2E auth token
+    // header marks the request as E2E so the cap check is bypassed.
+    const e2eToken =
+      process.env.E2E_TEST_TOKEN ??
+      process.env[`E2E_TEST_TOKEN_${Project.env.toUpperCase()}`] ??
+      ''
+    const projectRes = await request.post(`${api}projects/`, {
+      data: {
+        name: `Deep Link Project ${runId}`,
+        organisation: organisation.id,
+      },
+      headers: { ...headers, 'X-E2E-Test-Auth-Token': e2eToken.trim() },
+    })
+    expect(projectRes.ok()).toBeTruthy()
+    const project = (await projectRes.json()) as { id: number }
+
+    const environmentRes = await request.post(`${api}environments/`, {
+      data: { name: 'Development', project: project.id },
+      headers,
+    })
+    expect(environmentRes.ok()).toBeTruthy()
+    const environment = (await environmentRes.json()) as {
+      id: number
+      api_key: string
+    }
 
     log(`Create ${FEATURE_COUNT} features`)
-    // Unique names per run so the flakiness check (`E2E_REPEAT` / `/e2e N`) does
-    // not collide with features created by a previous iteration.
-    const runId = Date.now()
     const featureName = (i: number) =>
       `${FEATURE_PREFIX}${runId}_${String(i).padStart(3, '0')}`
-    const createdFeatureIds: number[] = []
-
-    try {
-      const created = await Promise.all(
-        Array.from({ length: FEATURE_COUNT }, (_, i) =>
-          request.post(`${api}projects/${project.id}/features/`, {
-            data: { name: featureName(i) },
-            headers,
-          }),
-        ),
-      )
-      for (const res of created) {
-        expect(res.ok()).toBeTruthy()
-        createdFeatureIds.push((await res.json()).id)
-      }
-
-      // The list renders sorted by name ascending, so page 1 holds the first
-      // PAGE_SIZE features and a feature on page 2 never mounts a row on page 1.
-      const listUrl = (pageNumber: number) =>
-        `${api}projects/${project.id}/features/?environment=${environment.id}&page=${pageNumber}&page_size=${PAGE_SIZE}&sort_field=name&sort_direction=ASC`
-      const page1 = await (await request.get(listUrl(1), { headers })).json()
-      const page2 = await (await request.get(listUrl(2), { headers })).json()
-      const onPageFeature = page1.results[0] as { id: number; name: string }
-      const offPageFeature = page2.results[0] as { id: number; name: string }
-      expect(onPageFeature).toBeTruthy()
-      expect(offPageFeature).toBeTruthy()
-      log(`On-page: ${onPageFeature.name}, off-page: ${offPageFeature.name}`)
-
-      await login(E2E_USER, PASSWORD)
-      const featuresPath = `/project/${project.id}/environment/${environment.api_key}/features`
-      const slideout = page.locator('.create-feature-modal')
-
-      // When/Then - this is the #7652 regression: a deep link to a feature that
-      // is NOT on the first page previously rendered the list without opening
-      // any modal, because the deep-link handler only fired for mounted rows.
-      await page.goto(`${featuresPath}?feature=${offPageFeature.id}&tab=value`)
-      await expect(slideout).toBeVisible({ timeout: LONG_TIMEOUT })
-      await expect(slideout).toContainText(offPageFeature.name)
-
-      // And - the existing on-page deep link still works (no regression). A
-      // fresh navigation reloads the page, dismissing the previous slideout.
-      await page.goto(`${featuresPath}?feature=${onPageFeature.id}&tab=value`)
-      await expect(slideout).toBeVisible({ timeout: LONG_TIMEOUT })
-      await expect(slideout).toContainText(onPageFeature.name)
-
-      // And - an unknown feature id degrades gracefully (no slideout, no crash).
-      await page.goto(`${featuresPath}?feature=999999999&tab=value`)
-      await expect(page.locator('[data-test="features-page"]')).toBeVisible({
-        timeout: LONG_TIMEOUT,
-      })
-      await expect(slideout).toBeHidden()
-    } finally {
-      // Clean up so reruns against a persistent project don't accumulate rows.
-      await Promise.all(
-        createdFeatureIds.map((id) =>
-          request.delete(`${api}projects/${project.id}/features/${id}/`, {
-            headers,
-          }),
-        ),
-      )
+    const created = await Promise.all(
+      Array.from({ length: FEATURE_COUNT }, (_, i) =>
+        request.post(`${api}projects/${project.id}/features/`, {
+          data: { name: featureName(i) },
+          headers,
+        }),
+      ),
+    )
+    for (const res of created) {
+      expect(res.ok()).toBeTruthy()
     }
+
+    // The list renders sorted by name ascending, so page 1 holds the first
+    // PAGE_SIZE features and a feature on page 2 never mounts a row on page 1.
+    const listUrl = (pageNumber: number) =>
+      `${api}projects/${project.id}/features/?environment=${environment.id}&page=${pageNumber}&page_size=${PAGE_SIZE}&sort_field=name&sort_direction=ASC`
+    const page1 = await (await request.get(listUrl(1), { headers })).json()
+    const page2 = await (await request.get(listUrl(2), { headers })).json()
+    const onPageFeature = page1.results[0] as { id: number; name: string }
+    const offPageFeature = page2.results[0] as { id: number; name: string }
+    expect(onPageFeature).toBeTruthy()
+    expect(offPageFeature).toBeTruthy()
+    log(`On-page: ${onPageFeature.name}, off-page: ${offPageFeature.name}`)
+
+    await login(E2E_USER, PASSWORD)
+    const featuresPath = `/project/${project.id}/environment/${environment.api_key}/features`
+    const slideout = page.locator('.create-feature-modal')
+
+    // When/Then - this is the #7652 regression: a deep link to a feature that
+    // is NOT on the first page previously rendered the list without opening
+    // any modal, because the deep-link handler only fired for mounted rows.
+    await page.goto(`${featuresPath}?feature=${offPageFeature.id}&tab=value`)
+    await expect(slideout).toBeVisible({ timeout: LONG_TIMEOUT })
+    await expect(slideout).toContainText(offPageFeature.name)
+
+    // And - the existing on-page deep link still works (no regression). A
+    // fresh navigation reloads the page, dismissing the previous slideout.
+    await page.goto(`${featuresPath}?feature=${onPageFeature.id}&tab=value`)
+    await expect(slideout).toBeVisible({ timeout: LONG_TIMEOUT })
+    await expect(slideout).toContainText(onPageFeature.name)
+
+    // And - an unknown feature id degrades gracefully (no slideout, no crash).
+    await page.goto(`${featuresPath}?feature=999999999&tab=value`)
+    await expect(page.locator('[data-test="features-page"]')).toBeVisible({
+      timeout: LONG_TIMEOUT,
+    })
+    await expect(slideout).toBeHidden()
   })
 })

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -26,6 +26,21 @@ test.describe('Onboarding', () => {
         .getByRole('heading', { name: /Welcome/ })
         .waitFor({ state: 'visible', timeout: 30000 });
 
+    // The features page syncs the slideout state to the URL with
+    // history.replace, which aborts a full navigation that is still in
+    // flight - let the page settle and retry.
+    const gotoOnboarding = async () => {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await page.goto('/getting-started?connected');
+          return;
+        } catch (e) {
+          if (attempt >= 2) throw e;
+          await page.waitForTimeout(1000);
+        }
+      }
+    };
+
     log('Sign up');
     await page.goto('/');
     await click(byId('jsSignup'));
@@ -62,7 +77,7 @@ test.describe('Onboarding', () => {
     // No real first evaluation in a test, so force the connected state via
     // ?connected (the #7767 stub); that unlocks the toggle and flips LIVE.
     log('Force the connected state');
-    await page.goto('/getting-started?connected');
+    await gotoOnboarding();
     await flowReady();
     await expect(page.getByText('LIVE', { exact: true })).toBeVisible();
 
@@ -119,12 +134,12 @@ test.describe('Onboarding', () => {
       /\/features\?feature=\d+&tab=segment-overrides/,
     );
 
-    await page.goto('/getting-started?connected');
+    await gotoOnboarding();
     await flowReady();
     await page.getByRole('button', { name: /Remote config/ }).click();
     await expect(page).toHaveURL(/\/features\?feature=\d+&tab=value/);
 
-    await page.goto('/getting-started?connected');
+    await gotoOnboarding();
     await flowReady();
     await page.getByRole('button', { name: /Experiment/ }).click();
     await expect(page).toHaveURL(/\/experiments$/);

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -139,14 +139,23 @@ const App = class extends Component {
       // New users with no organisation go through the single-page onboarding
       // flow when it's enabled - it creates the organisation itself, so it
       // replaces the legacy /create page. Everyone else still gets /create.
-      if (
-        AccountStore.getUser()?.isGettingStarted &&
-        Utils.getFlagsmithHasFeature('onboarding_quickstart_flow')
-      ) {
-        this.props.history.replace('/getting-started')
-      } else {
-        this.props.history.replace(`/create${query}`)
-      }
+      // The flag must be evaluated for the identified user, not whatever the
+      // SDK last held, so wait for identify to settle before routing.
+      // Capped at 2s: a degraded flags API falls back to routing with the
+      // already-loaded flags instead of blocking the redirect.
+      Promise.race([
+        Promise.resolve(API.flagsmithIdentify()).catch(() => {}),
+        new Promise((resolve) => setTimeout(resolve, 2000)),
+      ]).then(() => {
+        if (
+          AccountStore.getUser()?.isGettingStarted &&
+          Utils.getFlagsmithHasFeature('onboarding_quickstart_flow')
+        ) {
+          this.props.history.replace('/getting-started')
+        } else {
+          this.props.history.replace(`/create${query}`)
+        }
+      })
       return
     }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes the staging E2E failures red since 15 Jul. Two causes:

1. The deep-link test seeds 60 `e2e_deeplink_*` features in the shared project, filling page 1 of the feature list. Features created by concurrent tests end up on page 2 and their waits time out. The test now uses its own per-run project, cleaned up by the e2etests teardown.
2. `App.js` routes new signups to `/getting-started` or `/create` before `flagsmithIdentify()` settles, so the flag check can miss user-level values. It now waits for identify, capped at 2s so a degraded flags API falls back to routing with the already-loaded flags (today's behaviour) instead of blocking the redirect. The onboarding test also retries its `?connected` navigation, which the features page's URL sync can abort.

## How did you test this code?

Both tests pass against staging, where CI has been failing.