### PR TITLE
feat(experimentation): seed per-environment ingestion destination in Redis

### DIFF
--- a/api/experimentation/ingestion_sync_service.py
+++ b/api/experimentation/ingestion_sync_service.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 INGESTION_ENVIRONMENT_KEY_PREFIX = "experimentation:environment_keys:"
+INGESTION_ENVIRONMENT_DESTINATION_PREFIX = "experimentation:environment_destinations:"
 
 
 SOCKET_TIMEOUT = 1
@@ -40,4 +41,14 @@ def set_ingestion_key(
 
 def delete_ingestion_key(key: str) -> None:
     redis_key = f"{INGESTION_ENVIRONMENT_KEY_PREFIX}{key}"
+    _get_client().delete(redis_key)
+
+
+def set_ingestion_destination(client_api_key: str, *, stream_name: str) -> None:
+    redis_key = f"{INGESTION_ENVIRONMENT_DESTINATION_PREFIX}{client_api_key}"
+    _get_client().set(redis_key, stream_name)
+
+
+def delete_ingestion_destination(client_api_key: str) -> None:
+    redis_key = f"{INGESTION_ENVIRONMENT_DESTINATION_PREFIX}{client_api_key}"
     _get_client().delete(redis_key)

--- a/api/experimentation/tasks.py
+++ b/api/experimentation/tasks.py
@@ -64,14 +64,16 @@ def provision_external_warehouse_ingestion_infrastructure(environment_id: int) -
         return
 
     infrastructure = enable_ingestion_for_organisation(environment.project.organisation)
-    write_environment_ingestion_keys(environment_id)
-    # Route the environment's events to the org's stream; absent this key the
-    # pipeline falls back to its default stream.
-    assert infrastructure.stream_name is not None  # set once provisioned
+    if infrastructure.stream_name is None:
+        raise RuntimeError("Provisioned ingestion infrastructure has no stream name")
+    # Set the destination before publishing the ingestion keys: the keys gate
+    # the pipeline, so a key without a destination would route events to the
+    # default stream until this write lands.
     ingestion_sync_service.set_ingestion_destination(
         environment.api_key,
         stream_name=infrastructure.stream_name,
     )
+    write_environment_ingestion_keys(environment_id)
 
 
 @register_task_handler()

--- a/api/experimentation/tasks.py
+++ b/api/experimentation/tasks.py
@@ -50,6 +50,7 @@ def remove_environment_ingestion_keys(environment_id: int) -> None:
     ingestion_sync_service.delete_ingestion_key(environment.api_key)
     for api_key in environment.api_keys.all():
         ingestion_sync_service.delete_ingestion_key(api_key.key)
+    ingestion_sync_service.delete_ingestion_destination(environment.api_key)
 
 
 @register_task_handler()
@@ -62,8 +63,15 @@ def provision_external_warehouse_ingestion_infrastructure(environment_id: int) -
     if environment is None:
         return
 
-    enable_ingestion_for_organisation(environment.project.organisation)
+    infrastructure = enable_ingestion_for_organisation(environment.project.organisation)
     write_environment_ingestion_keys(environment_id)
+    # Route the environment's events to the org's stream; absent this key the
+    # pipeline falls back to its default stream.
+    assert infrastructure.stream_name is not None  # set once provisioned
+    ingestion_sync_service.set_ingestion_destination(
+        environment.api_key,
+        stream_name=infrastructure.stream_name,
+    )
 
 
 @register_task_handler()

--- a/api/experimentation/tasks.py
+++ b/api/experimentation/tasks.py
@@ -64,7 +64,7 @@ def provision_external_warehouse_ingestion_infrastructure(environment_id: int) -
         return
 
     infrastructure = enable_ingestion_for_organisation(environment.project.organisation)
-    if infrastructure.stream_name is None:
+    if not infrastructure.stream_name:
         raise RuntimeError("Provisioned ingestion infrastructure has no stream name")
     # Set the destination before publishing the ingestion keys: the keys gate
     # the pipeline, so a key without a destination would route events to the

--- a/api/tests/unit/experimentation/test_ingestion_sync_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_sync_service.py
@@ -99,6 +99,48 @@ def test_delete_ingestion_key__valid_key__deletes_from_redis(
     )
 
 
+def test_set_ingestion_destination__valid_stream__writes_stream_name(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "experimentation.ingestion_sync_service._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    ingestion_sync_service.set_ingestion_destination(
+        "client-env-key",
+        stream_name="events-ingestion-org-1",
+    )
+
+    # Then
+    mock_client.set.assert_called_once_with(
+        "experimentation:environment_destinations:client-env-key",
+        "events-ingestion-org-1",
+    )
+
+
+def test_delete_ingestion_destination__valid_key__deletes_from_redis(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "experimentation.ingestion_sync_service._get_client",
+        return_value=mock_client,
+    )
+
+    # When
+    ingestion_sync_service.delete_ingestion_destination("client-env-key")
+
+    # Then
+    mock_client.delete.assert_called_once_with(
+        "experimentation:environment_destinations:client-env-key",
+    )
+
+
 def test_set_ingestion_key__redis_error__propagates(
     mocker: MockerFixture,
 ) -> None:

--- a/api/tests/unit/experimentation/test_tasks.py
+++ b/api/tests/unit/experimentation/test_tasks.py
@@ -105,6 +105,9 @@ def test_remove_environment_ingestion_keys__client_and_server_keys__all_removed(
     mock_delete = mocker.patch(
         "experimentation.tasks.ingestion_sync_service.delete_ingestion_key",
     )
+    mock_delete_destination = mocker.patch(
+        "experimentation.tasks.ingestion_sync_service.delete_ingestion_destination",
+    )
 
     # When
     remove_environment_ingestion_keys(environment_id=environment.id)
@@ -115,6 +118,8 @@ def test_remove_environment_ingestion_keys__client_and_server_keys__all_removed(
         mocker.call(active_key.key),
         mocker.call(inactive_key.key),
     ]
+    # And the environment's destination routing is cleared
+    mock_delete_destination.assert_called_once_with(environment.api_key)
 
 
 def test_remove_environment_ingestion_keys__missing_environment__does_nothing(
@@ -585,6 +590,9 @@ def test_provision_external_warehouse_ingestion_infrastructure__valid_environmen
     set_ingestion_key = mocker.patch(
         "experimentation.tasks.ingestion_sync_service.set_ingestion_key",
     )
+    set_ingestion_destination = mocker.patch(
+        "experimentation.tasks.ingestion_sync_service.set_ingestion_destination",
+    )
 
     # When
     provision_external_warehouse_ingestion_infrastructure(environment_id=environment.id)
@@ -597,6 +605,10 @@ def test_provision_external_warehouse_ingestion_infrastructure__valid_environmen
     ).exists()
     set_ingestion_key.assert_called_once_with(
         environment.api_key, environment_key=environment.api_key
+    )
+    # And the environment is routed to the org's provisioned stream
+    set_ingestion_destination.assert_called_once_with(
+        environment.api_key, stream_name="events-ingestion-org-1"
     )
 
 

--- a/api/tests/unit/experimentation/test_tasks.py
+++ b/api/tests/unit/experimentation/test_tasks.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
+import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 from pytest_mock import MockerFixture
@@ -610,6 +611,36 @@ def test_provision_external_warehouse_ingestion_infrastructure__valid_environmen
     set_ingestion_destination.assert_called_once_with(
         environment.api_key, stream_name="events-ingestion-org-1"
     )
+
+
+def test_provision_external_warehouse_ingestion_infrastructure__no_stream_name__raises(
+    environment: Environment,
+    mocker: MockerFixture,
+) -> None:
+    # Given provisioning returns infrastructure without a stream name
+    infrastructure = OrganisationIngestionInfrastructure(
+        organisation=environment.project.organisation,
+        status=IngestionInfrastructureStatus.CREATED,
+        stream_name=None,
+    )
+    mocker.patch(
+        "experimentation.tasks.enable_ingestion_for_organisation",
+        return_value=infrastructure,
+    )
+    set_ingestion_destination = mocker.patch(
+        "experimentation.tasks.ingestion_sync_service.set_ingestion_destination",
+    )
+    write_keys = mocker.patch(
+        "experimentation.tasks.write_environment_ingestion_keys",
+    )
+
+    # When / Then the task fails loudly without seeding a broken destination
+    with pytest.raises(RuntimeError, match="no stream name"):
+        provision_external_warehouse_ingestion_infrastructure(
+            environment_id=environment.id
+        )
+    set_ingestion_destination.assert_not_called()
+    write_keys.assert_not_called()
 
 
 def test_provision_external_warehouse_ingestion_infrastructure__missing_environment__does_nothing(

--- a/api/tests/unit/experimentation/test_tasks.py
+++ b/api/tests/unit/experimentation/test_tasks.py
@@ -613,15 +613,17 @@ def test_provision_external_warehouse_ingestion_infrastructure__valid_environmen
     )
 
 
+@pytest.mark.parametrize("stream_name", [None, ""], ids=["none", "blank"])
 def test_provision_external_warehouse_ingestion_infrastructure__no_stream_name__raises(
     environment: Environment,
     mocker: MockerFixture,
+    stream_name: str | None,
 ) -> None:
-    # Given provisioning returns infrastructure without a stream name
+    # Given provisioning returns infrastructure without a usable stream name
     infrastructure = OrganisationIngestionInfrastructure(
         organisation=environment.project.organisation,
         status=IngestionInfrastructureStatus.CREATED,
-        stream_name=None,
+        stream_name=stream_name,
     )
     mocker.patch(
         "experimentation.tasks.enable_ingestion_for_organisation",

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -91,7 +91,7 @@ Attributes:
 ### `experimentation.exposures.compute_failed`
 
 Logged at `error` from:
- - `api/experimentation/tasks.py:131`
+ - `api/experimentation/tasks.py:133`
 
 Attributes:
  - `environment.id`
@@ -159,7 +159,7 @@ Attributes:
 ### `experimentation.results.compute_failed`
 
 Logged at `error` from:
- - `api/experimentation/tasks.py:167`
+ - `api/experimentation/tasks.py:169`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -91,7 +91,7 @@ Attributes:
 ### `experimentation.exposures.compute_failed`
 
 Logged at `error` from:
- - `api/experimentation/tasks.py:123`
+ - `api/experimentation/tasks.py:131`
 
 Attributes:
  - `environment.id`
@@ -159,7 +159,7 @@ Attributes:
 ### `experimentation.results.compute_failed`
 
 Logged at `error` from:
- - `api/experimentation/tasks.py:159`
+ - `api/experimentation/tasks.py:167`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The Django side of [flagsmith-analytics-pipeline#21](https://github.com/Flagsmith/flagsmith-analytics-pipeline/pull/21): the pipeline now routes each environment's events to a per-destination Firehose stream, resolved from a new Redis key. This seeds that key.

- Adds `set_ingestion_destination` / `delete_ingestion_destination` to `ingestion_sync_service`, writing `experimentation:environment_destinations:<client_api_key>` = the org's stream name.
- Writes the destination when provisioning external-warehouse ingestion, keyed on the environment's client key so `ser.*` keys follow their environment; the value is the stream name actually recorded on the infrastructure row.
- Clears it alongside the auth keys on connection delete (a no-op for Flagsmith connections, which have no custom stream).

Flagsmith-warehouse connections write no destination key, so the pipeline falls back to its default stream.

## How did you test this code?

Unit tests: assert the destination key is written on external-warehouse provisioning (keyed on the client key, valued with the provisioned stream) and removed on teardown, plus the `set`/`delete` Redis calls. Both changed modules stay at 100% coverage.
