### PR TITLE
fix(API): _validate_owner_removal counts request IDs instead of actual existing owners

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -487,26 +487,15 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         if not feature.project.enforce_feature_owners:
             return
 
-        existing_owners = list(feature.owners.all())
-        existing_group_owners = list(feature.group_owners.all())
-
-        existing_owner_ids = {o.id for o in existing_owners}
-        existing_group_owner_ids = {g.id for g in existing_group_owners}
-
-        actual_owners_to_remove = (
-            len(owner_ids & existing_owner_ids) if owner_ids else 0
-        )
-        actual_group_owners_to_remove = (
-            len(group_owner_ids & existing_group_owner_ids) if group_owner_ids else 0
+        existing_owner_ids = set(feature.owners.values_list("id", flat=True))
+        existing_group_owner_ids = set(
+            feature.group_owners.values_list("id", flat=True)
         )
 
-        remaining = (
-            len(existing_owners)
-            - actual_owners_to_remove
-            + len(existing_group_owners)
-            - actual_group_owners_to_remove
-        )
-        if remaining < 1:
+        if not (
+            (existing_owner_ids - owner_ids)
+            or (existing_group_owner_ids - group_owner_ids)
+        ):
             raise serializers.ValidationError(
                 "This project requires at least one owner or group owner per feature."
             )

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -487,10 +487,11 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         if not feature.project.enforce_feature_owners:
             return
 
-        existing_owner_ids = set(feature.owners.values_list("id", flat=True))
-        existing_group_owner_ids = set(
-            feature.group_owners.values_list("id", flat=True)
-        )
+        existing_owners = feature.owners.all()
+        existing_group_owners = feature.group_owners.all()
+
+        existing_owner_ids = {owner.id for owner in existing_owners}
+        existing_group_owner_ids = {group.id for group in existing_group_owners}
 
         if not (
             (existing_owner_ids - owner_ids)

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -433,8 +433,8 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         serializer.is_valid(raise_exception=True)
         self._validate_owner_removal(
             feature,
-            owners_to_remove=0,
-            group_owners_to_remove=len(serializer.validated_data["group_ids"]),
+            owner_ids=set(),
+            group_owner_ids=set(serializer.validated_data["group_ids"]),
         )
         serializer.remove_group_owners(feature)
         response = Response(self.get_serializer(instance=feature).data)
@@ -471,8 +471,8 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         feature = self.get_object()
         self._validate_owner_removal(
             feature,
-            owners_to_remove=len(serializer.validated_data["user_ids"]),
-            group_owners_to_remove=0,
+            owner_ids=set(serializer.validated_data["user_ids"]),
+            group_owner_ids=set(),
         )
         serializer.remove_users(feature)
 
@@ -481,16 +481,32 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     def _validate_owner_removal(
         self,
         feature: Feature,
-        owners_to_remove: int,
-        group_owners_to_remove: int,
+        owner_ids: set[int],
+        group_owner_ids: set[int],
     ) -> None:
         if not feature.project.enforce_feature_owners:
             return
+
+        existing_owners = list(feature.owners.all())
+        existing_group_owners = list(feature.group_owners.all())
+
+        existing_owner_ids = {o.id for o in existing_owners}
+        existing_group_owner_ids = {g.id for g in existing_group_owners}
+
+        actual_owners_to_remove = (
+            len(owner_ids & existing_owner_ids) if owner_ids else 0
+        )
+        actual_group_owners_to_remove = (
+            len(group_owner_ids & existing_group_owner_ids)
+            if group_owner_ids
+            else 0
+        )
+
         remaining = (
-            feature.owners.count()
-            - owners_to_remove
-            + feature.group_owners.count()
-            - group_owners_to_remove
+            len(existing_owners)
+            - actual_owners_to_remove
+            + len(existing_group_owners)
+            - actual_group_owners_to_remove
         )
         if remaining < 1:
             raise serializers.ValidationError(

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -497,9 +497,7 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             len(owner_ids & existing_owner_ids) if owner_ids else 0
         )
         actual_group_owners_to_remove = (
-            len(group_owner_ids & existing_group_owner_ids)
-            if group_owner_ids
-            else 0
+            len(group_owner_ids & existing_group_owner_ids) if group_owner_ids else 0
         )
 
         remaining = (

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -5346,3 +5346,73 @@ def test_remove_group_owners__enforce_owners_user_owners_remain__returns_200(
     feature.refresh_from_db()
     assert group not in feature.group_owners.all()
     assert admin_user in feature.owners.all()
+
+
+def test_remove_owners__enforce_owners_with_nonexistent_user_ids__still_blocks_when_needed(
+    admin_client_new: APIClient,
+    project: Project,
+    feature: Feature,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given — feature has only one owner, enforce_feature_owners is on
+    project.enforce_feature_owners = True
+    project.save()
+    # Create a real user who is NOT an owner of this feature
+    non_owner = FFAdminUser.objects.create_user(email="nonowner@example.com")  # type: ignore[no-untyped-call]
+    feature.owners.add(admin_user)
+
+    url = reverse(
+        "api-v1:projects:project-features-remove-owners",
+        args=[project.id, feature.id],
+    )
+    # Request removes the real owner AND a user who is not an owner
+    data = {"user_ids": [admin_user.id, non_owner.id]}
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then — should still block because the real owner would be removed
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    feature.refresh_from_db()
+    assert admin_user in feature.owners.all()
+
+
+def test_remove_group_owners__enforce_owners_with_nonexistent_group_ids__allows_when_real_owner_remains(
+    admin_client_new: APIClient,
+    project: Project,
+    feature: Feature,
+    admin_user: FFAdminUser,
+    organisation: Organisation,
+) -> None:
+    # Given — feature has one user owner and one group owner
+    project.enforce_feature_owners = True
+    project.save()
+    group = UserPermissionGroup.objects.create(
+        name="Test Group", organisation=organisation
+    )
+    # Create a real group that is NOT an owner of this feature
+    non_owner_group = UserPermissionGroup.objects.create(
+        name="Non Owner Group", organisation=organisation
+    )
+    feature.owners.add(admin_user)
+    feature.group_owners.add(group)
+
+    url = reverse(
+        "api-v1:projects:project-features-remove-group-owners",
+        args=[project.id, feature.id],
+    )
+    # Request removes the real group and a group that is not an owner
+    data = {"group_ids": [group.id, non_owner_group.id]}
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then — should allow because admin_user remains as owner
+    assert response.status_code == status.HTTP_200_OK
+    feature.refresh_from_db()
+    assert group not in feature.group_owners.all()
+    assert admin_user in feature.owners.all()

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -5354,26 +5354,17 @@ def test_remove_owners__enforce_owners_with_nonexistent_user_ids__still_blocks_w
     feature: Feature,
     admin_user: FFAdminUser,
 ) -> None:
-    # Given — feature has only one owner, enforce_feature_owners is on
     project.enforce_feature_owners = True
     project.save()
-    # Create a real user who is NOT an owner of this feature
     non_owner = FFAdminUser.objects.create_user(email="nonowner@example.com")  # type: ignore[no-untyped-call]
     feature.owners.add(admin_user)
 
-    url = reverse(
-        "api-v1:projects:project-features-remove-owners",
-        args=[project.id, feature.id],
-    )
-    # Request removes the real owner AND a user who is not an owner
-    data = {"user_ids": [admin_user.id, non_owner.id]}
-
-    # When
     response = admin_client_new.post(
-        url, data=json.dumps(data), content_type="application/json"
+        f"/api/v1/projects/{project.id}/features/{feature.id}/remove-owners/",
+        data={"user_ids": [admin_user.id, non_owner.id]},
+        format="json",
     )
 
-    # Then — should still block because the real owner would be removed
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     feature.refresh_from_db()
     assert admin_user in feature.owners.all()
@@ -5386,32 +5377,23 @@ def test_remove_group_owners__enforce_owners_with_nonexistent_group_ids__allows_
     admin_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
-    # Given — feature has one user owner and one group owner
     project.enforce_feature_owners = True
     project.save()
     group = UserPermissionGroup.objects.create(
         name="Test Group", organisation=organisation
     )
-    # Create a real group that is NOT an owner of this feature
     non_owner_group = UserPermissionGroup.objects.create(
         name="Non Owner Group", organisation=organisation
     )
     feature.owners.add(admin_user)
     feature.group_owners.add(group)
 
-    url = reverse(
-        "api-v1:projects:project-features-remove-group-owners",
-        args=[project.id, feature.id],
-    )
-    # Request removes the real group and a group that is not an owner
-    data = {"group_ids": [group.id, non_owner_group.id]}
-
-    # When
     response = admin_client_new.post(
-        url, data=json.dumps(data), content_type="application/json"
+        f"/api/v1/projects/{project.id}/features/{feature.id}/remove-group-owners/",
+        data={"group_ids": [group.id, non_owner_group.id]},
+        format="json",
     )
 
-    # Then — should allow because admin_user remains as owner
     assert response.status_code == status.HTTP_200_OK
     feature.refresh_from_db()
     assert group not in feature.group_owners.all()

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -5354,17 +5354,20 @@ def test_remove_owners__enforce_owners_with_nonexistent_user_ids__still_blocks_w
     feature: Feature,
     admin_user: FFAdminUser,
 ) -> None:
+    # Given
     project.enforce_feature_owners = True
     project.save()
     non_owner = FFAdminUser.objects.create_user(email="nonowner@example.com")  # type: ignore[no-untyped-call]
     feature.owners.add(admin_user)
 
+    # When
     response = admin_client_new.post(
         f"/api/v1/projects/{project.id}/features/{feature.id}/remove-owners/",
         data={"user_ids": [admin_user.id, non_owner.id]},
         format="json",
     )
 
+    # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     feature.refresh_from_db()
     assert admin_user in feature.owners.all()
@@ -5377,6 +5380,7 @@ def test_remove_group_owners__enforce_owners_with_nonexistent_group_ids__allows_
     admin_user: FFAdminUser,
     organisation: Organisation,
 ) -> None:
+    # Given
     project.enforce_feature_owners = True
     project.save()
     group = UserPermissionGroup.objects.create(
@@ -5388,12 +5392,14 @@ def test_remove_group_owners__enforce_owners_with_nonexistent_group_ids__allows_
     feature.owners.add(admin_user)
     feature.group_owners.add(group)
 
+    # When
     response = admin_client_new.post(
         f"/api/v1/projects/{project.id}/features/{feature.id}/remove-group-owners/",
         data={"group_ids": [group.id, non_owner_group.id]},
         format="json",
     )
 
+    # Then
     assert response.status_code == status.HTTP_200_OK
     feature.refresh_from_db()
     assert group not in feature.group_owners.all()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to docs/ if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8038

- Fix _validate_owner_removal to filter requested IDs against actual existing owners before counting
- Use prefetch cache via .all() + set comprehension instead of .values_list() to avoid extra DB queries
- Add 2 test cases covering the non-existent group ID scenario with bare GWT comments

## How did you test this code?

Added 2 unit tests:
- 	est_remove_owners__enforce_owners_with_nonexistent_user_ids__still_blocks_when_needed - verifies that removing the only real owner still blocks even with a non-existent user ID in the request
- 	est_remove_group_owners__enforce_owners_with_nonexistent_group_ids__allows_when_real_owner_remains - verifies that a non-existent group ID doesn't prevent removal of a real group when a user owner remains