### PR TITLE
fix: block HubSpot and Google Analytics in E2E runs

### DIFF
--- a/frontend/e2e/test-setup.ts
+++ b/frontend/e2e/test-setup.ts
@@ -1,8 +1,17 @@
 import { test as base, expect } from '@playwright/test';
 import { setupBrowserLogging } from './helpers';
 
+// Third-party widgets (e.g. the HubSpot chat bubble) can overlay UI elements
+// and intercept pointer events, so block them at the network level.
+const THIRD_PARTY_SCRIPT_HOSTS =
+  /(hubspot|hs-scripts|hs-analytics|hs-banner|hsforms|usemessages|google-analytics)\./;
+
 const test = base.extend<{ e2eSetup: void }>({
-  e2eSetup: [async ({ page }, use) => {
+  e2eSetup: [async ({ context, page }, use) => {
+    await context.route(
+      (url) => THIRD_PARTY_SCRIPT_HOSTS.test(url.hostname),
+      (route) => route.abort(),
+    );
     setupBrowserLogging(page);
     await use();
   }, { auto: true }],

--- a/frontend/web/project/libs.js
+++ b/frontend/web/project/libs.js
@@ -42,8 +42,10 @@ window.RequiredElement = propTypes.node.isRequired;
 window.Link = Link;
 window.NavLink = NavLink;
 
-// Analytics
-if (Project.ga) {
+// Analytics — not loaded in E2E runs, where widgets can overlay the UI
+const disableThirdPartyScripts = !!window.E2E
+
+if (Project.ga && !disableThirdPartyScripts) {
     (function (i, s, o, g, r, a, m) {
         i.GoogleAnalyticsObject = r; i[r] = i[r] || function () {
             (i[r].q = i[r].q || []).push(arguments);
@@ -85,7 +87,7 @@ if(Project.linkedinPartnerTracking) {
     document.body.appendChild(img);
 }
 
-if(Project.hubspot) {
+if(Project.hubspot && !disableThirdPartyScripts) {
     var script = document.createElement("script");
     script.type = "text/javascript";
     script.id = "hs-script-loader";


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The HubSpot chat bubble started appearing in E2E runs (external chatflow targeting change) and intercepts pointer events, failing the production deploy

- `web/project/libs.js`: skip loading GA and HubSpot scripts when `window.E2E` is set
- `e2e/test-setup.ts`: abort requests to HubSpot and Google Analytics hosts at the network level (hostname match, so app API paths are unaffected)

## How did you test this code?

Served the production bundle locally via `NODE_ENV=production node ./api/index.js` and loaded it in Firefox (Playwright), with and without the `E2E` env var:

- without `E2E`: `hs-script-loader` tag injected, 8 requests to HubSpot hosts (reproduces the CI failure)
- with `E2E=1`: no script tag, 0 HubSpot requests