### PR TITLE
fix(code-help): make the React identity snippets runnable

### DIFF
--- a/frontend/common/code-help/create-user/create-user-react.js
+++ b/frontend/common/code-help/create-user/create-user-react.js
@@ -6,6 +6,7 @@ export default (
   userId,
 ) => `
 // Option 1: Initialise with an identity
+import flagsmith from '${NPM_CLIENT}';
 import { FlagsmithProvider } from '${NPM_CLIENT}/react';
 
 export default function App() {

--- a/frontend/common/code-help/init/init-react.js
+++ b/frontend/common/code-help/init/init-react.js
@@ -12,8 +12,8 @@ export function HomePage() {
   const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
   return (
     <>
-      {\`${FEATURE_NAME}: \${${FEATURE_NAME}}\`}
-      {\`${FEATURE_NAME_ALT}: \${${FEATURE_NAME_ALT}}\`}
+      <div>{\`${FEATURE_NAME}: \${${FEATURE_NAME}}\`}</div>
+      <div>{\`${FEATURE_NAME_ALT}: \${${FEATURE_NAME_ALT}}\`}</div>
     </>
   );
 }

--- a/frontend/common/code-help/traits/traits-react.js
+++ b/frontend/common/code-help/traits/traits-react.js
@@ -6,6 +6,7 @@ export default (
   userId,
 ) => `
 // Option 1: Initialise with an identity and traits
+import flagsmith from '${NPM_CLIENT}';
 import { FlagsmithProvider } from '${NPM_CLIENT}/react';
 
 export default function App() {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes two snippet bugs CodeRabbit flagged on #8062 (both pre-existing there):

- Option 1 of the create-user and traits React snippets passed `flagsmith={flagsmith}` without importing the client, so the copied code didn't run. Import it the way Option 2 already does.
- The React init snippet's two demo output lines rendered concatenated (`my_cool_feature: truebanner_size: 42`); each gets its own line now.

Not addressed: interpolating flag names as JS identifiers breaks for dashed names (`flags.checkout-beta.enabled`). Systemic across templates and needs a call on whether dashed names are supported; left out deliberately.

Stacked on #8062; will retarget `main` once it merges.

## How did you test this code?

- [ ] Features page → SDK snippet → React, "Create user" and "Traits" tabs: Option 1 imports `flagsmith` and passes it to the provider
- [ ] Copy Option 1, paste into an editor: no undefined `flagsmith`
- [ ] Init snippet: the two example output lines are separate

`lint` passes; snippet templates only, no component changes.
