### PR TITLE
feat: clickhouse warehouse setup UI

### DIFF
--- a/frontend/common/services/useWarehouseConnection.ts
+++ b/frontend/common/services/useWarehouseConnection.ts
@@ -48,6 +48,16 @@ export const warehouseConnectionService = service
           url: `environments/${environmentId}/warehouse-connections/${id}/test-warehouse-connection/`,
         }),
       }),
+      testWarehouseConnectionConfig: builder.mutation<
+        Res['warehouseConnectionTestResult'],
+        Req['testWarehouseConnectionConfig']
+      >({
+        query: ({ environmentId, ...body }) => ({
+          body,
+          method: 'POST',
+          url: `environments/${environmentId}/warehouse-connections/test-warehouse-connection/`,
+        }),
+      }),
       updateWarehouseConnection: builder.mutation<
         Res['warehouseConnections'][number],
         Req['updateWarehouseConnection']
@@ -66,6 +76,7 @@ export const {
   useCreateWarehouseConnectionMutation,
   useDeleteWarehouseConnectionMutation,
   useGetWarehouseConnectionsQuery,
+  useTestWarehouseConnectionConfigMutation,
   useTestWarehouseConnectionMutation,
   useUpdateWarehouseConnectionMutation,
 } = warehouseConnectionService

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -147,6 +147,8 @@ export interface PipelineStageRequest {
   actions: StageActionRequest[]
 }
 
+type WarehouseConfigValue = string | number | boolean
+
 export type Req = {
   getFeatureCodeReferences: {
     projectId: number
@@ -1028,7 +1030,7 @@ export type Req = {
     environmentId: string
     warehouse_type: string
     name?: string
-    config?: Record<string, string | number | boolean>
+    config?: Record<string, WarehouseConfigValue>
     credentials?: { password: string }
   }
   deleteWarehouseConnection: { environmentId: string; id: number }
@@ -1037,7 +1039,7 @@ export type Req = {
     environmentId: string
     id: number
     name?: string
-    config?: Record<string, string | number | boolean>
+    config?: Record<string, WarehouseConfigValue>
     credentials?: { password: string }
   }
   getExperiments: PagedRequest<{

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -1035,6 +1035,13 @@ export type Req = {
   }
   deleteWarehouseConnection: { environmentId: string; id: number }
   testWarehouseConnection: { environmentId: string; id: number }
+  testWarehouseConnectionConfig: {
+    environmentId: string
+    warehouse_type: string
+    name?: string
+    config?: Record<string, WarehouseConfigValue>
+    credentials?: { password: string }
+  }
   updateWarehouseConnection: {
     environmentId: string
     id: number

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -1028,7 +1028,8 @@ export type Req = {
     environmentId: string
     warehouse_type: string
     name?: string
-    config?: Record<string, string>
+    config?: Record<string, string | number | boolean>
+    credentials?: { password: string }
   }
   deleteWarehouseConnection: { environmentId: string; id: number }
   testWarehouseConnection: { environmentId: string; id: number }
@@ -1036,7 +1037,8 @@ export type Req = {
     environmentId: string
     id: number
     name?: string
-    config?: Record<string, string>
+    config?: Record<string, string | number | boolean>
+    credentials?: { password: string }
   }
   getExperiments: PagedRequest<{
     environmentId: string

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1271,6 +1271,7 @@ export type WarehouseConnection = {
   id: number
   warehouse_type: WarehouseType
   status: WarehouseConnectionStatus
+  status_detail: string | null
   name: string
   config: SnowflakeConfig | ClickHouseConfig | Record<string, never>
   created_at: string

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1272,6 +1272,11 @@ export type WarehouseConfigResponse =
   | ClickHouseConfig
   | Record<string, never>
 
+export type WarehouseConnectionTestResult = {
+  status: WarehouseConnectionStatus
+  status_detail: string | null
+}
+
 export type WarehouseConnection = {
   id: number
   warehouse_type: WarehouseType
@@ -1510,6 +1515,7 @@ export type Res = {
   gitlabIssues: PagedResponse<GitLabIssue>
   gitlabMergeRequests: PagedResponse<GitLabMergeRequest>
   warehouseConnections: WarehouseConnection[]
+  warehouseConnectionTestResult: WarehouseConnectionTestResult
   experiments: PagedResponse<Experiment> & {
     currentPage: number
     pageSize: number

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1259,12 +1259,20 @@ export type SnowflakeConfig = {
   user: string
 }
 
+export type ClickHouseConfig = {
+  host: string
+  port: number
+  database: string
+  username: string
+  secure: boolean
+}
+
 export type WarehouseConnection = {
   id: number
   warehouse_type: WarehouseType
   status: WarehouseConnectionStatus
   name: string
-  config: SnowflakeConfig | Record<string, never>
+  config: SnowflakeConfig | ClickHouseConfig | Record<string, never>
   created_at: string
   total_events_received: number | null
   unique_events_count: number | null

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1267,13 +1267,18 @@ export type ClickHouseConfig = {
   secure: boolean
 }
 
+export type WarehouseConfigResponse =
+  | SnowflakeConfig
+  | ClickHouseConfig
+  | Record<string, never>
+
 export type WarehouseConnection = {
   id: number
   warehouse_type: WarehouseType
   status: WarehouseConnectionStatus
   status_detail: string | null
   name: string
-  config: SnowflakeConfig | ClickHouseConfig | Record<string, never>
+  config: WarehouseConfigResponse
   created_at: string
   total_events_received: number | null
   unique_events_count: number | null

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -90,11 +90,22 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         environmentId,
         warehouse_type: 'clickhouse',
       }).unwrap()
-      setTestState(result.status === 'connected' ? 'connected' : 'errored')
-      setTestDetail(result.status_detail)
+      if (result.status === 'connected') {
+        setTestState('connected')
+        setTestDetail(null)
+        toast('Connection verified')
+      } else {
+        setTestState('errored')
+        setTestDetail(result.status_detail)
+        toast(
+          result.status_detail || 'Connection failed — check your credentials',
+          'danger',
+        )
+      }
     } catch {
       setTestState('errored')
       setTestDetail(null)
+      toast('Failed to test connection', 'danger')
     }
   }
 
@@ -243,12 +254,19 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         </div>
 
         {testState === 'connected' && (
-          <span className='wh-config-form__hint text-success'>
-            Connection verified. You can now save.
-          </span>
+          <div className='d-flex justify-content-end'>
+            <span className='wh-config-form__hint text-success'>
+              Connection verified. You can now save.
+            </span>
+          </div>
         )}
         {testState === 'errored' && (
-          <WarningMessage warningMessage={getTestFailureWarning(testDetail)} />
+          <div className='d-flex justify-content-end'>
+            <WarningMessage
+              warningMessage={getTestFailureWarning(testDetail)}
+              warningMessageClass='mb-0'
+            />
+          </div>
         )}
       </div>
     </form>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -3,6 +3,7 @@ import Button from 'components/base/forms/Button'
 import Input from 'components/base/forms/Input'
 import Switch from 'components/Switch'
 import ErrorMessage from 'components/ErrorMessage'
+import WarningMessage from 'components/WarningMessage'
 import { ClickHouseConfig } from 'common/types/responses'
 import { useTestWarehouseConnectionConfigMutation } from 'common/services/useWarehouseConnection'
 import {
@@ -64,7 +65,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
   const isValid = isClickHouseFormValid(form, isEdit)
   const requiresTest = !isEdit || isClickHouseConfigDirty(form, initialConfig)
   const canTest = canTestClickHouseConnection(form)
-  const canSave = isValid && (!requiresTest || testState === 'connected')
+  const canSave = isValid && (!requiresTest || testState !== 'idle')
 
   const setField =
     <T,>(setter: (value: T) => void) =>
@@ -200,19 +201,6 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
           </div>
         </div>
 
-        {testState === 'errored' && (
-          <ErrorMessage
-            error={
-              testDetail || 'Connection failed — check your connection details.'
-            }
-          />
-        )}
-        {testState === 'connected' && (
-          <span className='wh-config-form__hint text-success'>
-            Connection verified. You can now save.
-          </span>
-        )}
-
         {error && (
           <ErrorMessage
             error={`Failed to ${
@@ -255,6 +243,19 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
             {getButtonLabel(isEdit, isSaving)}
           </Button>
         </div>
+
+        {testState === 'connected' && (
+          <span className='wh-config-form__hint text-success'>
+            Connection verified. You can now save.
+          </span>
+        )}
+        {testState === 'errored' && (
+          <WarningMessage
+            warningMessage={`We couldn't establish a connection${
+              testDetail ? `: ${testDetail}` : '.'
+            } You can save anyway and test again later, but events won't be delivered until the connection succeeds.`}
+          />
+        )}
       </div>
     </form>
   )

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -11,6 +11,7 @@ import {
   ClickHouseFormState,
   isClickHouseFormValid,
 } from './clickhouseConfig'
+import { getButtonLabel } from './warehouseFormUtils'
 import './ConfigForm.scss'
 
 type ClickHouseConfigFormProps = {
@@ -19,11 +20,6 @@ type ClickHouseConfigFormProps = {
   isEdit?: boolean
   initialConfig?: ClickHouseConfig
   initialName?: string
-}
-
-const getButtonLabel = (isEdit: boolean, isSaving: boolean): string => {
-  if (isSaving) return isEdit ? 'Saving...' : 'Creating...'
-  return isEdit ? 'Save changes' : 'Save and continue'
 }
 
 const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
@@ -169,10 +165,17 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         )}
 
         <div className='wh-config-form__actions'>
-          <Button theme='outline' size='small' onClick={onCancel} type='button'>
+          <Button
+            id='warehouse-config-cancel'
+            theme='outline'
+            size='small'
+            onClick={onCancel}
+            type='button'
+          >
             Cancel
           </Button>
           <Button
+            id='warehouse-config-save'
             theme='primary'
             size='small'
             type='submit'

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -1,0 +1,190 @@
+import React, { FC, useState } from 'react'
+import Button from 'components/base/forms/Button'
+import Input from 'components/base/forms/Input'
+import Switch from 'components/Switch'
+import ErrorMessage from 'components/ErrorMessage'
+import { ClickHouseConfig } from 'common/types/responses'
+import {
+  buildClickHousePayload,
+  CLICKHOUSE_DEFAULTS,
+  ClickHouseFormData,
+  ClickHouseFormState,
+  isClickHouseFormValid,
+} from './clickhouseConfig'
+import './ConfigForm.scss'
+
+type ClickHouseConfigFormProps = {
+  onSave: (data: ClickHouseFormData) => Promise<unknown>
+  onCancel: () => void
+  isEdit?: boolean
+  initialConfig?: ClickHouseConfig
+  initialName?: string
+}
+
+const getButtonLabel = (isEdit: boolean, isSaving: boolean): string => {
+  if (isSaving) return isEdit ? 'Saving...' : 'Creating...'
+  return isEdit ? 'Save changes' : 'Save and continue'
+}
+
+const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
+  initialConfig,
+  initialName = '',
+  isEdit = false,
+  onCancel,
+  onSave,
+}) => {
+  const defaults = { ...CLICKHOUSE_DEFAULTS, ...initialConfig }
+  const [name, setName] = useState(initialName)
+  const [host, setHost] = useState(defaults.host)
+  const [port, setPort] = useState(String(defaults.port))
+  const [database, setDatabase] = useState(defaults.database)
+  const [username, setUsername] = useState(defaults.username)
+  const [password, setPassword] = useState('')
+  const [secure, setSecure] = useState(defaults.secure)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState(false)
+
+  const form: ClickHouseFormState = {
+    database,
+    host,
+    name,
+    password,
+    port,
+    secure,
+    username,
+  }
+  const isValid = isClickHouseFormValid(form, isEdit)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!isValid) return
+
+    setIsSaving(true)
+    setError(false)
+    try {
+      await onSave(buildClickHousePayload(form))
+    } catch {
+      setError(true)
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className='wh-config-form'>
+      <div className='wh-config-form__card'>
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Host</label>
+          <Input
+            value={host}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setHost(e.target.value)
+            }
+            placeholder='your-instance.clickhouse.cloud'
+            disabled={isEdit}
+          />
+          <span className='wh-config-form__hint'>
+            {isEdit
+              ? "Host can't be changed. To use a different ClickHouse instance, disconnect and create a new connection."
+              : 'The hostname of your ClickHouse instance, without protocol or port.'}
+          </span>
+        </div>
+
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Name</label>
+          <Input
+            value={name}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setName(e.target.value)
+            }
+            placeholder='e.g. Production ClickHouse'
+          />
+        </div>
+
+        <div className='wh-config-form__row'>
+          <div className='wh-config-form__field'>
+            <label className='wh-config-form__label'>Port</label>
+            <Input
+              value={port}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setPort(e.target.value)
+              }
+              placeholder='9440'
+            />
+          </div>
+          <div className='wh-config-form__field'>
+            <label className='wh-config-form__label'>Database</label>
+            <Input
+              value={database}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setDatabase(e.target.value)
+              }
+              placeholder='flagsmith'
+            />
+          </div>
+        </div>
+
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Username</label>
+          <Input
+            value={username}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setUsername(e.target.value)
+            }
+            placeholder='default'
+          />
+        </div>
+
+        <div className='wh-config-form__field'>
+          <label className='wh-config-form__label'>Password</label>
+          <Input
+            value={password}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setPassword(e.target.value)
+            }
+            type='password'
+            placeholder={isEdit ? '••••••••' : 'Password'}
+          />
+          {isEdit && (
+            <span className='wh-config-form__hint'>
+              Leave blank to keep the current password.
+            </span>
+          )}
+        </div>
+
+        <div className='wh-config-form__field'>
+          <div className='d-flex flex-row align-items-center gap-2'>
+            <Switch checked={secure} onChange={setSecure} />
+            <label className='wh-config-form__label mb-0'>
+              Secure connection (TLS)
+            </label>
+          </div>
+        </div>
+
+        {error && (
+          <ErrorMessage
+            error={`Failed to ${
+              isEdit ? 'update' : 'create'
+            } warehouse connection. Please try again.`}
+          />
+        )}
+
+        <div className='wh-config-form__actions'>
+          <Button theme='outline' size='small' onClick={onCancel} type='button'>
+            Cancel
+          </Button>
+          <Button
+            theme='primary'
+            size='small'
+            type='submit'
+            disabled={isSaving || !isValid}
+          >
+            {getButtonLabel(isEdit, isSaving)}
+          </Button>
+        </div>
+      </div>
+    </form>
+  )
+}
+
+ClickHouseConfigForm.displayName = 'ClickHouseConfigForm'
+export default ClickHouseConfigForm

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -15,7 +15,11 @@ import {
   isClickHouseConfigDirty,
   isClickHouseFormValid,
 } from './clickhouseConfig'
-import { getButtonLabel } from './warehouseFormUtils'
+import {
+  getButtonLabel,
+  getTestFailureWarning,
+  getWarehouseErrorMessage,
+} from './warehouseFormUtils'
 import './ConfigForm.scss'
 
 type ClickHouseConfigFormProps = {
@@ -201,13 +205,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
           </div>
         </div>
 
-        {error && (
-          <ErrorMessage
-            error={`Failed to ${
-              isEdit ? 'update' : 'create'
-            } warehouse connection. Please try again.`}
-          />
-        )}
+        {error && <ErrorMessage error={getWarehouseErrorMessage(isEdit)} />}
 
         <div className='wh-config-form__actions'>
           {isEdit && onCancel && (
@@ -250,11 +248,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
           </span>
         )}
         {testState === 'errored' && (
-          <WarningMessage
-            warningMessage={`We couldn't establish a connection${
-              testDetail ? `: ${testDetail}` : '.'
-            } You can save anyway and test again later, but events won't be delivered until the connection succeeds.`}
-          />
+          <WarningMessage warningMessage={getTestFailureWarning(testDetail)} />
         )}
       </div>
     </form>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -230,18 +230,16 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
               Cancel
             </Button>
           )}
-          {requiresTest && (
-            <Button
-              id='warehouse-config-test'
-              theme='outline'
-              size='small'
-              type='button'
-              onClick={handleTest}
-              disabled={!canTest || isTesting}
-            >
-              {isTesting ? 'Testing...' : 'Test connection'}
-            </Button>
-          )}
+          <Button
+            id='warehouse-config-test'
+            theme='outline'
+            size='small'
+            type='button'
+            onClick={handleTest}
+            disabled={!requiresTest || !canTest || isTesting}
+          >
+            {isTesting ? 'Testing...' : 'Test connection'}
+          </Button>
           <Button
             id='warehouse-config-save'
             theme='primary'

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useRef, useState } from 'react'
 import Button from 'components/base/forms/Button'
 import Input from 'components/base/forms/Input'
 import Switch from 'components/Switch'
@@ -53,6 +53,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
   const [error, setError] = useState(false)
   const [testState, setTestState] = useState<TestState>('idle')
   const [testDetail, setTestDetail] = useState<string | null>(null)
+  const testRevision = useRef(0)
 
   const [testConnectionConfig, { isLoading: isTesting }] =
     useTestWarehouseConnectionConfigMutation()
@@ -75,6 +76,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
     <T,>(setter: (value: T) => void) =>
     (value: T) => {
       setter(value)
+      testRevision.current += 1
       setTestState('idle')
       setTestDetail(null)
     }
@@ -82,6 +84,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
   const handleTest = async () => {
     if (!canTest || isTesting) return
     setError(false)
+    const revision = testRevision.current
     try {
       const { config, credentials } = buildClickHousePayload(form)
       const result = await testConnectionConfig({
@@ -90,6 +93,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         environmentId,
         warehouse_type: 'clickhouse',
       }).unwrap()
+      if (revision !== testRevision.current) return
       if (result.status === 'connected') {
         setTestState('connected')
         setTestDetail(null)
@@ -103,6 +107,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         )
       }
     } catch {
+      if (revision !== testRevision.current) return
       setTestState('errored')
       setTestDetail(null)
       toast('Failed to test connection', 'danger')

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -4,25 +4,32 @@ import Input from 'components/base/forms/Input'
 import Switch from 'components/Switch'
 import ErrorMessage from 'components/ErrorMessage'
 import { ClickHouseConfig } from 'common/types/responses'
+import { useTestWarehouseConnectionConfigMutation } from 'common/services/useWarehouseConnection'
 import {
   buildClickHousePayload,
+  canTestClickHouseConnection,
   CLICKHOUSE_DEFAULTS,
   ClickHouseFormData,
   ClickHouseFormState,
+  isClickHouseConfigDirty,
   isClickHouseFormValid,
 } from './clickhouseConfig'
 import { getButtonLabel } from './warehouseFormUtils'
 import './ConfigForm.scss'
 
 type ClickHouseConfigFormProps = {
+  environmentId: string
   onSave: (data: ClickHouseFormData) => Promise<unknown>
-  onCancel: () => void
+  onCancel?: () => void
   isEdit?: boolean
   initialConfig?: ClickHouseConfig
   initialName?: string
 }
 
+type TestState = 'idle' | 'connected' | 'errored'
+
 const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
+  environmentId,
   initialConfig,
   initialName = '',
   isEdit = false,
@@ -39,6 +46,11 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
   const [secure, setSecure] = useState(defaults.secure)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState(false)
+  const [testState, setTestState] = useState<TestState>('idle')
+  const [testDetail, setTestDetail] = useState<string | null>(null)
+
+  const [testConnectionConfig, { isLoading: isTesting }] =
+    useTestWarehouseConnectionConfigMutation()
 
   const form: ClickHouseFormState = {
     database,
@@ -50,10 +62,40 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
     username,
   }
   const isValid = isClickHouseFormValid(form, isEdit)
+  const requiresTest = !isEdit || isClickHouseConfigDirty(form, initialConfig)
+  const canTest = canTestClickHouseConnection(form)
+  const canSave = isValid && (!requiresTest || testState === 'connected')
+
+  const setField =
+    <T,>(setter: (value: T) => void) =>
+    (value: T) => {
+      setter(value)
+      setTestState('idle')
+      setTestDetail(null)
+    }
+
+  const handleTest = async () => {
+    if (!canTest || isTesting) return
+    setError(false)
+    try {
+      const { config, credentials } = buildClickHousePayload(form)
+      const result = await testConnectionConfig({
+        config,
+        credentials,
+        environmentId,
+        warehouse_type: 'clickhouse',
+      }).unwrap()
+      setTestState(result.status === 'connected' ? 'connected' : 'errored')
+      setTestDetail(result.status_detail)
+    } catch {
+      setTestState('errored')
+      setTestDetail(null)
+    }
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!isValid) return
+    if (!canSave || isSaving) return
 
     setIsSaving(true)
     setError(false)
@@ -73,7 +115,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
           <Input
             value={host}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setHost(e.target.value)
+              setField(setHost)(e.target.value)
             }
             placeholder='your-instance.clickhouse.cloud'
             disabled={isEdit}
@@ -102,7 +144,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
             <Input
               value={port}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setPort(e.target.value)
+                setField(setPort)(e.target.value)
               }
               placeholder='9440'
             />
@@ -112,7 +154,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
             <Input
               value={database}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setDatabase(e.target.value)
+                setField(setDatabase)(e.target.value)
               }
               placeholder='flagsmith'
             />
@@ -124,7 +166,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
           <Input
             value={username}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setUsername(e.target.value)
+              setField(setUsername)(e.target.value)
             }
             placeholder='default'
           />
@@ -135,26 +177,41 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
           <Input
             value={password}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setPassword(e.target.value)
+              setField(setPassword)(e.target.value)
             }
             type='password'
             placeholder={isEdit ? '••••••••' : 'Password'}
           />
           {isEdit && (
             <span className='wh-config-form__hint'>
-              Leave blank to keep the current password.
+              {requiresTest && !password
+                ? 'Enter your password to test the connection before saving.'
+                : 'Leave blank to keep the current password.'}
             </span>
           )}
         </div>
 
         <div className='wh-config-form__field'>
           <div className='d-flex flex-row align-items-center gap-2'>
-            <Switch checked={secure} onChange={setSecure} />
+            <Switch checked={secure} onChange={setField(setSecure)} />
             <label className='wh-config-form__label mb-0'>
               Secure connection (TLS)
             </label>
           </div>
         </div>
+
+        {testState === 'errored' && (
+          <ErrorMessage
+            error={
+              testDetail || 'Connection failed — check your connection details.'
+            }
+          />
+        )}
+        {testState === 'connected' && (
+          <span className='wh-config-form__hint text-success'>
+            Connection verified. You can now save.
+          </span>
+        )}
 
         {error && (
           <ErrorMessage
@@ -165,21 +222,35 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         )}
 
         <div className='wh-config-form__actions'>
-          <Button
-            id='warehouse-config-cancel'
-            theme='outline'
-            size='small'
-            onClick={onCancel}
-            type='button'
-          >
-            Cancel
-          </Button>
+          {isEdit && onCancel && (
+            <Button
+              id='warehouse-config-cancel'
+              theme='outline'
+              size='small'
+              onClick={onCancel}
+              type='button'
+            >
+              Cancel
+            </Button>
+          )}
+          {requiresTest && (
+            <Button
+              id='warehouse-config-test'
+              theme='outline'
+              size='small'
+              type='button'
+              onClick={handleTest}
+              disabled={!canTest || isTesting}
+            >
+              {isTesting ? 'Testing...' : 'Test connection'}
+            </Button>
+          )}
           <Button
             id='warehouse-config-save'
             theme='primary'
             size='small'
             type='submit'
-            disabled={isSaving || !isValid}
+            disabled={isSaving || !canSave}
           >
             {getButtonLabel(isEdit, isSaving)}
           </Button>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ConfigForm.tsx
@@ -3,6 +3,7 @@ import Button from 'components/base/forms/Button'
 import Input from 'components/base/forms/Input'
 import ErrorMessage from 'components/ErrorMessage'
 import { SnowflakeConfig } from 'common/types/responses'
+import { getButtonLabel } from './warehouseFormUtils'
 import './ConfigForm.scss'
 
 export type ConfigFormData = SnowflakeConfig & { name: string }
@@ -13,11 +14,6 @@ type ConfigFormProps = {
   isEdit?: boolean
   initialConfig?: SnowflakeConfig
   initialName?: string
-}
-
-const getButtonLabel = (isEdit: boolean, isSaving: boolean): string => {
-  if (isSaving) return isEdit ? 'Saving...' : 'Creating...'
-  return isEdit ? 'Save changes' : 'Save and continue'
 }
 
 const DEFAULTS: SnowflakeConfig = {

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -16,6 +16,7 @@ type WarehouseConnectionCardProps = {
   onDelete: () => void
   onEdit?: () => void
   onSendTestEvent: () => void
+  onTestConnection?: () => void
   isSendingTestEvent: boolean
   isLoadingStats?: boolean
 }
@@ -46,6 +47,7 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
   onDelete,
   onEdit,
   onSendTestEvent,
+  onTestConnection,
 }) => {
   const typeLabel =
     connection.warehouse_type !== 'flagsmith'
@@ -90,6 +92,10 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
                 'account_identifier' in connection.config &&
                 connection.config.account_identifier &&
                 `: ${connection.config.account_identifier}`}
+              {connection.config &&
+                'host' in connection.config &&
+                connection.config.host &&
+                `: ${connection.config.host}`}
             </span>
           )}
         </div>
@@ -139,9 +145,10 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
             id='warehouse-connection-test'
             theme='outline'
             size='small'
-            disabled
+            onClick={onTestConnection}
+            disabled={!onTestConnection || isSendingTestEvent}
           >
-            Test connection
+            {isSendingTestEvent ? 'Testing...' : 'Test connection'}
           </Button>
         )}
         {isFlagsmith && !isPending && !isConnected && (

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -144,13 +144,13 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
       )}
       <WarehouseEventCodeHelp />
       <div className='d-flex justify-content-end mt-3'>
-        {!isFlagsmith && (
+        {onTestConnection && (
           <Button
             id='warehouse-connection-test'
             theme='outline'
             size='small'
             onClick={onTestConnection}
-            disabled={!onTestConnection || isSendingTestEvent}
+            disabled={isSendingTestEvent}
           >
             {isSendingTestEvent ? 'Testing...' : 'Test connection'}
           </Button>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -82,7 +82,11 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
               }
               place='top'
             >
-              {STATUS_LABEL[connection.status]}
+              {connection.status === 'errored' && connection.status_detail
+                ? `${STATUS_LABEL[connection.status]}: ${
+                    connection.status_detail
+                  }`
+                : STATUS_LABEL[connection.status]}
             </Tooltip>
           </div>
           {typeLabel && (

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
@@ -5,25 +5,32 @@ import { WarehouseType } from 'common/types/responses'
 import { ConfigFormData } from './ConfigForm'
 import SelectableCard from 'components/base/SelectableCard'
 import ConfigForm from './ConfigForm'
+import Utils from 'common/utils/utils'
+import ClickHouseConfigForm from './ClickHouseConfigForm'
+import { ClickHouseFormData } from './clickhouseConfig'
 import './WarehouseSetup.scss'
 
 type WarehouseSetupProps = {
   onEnableFlagsmith: () => void
   onCreateSnowflake: (data: ConfigFormData) => Promise<unknown>
+  onCreateClickHouse: (data: ClickHouseFormData) => Promise<unknown>
   isCreating: boolean
 }
 
 type WarehouseTypeOption = WarehouseType | 'bigquery' | 'databricks'
 
-const CONFIGURABLE_TYPES: WarehouseTypeOption[] = ['flagsmith']
-
 const WarehouseSetup: FC<WarehouseSetupProps> = ({
   isCreating,
+  onCreateClickHouse,
   onCreateSnowflake,
   onEnableFlagsmith,
 }) => {
   const [selectedType, setSelectedType] =
     useState<WarehouseTypeOption>('flagsmith')
+  const clickhouseEnabled = Utils.getFlagsmithHasFeature('clickhouse_warehouse')
+  const configurableTypes: WarehouseTypeOption[] = clickhouseEnabled
+    ? ['flagsmith', 'clickhouse']
+    : ['flagsmith']
 
   return (
     <div className='warehouse-setup'>
@@ -45,6 +52,19 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
               selected={selectedType === 'flagsmith'}
               onClick={() => setSelectedType('flagsmith')}
             />
+          </div>
+          <div className='warehouse-setup__type-card'>
+            <SelectableCard
+              icon={<Icon name='layers' width={20} />}
+              title='ClickHouse'
+              description='Open-source OLAP database'
+              selected={selectedType === 'clickhouse'}
+              onClick={() => clickhouseEnabled && setSelectedType('clickhouse')}
+              disabled={!clickhouseEnabled}
+            />
+            {!clickhouseEnabled && (
+              <span className='warehouse-setup__coming-soon'>Coming Soon</span>
+            )}
           </div>
           <div className='warehouse-setup__type-card'>
             <SelectableCard
@@ -109,7 +129,14 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
         />
       )}
 
-      {!CONFIGURABLE_TYPES.includes(selectedType) && (
+      {selectedType === 'clickhouse' && (
+        <ClickHouseConfigForm
+          onSave={onCreateClickHouse}
+          onCancel={() => setSelectedType('flagsmith')}
+        />
+      )}
+
+      {!configurableTypes.includes(selectedType) && (
         <div className='warehouse-setup__flagsmith-card'>
           <p className='warehouse-setup__flagsmith-description'>
             Coming soon. This warehouse type is not yet available.

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
@@ -11,6 +11,7 @@ import { ClickHouseFormData } from './clickhouseConfig'
 import './WarehouseSetup.scss'
 
 type WarehouseSetupProps = {
+  environmentId: string
   onEnableFlagsmith: () => void
   onCreateSnowflake: (data: ConfigFormData) => Promise<unknown>
   onCreateClickHouse: (data: ClickHouseFormData) => Promise<unknown>
@@ -20,6 +21,7 @@ type WarehouseSetupProps = {
 type WarehouseTypeOption = WarehouseType | 'bigquery' | 'databricks'
 
 const WarehouseSetup: FC<WarehouseSetupProps> = ({
+  environmentId,
   isCreating,
   onCreateClickHouse,
   onCreateSnowflake,
@@ -131,8 +133,8 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
 
       {selectedType === 'clickhouse' && (
         <ClickHouseConfigForm
+          environmentId={environmentId}
           onSave={onCreateClickHouse}
-          onCancel={() => setSelectedType('flagsmith')}
         />
       )}
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseConfig.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseConfig.test.ts
@@ -1,6 +1,8 @@
 import {
   buildClickHousePayload,
+  canTestClickHouseConnection,
   ClickHouseFormState,
+  isClickHouseConfigDirty,
   isClickHouseFormValid,
   isValidPort,
 } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig'
@@ -49,6 +51,58 @@ describe('isClickHouseFormValid', () => {
     expect(isClickHouseFormValid({ ...validForm, password: '' }, true)).toBe(
       true,
     )
+  })
+})
+
+describe('canTestClickHouseConnection', () => {
+  it('accepts a complete form regardless of name', () => {
+    expect(canTestClickHouseConnection({ ...validForm, name: '' })).toBe(true)
+  })
+
+  it.each(['host', 'port', 'database', 'username', 'password'] as const)(
+    'rejects a form with empty %s',
+    (field) => {
+      expect(canTestClickHouseConnection({ ...validForm, [field]: '' })).toBe(
+        false,
+      )
+    },
+  )
+})
+
+describe('isClickHouseConfigDirty', () => {
+  const initialConfig = {
+    database: 'flagsmith',
+    host: 'ch.example.com',
+    port: 9440,
+    secure: true,
+    username: 'default',
+  }
+
+  it('is clean when the form matches the stored config with a blank password', () => {
+    expect(
+      isClickHouseConfigDirty({ ...validForm, password: '' }, initialConfig),
+    ).toBe(false)
+  })
+
+  it.each([
+    ['port', { port: '9000' }],
+    ['database', { database: 'analytics' }],
+    ['username', { username: 'svc' }],
+    ['secure', { secure: false }],
+    ['password', { password: 'hunter2' }],
+  ] as const)('is dirty when %s changes', (_, change) => {
+    expect(
+      isClickHouseConfigDirty(
+        { ...validForm, password: '', ...change },
+        initialConfig,
+      ),
+    ).toBe(true)
+  })
+
+  it('compares against defaults when there is no stored config', () => {
+    expect(
+      isClickHouseConfigDirty({ ...validForm, password: '' }, undefined),
+    ).toBe(true)
   })
 })
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseConfig.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseConfig.test.ts
@@ -1,0 +1,75 @@
+import {
+  buildClickHousePayload,
+  ClickHouseFormState,
+  isClickHouseFormValid,
+  isValidPort,
+} from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig'
+
+const validForm: ClickHouseFormState = {
+  database: 'flagsmith',
+  host: 'ch.example.com',
+  name: 'Production ClickHouse',
+  password: 'hunter2',
+  port: '9440',
+  secure: true,
+  username: 'default',
+}
+
+describe('isValidPort', () => {
+  it('accepts ports within 1-65535', () => {
+    expect(isValidPort('1')).toBe(true)
+    expect(isValidPort('9440')).toBe(true)
+    expect(isValidPort('65535')).toBe(true)
+  })
+
+  it('rejects out-of-range or non-numeric ports', () => {
+    expect(isValidPort('0')).toBe(false)
+    expect(isValidPort('65536')).toBe(false)
+    expect(isValidPort('abc')).toBe(false)
+    expect(isValidPort('94.4')).toBe(false)
+    expect(isValidPort('')).toBe(false)
+  })
+})
+
+describe('isClickHouseFormValid', () => {
+  it('accepts a complete form on create', () => {
+    expect(isClickHouseFormValid(validForm, false)).toBe(true)
+  })
+
+  it.each(['name', 'host', 'database', 'username', 'password'] as const)(
+    'rejects a form with empty %s on create',
+    (field) => {
+      expect(isClickHouseFormValid({ ...validForm, [field]: '' }, false)).toBe(
+        false,
+      )
+    },
+  )
+
+  it('allows an empty password on edit (keeps the stored one)', () => {
+    expect(isClickHouseFormValid({ ...validForm, password: '' }, true)).toBe(
+      true,
+    )
+  })
+})
+
+describe('buildClickHousePayload', () => {
+  it('builds config with a numeric port and separates credentials', () => {
+    expect(buildClickHousePayload(validForm)).toEqual({
+      config: {
+        database: 'flagsmith',
+        host: 'ch.example.com',
+        port: 9440,
+        secure: true,
+        username: 'default',
+      },
+      credentials: { password: 'hunter2' },
+      name: 'Production ClickHouse',
+    })
+  })
+
+  it('omits credentials when the password is blank (edit keeps stored)', () => {
+    expect(
+      buildClickHousePayload({ ...validForm, password: '' }).credentials,
+    ).toBeUndefined()
+  })
+})

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehouseFormUtils.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehouseFormUtils.test.ts
@@ -1,0 +1,12 @@
+import { getTestFailureWarning } from 'components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils'
+
+describe('getTestFailureWarning', () => {
+  it.each([
+    ['Authentication failed.', ': Authentication failed. You can save anyway'],
+    ['Connection refused', ': Connection refused. You can save anyway'],
+    ['Timed out!', ': Timed out! You can save anyway'],
+    [null, '. You can save anyway'],
+  ])('formats detail %p with a single sentence break', (detail, expected) => {
+    expect(getTestFailureWarning(detail)).toContain(expected)
+  })
+})

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
@@ -58,3 +58,27 @@ export const buildClickHousePayload = (
   credentials: form.password ? { password: form.password } : undefined,
   name: form.name,
 })
+
+export const canTestClickHouseConnection = (
+  form: ClickHouseFormState,
+): boolean =>
+  !!form.host &&
+  isValidPort(form.port) &&
+  !!form.database &&
+  !!form.username &&
+  !!form.password
+
+export const isClickHouseConfigDirty = (
+  form: ClickHouseFormState,
+  initialConfig: ClickHouseConfig | undefined,
+): boolean => {
+  const initial = { ...CLICKHOUSE_DEFAULTS, ...initialConfig }
+  return (
+    form.host !== initial.host ||
+    form.port !== String(initial.port) ||
+    form.database !== initial.database ||
+    form.username !== initial.username ||
+    form.secure !== initial.secure ||
+    !!form.password
+  )
+}

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
@@ -1,0 +1,60 @@
+import { ClickHouseConfig } from 'common/types/responses'
+
+export const CLICKHOUSE_DEFAULTS: ClickHouseConfig = {
+  database: 'flagsmith',
+  host: '',
+  port: 9440,
+  secure: true,
+  username: 'default',
+}
+
+export type ClickHouseFormState = {
+  name: string
+  host: string
+  port: string
+  database: string
+  username: string
+  password: string
+  secure: boolean
+}
+
+export type ClickHouseFormData = {
+  name: string
+  config: ClickHouseConfig
+  credentials?: { password: string }
+}
+
+export const isValidPort = (port: string): boolean => {
+  const value = Number(port)
+  return (
+    /^\d+$/.test(port) &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 65535
+  )
+}
+
+export const isClickHouseFormValid = (
+  form: ClickHouseFormState,
+  isEdit: boolean,
+): boolean =>
+  !!form.name &&
+  !!form.host &&
+  isValidPort(form.port) &&
+  !!form.database &&
+  !!form.username &&
+  (isEdit || !!form.password)
+
+export const buildClickHousePayload = (
+  form: ClickHouseFormState,
+): ClickHouseFormData => ({
+  config: {
+    database: form.database,
+    host: form.host,
+    port: Number(form.port),
+    secure: form.secure,
+    username: form.username,
+  },
+  credentials: form.password ? { password: form.password } : undefined,
+  name: form.name,
+})

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
@@ -6,11 +6,13 @@ import {
   useTestWarehouseConnectionMutation,
   useUpdateWarehouseConnectionMutation,
 } from 'common/services/useWarehouseConnection'
-import { SnowflakeConfig } from 'common/types/responses'
+import { ClickHouseConfig, SnowflakeConfig } from 'common/types/responses'
 import WarehouseConnectionCard from './WarehouseConnectionCard'
 import WarehouseSetup from './WarehouseSetup'
 import WarehouseSetupSkeleton from './WarehouseSetupSkeleton'
 import ConfigForm from './ConfigForm'
+import ClickHouseConfigForm from './ClickHouseConfigForm'
+import { ClickHouseFormData } from './clickhouseConfig'
 import sendWarehouseTestEvent from './sendWarehouseTestEvent'
 import { getWarehousePollingInterval } from './warehousePolling'
 
@@ -56,6 +58,7 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
   }, [baseConnection, connectionsWithStats])
   const connectionId = connection?.id
   const connectionStatus = connection?.status
+  const connectionType = connection?.warehouse_type
 
   const [testConnection, { isLoading: isSendingTestEvent }] =
     useTestWarehouseConnectionMutation()
@@ -65,6 +68,7 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
   }, [connection])
 
   useEffect(() => {
+    if (connectionType !== 'flagsmith') return
     const interval = getWarehousePollingInterval(connectionStatus)
     if (!interval || connectionId === undefined) return
     testConnection({ environmentId, id: connectionId })
@@ -72,7 +76,13 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
       testConnection({ environmentId, id: connectionId })
     }, interval)
     return () => clearInterval(timer)
-  }, [connectionStatus, connectionId, environmentId, testConnection])
+  }, [
+    connectionStatus,
+    connectionId,
+    connectionType,
+    environmentId,
+    testConnection,
+  ])
 
   const handleEnableFlagsmith = () => {
     openConfirm({
@@ -122,6 +132,43 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
       })
   }
 
+  const handleCreateClickHouse = (data: ClickHouseFormData) =>
+    createConnection({
+      environmentId,
+      warehouse_type: 'clickhouse',
+      ...data,
+    })
+      .unwrap()
+      .then(() => toast('Warehouse connection created'))
+
+  const handleUpdateClickHouse = (data: ClickHouseFormData) => {
+    if (!connection) return Promise.reject()
+    return updateConnection({
+      environmentId,
+      id: connection.id,
+      ...data,
+    })
+      .unwrap()
+      .then(() => {
+        setEditing(false)
+        toast('Warehouse connection updated')
+      })
+  }
+
+  const handleTestConnection = () => {
+    if (!connection) return
+    testConnection({ environmentId, id: connection.id })
+      .unwrap()
+      .then((result) => {
+        if (result.status === 'connected') {
+          toast('Connection verified')
+        } else {
+          toast('Connection failed — check your credentials', 'danger')
+        }
+      })
+      .catch(() => toast('Failed to test connection', 'danger'))
+  }
+
   const handleDelete = () => {
     if (!connection) return
     deleteConnection({ environmentId, id: connection.id })
@@ -169,6 +216,7 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
         <WarehouseSetup
           onEnableFlagsmith={handleEnableFlagsmith}
           onCreateSnowflake={handleCreateSnowflake}
+          onCreateClickHouse={handleCreateClickHouse}
           isCreating={isCreating || isEnabling}
         />
       </div>
@@ -189,6 +237,20 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
     )
   }
 
+  if (editing && connection.warehouse_type === 'clickhouse') {
+    return (
+      <div className='mt-4 col-md-12'>
+        <ClickHouseConfigForm
+          isEdit
+          initialConfig={connection.config as ClickHouseConfig}
+          initialName={connection.name}
+          onSave={handleUpdateClickHouse}
+          onCancel={() => setEditing(false)}
+        />
+      </div>
+    )
+  }
+
   return (
     <div className='mt-4 col-md-12'>
       <WarehouseConnectionCard
@@ -200,6 +262,11 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
             : undefined
         }
         onSendTestEvent={handleSendTestEvent}
+        onTestConnection={
+          connection.warehouse_type === 'clickhouse'
+            ? handleTestConnection
+            : undefined
+        }
         isSendingTestEvent={isSendingTestEvent}
         isLoadingStats={isFetchingStats}
       />

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
@@ -218,6 +218,7 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
     return (
       <div className='mt-4 col-md-12'>
         <WarehouseSetup
+          environmentId={environmentId}
           onEnableFlagsmith={handleEnableFlagsmith}
           onCreateSnowflake={handleCreateSnowflake}
           onCreateClickHouse={handleCreateClickHouse}
@@ -246,6 +247,7 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
       <div className='mt-4 col-md-12'>
         <ClickHouseConfigForm
           isEdit
+          environmentId={environmentId}
           initialConfig={connection.config as ClickHouseConfig}
           initialName={connection.name}
           onSave={handleUpdateClickHouse}

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/index.tsx
@@ -163,7 +163,11 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ environmentId }) => {
         if (result.status === 'connected') {
           toast('Connection verified')
         } else {
-          toast('Connection failed — check your credentials', 'danger')
+          toast(
+            result.status_detail ||
+              'Connection failed — check your credentials',
+            'danger',
+          )
         }
       })
       .catch(() => toast('Failed to test connection', 'danger'))

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
@@ -9,6 +9,6 @@ export const getWarehouseErrorMessage = (isEdit: boolean): string =>
   } warehouse connection. Please try again.`
 
 export const getTestFailureWarning = (detail: string | null): string => {
-  const reason = detail ? `: ${detail}${detail.endsWith('.') ? '' : '.'}` : '.'
+  const reason = detail ? `: ${detail}${/[.!?]$/.test(detail) ? '' : '.'}` : '.'
   return `We couldn't establish a connection${reason} You can save anyway and test again later, but events won't be delivered until the connection succeeds.`
 }

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
@@ -1,0 +1,4 @@
+export const getButtonLabel = (isEdit: boolean, isSaving: boolean): string => {
+  if (isSaving) return isEdit ? 'Saving...' : 'Creating...'
+  return isEdit ? 'Save changes' : 'Save and continue'
+}

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
@@ -2,3 +2,13 @@ export const getButtonLabel = (isEdit: boolean, isSaving: boolean): string => {
   if (isSaving) return isEdit ? 'Saving...' : 'Creating...'
   return isEdit ? 'Save changes' : 'Save and continue'
 }
+
+export const getWarehouseErrorMessage = (isEdit: boolean): string =>
+  `Failed to ${
+    isEdit ? 'update' : 'create'
+  } warehouse connection. Please try again.`
+
+export const getTestFailureWarning = (detail: string | null): string => {
+  const reason = detail ? `: ${detail}${detail.endsWith('.') ? '' : '.'}` : '.'
+  return `We couldn't establish a connection${reason} You can save anyway and test again later, but events won't be delivered until the connection succeeds.`
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Frontend for the `clickhouse` warehouse connection type, gated behind the `clickhouse_warehouse` flag (off by default). Builds on the backend in #8020 and the stateless test endpoint in #8060.

- New ClickHouse config form, visually identical to the Snowflake one: host, name, port, database, username, password and a TLS toggle, with defaults matching the backend. The host is locked when editing; leaving the password blank on edit keeps the stored credentials.
- Test-before-save flow: Save starts disabled and enables after a connection test against the stateless endpoint (#8060). A successful test confirms inline; a failed test still allows saving, with a warning that events won't be delivered until the connection succeeds. Changing any connection field resets the test; name-only edits save without one.
- No Cancel button on create (the warehouse type cards handle switching); Cancel is kept on edit to return to the connection card.
- The warehouse setup flow offers ClickHouse alongside Flagsmith and Snowflake when the flag is enabled.
- The connection card wires the Test connection button for ClickHouse and surfaces the `status_detail` field: the status tooltip shows the failure reason when the connection is errored, and the test-connection toast reports it instead of a generic message.
- API layer types updated: write-only `credentials`, read-only `status_detail`, new `testWarehouseConnectionConfig` mutation with a `WarehouseConnectionTestResult` response type.

## How did you test this code?

Unit tests for the form validation, payload and test-flow helpers (`npm run test:unit -- --testPathPatterns=clickhouseConfig`), `npm run lint`, `npm run typecheck` (no new errors against the baseline).

Manually: enable the `clickhouse_warehouse` flag, go to Environment Settings → Warehouse, test and connect a ClickHouse instance (both reachable and unreachable), save after a failed test to check the warning, then edit it and re-test with changed connection details.
