### PR TITLE
ci(Renovate): Add force-update input to Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,11 +2,11 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       packages:
-        description: 'Comma-separated packages to force-update out of band (leave empty for a normal run)'
+        description: "Comma-separated packages to force-update out of band (leave empty for a normal run)"
         required: false
         type: string
 
@@ -27,9 +27,9 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ vars.FLAGSMITH_ENGINEERING_GH_APP_ID }}
+          client-id: ${{ vars.FLAGSMITH_ENGINEERING_GH_APP_ID }}
           private-key: ${{ secrets.FLAGSMITH_ENGINEERING_GH_APP_PRIVATE_KEY }}
 
       - name: Compute Renovate force override
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v46.1.14
+        uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           RENOVATE_FORCE: ${{ steps.force.outputs.value }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,13 +34,16 @@ jobs:
 
       - name: Compute Renovate force override
         id: force
+        shell: python
         env:
           PACKAGES: ${{ inputs.packages }}
         run: |
-          if [ -n "$PACKAGES" ]; then
-            names=$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))' <<< "$PACKAGES")
-            printf 'value={"packageRules":[{"matchPackageNames":%s,"enabled":true,"rangeStrategy":"bump"}]}\n' "$names" >> "$GITHUB_OUTPUT"
-          fi
+          import json, os
+          names = [n for part in os.environ["PACKAGES"].split(",") if (n := part.strip())]
+          if names:
+              value = {"packageRules": [{"matchPackageNames": names, "enabled": True, "rangeStrategy": "bump"}]}
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write(f"value={json.dumps(value)}\n")
 
       - name: Run Renovate
         uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,7 +3,12 @@ name: Renovate
 on:
   schedule:
     - cron: '0 3 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Comma-separated packages to force-update out of band (leave empty for a normal run)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -27,10 +32,21 @@ jobs:
           app-id: ${{ vars.FLAGSMITH_ENGINEERING_GH_APP_ID }}
           private-key: ${{ secrets.FLAGSMITH_ENGINEERING_GH_APP_PRIVATE_KEY }}
 
+      - name: Compute Renovate force override
+        id: force
+        env:
+          PACKAGES: ${{ inputs.packages }}
+        run: |
+          if [ -n "$PACKAGES" ]; then
+            names=$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))' <<< "$PACKAGES")
+            printf 'value={"packageRules":[{"matchPackageNames":%s,"enabled":true,"rangeStrategy":"bump"}]}\n' "$names" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.14
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+          RENOVATE_FORCE: ${{ steps.force.outputs.value }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
           RENOVATE_HOST_RULES: >-


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Sometimes we need to perform a targeted dependency bump. In this PR, we're adding support for `packages` input to the Renovate workflow that should help automate this.

## How did you test this code?

This is a CI change.
