### PR TITLE
Add audit logs for project creation and deletion

### DIFF
--- a/api/audit/constants.py
+++ b/api/audit/constants.py
@@ -81,3 +81,5 @@ PHASED_ROLLOUT_STATE_CREATED_MESSAGE = (
     "Phased rollout created for feature: %s by release pipeline: %s (stage: %s)"
 )
 PHASED_ROLLOUT_STATE_UPDATED_MESSAGE = "Phased rollout split changed from '%s%%' to '%s%%' for feature '%s' by release pipeline '%s' (stage: '%s')"
+PROJECT_CREATED_MESSAGE = "New Project created: %s"
+PROJECT_DELETED_MESSAGE = "Project deleted: %s"

--- a/api/audit/related_object_type.py
+++ b/api/audit/related_object_type.py
@@ -15,3 +15,5 @@ class RelatedObjectType(enum.Enum):
     WAREHOUSE_CONNECTION = "Warehouse connection"
     EXPERIMENT = "Experiment"
     METRIC = "Metric"
+    PROJECT = "project"
+    

--- a/api/audit/related_object_type.py
+++ b/api/audit/related_object_type.py
@@ -16,4 +16,3 @@ class RelatedObjectType(enum.Enum):
     EXPERIMENT = "Experiment"
     METRIC = "Metric"
     PROJECT = "project"
-    

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -49,7 +49,9 @@ from projects.serializers import (
     ProjectUpdateSerializer,
 )
 from users.models import FFAdminUser
-
+from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
+from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
 
 @method_decorator(
     name="retrieve",
@@ -110,7 +112,23 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             UserProjectPermission.objects.create(  # type: ignore[misc]
                 user=self.request.user, project=project, admin=True
             )
-
+        AuditLog.objects.create(
+            project=project,
+            author=self.request.user if not getattr(self.request.user,"is_master_api_key_user",False) else None,
+            related_object_id=project.id,
+            related_object_type=RelatedObjectType.PROJECT.name,
+            log=PROJECT_CREATED_MESSAGE % project.name
+        )
+    
+    def perform_destroy(self, instance):
+         AuditLog.objects.create(
+            project=instance,
+            author=self.request.user if not getattr(self.request.user,"is_master_api_key_user",False) else None,
+            related_object_id=instance.id,
+            related_object_type=RelatedObjectType.PROJECT.name,
+            log=PROJECT_DELETED_MESSAGE % instance.name
+        )
+         instance.delete()
     @action(
         detail=False,
         url_path=r"get-by-uuid/(?P<uuid>[0-9a-f-]+)",

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -122,7 +122,7 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         AuditLog.objects.create(
             project=project,
             author=None if is_master_api_key_user else self.request.user,
-            master_api_key=self.request.user.key if is_master_api_key_user else None,  # type: ignore[union-attr]
+            master_api_key=getattr(self.request.user, "key", None) if is_master_api_key_user else None,
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_CREATED_MESSAGE % project.name,
@@ -136,9 +136,7 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             AuditLog.objects.create(
                 project=None,
                 author=None if is_master_api_key_user else self.request.user,
-                master_api_key=self.request.user.key
-                if is_master_api_key_user
-                else None,  # type: ignore[union-attr]
+                master_api_key=getattr(self.request.user, "key", None) if is_master_api_key_user else None, 
                 related_object_id=instance.id,
                 related_object_type=RelatedObjectType.PROJECT.name,
                 log=PROJECT_DELETED_MESSAGE % instance.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -15,6 +15,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from django.db import transaction
 
 from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
 from audit.models import AuditLog
@@ -124,18 +125,19 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         )
 
     def perform_destroy(self, instance):
-        is_master_api_key_user = getattr(
-            self.request.user, "is_master_api_key_user", False
-        )
-        AuditLog.objects.create(
-            project=instance,
-            author=None if is_master_api_key_user else self.request.user,
-            master_api_key=self.request.user.key if is_master_api_key_user else None,
-            related_object_id=instance.id,
-            related_object_type=RelatedObjectType.PROJECT.name,
-            log=PROJECT_DELETED_MESSAGE % instance.name,
-        )
-        instance.delete()
+        with transaction.atomic():
+            is_master_api_key_user = getattr(
+                self.request.user, "is_master_api_key_user", False
+            )
+            AuditLog.objects.create(
+                project=instance,
+                author=None if is_master_api_key_user else self.request.user,
+                master_api_key=self.request.user.key if is_master_api_key_user else None,
+                related_object_id=instance.id,
+                related_object_type=RelatedObjectType.PROJECT.name,
+                log=PROJECT_DELETED_MESSAGE % instance.name,
+            )
+            instance.delete()
 
     @action(
         detail=False,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import typing
+
 from common.projects.permissions import (
     TAG_SUPPORTED_PERMISSIONS,
     VIEW_PROJECT,
@@ -16,7 +18,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-import typing
+
 from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
@@ -120,7 +122,7 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         AuditLog.objects.create(
             project=project,
             author=None if is_master_api_key_user else self.request.user,
-            master_api_key=self.request.user.key if is_master_api_key_user else None, # type: ignore[union-attr]
+            master_api_key=self.request.user.key if is_master_api_key_user else None,  # type: ignore[union-attr]
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_CREATED_MESSAGE % project.name,
@@ -134,7 +136,9 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             AuditLog.objects.create(
                 project=None,
                 author=None if is_master_api_key_user else self.request.user,
-                master_api_key=self.request.user.key if is_master_api_key_user else None,  # type: ignore[union-attr]
+                master_api_key=self.request.user.key
+                if is_master_api_key_user
+                else None,  # type: ignore[union-attr]
                 related_object_id=instance.id,
                 related_object_type=RelatedObjectType.PROJECT.name,
                 log=PROJECT_DELETED_MESSAGE % instance.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -6,6 +6,7 @@ from common.projects.permissions import (
     VIEW_PROJECT,
 )
 from django.conf import settings
+from django.db import transaction
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
@@ -15,7 +16,6 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from django.db import transaction
 
 from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
 from audit.models import AuditLog
@@ -132,7 +132,9 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             AuditLog.objects.create(
                 project=instance,
                 author=None if is_master_api_key_user else self.request.user,
-                master_api_key=self.request.user.key if is_master_api_key_user else None,
+                master_api_key=self.request.user.key
+                if is_master_api_key_user
+                else None,
                 related_object_id=instance.id,
                 related_object_type=RelatedObjectType.PROJECT.name,
                 log=PROJECT_DELETED_MESSAGE % instance.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -124,7 +124,9 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         )
 
     def perform_destroy(self, instance):
-        is_master_api_key_user = getattr(self.request.user, "is_master_api_key_user", False)
+        is_master_api_key_user = getattr(
+            self.request.user, "is_master_api_key_user", False
+        )
         AuditLog.objects.create(
             project=instance,
             author=None if is_master_api_key_user else self.request.user,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -16,7 +16,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-
+import typing
 from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
@@ -120,13 +120,13 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         AuditLog.objects.create(
             project=project,
             author=None if is_master_api_key_user else self.request.user,
-            master_api_key=self.request.user.key if is_master_api_key_user else None,
+            master_api_key=self.request.user.key if is_master_api_key_user else None, # type: ignore[union-attr]
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_CREATED_MESSAGE % project.name,
         )
 
-    def perform_destroy(self, instance):
+    def perform_destroy(self, instance: typing.Any) -> None:
         with transaction.atomic():
             is_master_api_key_user = getattr(
                 self.request.user, "is_master_api_key_user", False
@@ -134,9 +134,7 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             AuditLog.objects.create(
                 project=None,
                 author=None if is_master_api_key_user else self.request.user,
-                master_api_key=self.request.user.key
-                if is_master_api_key_user
-                else None,
+                master_api_key=self.request.user.key if is_master_api_key_user else None,  # type: ignore[union-attr]
                 related_object_id=instance.id,
                 related_object_type=RelatedObjectType.PROJECT.name,
                 log=PROJECT_DELETED_MESSAGE % instance.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -116,9 +116,8 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             )
         AuditLog.objects.create(
             project=project,
-            author=self.request.user
-            if not getattr(self.request.user, "is_master_api_key_user", False)
-            else None,
+            author=None if is_master_api_key_user else self.request.user,
+            master_api_key=self.request.user.key if is_master_api_key_user else None,            else None,
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_CREATED_MESSAGE % project.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -124,11 +124,11 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         )
 
     def perform_destroy(self, instance):
+        is_master_api_key_user = getattr(self.request.user, "is_master_api_key_user", False)
         AuditLog.objects.create(
             project=instance,
-            author=self.request.user
-            if not getattr(self.request.user, "is_master_api_key_user", False)
-            else None,
+            author=None if is_master_api_key_user else self.request.user,
+            master_api_key=self.request.user.key if is_master_api_key_user else None,
             related_object_id=instance.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_DELETED_MESSAGE % instance.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -110,6 +110,9 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
 
     def perform_create(self, serializer):  # type: ignore[no-untyped-def]
         project = serializer.save()
+        is_master_api_key_user = getattr(
+            self.request.user, "is_master_api_key_user", False
+        )
         if getattr(self.request.user, "is_master_api_key_user", False) is False:
             UserProjectPermission.objects.create(  # type: ignore[misc]
                 user=self.request.user, project=project, admin=True

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -122,7 +122,9 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         AuditLog.objects.create(
             project=project,
             author=None if is_master_api_key_user else self.request.user,
-            master_api_key=getattr(self.request.user, "key", None) if is_master_api_key_user else None,
+            master_api_key=getattr(self.request.user, "key", None)
+            if is_master_api_key_user
+            else None,
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_CREATED_MESSAGE % project.name,
@@ -136,7 +138,9 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             AuditLog.objects.create(
                 project=None,
                 author=None if is_master_api_key_user else self.request.user,
-                master_api_key=getattr(self.request.user, "key", None) if is_master_api_key_user else None, 
+                master_api_key=getattr(self.request.user, "key", None)
+                if is_master_api_key_user
+                else None,
                 related_object_id=instance.id,
                 related_object_type=RelatedObjectType.PROJECT.name,
                 log=PROJECT_DELETED_MESSAGE % instance.name,

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -132,7 +132,7 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
                 self.request.user, "is_master_api_key_user", False
             )
             AuditLog.objects.create(
-                project=instance,
+                project=None,
                 author=None if is_master_api_key_user else self.request.user,
                 master_api_key=self.request.user.key
                 if is_master_api_key_user

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -16,6 +16,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
+from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
 from environments.dynamodb.migrator import IdentityMigrator
 from environments.identities.models import Identity
 from environments.serializers import EnvironmentSerializerLight
@@ -49,9 +52,7 @@ from projects.serializers import (
     ProjectUpdateSerializer,
 )
 from users.models import FFAdminUser
-from audit.models import AuditLog
-from audit.related_object_type import RelatedObjectType
-from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
+
 
 @method_decorator(
     name="retrieve",
@@ -114,21 +115,26 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             )
         AuditLog.objects.create(
             project=project,
-            author=self.request.user if not getattr(self.request.user,"is_master_api_key_user",False) else None,
+            author=self.request.user
+            if not getattr(self.request.user, "is_master_api_key_user", False)
+            else None,
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
-            log=PROJECT_CREATED_MESSAGE % project.name
+            log=PROJECT_CREATED_MESSAGE % project.name,
         )
-    
+
     def perform_destroy(self, instance):
-         AuditLog.objects.create(
+        AuditLog.objects.create(
             project=instance,
-            author=self.request.user if not getattr(self.request.user,"is_master_api_key_user",False) else None,
+            author=self.request.user
+            if not getattr(self.request.user, "is_master_api_key_user", False)
+            else None,
             related_object_id=instance.id,
             related_object_type=RelatedObjectType.PROJECT.name,
-            log=PROJECT_DELETED_MESSAGE % instance.name
+            log=PROJECT_DELETED_MESSAGE % instance.name,
         )
-         instance.delete()
+        instance.delete()
+
     @action(
         detail=False,
         url_path=r"get-by-uuid/(?P<uuid>[0-9a-f-]+)",

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -117,7 +117,7 @@ class ProjectViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         AuditLog.objects.create(
             project=project,
             author=None if is_master_api_key_user else self.request.user,
-            master_api_key=self.request.user.key if is_master_api_key_user else None,            else None,
+            master_api_key=self.request.user.key if is_master_api_key_user else None,
             related_object_id=project.id,
             related_object_type=RelatedObjectType.PROJECT.name,
             log=PROJECT_CREATED_MESSAGE % project.name,

--- a/api/tests/integration/audit/test_audit_logs.py
+++ b/api/tests/integration/audit/test_audit_logs.py
@@ -28,7 +28,6 @@ def _subscription_metadata(mocker: MockerFixture) -> None:
         return_value=metadata,
     )
 
-
 def test_list_audit_logs__with_project_filter__makes_expected_queries(  # type: ignore[no-untyped-def]
     admin_client,
     project,
@@ -46,9 +45,8 @@ def test_list_audit_logs__with_project_filter__makes_expected_queries(  # type: 
 
     # Then
     assert res.status_code == status.HTTP_200_OK
-    assert res.json()["count"] == 3
-
-
+    assert res.json()["count"] == 4
+    
 def test_retrieve_audit_log__environment_change__includes_change_details(
     admin_client: APIClient,
     project: int,
@@ -363,7 +361,7 @@ def test_retrieve_audit_log__segment_override_created_and_deleted__includes_chan
     get_audit_logs_response_2 = admin_client.get(get_audit_logs_url)
     assert get_audit_logs_response_2.status_code == status.HTTP_200_OK
     results = get_audit_logs_response_2.json()["results"]
-    assert len(results) == 5
+    assert len(results) == 6
 
     # and the first one in the list should be for the deletion of the segment override
     delete_override_audit_log_id = results[0]["id"]
@@ -383,7 +381,7 @@ def test_retrieve_audit_log__segment_override_created_and_deleted__includes_chan
     # now let's check that we have some information about the change
     assert delete_override_audit_log_details["change_type"] == "DELETE"
     assert delete_override_audit_log_details["change_details"] == []
-
+    
 
 def test_retrieve_audit_log__segment_override_created_for_feature_value__includes_change_details(
     admin_client: APIClient,
@@ -421,9 +419,9 @@ def test_retrieve_audit_log__segment_override_created_for_feature_value__include
 
     # and we should only have one audit log in the list related to the segment override
     # (since the FeatureState hasn't changed)
-    # 1 for creating the feature + 1 for creating the environment + 1 for creating the segment
-    # + 1 for the segment override = 4
-    assert len(results) == 4
+    # 1 for creating the project + 1 for creating the feature + 1 for creating the environment + 1 for creating the segment
+    # + 1 for the segment override = 5
+    assert len(results) == 5
 
     # the first audit log in the list (i.e. most recent) should be the one that we want
     audit_log_id = results[0]["id"]
@@ -440,3 +438,4 @@ def test_retrieve_audit_log__segment_override_created_for_feature_value__include
     assert audit_log_details["change_details"] == [
         {"field": "string_value", "old": "default_value", "new": "foo"},
     ]
+    

--- a/api/tests/integration/audit/test_audit_logs.py
+++ b/api/tests/integration/audit/test_audit_logs.py
@@ -28,6 +28,7 @@ def _subscription_metadata(mocker: MockerFixture) -> None:
         return_value=metadata,
     )
 
+
 def test_list_audit_logs__with_project_filter__makes_expected_queries(  # type: ignore[no-untyped-def]
     admin_client,
     project,
@@ -46,7 +47,8 @@ def test_list_audit_logs__with_project_filter__makes_expected_queries(  # type: 
     # Then
     assert res.status_code == status.HTTP_200_OK
     assert res.json()["count"] == 4
-    
+
+
 def test_retrieve_audit_log__environment_change__includes_change_details(
     admin_client: APIClient,
     project: int,
@@ -381,7 +383,7 @@ def test_retrieve_audit_log__segment_override_created_and_deleted__includes_chan
     # now let's check that we have some information about the change
     assert delete_override_audit_log_details["change_type"] == "DELETE"
     assert delete_override_audit_log_details["change_details"] == []
-    
+
 
 def test_retrieve_audit_log__segment_override_created_for_feature_value__includes_change_details(
     admin_client: APIClient,
@@ -438,4 +440,3 @@ def test_retrieve_audit_log__segment_override_created_for_feature_value__include
     assert audit_log_details["change_details"] == [
         {"field": "string_value", "old": "default_value", "new": "foo"},
     ]
-    

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1074,7 +1074,9 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
     assert response.json()[0]["enforce_feature_owners"] is False
 
 
-def test_create_project__valid_request__creates_audit_log(admin_client, organisation) -> None:
+def test_create_project__valid_request__creates_audit_log(
+    admin_client, organisation
+) -> None:
     # Given
     url = reverse("api-v1:projects:project-list")
     project_name = "New Audit Log Project"
@@ -1095,7 +1097,7 @@ def test_create_project__valid_request__creates_audit_log(admin_client, organisa
     assert audit_log.project_id == response.data["id"]
 
 
-def test_delete_project__valid_request__creates_audit_log (
+def test_delete_project__valid_request__creates_audit_log(
     admin_client, project, organisation
 ) -> None:
     # Given

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1095,9 +1095,9 @@ def test_create_project__valid_request__creates_audit_log(admin_client, organisa
     assert audit_log.project_id == response.data["id"]
 
 
-def test_delete_project__valid_request__creates_audit_log -> None(
+def test_delete_project__valid_request__creates_audit_log (
     admin_client, project, organisation
-):
+) -> None:
     # Given
     url = reverse("api-v1:projects:project-detail", args=[project.id])
     project_name = project.name

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1112,3 +1112,4 @@ def test_delete_project_creates_audit_log(admin_client, project, organisation):
     audit_log = AuditLog.objects.order_by("-created_date").first()
     assert audit_log.related_object_type == RelatedObjectType.PROJECT.name
     assert audit_log.log == PROJECT_DELETED_MESSAGE % project_name
+    assert audit_log.related_object_id == project.id

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1075,7 +1075,7 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
 
 
 def test_create_project__valid_request__creates_audit_log(
-    admin_client, organisation
+    admin_client: APIClient, organisation: Organisation
 ) -> None:
     # Given
     url = reverse("api-v1:projects:project-list")
@@ -1098,7 +1098,7 @@ def test_create_project__valid_request__creates_audit_log(
 
 
 def test_delete_project__valid_request__creates_audit_log(
-    admin_client, project, organisation
+    admin_client: APIClient, project: Project, organisation: Organisation
 ) -> None:
     # Given
     url = reverse("api-v1:projects:project-detail", args=[project.id])
@@ -1117,3 +1117,4 @@ def test_delete_project__valid_request__creates_audit_log(
     assert audit_log.related_object_type == RelatedObjectType.PROJECT.name
     assert audit_log.log == PROJECT_DELETED_MESSAGE % project_name
     assert audit_log.related_object_id == project.id
+    

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1,6 +1,8 @@
 import json
 from datetime import timedelta
-
+from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
+from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
 import pytest
 from common.projects.permissions import (
     CREATE_ENVIRONMENT,
@@ -1069,3 +1071,43 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
     assert len(response.json()) > 0
     assert "enforce_feature_owners" in response.json()[0]
     assert response.json()[0]["enforce_feature_owners"] is False
+    
+    
+def test_create_project_creates_audit_log(admin_client, organisation):
+    # Given
+    url = reverse("api-v1:projects:project-list")
+    project_name = "New Audit Log Project"
+    data = {"name": project_name, "organisation": organisation.id}
+    initial_audit_log_count = AuditLog.objects.count()
+
+    # When
+    response = admin_client.post(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert AuditLog.objects.count() == initial_audit_log_count + 1
+    
+    # Verify the audit log details
+    audit_log = AuditLog.objects.order_by("-created_date").first()
+    assert audit_log.related_object_type == RelatedObjectType.PROJECT.name
+    assert audit_log.log == PROJECT_CREATED_MESSAGE % project_name
+    assert audit_log.project_id == response.data["id"]
+
+
+def test_delete_project_creates_audit_log(admin_client, project, organisation):
+    # Given
+    url = reverse("api-v1:projects:project-detail", args=[project.id])
+    project_name = project.name
+    initial_audit_log_count = AuditLog.objects.count()
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert AuditLog.objects.count() == initial_audit_log_count + 1
+    
+    # Verify the audit log details
+    audit_log = AuditLog.objects.order_by("-created_date").first()
+    assert audit_log.related_object_type == RelatedObjectType.PROJECT.name
+    assert audit_log.log == PROJECT_DELETED_MESSAGE % project_name

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1074,7 +1074,7 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
     assert response.json()[0]["enforce_feature_owners"] is False
 
 
-def test_create_project_creates_audit_log(admin_client, organisation):
+def test_create_project__valid_request__creates_audit_log(admin_client, organisation):
     # Given
     url = reverse("api-v1:projects:project-list")
     project_name = "New Audit Log Project"
@@ -1095,7 +1095,9 @@ def test_create_project_creates_audit_log(admin_client, organisation):
     assert audit_log.project_id == response.data["id"]
 
 
-def test_delete_project_creates_audit_log(admin_client, project, organisation):
+def test_delete_project__valid_request__creates_audit_log(
+    admin_client, project, organisation
+):
     # Given
     url = reverse("api-v1:projects:project-detail", args=[project.id])
     project_name = project.name

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1074,7 +1074,7 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
     assert response.json()[0]["enforce_feature_owners"] is False
 
 
-def test_create_project__valid_request__creates_audit_log(admin_client, organisation):
+def test_create_project__valid_request__creates_audit_log(admin_client, organisation) -> None:
     # Given
     url = reverse("api-v1:projects:project-list")
     project_name = "New Audit Log Project"
@@ -1095,7 +1095,7 @@ def test_create_project__valid_request__creates_audit_log(admin_client, organisa
     assert audit_log.project_id == response.data["id"]
 
 
-def test_delete_project__valid_request__creates_audit_log(
+def test_delete_project__valid_request__creates_audit_log -> None(
     admin_client, project, organisation
 ):
     # Given

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1117,4 +1117,3 @@ def test_delete_project__valid_request__creates_audit_log(
     assert audit_log.related_object_type == RelatedObjectType.PROJECT.name
     assert audit_log.log == PROJECT_DELETED_MESSAGE % project_name
     assert audit_log.related_object_id == project.id
-    

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1,8 +1,6 @@
 import json
 from datetime import timedelta
-from audit.models import AuditLog
-from audit.related_object_type import RelatedObjectType
-from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
+
 import pytest
 from common.projects.permissions import (
     CREATE_ENVIRONMENT,
@@ -19,6 +17,9 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from task_processor.task_run_method import TaskRunMethod
 
+from audit.constants import PROJECT_CREATED_MESSAGE, PROJECT_DELETED_MESSAGE
+from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
 from environments.dynamodb.types import ProjectIdentityMigrationStatus
 from environments.identities.models import Identity
 from features.models import Feature, FeatureSegment
@@ -1071,8 +1072,8 @@ def test_list_projects__default_enforce_feature_owners__returns_false(
     assert len(response.json()) > 0
     assert "enforce_feature_owners" in response.json()[0]
     assert response.json()[0]["enforce_feature_owners"] is False
-    
-    
+
+
 def test_create_project_creates_audit_log(admin_client, organisation):
     # Given
     url = reverse("api-v1:projects:project-list")
@@ -1086,7 +1087,7 @@ def test_create_project_creates_audit_log(admin_client, organisation):
     # Then
     assert response.status_code == status.HTTP_201_CREATED
     assert AuditLog.objects.count() == initial_audit_log_count + 1
-    
+
     # Verify the audit log details
     audit_log = AuditLog.objects.order_by("-created_date").first()
     assert audit_log.related_object_type == RelatedObjectType.PROJECT.name
@@ -1106,7 +1107,7 @@ def test_delete_project_creates_audit_log(admin_client, project, organisation):
     # Then
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert AuditLog.objects.count() == initial_audit_log_count + 1
-    
+
     # Verify the audit log details
     audit_log = AuditLog.objects.order_by("-created_date").first()
     assert audit_log.related_object_type == RelatedObjectType.PROJECT.name


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7571 

- Added `PROJECT_CREATED_MESSAGE` and `PROJECT_DELETED_MESSAGE` constants in `api/audit/constants.py`.
- Updated `ProjectViewSet.perform_create` and `perform_destroy` in `api/projects/views.py` to automatically record an `AuditLog` entry upon project creation and deletion.
- Added comprehensive unit tests in `api/tests/unit/projects/test_unit_projects_views.py` to verify audit log generation for both actions.

## How did you test this code?

Ran unit tests locally using `pytest` with the test Django settings and verified that all test cases passed successfully, confirming proper audit log count, message formatting, and object relationship mapping.