### PR TITLE
chore: Add client_name to separate experimentation connection

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -806,9 +806,6 @@ REDIS_CLUSTER_READ_FROM_REPLICAS = env.bool(
 # Redis Cluster URL used to communicate with the event ingestion server.
 INGESTION_REDIS_URL = env.str("INGESTION_REDIS_URL", default="")
 
-# DSN for the ClickHouse instance holding ingested experimentation events.
-EXPERIMENTATION_CLICKHOUSE_URL = env.str("EXPERIMENTATION_CLICKHOUSE_URL", default=None)
-
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
@@ -1501,6 +1498,13 @@ CLICKHOUSE_SECURE = env.bool("CLICKHOUSE_SECURE", default=None)
 
 CLICKHOUSE_ENABLED = bool(CLICKHOUSE_URL or CLICKHOUSE_HOST)
 
+CLICKHOUSE_CONNECTION_CLIENT_NAME = "flagsmith-core-api"
+
+# DSN for the ClickHouse instance holding ingested experimentation events.
+# TODO: consolidate connection management across the two CH use cases
+#  https://github.com/Flagsmith/flagsmith/issues/8033
+EXPERIMENTATION_CLICKHOUSE_URL = env.str("EXPERIMENTATION_CLICKHOUSE_URL", default=None)
+
 SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS = env.int(
     "SEGMENT_MEMBERSHIP_REFRESH_INTERVAL_HOURS", default=6
 )
@@ -1543,7 +1547,7 @@ if CLICKHOUSE_ENABLED:
                 # from breaking migrations with Error 517.
                 "alter_sync": 2,
             },
-            "client_name": "flagsmith-core-api",
+            "client_name": CLICKHOUSE_CONNECTION_CLIENT_NAME,
         },
     }
     DATABASES["clickhouse"] = _clickhouse_db  # type: ignore[assignment]

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -117,6 +117,7 @@ def _get_clickhouse_client() -> Client:
     host, kwargs = parse_url(settings.EXPERIMENTATION_CLICKHOUSE_URL)
     kwargs.setdefault("connect_timeout", CLICKHOUSE_CONNECT_TIMEOUT_SECONDS)
     kwargs.setdefault("send_receive_timeout", CLICKHOUSE_QUERY_TIMEOUT_SECONDS)
+    kwargs.setdefault("client_name", settings.CLICKHOUSE_CONNECTION_CLIENT_NAME)
     return Client(host, **kwargs)
 
 

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -71,7 +71,7 @@ def test_get_clickhouse_client__configured_url__builds_client_with_timeouts(
         secure=True,
         connect_timeout=services.CLICKHOUSE_CONNECT_TIMEOUT_SECONDS,
         send_receive_timeout=services.CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
-        client_name=settings.CLICKHOUSE_CLIENT_NAME,
+        client_name=settings.CLICKHOUSE_CONNECTION_CLIENT_NAME,
     )
     assert client is mock_client_cls.return_value
     services._get_clickhouse_client.cache_clear()

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -98,6 +98,7 @@ def test_get_clickhouse_client__dsn_timeouts__are_preserved(
         database="db",
         connect_timeout=1,
         send_receive_timeout=2,
+        client_name=settings.CLICKHOUSE_CONNECTION_CLIENT_NAME,
     )
     services._get_clickhouse_client.cache_clear()
 

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -71,6 +71,7 @@ def test_get_clickhouse_client__configured_url__builds_client_with_timeouts(
         secure=True,
         connect_timeout=services.CLICKHOUSE_CONNECT_TIMEOUT_SECONDS,
         send_receive_timeout=services.CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
+        client_name=settings.CLICKHOUSE_CLIENT_NAME,
     )
     assert client is mock_client_cls.return_value
     services._get_clickhouse_client.cache_clear()

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -532,7 +532,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:802`
+ - `api/experimentation/services.py:803`
 
 Attributes:
  - `environment.id`
@@ -541,7 +541,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:782`
+ - `api/experimentation/services.py:783`
 
 Attributes:
  - `environment.id`
@@ -550,7 +550,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:404`
+ - `api/experimentation/services.py:405`
 
 Attributes:
  - `environment.id`
@@ -560,7 +560,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:390`
+ - `api/experimentation/services.py:391`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds `client_name` parameter to separate experimentation connection to ClickHouse. 

## How did you test this code?

N/a - trivial change based on documentation. 
