### PR TITLE
refactor(analytics): make trackEvent/trackTraits error-safe, tag onboarding variant when flags are ready

### DIFF
--- a/frontend/web/components/pages/onboarding/GettingStartedGate.tsx
+++ b/frontend/web/components/pages/onboarding/GettingStartedGate.tsx
@@ -1,4 +1,6 @@
 import React, { FC, useEffect } from 'react'
+import flagsmith from '@flagsmith/flagsmith'
+import ConfigProvider from 'common/providers/ConfigProvider'
 import {
   getOnboardingVariant,
   isSinglePageOnboarding,
@@ -8,13 +10,21 @@ import GettingStartedPage from 'components/pages/GettingStartedPage'
 import OnboardingFlow from './OnboardingFlow'
 
 const GettingStartedGate: FC = () => {
+  // ConfigProvider re-renders the gate on every SDK fetch; only tag the
+  // variant once the server has answered for this identity.
+  const trustworthy =
+    !flagsmith.loadingState?.isFetching &&
+    flagsmith.loadingState?.source === 'SERVER' &&
+    !!flagsmith.getContext().identity
+
   const variant = getOnboardingVariant()
 
   useEffect(() => {
+    if (!trustworthy) return
     API.trackTraits({ onboarding_variant: variant })
-  }, [variant])
+  }, [trustworthy, variant])
 
   return isSinglePageOnboarding() ? <OnboardingFlow /> : <GettingStartedPage />
 }
 
-export default GettingStartedGate
+export default ConfigProvider(GettingStartedGate)

--- a/frontend/web/project/api.ts
+++ b/frontend/web/project/api.ts
@@ -309,27 +309,33 @@ const API = {
     label?: string
     extra?: Record<string, any>
   }): void {
-    if (Project.ga) {
-      if (Project.logAnalytics) console.log('ANALYTICS EVENT', data)
-      if (!data || !data.category || !data.event)
-        return console.error('Invalid event provided', data)
-      if (data.category === 'First')
-        API.postEvent(
-          `${data.event}${data.extra ? ` ${JSON.stringify(data.extra)}` : ''}`,
-          'first_events',
-        )
-      ga('send', {
-        eventAction: data.event,
-        eventCategory: data.category,
-        eventLabel: data.label,
-        hitType: 'event',
-      })
-    }
-    if (Project.amplitude) {
-      amplitude.track(data.event, {
-        category: data.category,
-        ...(data.extra || {}),
-      })
+    try {
+      if (Project.ga) {
+        if (Project.logAnalytics) console.log('ANALYTICS EVENT', data)
+        if (!data || !data.category || !data.event)
+          return console.error('Invalid event provided', data)
+        if (data.category === 'First')
+          API.postEvent(
+            `${data.event}${
+              data.extra ? ` ${JSON.stringify(data.extra)}` : ''
+            }`,
+            'first_events',
+          )
+        ga('send', {
+          eventAction: data.event,
+          eventCategory: data.category,
+          eventLabel: data.label,
+          hitType: 'event',
+        })
+      }
+      if (Project.amplitude) {
+        amplitude.track(data.event, {
+          category: data.category,
+          ...(data.extra || {}),
+        })
+      }
+    } catch (err) {
+      console.error('Error tracking event', err)
     }
   },
 
@@ -344,12 +350,16 @@ const API = {
   },
 
   trackTraits(traits: Record<string, any>): void {
-    if (Project.amplitude && traits) {
-      const identifyObj = new amplitude.Identify()
-      Object.entries(traits).forEach(([key, value]) =>
-        identifyObj.set(key, value),
-      )
-      amplitude.identify(identifyObj)
+    try {
+      if (Project.amplitude && traits) {
+        const identifyObj = new amplitude.Identify()
+        Object.entries(traits).forEach(([key, value]) =>
+          identifyObj.set(key, value),
+        )
+        amplitude.identify(identifyObj)
+      }
+    } catch (err) {
+      console.error('Error tracking traits', err)
     }
   },
 }


### PR DESCRIPTION
**Reviewing this:** Start with `GettingStartedGate.tsx`, the only behaviour change: the onboarding variant is now written to analytics only after the flag service has answered for the logged-in user, so a stale or default value is never recorded. `api.ts` is mechanical, both tracking helpers wrapped in try/catch. The timing guard is the bit to scrutinise; the rest can be skimmed.

Follow-up to #7960 (rebased on main now that it merged). Two robustness fixes to the shared analytics helpers.

## Changes

- `trackEvent` and `trackTraits` wrapped in try/catch so a failing tracker can't break the caller, e.g. the onboarding bootstrap firing milestone events (kyle's note).
- The getting-started gate writes the `onboarding_variant` user property only once flags have loaded from the server for the current user, closing the race where a stale or default variant could be recorded (Wadii's note; replaces the earlier `setOnce` approach).

## How did you test this code?

- [x] Reproduced the race by delaying the flag-service identify request 4s: without the guard the variant was written mid-fetch (and twice); with the guard, exactly once after the server answered.
- [x] Revisited `/getting-started`: property unchanged (a rewrite with the same value is expected, it's a mutable trait now).
- [ ] Fresh signup on the deploy preview: `onboarding_variant` appears in Amplitude with the served variant (localhost has no Amplitude key).
- [ ] Ad-blocker on (tracker requests fail): onboarding still loads, no uncaught console errors.
