### PR TITLE
fix(workflows): block stale change request commits that conflict with published changes

### DIFF
--- a/api/core/workflows_services.py
+++ b/api/core/workflows_services.py
@@ -8,7 +8,10 @@ from environments.tasks import rebuild_environment_document
 from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.signals import environment_feature_version_published
 from features.versioning.tasks import trigger_update_version_webhooks
-from features.workflows.core.exceptions import ChangeRequestNotApprovedError
+from features.workflows.core.exceptions import (
+    ChangeRequestConflictError,
+    ChangeRequestNotApprovedError,
+)
 
 if TYPE_CHECKING:
     from features.workflows.core.models import ChangeRequest
@@ -27,6 +30,7 @@ class ChangeRequestCommitService:
                 "Change request has not been approved by all required approvers."
             )
 
+        self._check_for_conflicts()
         self._publish_feature_states()
         self._publish_environment_feature_versions(committed_by)
         self._publish_change_sets(committed_by)
@@ -44,6 +48,27 @@ class ChangeRequestCommitService:
             )
 
         self.change_request.save()
+
+    def _check_for_conflicts(self) -> None:
+        # Stale detection already runs when a scheduled change set is published
+        # by the task processor (see ``publish_version_change_set``). Manual
+        # commits publish their change sets immediately and previously skipped
+        # this check, silently reverting any changes that were published after
+        # the change request was created. Run the same conflict check here so
+        # that an out-of-date commit is blocked rather than overwriting newer
+        # changes.
+        if self.change_request.ignore_conflicts:
+            return
+
+        now = timezone.now()
+        for change_set in self.change_request.change_sets.all():
+            # Scheduled change sets are conflict-checked when their task fires,
+            # since further conflicts can appear before they go live.
+            is_scheduled = change_set.live_from and change_set.live_from >= now
+            if is_scheduled:
+                continue
+            if change_set.get_conflicts():
+                raise ChangeRequestConflictError()
 
     def _publish_feature_states(self) -> None:
         now = timezone.now()

--- a/api/features/workflows/core/exceptions.py
+++ b/api/features/workflows/core/exceptions.py
@@ -16,3 +16,13 @@ class CannotApproveOwnChangeRequest(FeatureWorkflowError):
 
 class ChangeRequestDeletionError(FeatureWorkflowError):
     status_code = status.HTTP_400_BAD_REQUEST  # type: ignore[assignment]
+
+
+class ChangeRequestConflictError(FeatureWorkflowError):
+    status_code = status.HTTP_409_CONFLICT  # type: ignore[assignment]
+    default_code = "change_request_conflict"
+    default_detail = (
+        "This change request conflicts with changes that were published since "
+        "it was created. Refresh the change request, or set ignore_conflicts to "
+        "commit it anyway."
+    )

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -31,6 +31,7 @@ from features.versioning.versioning_service import (
     get_environment_flags_dict,
     get_environment_flags_queryset,
 )
+from features.workflows.core.exceptions import ChangeRequestConflictError
 from features.workflows.core.models import ChangeRequest
 from organisations.models import Organisation
 from projects.models import Project
@@ -678,6 +679,158 @@ def test_publish_version_change_set__conflict_with_scheduled_change__sends_confl
     assert (
         latest_flags[(feature.id, None, None)].get_feature_state_value()
         == conflict_feature_value
+    )
+
+
+def test_manual_commit__conflict_with_published_change__blocks_commit(
+    feature: Feature,
+    environment_v2_versioning: Environment,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    # A change request whose change set updates the environment default. It is
+    # created first, so it captures the current state of the flag.
+    change_request_1 = ChangeRequest.objects.create(
+        title="CR 1",
+        environment=environment_v2_versioning,
+        user=staff_user,
+    )
+    change_set_1 = VersionChangeSet.objects.create(
+        feature=feature,
+        change_request=change_request_1,
+        feature_states_to_update=json.dumps(
+            [
+                {
+                    "feature": feature.id,
+                    "enabled": True,
+                    "feature_segment": None,
+                    "feature_state_value": {"type": "unicode", "string_value": "foo"},
+                }
+            ]
+        ),
+    )
+
+    # Another change request changes the same environment default and is
+    # committed immediately, making the first change request out of date.
+    conflict_feature_value = "bar"
+    conflict_feature_enabled = False
+    conflict_change_request = ChangeRequest.objects.create(
+        title="Conflict CR",
+        environment=environment_v2_versioning,
+        user=staff_user,
+    )
+    VersionChangeSet.objects.create(
+        feature=feature,
+        change_request=conflict_change_request,
+        feature_states_to_update=json.dumps(
+            [
+                {
+                    "feature": feature.id,
+                    "enabled": conflict_feature_enabled,
+                    "feature_segment": None,
+                    "feature_state_value": {
+                        "type": "unicode",
+                        "string_value": conflict_feature_value,
+                    },
+                }
+            ]
+        ),
+    )
+    conflict_change_request.commit(staff_user)
+
+    # Sanity check: the first change request is now considered in conflict.
+    assert change_set_1.get_conflicts()
+
+    # When
+    # We commit the (now stale) first change request immediately.
+    with pytest.raises(ChangeRequestConflictError):
+        change_request_1.commit(staff_user)
+
+    # Then
+    # The stale commit is blocked...
+    change_request_1.refresh_from_db()
+    assert change_request_1.committed_at is None
+
+    # ...and the newer change is still reflected in the flags.
+    latest_flags = get_environment_flags_dict(environment=environment_v2_versioning)
+    assert latest_flags[(feature.id, None, None)].enabled is conflict_feature_enabled
+    assert (
+        latest_flags[(feature.id, None, None)].get_feature_state_value()
+        == conflict_feature_value
+    )
+
+
+def test_manual_commit__conflict_with_ignore_conflicts__commits(
+    feature: Feature,
+    environment_v2_versioning: Environment,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    # A stale change request that has ignore_conflicts set explicitly.
+    change_request_1 = ChangeRequest.objects.create(
+        title="CR 1",
+        environment=environment_v2_versioning,
+        user=staff_user,
+        ignore_conflicts=True,
+    )
+    stale_feature_value = "foo"
+    stale_feature_enabled = True
+    VersionChangeSet.objects.create(
+        feature=feature,
+        change_request=change_request_1,
+        feature_states_to_update=json.dumps(
+            [
+                {
+                    "feature": feature.id,
+                    "enabled": stale_feature_enabled,
+                    "feature_segment": None,
+                    "feature_state_value": {
+                        "type": "unicode",
+                        "string_value": stale_feature_value,
+                    },
+                }
+            ]
+        ),
+    )
+
+    conflict_change_request = ChangeRequest.objects.create(
+        title="Conflict CR",
+        environment=environment_v2_versioning,
+        user=staff_user,
+    )
+    VersionChangeSet.objects.create(
+        feature=feature,
+        change_request=conflict_change_request,
+        feature_states_to_update=json.dumps(
+            [
+                {
+                    "feature": feature.id,
+                    "enabled": False,
+                    "feature_segment": None,
+                    "feature_state_value": {
+                        "type": "unicode",
+                        "string_value": "bar",
+                    },
+                }
+            ]
+        ),
+    )
+    conflict_change_request.commit(staff_user)
+
+    # When
+    # The change request is committed despite the conflict.
+    change_request_1.commit(staff_user)
+
+    # Then
+    # The commit succeeds and the change request's values win.
+    change_request_1.refresh_from_db()
+    assert change_request_1.committed_at is not None
+
+    latest_flags = get_environment_flags_dict(environment=environment_v2_versioning)
+    assert latest_flags[(feature.id, None, None)].enabled is stale_feature_enabled
+    assert (
+        latest_flags[(feature.id, None, None)].get_feature_state_value()
+        == stale_feature_value
     )
 
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7931

On v2 feature versioning, a Change Request captures the overrides it touches when it is created. If another Change Request then modifies and publishes those same overrides, the first CR becomes stale, yet it could still be committed manually — silently reverting the newer values. The only feedback was a passive notice.

Stale detection already existed, but it only ran for **scheduled** publishes inside the task processor (`publish_version_change_set(..., is_scheduled=True)`). A **manual commit** publishes its change sets immediately (`VersionChangeSet.publish` calls `publish_version_change_set` synchronously with `is_scheduled=False`), so the conflict check was skipped entirely.

This PR runs the existing conflict check on manual commits too:

- `ChangeRequestCommitService.commit` now calls a new `_check_for_conflicts()` **before** publishing anything. For every change set that would publish immediately, it reuses `VersionChangeSet.get_conflicts()` and raises a new `ChangeRequestConflictError` (HTTP 409) when the change request is out of date. The commit is blocked atomically, before any state is written.
- Scheduled change sets are left untouched — they are still conflict-checked when their task fires (further conflicts can appear before they go live).
- Change requests with `ignore_conflicts` set continue to commit as before.

`ChangeRequestConflictError` is added alongside the other change-request exceptions in `features/workflows/core/exceptions.py`.

Scope note: this addresses the core of the report — running the existing conflict check on manual commits and blocking the stale commit. The reorder-only diff separation described in the issue's "Requested outcome" is a larger, separate change and is intentionally out of scope here.

## How did you test this code?

Added focused regression tests in `api/tests/unit/features/versioning/test_unit_versioning_tasks.py`:

- `test_manual_commit__conflict_with_published_change__blocks_commit` — a stale CR committed immediately after a conflicting CR is published now raises `ChangeRequestConflictError`, `committed_at` stays `None`, and the newer value survives. Verified this test **fails** (`DID NOT RAISE`) without the fix and passes with it.
- `test_manual_commit__conflict_with_ignore_conflicts__commits` — a CR with `ignore_conflicts=True` still commits and its values win.

Gates run locally (Postgres 15.5, `uv run pytest`):

- `tests/unit/features/versioning/test_unit_versioning_tasks.py` and `tests/unit/features/workflows/` — 56 passed, including the pre-existing scheduled-conflict email test (unchanged behaviour).
- `ruff check` and `ruff format --check` — clean.
- `mypy` on the changed source modules — no issues.
