### PR TITLE
fix(organisations): Treat self-hosted licence as paid

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -115,8 +115,15 @@ class Organisation(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
             self.subscription_information_cache
         )
 
+    def has_enterprise_licence(self) -> bool:
+        return is_enterprise() and hasattr(self, "licence")
+
     @property
     def is_paid(self):  # type: ignore[no-untyped-def]
+        # A self-hosted licence is the entitlement in its own right; it has no
+        # billing provider, so there is no subscription_id to check.
+        if self.has_enterprise_licence():
+            return True
         return (
             self.has_paid_subscription() and self.subscription.cancellation_date is None
         )
@@ -443,7 +450,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         return cb_metadata
 
     def _get_subscription_metadata_for_self_hosted(self) -> BaseSubscriptionMetadata:
-        if is_enterprise() and hasattr(self.organisation, "licence"):
+        if self.organisation.has_enterprise_licence():
             licence_information = self.organisation.licence.get_licence_information()
             return BaseSubscriptionMetadata(
                 seats=licence_information.num_seats,

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -377,6 +377,26 @@ def test_is_paid__cancelled_subscription__returns_false(  # type: ignore[no-unty
     assert organisation.is_paid is False
 
 
+def test_is_paid__self_hosted_licence__returns_true(
+    organisation: Organisation,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    # A self-hosted licence grants is_paid on its own, without a billing id.
+    mocker.patch.object(
+        Organisation,
+        "licence",
+        new_callable=mocker.PropertyMock,
+        return_value=mocker.Mock(),
+        create=True,
+    )
+    mocker.patch("organisations.models.is_enterprise", return_value=True)
+
+    # When / Then
+    assert organisation.subscription.subscription_id is None
+    assert organisation.is_paid is True
+
+
 def test_get_subscription_metadata__chargebee_subscription__returns_chargebee_metadata(  # type: ignore[no-untyped-def]
     organisation: Organisation,
     mocker: MockerFixture,

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -377,24 +377,64 @@ def test_is_paid__cancelled_subscription__returns_false(  # type: ignore[no-unty
     assert organisation.is_paid is False
 
 
-def test_is_paid__self_hosted_licence__returns_true(
+@pytest.fixture
+def self_hosted_licenced_organisation(
     organisation: Organisation,
     mocker: MockerFixture,
-) -> None:
-    # Given
-    # A self-hosted licence grants is_paid on its own, without a billing id.
+) -> Organisation:
+    # A self-hosted enterprise licence: enterprise plan, no billing provider
+    # (so no subscription_id), and entitlements sourced from the licence.
+    organisation.subscription.plan = "enterprise"
+    organisation.subscription.save()
+
+    licence = mocker.Mock()
+    licence.get_licence_information.return_value = mocker.Mock(
+        num_seats=3,
+        num_projects=5,
+    )
     mocker.patch.object(
         Organisation,
         "licence",
         new_callable=mocker.PropertyMock,
-        return_value=mocker.Mock(),
+        return_value=licence,
         create=True,
     )
     mocker.patch("organisations.models.is_enterprise", return_value=True)
+    mocker.patch("organisations.models.is_saas", return_value=False)
+    return organisation
 
-    # When / Then
-    assert organisation.subscription.subscription_id is None
-    assert organisation.is_paid is True
+
+def test_is_paid__self_hosted_licence__returns_true(
+    self_hosted_licenced_organisation: Organisation,
+) -> None:
+    # Given a self-hosted licenced organisation
+    # When we read its paid status
+    # Then it is paid despite having no billing subscription_id
+    assert self_hosted_licenced_organisation.subscription.subscription_id is None
+    assert self_hosted_licenced_organisation.is_paid is True
+
+
+def test_has_enterprise_subscription__self_hosted_licence__returns_true(
+    self_hosted_licenced_organisation: Organisation,
+) -> None:
+    # Given a self-hosted licenced organisation
+    # When we check the enterprise entitlement gate
+    # Then it is granted
+    assert self_hosted_licenced_organisation.has_enterprise_subscription() is True
+
+
+def test_get_subscription_metadata__self_hosted_licence__uses_licence_limits(
+    self_hosted_licenced_organisation: Organisation,
+) -> None:
+    # Given a self-hosted licenced organisation
+    # When we read its subscription metadata
+    metadata = (
+        self_hosted_licenced_organisation.subscription.get_subscription_metadata()
+    )
+
+    # Then the limits come from the licence, not a billing subscription
+    assert metadata.seats == 3
+    assert metadata.projects == 5
 
 
 def test_get_subscription_metadata__chargebee_subscription__returns_chargebee_metadata(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`is_paid` required a billing `subscription_id`, which a licence never sets, so `has_enterprise_subscription` returned `False` and SCIM/SAML/RBAC 403'd for licensed self-hosted enterprises.

Recognise a licence as a paid entitlement via a shared `has_enterprise_licence()`.

## How did you test this code?

```shell
make test
``` 