### PR TITLE
fix: import is free email domains json directly

### DIFF
--- a/frontend/common/utils/isFreeEmailDomain.ts
+++ b/frontend/common/utils/isFreeEmailDomain.ts
@@ -1,4 +1,4 @@
-import freeEmailDomains from 'free-email-domains'
+import freeEmailDomains from 'free-email-domains/domains.json'
 
 export default function (value: string | null | undefined) {
   if (!value) return false


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Rspack prod builds tree-shake free-email-domains' JSON list to an empty stub, so isFreeEmailDomain() always returns false in production. Dev builds skip the optimisation, so it was invisible locally.

## How did you test this code?
- Bundled the app before and after fix and confirmed