### PR TITLE
Fix #7983: Add EDGE_IDENTITY to allowed integration audit events

### DIFF
--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -121,6 +121,7 @@ def track_only_feature_related_events(signal_function):  # type: ignore[no-untyp
         RelatedObjectType.FEATURE_STATE,
         RelatedObjectType.SEGMENT,
         RelatedObjectType.EF_VERSION,
+        RelatedObjectType.EDGE_IDENTITY,
     ]
     return track_only(allowed_types)(signal_function)
 

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -596,3 +596,33 @@ def test_send_feature_flag_went_live_signal__non_feature_state_instance__skips_s
 
     # Then
     mock_signal_send.assert_not_called()
+
+def test_send_audit_log_event_to_grafana__edge_identity__calls_expected(
+    mocker: MockerFixture,
+    project: Project,
+) -> None:
+    # Given
+    audit_log_record = AuditLog.objects.create(
+        project=project,
+        related_object_type=RelatedObjectType.EDGE_IDENTITY.name,
+    )
+    grafana_wrapper_mock = mocker.patch("audit.signals.GrafanaWrapper", autospec=True)
+    grafana_wrapper_instance_mock = grafana_wrapper_mock.return_value
+
+    grafana_config = GrafanaProjectConfiguration(base_url="test.com", api_key="test")
+    project.grafana_config = grafana_config
+
+    # When
+    send_audit_log_event_to_grafana(AuditLog, audit_log_record)
+
+    # Then
+    grafana_wrapper_mock.assert_called_once_with(
+        base_url=grafana_config.base_url,
+        api_key=grafana_config.api_key,
+    )
+    grafana_wrapper_instance_mock.generate_event_data.assert_called_once_with(
+        audit_log_record
+    )
+    grafana_wrapper_instance_mock.track_event_async.assert_called_once_with(
+        event=grafana_wrapper_instance_mock.generate_event_data.return_value
+    )

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -597,6 +597,7 @@ def test_send_feature_flag_went_live_signal__non_feature_state_instance__skips_s
     # Then
     mock_signal_send.assert_not_called()
 
+
 def test_send_audit_log_event_to_grafana__edge_identity__calls_expected(
     mocker: MockerFixture,
     project: Project,

--- a/api/tests/unit/audit/test_unit_audit_signals.py
+++ b/api/tests/unit/audit/test_unit_audit_signals.py
@@ -622,7 +622,7 @@ def test_send_audit_log_event_to_grafana__edge_identity__calls_expected(
         api_key=grafana_config.api_key,
     )
     grafana_wrapper_instance_mock.generate_event_data.assert_called_once_with(
-        audit_log_record
+        audit_log_record=audit_log_record
     )
     grafana_wrapper_instance_mock.track_event_async.assert_called_once_with(
         event=grafana_wrapper_instance_mock.generate_event_data.return_value


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7983

_Please describe._
Added `RelatedObjectType.EDGE_IDENTITY` to the `track_only_feature_related_events` signal filter decorator in `api/audit/signals.py`. This ensures audit events triggered by identity flag overrides in Edge/SaaS environments are properly processed and sent to messaging integrations like Slack, Grafana, Datadog, and Webhooks.

## How did you test this code?

_Please describe._
- Added a new unit test (`test_send_audit_log_event_to_grafana__edge_identity__calls_expected`) in `api/tests/unit/audit/test_unit_audit_signals.py` to cover `EDGE_IDENTITY` events.
- Ran the specific test file locally using `uv run pytest` to verify that the audit signal properly triggers integration events for edge identities.