### PR TITLE
feat(experimentation): enable Firehose CloudWatch error logging

### DIFF
--- a/api/experimentation/ingestion_infra_service.py
+++ b/api/experimentation/ingestion_infra_service.py
@@ -47,6 +47,10 @@ OBJECT_EXPIRATION_DAYS = 30
 # be attributed per organisation.
 ORGANISATION_TAG_KEY = "organisation_id"
 
+# Firehose writes delivery failures to this CloudWatch log group and stream.
+LOG_GROUP_NAME_PREFIX = "/aws/kinesisfirehose/"
+LOG_STREAM_NAME = "DestinationDelivery"
+
 
 def _add_account_regional_namespace_header(
     params: dict[str, Any],
@@ -73,6 +77,11 @@ def _get_firehose_client() -> "Any":
 
 
 @lru_cache(maxsize=1)
+def _get_logs_client() -> "Any":
+    return boto3.client("logs", region_name=AWS_REGION)
+
+
+@lru_cache(maxsize=1)
 def _get_account_id() -> str:
     sts = boto3.client("sts", region_name=AWS_REGION)
     return sts.get_caller_identity()["Account"]  # type: ignore[no-any-return]
@@ -84,6 +93,10 @@ def get_bucket_name(organisation_id: int) -> str:
 
 def get_stream_name(organisation_id: int) -> str:
     return f"{STREAM_NAME_PREFIX}{organisation_id}"
+
+
+def get_log_group_name(organisation_id: int) -> str:
+    return f"{LOG_GROUP_NAME_PREFIX}{get_stream_name(organisation_id)}"
 
 
 def _create_events_bucket(bucket_name: str, *, organisation_id: int) -> None:
@@ -127,12 +140,20 @@ def _create_events_bucket(bucket_name: str, *, organisation_id: int) -> None:
     )
 
 
-def _expected_destination_configuration(bucket_name: str) -> dict[str, Any]:
+def _expected_destination_configuration(
+    bucket_name: str,
+    log_group_name: str,
+) -> dict[str, Any]:
     return {
         "RoleARN": settings.INGESTION_FIREHOSE_DELIVERY_ROLE_ARN,
         "BucketARN": f"arn:aws:s3:::{bucket_name}",
         "Prefix": EVENTS_PREFIX,
         "ErrorOutputPrefix": ERRORS_PREFIX,
+        "CloudWatchLoggingOptions": {
+            "Enabled": True,
+            "LogGroupName": log_group_name,
+            "LogStreamName": LOG_STREAM_NAME,
+        },
         "BufferingHints": {
             "SizeInMBs": BUFFERING_SIZE_MB,
             "IntervalInSeconds": BUFFERING_INTERVAL_SECONDS,
@@ -175,11 +196,19 @@ def _create_delivery_stream(
     bucket_name: str,
     organisation_id: int,
 ) -> None:
+    log_group_name = get_log_group_name(organisation_id)
+    logs = _get_logs_client()
+    logs.create_log_group(logGroupName=log_group_name)
+    logs.create_log_stream(
+        logGroupName=log_group_name,
+        logStreamName=LOG_STREAM_NAME,
+    )
     _get_firehose_client().create_delivery_stream(
         DeliveryStreamName=stream_name,
         DeliveryStreamType="DirectPut",
         ExtendedS3DestinationConfiguration=_expected_destination_configuration(
-            bucket_name
+            bucket_name,
+            log_group_name,
         ),
         Tags=[{"Key": ORGANISATION_TAG_KEY, "Value": str(organisation_id)}],
     )
@@ -221,12 +250,14 @@ def _delete_events_bucket(bucket_name: str) -> None:
 def deprovision_ingestion_infrastructure(organisation_id: int) -> None:
     bucket_name = get_bucket_name(organisation_id)
     stream_name = get_stream_name(organisation_id)
+    log_group_name = get_log_group_name(organisation_id)
 
     _get_firehose_client().delete_delivery_stream(
         DeliveryStreamName=stream_name,
         AllowForceDelete=True,
     )
     _delete_events_bucket(bucket_name)
+    _get_logs_client().delete_log_group(logGroupName=log_group_name)
     logger.info(
         "ingestion_infra.deprovisioned",
         organisation__id=organisation_id,

--- a/api/tests/unit/experimentation/test_ingestion_infra_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_infra_service.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 from django.core.exceptions import ImproperlyConfigured
 from moto import (  # type: ignore[import-untyped]
     mock_firehose,
+    mock_logs,
     mock_s3,
     mock_sts,
 )
@@ -29,13 +30,14 @@ def ingestion_infra_settings(settings: SettingsWrapper) -> SettingsWrapper:
 def _clear_client_caches() -> None:
     ingestion_infra_service._get_s3_client.cache_clear()
     ingestion_infra_service._get_firehose_client.cache_clear()
+    ingestion_infra_service._get_logs_client.cache_clear()
     ingestion_infra_service._get_account_id.cache_clear()
 
 
 @pytest.fixture()
 def aws_backends(aws_credentials: None) -> Iterator[None]:
     _clear_client_caches()
-    with mock_s3(), mock_firehose(), mock_sts():
+    with mock_s3(), mock_firehose(), mock_logs(), mock_sts():
         yield
     _clear_client_caches()
 
@@ -120,6 +122,11 @@ def test_provision_ingestion_infrastructure__fresh_account__creates_bucket_and_s
         "Enabled": True,
         "RetryOptions": {"DurationInSeconds": 300},
     }
+    assert destination["CloudWatchLoggingOptions"] == {
+        "Enabled": True,
+        "LogGroupName": "/aws/kinesisfirehose/events-ingestion-org-42",
+        "LogStreamName": "DestinationDelivery",
+    }
     assert destination["ProcessingConfiguration"] == {
         "Enabled": True,
         "Processors": [
@@ -148,6 +155,14 @@ def test_provision_ingestion_infrastructure__fresh_account__creates_bucket_and_s
         DeliveryStreamName=result.stream_name
     )
     assert stream_tags["Tags"] == [{"Key": "organisation_id", "Value": "42"}]
+
+    logs = boto3.client("logs", region_name="eu-west-2")
+    log_streams = logs.describe_log_streams(
+        logGroupName="/aws/kinesisfirehose/events-ingestion-org-42",
+    )["logStreams"]
+    assert [stream["logStreamName"] for stream in log_streams] == [
+        "DestinationDelivery"
+    ]
 
     assert log.events == [
         {
@@ -221,6 +236,10 @@ def test_provision_ingestion_infrastructure__stream_creation_fails__propagates_c
         "experimentation.ingestion_infra_service._get_s3_client",
         return_value=mocker.Mock(),
     )
+    mocker.patch(
+        "experimentation.ingestion_infra_service._get_logs_client",
+        return_value=mocker.Mock(),
+    )
     mock_firehose_client: Any = mocker.Mock()
     mock_firehose_client.create_delivery_stream.side_effect = ClientError(
         {"Error": {"Code": "LimitExceededException", "Message": "too many"}},
@@ -257,6 +276,12 @@ def test_deprovision_ingestion_infrastructure__existing_resources__deletes_bucke
     firehose = boto3.client("firehose", region_name="eu-west-2")
     with pytest.raises(ClientError):
         firehose.describe_delivery_stream(DeliveryStreamName=result.stream_name)
+
+    logs = boto3.client("logs", region_name="eu-west-2")
+    with pytest.raises(ClientError):
+        logs.describe_log_streams(
+            logGroupName="/aws/kinesisfirehose/events-ingestion-org-42",
+        )
 
     assert {
         "level": "info",

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -103,7 +103,7 @@ Attributes:
 ### `experimentation.ingestion_infra.bucket_created`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:95`
+ - `api/experimentation/ingestion_infra_service.py:108`
 
 Attributes:
  - `bucket.name`
@@ -112,7 +112,7 @@ Attributes:
 ### `experimentation.ingestion_infra.deprovisioned`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:230`
+ - `api/experimentation/ingestion_infra_service.py:261`
 
 Attributes:
  - `bucket.name`
@@ -141,7 +141,7 @@ Attributes:
 ### `experimentation.ingestion_infra.stream_created`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:186`
+ - `api/experimentation/ingestion_infra_service.py:215`
 
 Attributes:
  - `bucket.name`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Enables Amazon Data Firehose CloudWatch error logging on the per-organisation delivery streams, as AWS recommends, so delivery failures are diagnosable.

- Creates a per-organisation CloudWatch log group (`/aws/kinesisfirehose/events-ingestion-org-{id}`) and `DestinationDelivery` log stream when provisioning, and removes them on teardown.
- Sets `CloudWatchLoggingOptions` on the Firehose delivery stream's S3 destination.

Depends on matching Pulumi IAM changes: the Firehose delivery role needs `logs:PutLogEvents`, and the task-processor role needs `logs:CreateLogGroup`/`CreateLogStream`/`DeleteLogGroup` on `/aws/kinesisfirehose/events-ingestion-org-*` (separate Pulumi PR).

## How did you test this code?

Unit tests (moto): assert the log group + `DestinationDelivery` stream are created, `CloudWatchLoggingOptions` is set on the delivery stream, and both are removed on teardown. `experimentation.ingestion_infra_service` remains at 100% coverage.
