### PR TITLE
refactor(code-help): escape snippets centrally instead of in source strings

### DIFF
--- a/frontend/common/code-help/create-user/create-user-next.js
+++ b/frontend/common/code-help/create-user/create-user-next.js
@@ -23,7 +23,7 @@ export default function HomePage() {
 
 export default function App({ Component, pageProps, flagsmithState } {
   return (
-    &lt;FlagsmithProvider
+    <FlagsmithProvider
       serverState={flagsmithState}
       options={{
         environmentID: "${envId}",${
@@ -32,9 +32,9 @@ export default function App({ Component, pageProps, flagsmithState } {
     : ''
 }
       }}
-      flagsmith={flagsmith}&gt;
-        &lt;Component {...pageProps} />
-    &lt;/FlagsmithProvider>
+      flagsmith={flagsmith}>
+        <Component {...pageProps} />
+    </FlagsmithProvider>
   );
 }
 

--- a/frontend/common/code-help/create-user/create-user-react.js
+++ b/frontend/common/code-help/create-user/create-user-react.js
@@ -10,7 +10,7 @@ import { FlagsmithProvider } from '${NPM_CLIENT}/react';
 
 export default function App() {
   return (
-    &lt;FlagsmithProvider
+    <FlagsmithProvider
       options={{
         environmentID: '${envId}',${
   Constants.isCustomFlagsmithUrl()
@@ -20,9 +20,9 @@ export default function App() {
         identity: '${userId || USER_ID}',
         traits: {${TRAIT_NAME}: 21},
       }}
-      flagsmith={flagsmith}&gt;
+      flagsmith={flagsmith}>
       {...Your app}
-    &lt;/FlagsmithProvider>
+    </FlagsmithProvider>
   );
 }
 

--- a/frontend/common/code-help/init/init-next-app-router.js
+++ b/frontend/common/code-help/init/init-next-app-router.js
@@ -9,9 +9,9 @@ import { FeatureFlagProvider } from "./components/FeatureFlagProvider";
 
 export default async function RootLayout({
   children,
-}: Readonly&lt;{
+}: Readonly<{
   children: React.ReactNode;
-}&gt;) {
+}>) {
   await flagsmith.init({
     environmentID: "${envId}",${
   Constants.isCustomFlagsmithUrl()
@@ -21,16 +21,16 @@ export default async function RootLayout({
   const serverState = flagsmith.getState();
 
   return (
-    &lt;html lang="en"&gt;
-      &lt;head&gt;
-        &lt;meta name="viewport" content="initial-scale=1, width=device-width" /&gt;
-      &lt;/head&gt;
-      &lt;body&gt;
-        &lt;FeatureFlagProvider serverState={serverState}&gt;
+    <html lang="en">
+      <head>
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
+      </head>
+      <body>
+        <FeatureFlagProvider serverState={serverState}>
           {children}
-        &lt;/FeatureFlagProvider&gt;
-      &lt;/body&gt;
-    &lt;/html&gt;
+        </FeatureFlagProvider>
+      </body>
+    </html>
   );
 }
 
@@ -48,13 +48,13 @@ export const FeatureFlagProvider = ({
 }: {
   serverState: IState;
   children: ReactNode;
-}) =&gt; {
+}) => {
   const flagsmithInstance = useRef(createFlagsmithInstance());
   
   return (
-    &lt;FlagsmithProvider flagsmith={flagsmithInstance.current} serverState={serverState}>
-      &lt;&gt;{children}&lt;/&gt;
-    &lt;/FlagsmithProvider&gt;
+    <FlagsmithProvider flagsmith={flagsmithInstance.current} serverState={serverState}>
+      <>{children}</>
+    </FlagsmithProvider>
   );
 };
 
@@ -69,6 +69,6 @@ export default function HomePage() {
   const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
   
   return (
-    &lt;&gt;{...}&lt;/&gt;
+    <>{...}</>
   );
 }`

--- a/frontend/common/code-help/init/init-next-pages-router.js
+++ b/frontend/common/code-help/init/init-next-pages-router.js
@@ -8,7 +8,7 @@ import { FlagsmithProvider } from '@flagsmith/flagsmith/react';
 
 export default function App({ Component, pageProps, flagsmithState } {
   return (
-    &lt;FlagsmithProvider
+    <FlagsmithProvider
       serverState={flagsmithState}
       options={{
         environmentID: "${envId}",${
@@ -17,9 +17,9 @@ export default function App({ Component, pageProps, flagsmithState } {
     : ''
 }
       }}
-      flagsmith={flagsmith}&gt;
-        &lt;Component {...pageProps} />
-    &lt;/FlagsmithProvider>
+      flagsmith={flagsmith}>
+        <Component {...pageProps} />
+    </FlagsmithProvider>
   );
 }
 
@@ -43,6 +43,6 @@ export default function HomePage() {
   const ${FEATURE_NAME} = flags.${FEATURE_NAME}.enabled
   const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
   return (
-    &lt;>{...}&lt;/>
+    <>{...}</>
   );
 }`

--- a/frontend/common/code-help/init/init-react.js
+++ b/frontend/common/code-help/init/init-react.js
@@ -3,13 +3,24 @@ import Constants from 'common/constants'
 export default (
   envId,
   { FEATURE_NAME, FEATURE_NAME_ALT, LIB_NAME, NPM_CLIENT },
-) => `// App root
-import ${LIB_NAME} from "${NPM_CLIENT}";
-import { FlagsmithProvider } from '@flagsmith/flagsmith/react';
+) => `import ${LIB_NAME} from "${NPM_CLIENT}";
+import { FlagsmithProvider, useFlags } from '${NPM_CLIENT}/react';
+
+export function HomePage() {
+  const flags = useFlags(['${FEATURE_NAME}','${FEATURE_NAME_ALT}']); // only causes re-render if specified flag values / traits change
+  const ${FEATURE_NAME} = flags.${FEATURE_NAME}.enabled
+  const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
+  return (
+    <>
+      {\`${FEATURE_NAME}: \${${FEATURE_NAME}}\`}
+      {\`${FEATURE_NAME_ALT}: \${${FEATURE_NAME_ALT}}\`}
+    </>
+  );
+}
 
 export default function App() {
   return (
-    &lt;FlagsmithProvider
+    <FlagsmithProvider
       options={{
         environmentID: '${envId}',${
   Constants.isCustomFlagsmithUrl()
@@ -17,21 +28,8 @@ export default function App() {
     : ''
 }
       }}
-      flagsmith={flagsmith}&gt;
-      {...Your app}
-    &lt;/FlagsmithProvider>
-  );
-}
-
-// Home Page
-import ${LIB_NAME} from '${NPM_CLIENT}';
-import { useFlags, useFlagsmith } from '${NPM_CLIENT}/react';
-
-export default function HomePage() {
-  const flags = useFlags(['${FEATURE_NAME}','${FEATURE_NAME_ALT}']); // only causes re-render if specified flag values / traits change
-  const ${FEATURE_NAME} = flags.${FEATURE_NAME}.enabled
-  const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
-  return (
-    &lt;>{...}&lt;/>
+      flagsmith={${LIB_NAME}}>
+      <HomePage />
+    </FlagsmithProvider>
   );
 }`

--- a/frontend/common/code-help/install/install-curl.js
+++ b/frontend/common/code-help/install/install-curl.js
@@ -1,5 +1,5 @@
-export default () => `You can access the API directly with tools like <a href="https://curl.haxx.se/">curl</a> or <a href='https://httpie.org/'>httpie</a>, 
+export default () => `You can access the API directly with tools like curl or httpie,
 or with clients for languages that we do not currently have SDKs for.
 
-You can view the API via Swagger at <a href="https://api.flagsmith.com/api/v1/docs/">https://api.flagsmith.com/api/v1/docs/</a>.
+You can view the API via Swagger at https://api.flagsmith.com/api/v1/docs/.
 `

--- a/frontend/common/code-help/install/install-dotnet.js
+++ b/frontend/common/code-help/install/install-dotnet.js
@@ -1,5 +1,3 @@
-import Utils from 'common/utils/utils'
-
 export default () => `// Package Manager
 PM> Install-Package Flagsmith -Version 4.0.0
 
@@ -7,7 +5,7 @@ PM> Install-Package Flagsmith -Version 4.0.0
 dotnet add package Flagsmith --version 4.0.0
 
 // PackageReference
-${Utils.escapeHtml('<PackageReference Include="Flagsmith" Version="4.0.0" />')}
+<PackageReference Include="Flagsmith" Version="4.0.0" />
 
 // Paket CLI
 paket add Flagsmith --version 4.0.0

--- a/frontend/common/code-help/install/install-flutter.js
+++ b/frontend/common/code-help/install/install-flutter.js
@@ -1,4 +1,4 @@
-export default () => `The client library is available from the <a href='https://pub.dev/packages/flagsmith'>https://pub.dev/packages/flagsmith</a>:
+export default () => `The client library is available from the https://pub.dev/packages/flagsmith:
 
 dependencies:
   flagsmith:

--- a/frontend/common/code-help/install/install-java.js
+++ b/frontend/common/code-help/install/install-java.js
@@ -1,11 +1,9 @@
-import Utils from 'common/utils/utils'
-
 export default () => `// Maven
-${Utils.escapeHtml('<dependency>')}
-    ${Utils.escapeHtml('<groupId>com.flagsmith</groupId>')}
-    ${Utils.escapeHtml('<artifactId>flagsmith-java-client</artifactId>')}
-    ${Utils.escapeHtml('<version>7.4.1</version>')}
-${Utils.escapeHtml('</dependency>')}
+<dependency>
+    <groupId>com.flagsmith</groupId>
+    <artifactId>flagsmith-java-client</artifactId>
+    <version>7.4.1</version>
+</dependency>
 
 // Gradle
 implementation 'com.flagsmith:flagsmith-java-client:7.4.1'

--- a/frontend/common/code-help/install/install-rust.js
+++ b/frontend/common/code-help/install/install-rust.js
@@ -1,2 +1,2 @@
 export default () =>
-  'The package can be found at <a href="https://crates.io/crates/flagsmith">https://crates.io/crates/flagsmith</a>;'
+  'The package can be found at https://crates.io/crates/flagsmith;'

--- a/frontend/common/code-help/traits/traits-next.js
+++ b/frontend/common/code-help/traits/traits-next.js
@@ -23,7 +23,7 @@ export default function HomePage() {
   };
 
   return (
-    &lt;>{...}&lt;/>
+    <>{...}</>
   );
 }
 
@@ -31,7 +31,7 @@ export default function HomePage() {
 
 export default function App({ Component, pageProps, flagsmithState } {
   return (
-    &lt;FlagsmithProvider
+    <FlagsmithProvider
       serverState={flagsmithState}
       options={{
         environmentID: "${envId}",${
@@ -40,9 +40,9 @@ export default function App({ Component, pageProps, flagsmithState } {
     : ''
 }
       }}
-      flagsmith={flagsmith}&gt;
-        &lt;Component {...pageProps} />
-    &lt;/FlagsmithProvider>
+      flagsmith={flagsmith}>
+        <Component {...pageProps} />
+    </FlagsmithProvider>
   );
 }
 

--- a/frontend/common/code-help/traits/traits-react.js
+++ b/frontend/common/code-help/traits/traits-react.js
@@ -10,7 +10,7 @@ import { FlagsmithProvider } from '${NPM_CLIENT}/react';
 
 export default function App() {
   return (
-    &lt;FlagsmithProvider
+    <FlagsmithProvider
       options={{
         environmentID: '${envId}',${
   Constants.isCustomFlagsmithUrl()
@@ -20,9 +20,9 @@ export default function App() {
         identity: '${userId || USER_ID}',
         traits: {${TRAIT_NAME}: 21},
       }}
-      flagsmith={flagsmith}&gt;
+      flagsmith={flagsmith}>
       {...Your app}
-    &lt;/FlagsmithProvider>
+    </FlagsmithProvider>
   );
 }
 
@@ -46,6 +46,6 @@ export default function HomePage() {
   };
 
   return (
-    &lt;>{...}&lt;/>
+    <>{...}</>
   );
 }`

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -180,12 +180,6 @@ const Utils = Object.assign({}, BaseUtils, {
     }
     return null
   },
-  escapeHtml(html: string) {
-    const text = document.createTextNode(html)
-    const p = document.createElement('p')
-    p.appendChild(text)
-    return p.innerHTML
-  },
   featureStateToValue(featureState: FeatureStateValue) {
     if (!featureState) {
       return null

--- a/frontend/web/components/CodeHelp.tsx
+++ b/frontend/web/components/CodeHelp.tsx
@@ -144,7 +144,6 @@ const SnippetItem: FC<SnippetItemProps> = ({
       />
       <Highlight
         forceExpanded
-        preventEscape
         className={
           Constants.codeHelp.keys[
             languageKey as keyof typeof Constants.codeHelp.keys

--- a/frontend/web/components/Highlight.js
+++ b/frontend/web/components/Highlight.js
@@ -134,7 +134,7 @@ class Highlight extends React.Component {
     }
 
     const raw = this.getRawHtml()
-    const html = this.props.preventEscape ? raw : escapeHtml(raw)
+    const html = escapeHtml(raw)
     return (
       <div className={this.state.expandable ? 'expandable' : ''}>
         <pre

--- a/frontend/web/components/integrations/mcp/MCPSnippet.tsx
+++ b/frontend/web/components/integrations/mcp/MCPSnippet.tsx
@@ -11,7 +11,7 @@ type MCPSnippetProps = {
 
 const MCPSnippet: FC<MCPSnippetProps> = ({ code, language = 'bash' }) => (
   <div className='hljs-container mt-2'>
-    <Highlight forceExpanded preventEscape className={language}>
+    <Highlight forceExpanded className={language}>
       {code}
     </Highlight>
     <div className='flex-column hljs-docs'>

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/sdkSnippets.ts
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/sdkSnippets.ts
@@ -1,11 +1,8 @@
 // Snippets for every SDK we support, sourced from the maintained
 // `Constants.codeHelp` (the same install/init the rest of the app uses, so
-// they don't drift). Two adaptations for this page:
-//   1. codeHelp snippets are authored for innerHTML rendering, so they carry
-//      HTML entities (&lt; etc.). We render via <Highlight> (escaping on), so
-//      we unescape first.
-//   2. They use a placeholder flag name; we swap it for the user's real flag,
-//      so the snippet references the flag this onboarding actually created.
+// they don't drift). One adaptation for this page: codeHelp uses a placeholder
+// flag name; we swap it for the user's real flag, so the snippet references
+// the flag this onboarding actually created.
 // The SDK list itself (labels, logos, codeHelp keys) lives in ./sdkLangs.
 import Constants from 'common/constants'
 import { SdkLang } from './sdkLangs'
@@ -13,14 +10,6 @@ import { SdkLang } from './sdkLangs'
 // Mirrors Constants' `keywords.FEATURE_NAME`. Kept local (keywords isn't
 // exported); if that placeholder ever changes, update this too.
 const PLACEHOLDER_FLAG = 'my_cool_feature'
-
-const unescapeHtml = (s: string): string =>
-  s
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#39;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, '&')
 
 export type SdkSnippet = {
   install: string
@@ -55,12 +44,12 @@ export const getSdkSnippet = (
     string,
     string
   >
-  const wire = unescapeHtml(inits[lang.initKey ?? lang.codeHelpKey] ?? '')
+  const wire = (inits[lang.initKey ?? lang.codeHelpKey] ?? '')
     .split(PLACEHOLDER_FLAG)
     .join(featureName)
   return {
     language: lang.language,
-    ...parseInstall(unescapeHtml(installs[lang.codeHelpKey] ?? '')),
+    ...parseInstall(installs[lang.codeHelpKey] ?? ''),
     wire: wire.trim(),
   }
 }


### PR DESCRIPTION
> **Reviewing this:** The bug: Copy Code put HTML entities (`&lt;`) in the clipboard, because snippet sources were pre-escaped and rendered as raw HTML. Now `Highlight` escapes everything it renders, once, and the sources are real code. Start with `Highlight.js` (one line); the snippet files are a mechanical entity-to-bracket swap, safe to skim. The two installs (Java, .NET) are the subtle ones: they escaped at runtime, not in the source.

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Split out of #8023 to keep that PR to theming only.

Copy Code was shipping HTML entities (`&lt;FlagsmithProvider`) to the clipboard: snippet sources were pre-escaped because `CodeHelp` rendered them as raw HTML. Escape centrally in `Highlight` instead.

- Snippet sources store real `< >` (literal entities removed; Java/.NET drop their runtime `Utils.escapeHtml`); `Highlight` always escapes at render, `preventEscape` is gone.
- Copy Code now pastes working code; rendering is unchanged from main.
- The onboarding card's unescape workaround is dead and removed.
- The prose install notes (curl, Flutter, Rust) drop their `<a>` tags: the links were already dead on prod (the highlighter strips them) and would have shown as raw markup here; same text, no markup.

## How did you test this code?

- [ ] Features page → SDK integration snippet: React shows `<FlagsmithProvider>`, Java shows the Maven `<dependency>` XML, .NET shows `<PackageReference>` (not `&lt;`)
- [ ] Copy Code on the React and Java snippets, paste into an editor: real brackets, working code
- [ ] Onboarding `/getting-started` (behind ff `onboarding_quickstart_flow`): code cards render and copy clean
- [ ] MCP integration page: config snippet renders unchanged
- [ ] Install snippets for curl, Flutter and Rust: prose renders without `<a href>` markup, same text as prod
- [ ] Flag value editor: a value containing `< >` still edits and renders (path unchanged, quick sanity)

`lint` + `typecheck` pass.

## Screenshots

| | Before (main) | After |
|---|---|---|
| Java SDK snippet on screen | | |
| React snippet pasted into an editor | | |

