### PR TITLE
docs(OIDC): Document OIDC trust relationships and token exchange

### DIFF
--- a/docs/docs/deployment-self-hosting/core-configuration/environment-variables.md
+++ b/docs/docs/deployment-self-hosting/core-configuration/environment-variables.md
@@ -38,6 +38,9 @@ relevant section below for more details.
 - `ORGANISATION_NAME`: Organisation name to use for the default organisation.
 - `PROJECT_NAME`: Project name to use for the default project.
 - `ENABLE_GZIP_COMPRESSION`: If Django should gzip compress HTTP responses. Defaults to `False`.
+- `TRUST_RELATIONSHIP_ACCESS_TOKEN_LIFETIME_SECONDS`: Lifetime of access tokens minted by the OIDC trust relationship
+  token exchange. Defaults to `3600`.
+- `OIDC_TOKEN_EXCHANGE_THROTTLE_RATE`: Rate limit for the OIDC token exchange endpoint. Defaults to `60/min`.
 - `GOOGLE_ANALYTICS_KEY`: If Google Analytics is required, add your tracking code.
 - `GOOGLE_SERVICE_ACCOUNT`: Service account JSON for accessing the Google API, used for getting usage of an
   organisation - needs access to analytics.readonly scope.

--- a/docs/docs/integrating-with-flagsmith/CLI.md
+++ b/docs/docs/integrating-with-flagsmith/CLI.md
@@ -97,6 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: Flagsmith/setup-cli@v1

--- a/docs/docs/integrating-with-flagsmith/CLI.md
+++ b/docs/docs/integrating-with-flagsmith/CLI.md
@@ -7,19 +7,21 @@ sidebar_position: 40
 # Flagsmith CLI
 
 The [Flagsmith CLI](https://github.com/Flagsmith/flagsmith-cli) lets you manage flags, segments, features, projects and
-environments from your terminal, and evaluate flags the way an SDK would. This enables CI/CD, scripting, and
-development workflows use cases.
+environments from your terminal, and evaluate flags the way an SDK would. This enables CI/CD, scripting, and development
+workflows use cases.
 
 :::info
 
-The Flagsmith CLI V2 is currently in open beta. We're excited for you to try it and provide any feedback via [GitHub Issues](https://github.com/Flagsmith/flagsmith-cli/issues).
+The Flagsmith CLI V2 is currently in open beta. We're excited for you to try it and provide any feedback via
+[GitHub Issues](https://github.com/Flagsmith/flagsmith-cli/issues).
 
 :::
 
 :::info
 
 Looking for the previous npm-based CLI (`@flagsmith/cli`)? Its documentation has moved to
-[Legacy CLI](/integrating-with-flagsmith/legacy-cli).
+[Legacy CLI](/integrating-with-flagsmith/legacy-cli), along with a
+[migration guide](/integrating-with-flagsmith/legacy-cli#migrating-to-the-new-cli).
 
 :::
 
@@ -39,8 +41,9 @@ On Windows:
 irm https://raw.githubusercontent.com/Flagsmith/flagsmith-cli/main/install.ps1 | iex
 ```
 
-You can also install with Go, run it via Docker, or download a pre-built archive from [GitHub Releases](https://github.com/Flagsmith/flagsmith-cli/releases).
-See the [README](https://github.com/Flagsmith/flagsmith-cli#install) for all installation options.
+You can also install with Go, run it via Docker, or download a pre-built archive from
+[GitHub Releases](https://github.com/Flagsmith/flagsmith-cli/releases). See the
+[README](https://github.com/Flagsmith/flagsmith-cli#install) for all installation options.
 
 ## Quickstart
 
@@ -48,6 +51,10 @@ See the [README](https://github.com/Flagsmith/flagsmith-cli#install) for all ins
 flagsmith init          # log in, pick a project + environment, write flagsmith.json
 flagsmith flag list     # list the flags in the current environment
 ```
+
+`flagsmith init` creates a `flagsmith.json` file in your current working directory with the project and environment you
+selected. The file does not bear any sensitive information and is safe to check in to your repository so your teammates'
+CLIs pick up your defaults.
 
 ## Usage
 
@@ -57,6 +64,7 @@ access. A few examples:
 ```bash
 flagsmith flag enable my_feature                 # toggle a flag in the current environment
 flagsmith evaluate --identity some_user          # the flags an SDK would resolve for an identity
+flagsmith eval --js > flags.json                 # the state a frontend SDK hydrates from
 flagsmith environment document                   # output the local-evaluation environment document
 flagsmith api /projects/                         # call any Flagsmith endpoint with the CLI's credentials
 ```
@@ -68,3 +76,69 @@ Common conventions:
 - Self-hosted: `--api-url` or `FLAGSMITH_API_URL`.
 
 For the full command reference, see the [README](https://github.com/Flagsmith/flagsmith-cli#commands).
+
+## Using the CLI in CI/CD
+
+### GitHub Actions
+
+Configure an
+[OIDC trust relationship](/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication#oidc-trust-relationships)
+for your repository, then use the [`Flagsmith/setup-cli`](https://github.com/Flagsmith/setup-cli) action:
+
+<!-- prettier-ignore -->
+```yaml
+jobs:
+  flagsmith:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Flagsmith/setup-cli@v1
+      - run: flagsmith flag list
+```
+
+The checkout step lets the CLI pick up the project and environment from the `flagsmith.json` file. Without one, select
+them explicitly with `--project` and `--environment`.
+
+### Other providers
+
+If your CI provider supports OIDC, you can set up
+[a generic trust relationship](/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication#other-oidc-providers)
+for it.
+
+Here are some of the CI providers that support OIDC:
+
+- GitLab CI/CD
+- Bitbucket Pipelines
+- CircleCI
+- Buildkite
+- Azure DevOps Pipelines
+- Semaphore
+- Spacelift
+- HCP Terraform / Terraform Enterprise
+- Google Cloud Platform (Cloud Build, Cloud Run, Compute Engine)
+
+On other CI systems, pass a static credential instead. Management commands expect a `FLAGSMITH_API_KEY` variable (a
+[Master API Key](/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication#generating-an-api-token)).
+If you only need `flagsmith eval`, providing an environment key via `FLAGSMITH_ENVIRONMENT_KEY` variable containing a
+[client-side](/integrating-with-flagsmith/flagsmith-api-overview/flags-api/authentication) or
+[server-side](/integrating-with-flagsmith/sdks#server-side-sdks) environment key will suffice.
+
+### Gating pipeline steps on a flag
+
+`flagsmith eval <feature> --test` prints the flag's resolved state and exits non-zero when the flag is disabled, so a
+pipeline can gate later steps on it.
+
+In GitHub Actions:
+
+```yaml
+- run: flagsmith eval canary-deploys --test
+- run: ./deploy.sh
+```
+
+Or in a shell script:
+
+```bash
+flagsmith eval canary-deploys --test && ./deploy.sh
+```

--- a/docs/docs/integrating-with-flagsmith/CLI.md
+++ b/docs/docs/integrating-with-flagsmith/CLI.md
@@ -12,13 +12,6 @@ workflows use cases.
 
 :::info
 
-The Flagsmith CLI V2 is currently in open beta. We're excited for you to try it and provide any feedback via
-[GitHub Issues](https://github.com/Flagsmith/flagsmith-cli/issues).
-
-:::
-
-:::info
-
 Looking for the previous npm-based CLI (`@flagsmith/cli`)? Its documentation has moved to
 [Legacy CLI](/integrating-with-flagsmith/legacy-cli), along with a
 [migration guide](/integrating-with-flagsmith/legacy-cli#migrating-to-the-new-cli).
@@ -27,10 +20,16 @@ Looking for the previous npm-based CLI (`@flagsmith/cli`)? Its documentation has
 
 ## Installation
 
-Install with the install script:
+Install from Homebrew:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Flagsmith/flagsmith-cli/main/install.sh | sh
+brew install Flagsmith/tap/flagsmith
+```
+
+Or with the install script:
+
+```bash
+curl -fsSL https://get.flagsmith.com | sh
 ```
 
 This installs the binary to `$HOME/.local/bin` and adds it to your `PATH`.
@@ -39,6 +38,12 @@ On Windows:
 
 ```powershell
 irm https://raw.githubusercontent.com/Flagsmith/flagsmith-cli/main/install.ps1 | iex
+```
+
+Via NPM:
+
+```bash
+npm install -g @flagsmith/cli
 ```
 
 You can also install with Go, run it via Docker, or download a pre-built archive from
@@ -119,11 +124,22 @@ Here are some of the CI providers that support OIDC:
 - HCP Terraform / Terraform Enterprise
 - Google Cloud Platform (Cloud Build, Cloud Run, Compute Engine)
 
-On other CI systems, pass a static credential instead. Management commands expect a `FLAGSMITH_API_KEY` variable (a
+### Static credentials
+
+On CI systems that don't support OIDC, pass a static credential instead. Management commands expect a
+`FLAGSMITH_API_KEY` variable (a
 [Master API Key](/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication#generating-an-api-token)).
+
 If you only need `flagsmith eval`, providing an environment key via `FLAGSMITH_ENVIRONMENT_KEY` variable containing a
 [client-side](/integrating-with-flagsmith/flagsmith-api-overview/flags-api/authentication) or
 [server-side](/integrating-with-flagsmith/sdks#server-side-sdks) environment key will suffice.
+
+:::info
+
+For self-hosted Flagsmith, the CLI expects static credentials scoped to your API host. For example, for
+`https://flagsmith.corp-internal.io:8000`, the CLI will expect `FLAGSMITH_API_KEY_flagsmith_corp__internal_io_8000`.
+
+:::
 
 ### Gating pipeline steps on a flag
 

--- a/docs/docs/integrating-with-flagsmith/CLI.md
+++ b/docs/docs/integrating-with-flagsmith/CLI.md
@@ -99,7 +99,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: Flagsmith/setup-cli@v1
       - run: flagsmith flag list
 ```

--- a/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication.md
+++ b/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication.md
@@ -6,6 +6,12 @@ sidebar_label: Authentication
 To interact with the Admin API, you need to authenticate your requests using an API Token associated with your
 Organisation, or a short-lived access token obtained through an [OIDC trust relationship](#oidc-trust-relationships).
 
+:::info
+
+Granular permissions for your API tokens and OIDC trust relationships require an [Enterprise or Scale-Up subscription](https://flagsmith.com/pricing).
+
+:::
+
 ## Generating an API Token
 
 You can generate an API Token from the **Organisation Settings** page in the Flagsmith dashboard.
@@ -48,8 +54,7 @@ the same way cloud providers implement workload identity federation.
 The GitHub Actions form only asks for a repository and, optionally, a GitHub environment:
 
 - **Repository**: with the Flagsmith GitHub integration installed, pick the repository from a list — the trust
-  relationship then pins the repository's immutable ID, which is robust against renames. Without the integration, type
-  the owner and name, which are matched against the token's `repository` claim.
+  relationship then pins the repository's ID. Without the integration, type the owner and name.
 - **GitHub environment**: if set, tokens must carry the matching `environment` claim, so the workflow job must run in
   that GitHub environment.
 - **Is admin / roles**: the permissions granted to exchanged tokens — either full organisation admin, or a set of RBAC

--- a/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication.md
+++ b/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication.md
@@ -8,7 +8,8 @@ Organisation, or a short-lived access token obtained through an [OIDC trust rela
 
 :::info
 
-Granular permissions for your API tokens and OIDC trust relationships require an [Enterprise or Scale-Up subscription](https://flagsmith.com/pricing).
+Granular permissions for your API tokens and OIDC trust relationships require an
+[Enterprise or Scale-Up subscription](https://flagsmith.com/pricing).
 
 :::
 
@@ -31,8 +32,9 @@ prefixed with `Api-Key`.
 Authorization: Api-Key <API TOKEN FROM ORGANISATION PAGE>
 ```
 
-This token grants access to manage all projects within that organisation, so be sure to keep it secure and never expose
-it in client-side applications.
+An API token acts with the permissions selected when it was created: either full organisation admin — able to manage all
+projects within that organisation — or a set of RBAC roles. Be sure to keep it secure and never expose it in client-side
+applications.
 
 For SaaS customers, the base URL for the Admin API is `https://api.flagsmith.com/`. If you are self-hosting, you will
 need to use your own API URL.
@@ -51,12 +53,14 @@ the same way cloud providers implement workload identity federation.
 
 #### GitHub Actions
 
-The GitHub Actions form only asks for a repository and, optionally, a GitHub environment:
+The GitHub Actions form asks for a repository and, optionally, a GitHub environment and a workflow filename:
 
 - **Repository**: with the Flagsmith GitHub integration installed, pick the repository from a list — the trust
   relationship then pins the repository's ID. Without the integration, type the owner and name.
 - **GitHub environment**: if set, tokens must carry the matching `environment` claim, so the workflow job must run in
   that GitHub environment.
+- **Workflow filename**: if set, tokens must come from that workflow file — matched via the `workflow_ref` claim —
+  regardless of branch or tag.
 - **Is admin / roles**: the permissions granted to exchanged tokens — either full organisation admin, or a set of RBAC
   roles, exactly as with Master API Keys.
 
@@ -82,6 +86,8 @@ curl -X POST 'https://api.flagsmith.com/api/v1/auth/oidc/token/' \
   -H 'Content-Type: application/json' \
   -d '{"token": "<OIDC TOKEN>"}'
 ```
+
+If you are self-hosting, replace `https://api.flagsmith.com` with your own API URL.
 
 A successful exchange returns a short-lived access token:
 

--- a/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication.md
+++ b/docs/docs/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication.md
@@ -3,26 +3,96 @@ title: Authentication
 sidebar_label: Authentication
 ---
 
-To interact with the Admin API, you need to authenticate your requests using an API Token associated with your Organisation.
+To interact with the Admin API, you need to authenticate your requests using an API Token associated with your
+Organisation, or a short-lived access token obtained through an [OIDC trust relationship](#oidc-trust-relationships).
 
 ## Generating an API Token
 
 You can generate an API Token from the **Organisation Settings** page in the Flagsmith dashboard.
 
-1.  Click on your Organisation name in the top navigation panel.
-2.  Go to the **API Keys** tab.
-3.  Click **Create API Key**.
+1. Click on your Organisation name in the top navigation panel.
+2. Go to the **API Access** tab.
+3. Click **Create API Key**.
 
 Give your key a descriptive name so you can remember what it's used for.
 
 ## Using the API Token
 
-Once you have your token, you need to include it in your API requests as an `Authorization` header. The token should be prefixed with `Api-Key`.
+Once you have your token, you need to include it in your API requests as an `Authorization` header. The token should be
+prefixed with `Api-Key`.
 
 ```bash
 Authorization: Api-Key <API TOKEN FROM ORGANISATION PAGE>
 ```
 
-This token grants access to manage all projects within that organisation, so be sure to keep it secure and never expose it in client-side applications.
+This token grants access to manage all projects within that organisation, so be sure to keep it secure and never expose
+it in client-side applications.
 
-For SaaS customers, the base URL for the Admin API is `https://api.flagsmith.com/`. If you are self-hosting, you will need to use your own API URL. 
+For SaaS customers, the base URL for the Admin API is `https://api.flagsmith.com/`. If you are self-hosting, you will
+need to use your own API URL.
+
+## OIDC trust relationships
+
+Trust relationships let a workload that already has an OIDC identity — for example, a GitHub Actions job — call the
+Admin API without any stored secrets. The workload exchanges its OIDC token for a short-lived Flagsmith access token, in
+the same way cloud providers implement workload identity federation.
+
+### Configuring a trust relationship
+
+1. Click on your Organisation name in the top navigation panel.
+2. Go to the **API Access** tab.
+3. Under **Trust relationships**, click **Add trust relationship** and pick a provider.
+
+#### GitHub Actions
+
+The GitHub Actions form only asks for a repository and, optionally, a GitHub environment:
+
+- **Repository**: with the Flagsmith GitHub integration installed, pick the repository from a list — the trust
+  relationship then pins the repository's immutable ID, which is robust against renames. Without the integration, type
+  the owner and name, which are matched against the token's `repository` claim.
+- **GitHub environment**: if set, tokens must carry the matching `environment` claim, so the workflow job must run in
+  that GitHub environment.
+- **Is admin / roles**: the permissions granted to exchanged tokens — either full organisation admin, or a set of RBAC
+  roles, exactly as with Master API Keys.
+
+The form shows a ready-made workflow snippet reflecting your configuration.
+
+#### Other OIDC providers
+
+The freeform option supports any OIDC identity provider, such as GitLab CI or Kubernetes:
+
+- **Trusted issuer URL**: the OIDC issuer. The issuer must serve OIDC discovery metadata over HTTPS.
+- **Expected audience**: the `aud` claim the token must carry. Each issuer and audience pair must be unique, so use a
+  distinct audience per trust relationship.
+- **Claim matching rules**: additional claims the token must match. Values support `*` wildcards, and a rule matches if
+  any of its values match. All rules must match.
+- **Is admin / roles**: as above.
+
+### Exchanging a token
+
+`POST /api/v1/auth/oidc/token/` with the OIDC token in the request body:
+
+```bash
+curl -X POST 'https://api.flagsmith.com/api/v1/auth/oidc/token/' \
+  -H 'Content-Type: application/json' \
+  -d '{"token": "<OIDC TOKEN>"}'
+```
+
+A successful exchange returns a short-lived access token:
+
+```json
+{
+ "access_token": "<ACCESS TOKEN>",
+ "token_type": "Bearer",
+ "expires_in": 3600
+}
+```
+
+Use it as a bearer token on Admin API requests:
+
+```bash
+Authorization: Bearer <ACCESS TOKEN>
+```
+
+Access tokens expire after one hour by default. Deleting a trust relationship, or changing its roles, applies to
+already-issued tokens immediately. Exchanged tokens cannot manage API keys or trust relationships.

--- a/docs/docs/integrating-with-flagsmith/legacy-cli.md
+++ b/docs/docs/integrating-with-flagsmith/legacy-cli.md
@@ -9,9 +9,31 @@ unlisted: true
 :::warning
 
 The npm-based CLI (`@flagsmith/cli`) is deprecated and no longer maintained. Use the new
-[Flagsmith CLI](/integrating-with-flagsmith/CLI) instead.
+[Flagsmith CLI](/integrating-with-flagsmith/CLI) instead — see [Migrating to the new CLI](#migrating-to-the-new-cli).
 
 :::
+
+## Migrating to the new CLI
+
+The legacy CLI's `flagsmith get` command is reimplemented as `flagsmith eval --js`:
+
+```bash
+# Before
+FLAGSMITH_ENVIRONMENT=<key> flagsmith get
+
+# After
+FLAGSMITH_ENVIRONMENT_KEY=<key> flagsmith eval --js > flags.json
+```
+
+The options map as follows:
+
+| Legacy CLI                       | New CLI                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `ENVIRONMENT` argument           | `--environment <key>`, or `flagsmith init` to bind the directory                |
+| `FLAGSMITH_ENVIRONMENT` variable | `FLAGSMITH_ENVIRONMENT_KEY`                                                     |
+| `-o, --output <file>`            | Redirect stdout: `> flags.json`                                                 |
+| `-a, --api <url>`                | `--sdk-api-url <url>` or `FLAGSMITH_SDK_API_URL`, without the `/api/v1/` suffix |
+| `-i, --identity <identity>`      | `--identity <identity>`                                                         |
 
 ## Installation
 

--- a/docs/docs/managing-flags/code-references.md
+++ b/docs/docs/managing-flags/code-references.md
@@ -53,7 +53,7 @@ jobs:
 This workflow needs the following added to [_Settings > Secrets and variables > Actions_](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) in GitHub:
 
 - `FLAGSMITH_PROJECT_ID` (variable): obtain from the Flagsmith dashboard URL, e.g. `/project/<id>/...`
-- `FLAGSMITH_CODE_REFERENCES_API_KEY` (secret): obtain from _Organisation Settings > API Keys_ in Flagsmith
+- `FLAGSMITH_CODE_REFERENCES_API_KEY` (secret): obtain from _Organisation Settings > API Access_ in Flagsmith
 
 ### Advanced configuration
 
@@ -109,7 +109,7 @@ jobs:
 This workflow needs the following added to [_Settings > Secrets and variables > Actions_](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) in GitHub:
 
 - `FLAGSMITH_PROJECT_ID` (variable): obtain from the Flagsmith dashboard URL, e.g. `/project/<id>/...`
-- `FLAGSMITH_CODE_REFERENCES_API_KEY` (secret): obtain from _Organisation Settings > API Keys_ in Flagsmith
+- `FLAGSMITH_CODE_REFERENCES_API_KEY` (secret): obtain from _Organisation Settings > API Access_ in Flagsmith
 
 ---
 

--- a/docs/docs/third-party-integrations/backstage.md
+++ b/docs/docs/third-party-integrations/backstage.md
@@ -39,7 +39,7 @@ proxy:
     Authorization: Api-Key FLAGSMITH_API_TOKEN
 ```
 
-- `FLAGSMITH_API_TOKEN`: obtain from Organisation Settings > API Keys in Flagsmith.
+- `FLAGSMITH_API_TOKEN`: obtain from Organisation Settings > API Access in Flagsmith.
 - If you are self-hosting Flagsmith, replace the `target` URL with your own Flagsmith API address, e.g.
   `https://flagsmith.example.com/api/v1`.
 

--- a/docs/docs/third-party-integrations/ci-cd/terraform.md
+++ b/docs/docs/third-party-integrations/ci-cd/terraform.md
@@ -25,7 +25,7 @@ from your account settings page which will help you access these variables.
 ### Organisation API Key
 
 In order to configure the Flagsmith Terraform provider we need an API key. To generate one, head over to the
-Organisation Settings page (click `Organisation` at the top of the page), then `API Keys`, then `Create API Key`.
+Organisation Settings page (click `Organisation` at the top of the page), then `API Access`, then `Create API Key`.
 
 :::info
 

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/GithubTrustRelationshipForm/GithubTrustRelationshipForm.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/GithubTrustRelationshipForm/GithubTrustRelationshipForm.tsx
@@ -19,7 +19,11 @@ import { trustRelationshipErrorMessage } from 'components/pages/organisation-set
 import useTrustRelationshipRoles from 'components/pages/organisation-settings/tabs/trust-relationships/hooks/useTrustRelationshipRoles'
 import TrustRelationshipPermissionsFields from 'components/pages/organisation-settings/tabs/trust-relationships/TrustRelationshipPermissionsFields'
 import WorkflowSetupSnippet from 'components/pages/organisation-settings/tabs/trust-relationships/WorkflowSetupSnippet'
-import { GITHUB_ISSUER } from 'components/pages/organisation-settings/tabs/trust-relationships/github'
+import {
+  GITHUB_ISSUER,
+  githubWorkflowRefPattern,
+  parseGithubWorkflowFilename,
+} from 'components/pages/organisation-settings/tabs/trust-relationships/github'
 
 type GithubTrustRelationshipFormProps = {
   organisationId: number
@@ -60,6 +64,10 @@ const GithubTrustRelationshipForm: FC<GithubTrustRelationshipFormProps> = ({
   )
   const [environment, setEnvironment] = useState(
     ruleValue(trustRelationship, 'environment') || '',
+  )
+  const [workflowFilename, setWorkflowFilename] = useState(
+    parseGithubWorkflowFilename(ruleValue(trustRelationship, 'workflow_ref')) ||
+      '',
   )
   const [isAdmin, setIsAdmin] = useState(trustRelationship?.is_admin ?? true)
   const { addRole, assignRoles, clearRoles, removeRole, roles } =
@@ -147,6 +155,12 @@ const GithubTrustRelationshipForm: FC<GithubTrustRelationshipFormProps> = ({
     }
     if (environment.trim()) {
       claimRules.push({ claim: 'environment', values: [environment.trim()] })
+    }
+    if (workflowFilename.trim()) {
+      claimRules.push({
+        claim: 'workflow_ref',
+        values: [githubWorkflowRefPattern(workflowFilename.trim())],
+      })
     }
     const body = {
       audience,
@@ -269,6 +283,16 @@ const GithubTrustRelationshipForm: FC<GithubTrustRelationshipFormProps> = ({
           setEnvironment(Utils.safeParseEventValue(e))
         }
         placeholder='e.g. production'
+      />
+      <InputGroup
+        title='Workflow filename (optional)'
+        tooltip='If set, only this workflow file can exchange tokens, on any branch or tag.'
+        inputProps={{ className: 'full-width' }}
+        value={workflowFilename}
+        onChange={(e: InputEvent) =>
+          setWorkflowFilename(Utils.safeParseEventValue(e))
+        }
+        placeholder='e.g. deploy.yml'
       />
       {!!audience && (
         <>

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/WorkflowSetupSnippet/WorkflowSetupSnippet.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/WorkflowSetupSnippet/WorkflowSetupSnippet.tsx
@@ -1,7 +1,20 @@
 import React, { FC, useMemo } from 'react'
 import CodeCard from 'components/pages/onboarding/OnboardingConnectPanel/CodeCard'
 import Icon from 'components/icons/Icon'
+import Project from 'common/project'
 import { isDefaultGithubAudience } from 'components/pages/organisation-settings/tabs/trust-relationships/github'
+
+const SAAS_API_URL = 'https://api.flagsmith.com'
+
+// The CLI defaults to the SaaS API, so the snippet only needs an explicit
+// api-url on other instances. It takes the base URL without /api/v1, which
+// the CLI appends itself.
+export const getNonDefaultApiUrl = (): string | undefined => {
+  // Project.api can be relative, e.g. /api/v1/
+  const resolved = new Request(Project.api).url
+  const baseUrl = resolved.replace(/\/api\/v1\/?$/, '')
+  return baseUrl === SAAS_API_URL ? undefined : baseUrl
+}
 
 type WorkflowSetupSnippetProps = {
   audience: string
@@ -24,8 +37,19 @@ const WorkflowSetupSnippet: FC<WorkflowSetupSnippetProps> = ({
       '    steps:',
       '      - uses: Flagsmith/setup-cli@v1',
     )
+    const withInputs: string[] = []
     if (!isDefaultAudience) {
-      lines.push('        with:', `          audience: ${audience}`)
+      withInputs.push(`audience: ${audience}`)
+    }
+    const apiUrl = getNonDefaultApiUrl()
+    if (apiUrl) {
+      withInputs.push(`api-url: ${apiUrl}`)
+    }
+    if (withInputs.length) {
+      lines.push(
+        '        with:',
+        ...withInputs.map((input) => `          ${input}`),
+      )
     }
     return lines.join('\n')
   }, [environment, isDefaultAudience, audience])

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/WorkflowSetupSnippet/WorkflowSetupSnippet.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/WorkflowSetupSnippet/WorkflowSetupSnippet.tsx
@@ -4,16 +4,18 @@ import Icon from 'components/icons/Icon'
 import Project from 'common/project'
 import { isDefaultGithubAudience } from 'components/pages/organisation-settings/tabs/trust-relationships/github'
 
-const SAAS_API_URL = 'https://api.flagsmith.com'
+const SAAS_API_HOST = 'api.flagsmith.com'
 
 // The CLI defaults to the SaaS API, so the snippet only needs an explicit
 // api-url on other instances. It takes the base URL without /api/v1, which
 // the CLI appends itself.
 export const getNonDefaultApiUrl = (): string | undefined => {
   // Project.api can be relative, e.g. /api/v1/
-  const resolved = new Request(Project.api).url
-  const baseUrl = resolved.replace(/\/api\/v1\/?$/, '')
-  return baseUrl === SAAS_API_URL ? undefined : baseUrl
+  const resolved = new URL(Project.api, window.location.origin)
+  if (resolved.host === SAAS_API_HOST) {
+    return undefined
+  }
+  return resolved.href.replace(/\/api\/v1\/?$/, '')
 }
 
 type WorkflowSetupSnippetProps = {

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/__tests__/isGithubFormEditable.test.ts
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/__tests__/isGithubFormEditable.test.ts
@@ -1,6 +1,8 @@
 import {
   GITHUB_ISSUER,
+  githubWorkflowRefPattern,
   isGithubFormEditable,
+  parseGithubWorkflowFilename,
 } from 'components/pages/organisation-settings/tabs/trust-relationships/github'
 import {
   TrustRelationship,
@@ -28,6 +30,14 @@ const ENVIRONMENT: TrustRelationshipClaimRule = {
   claim: 'environment',
   values: ['production'],
 }
+const WORKFLOW_REF: TrustRelationshipClaimRule = {
+  claim: 'workflow_ref',
+  values: [githubWorkflowRefPattern('deploy.yml')],
+}
+const FOREIGN_WORKFLOW_REF: TrustRelationshipClaimRule = {
+  claim: 'workflow_ref',
+  values: ['Flagsmith/flagsmith/.github/workflows/deploy.yml@refs/heads/main'],
+}
 
 describe('isGithubFormEditable', () => {
   it.each`
@@ -35,6 +45,8 @@ describe('isGithubFormEditable', () => {
     ${'a single repository rule'}       | ${[REPOSITORY]}                                      | ${true}
     ${'a repository and environment'}   | ${[REPOSITORY, ENVIRONMENT]}                         | ${true}
     ${'a repository pinned by id'}      | ${[REPOSITORY_ID]}                                   | ${true}
+    ${'a workflow filename rule'}       | ${[REPOSITORY, WORKFLOW_REF]}                        | ${true}
+    ${'a foreign workflow_ref rule'}    | ${[REPOSITORY, FOREIGN_WORKFLOW_REF]}                | ${false}
     ${'no repository selector'}         | ${[ENVIRONMENT]}                                     | ${false}
     ${'both repository selectors'}      | ${[REPOSITORY, REPOSITORY_ID]}                       | ${false}
     ${'a duplicated claim'}             | ${[REPOSITORY, ENVIRONMENT, ENVIRONMENT]}            | ${false}
@@ -51,5 +63,25 @@ describe('isGithubFormEditable', () => {
 
     // When / Then
     expect(isGithubFormEditable(relationship)).toBe(false)
+  })
+})
+
+describe('parseGithubWorkflowFilename', () => {
+  it('round-trips a pattern written by the form', () => {
+    // Given
+    const pattern = githubWorkflowRefPattern('deploy.yml')
+
+    // When / Then
+    expect(parseGithubWorkflowFilename(pattern)).toBe('deploy.yml')
+  })
+
+  it.each`
+    description               | workflowRef
+    ${'an undefined value'}   | ${undefined}
+    ${'a literal claim'}      | ${'a/b/.github/workflows/deploy.yml@refs/heads/main'}
+    ${'an unrelated pattern'} | ${'*/deploy.yml@*'}
+  `('returns undefined for $description', ({ workflowRef }) => {
+    // Given / When / Then
+    expect(parseGithubWorkflowFilename(workflowRef)).toBeUndefined()
   })
 })

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/github.ts
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/github.ts
@@ -4,7 +4,25 @@ export const GITHUB_ISSUER = 'https://token.actions.githubusercontent.com'
 export const GITHUB_LABEL = 'GitHub Actions'
 
 // Claims the GitHub form can round-trip; anything else edits as freeform.
-const GITHUB_FORM_CLAIMS = ['repository', 'repository_id', 'environment']
+const GITHUB_FORM_CLAIMS = [
+  'repository',
+  'repository_id',
+  'environment',
+  'workflow_ref',
+]
+
+// The repository rule already pins the repository, so the workflow rule only
+// needs to enforce the path — a wildcard prefix survives repository renames,
+// and the wildcard ref leaves branch filtering to the environment rule.
+export const githubWorkflowRefPattern = (filename: string): string =>
+  `*/.github/workflows/${filename}@*`
+
+const GITHUB_WORKFLOW_REF_REGEX = /^\*\/\.github\/workflows\/(.+)@\*$/
+
+export const parseGithubWorkflowFilename = (
+  workflowRef: string | undefined,
+): string | undefined =>
+  workflowRef ? GITHUB_WORKFLOW_REF_REGEX.exec(workflowRef)?.[1] : undefined
 
 export const isGithubFormEditable = (
   trustRelationship: TrustRelationship,
@@ -22,7 +40,10 @@ export const isGithubFormEditable = (
     repositorySelectors.length === 1 &&
     trustRelationship.claim_rules.every(
       (rule) =>
-        GITHUB_FORM_CLAIMS.includes(rule.claim) && rule.values.length === 1,
+        GITHUB_FORM_CLAIMS.includes(rule.claim) &&
+        rule.values.length === 1 &&
+        (rule.claim !== 'workflow_ref' ||
+          !!parseGithubWorkflowFilename(rule.values[0])),
     )
   )
 }


### PR DESCRIPTION


Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8040

In this PR, we add final documentation and UI improvements for the CLI and Trust Relationships before the CLI launch.

Docs changes:

- Document OIDC trust relationships on the Admin API authentication page: configuring GitHub Actions and generic OIDC providers, exchanging a token, and access token behaviour. [Preview](https://docs-git-feat-trust-relationships-docs-flagsmith.vercel.app/integrating-with-flagsmith/flagsmith-api-overview/admin-api/authentication#oidc-trust-relationships).
- Update the renamed API Keys tab references to API Access.
- Add a CI/CD section to the CLI page: GitHub Actions with `Flagsmith/setup-cli`, a list of OIDC-capable CI providers, and gating pipeline steps with `flagsmith eval --test`.
- Add a migration guide from the legacy npm CLI to the new CLI.
- Update the CLI install options (Homebrew, `get.flagsmith.com`, npm) and document host-scoped static credentials for self-hosted instances.
- Add the two new environment variables to the self-hosting reference.

Frontend changes:

- Add an optional workflow filename field to the GitHub trust relationship form. When set, only that workflow file can exchange tokens, matched via the `workflow_ref` claim on any branch or tag.
- Pass `api-url` to `Flagsmith/setup-cli` in the generated workflow snippet when the instance is not SaaS.

## How did you test this code?

Verified locally. Unit tests cover the `workflow_ref` pattern round-trip and GitHub form editability.
