### PR TITLE
fix(experiments): results page control-wins state, lift colours, dark mode

### DIFF
--- a/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
+++ b/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
@@ -199,8 +199,8 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
   const renderHypothesis = () => {
     if (isEditingHypothesis) {
       return (
-        <div className='mt-3' style={{ maxWidth: 640 }}>
-          <span className='fs-caption text-secondary fw-bold'>Hypothesis</span>
+        <div className='mt-3'>
+          <span className='fs-caption text-default fw-bold'>Hypothesis</span>
           <div className='d-flex align-items-start gap-2 mt-1'>
             <textarea
               autoFocus
@@ -251,14 +251,9 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
     }
 
     return (
-      <div className='mt-3' style={{ maxWidth: 640 }}>
-        <span className='fs-caption text-secondary fw-bold'>Hypothesis</span>
-        <div className='d-flex align-items-start gap-1'>
-          <p className='text-secondary mb-0'>
-            {experiment.hypothesis || (
-              <span className='fst-italic'>No hypothesis</span>
-            )}
-          </p>
+      <div className='mt-3'>
+        <div className='d-flex align-items-center gap-1'>
+          <span className='fs-caption text-default fw-bold'>Hypothesis</span>
           <Button
             theme='text'
             onClick={startEditingHypothesis}
@@ -267,6 +262,11 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
             <Icon name='edit' width={14} />
           </Button>
         </div>
+        <p className='text-secondary mb-0'>
+          {experiment.hypothesis || (
+            <span className='fst-italic'>No hypothesis</span>
+          )}
+        </p>
       </div>
     )
   }

--- a/frontend/web/components/experiments/results/ExperimentMetricScorecard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentMetricScorecard.tsx
@@ -55,7 +55,6 @@ const ExperimentMetricScorecard: FC<ExperimentMetricScorecardProps> = ({
     <>
       {metricResult && (
         <ExperimentResultsAxisChart
-          direction={metric.expected_direction}
           identities={identities}
           metricName={metric.metric_name}
           metricResult={metricResult}

--- a/frontend/web/components/experiments/results/ExperimentRecommendation.tsx
+++ b/frontend/web/components/experiments/results/ExperimentRecommendation.tsx
@@ -1,8 +1,8 @@
 import { FC, useMemo } from 'react'
 import Icon from 'components/icons/Icon'
-import { colorTextSuccess } from 'common/theme/tokens'
+import { colorTextSuccess, colorTextWarning } from 'common/theme/tokens'
 import { BayesianResultsSummary, Experiment } from 'common/types/responses'
-import { deriveSummary } from './ExperimentSummaryScorecard'
+import { deriveSummary } from './derive'
 import VariantName from './VariantName'
 
 type ExperimentRecommendationProps = {
@@ -20,6 +20,29 @@ const ExperimentRecommendation: FC<ExperimentRecommendationProps> = ({
   )
 
   if (!summary) return null
+
+  if (summary.controlWins) {
+    return (
+      <div className='alert alert-warning experiment-recommendation mb-3'>
+        <div className='d-flex align-items-center gap-2 mb-2'>
+          <Icon name='warning' width={20} fill={colorTextWarning} />
+          <span className='text-warning fw-semibold'>
+            Control is the winner
+          </span>
+        </div>
+        <div>
+          <VariantName name='Control' colour={summary.controlColour} /> has
+          shown the best performance, with {summary.chanceToBest} probability of
+          being the best arm. No variant has outperformed it.
+        </div>
+        <div className='mt-2'>
+          Consider rolling out{' '}
+          <VariantName name='Control' colour={summary.controlColour} /> to all
+          users.
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className='alert alert-success experiment-recommendation mb-3'>

--- a/frontend/web/components/experiments/results/ExperimentResultsAxisChart.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsAxisChart.tsx
@@ -1,18 +1,14 @@
 import { FC, useMemo } from 'react'
 import ColorSwatch from 'components/ColorSwatch'
-import { colorTextDanger, colorTextSuccess } from 'common/theme/tokens'
 import { BayesianMetricResult } from 'common/types/responses'
 import {
   AxisRange,
   VariantIdentity,
   buildTicks,
   formatLiftPct,
-  isLiftFavourable,
+  getLiftColour,
   valueToPercent,
 } from './derive'
-
-const getLiftColour = (lift: number): string =>
-  isLiftFavourable(lift) ? colorTextSuccess : colorTextDanger
 
 const TickLines: FC<{ ticks: number[]; range: AxisRange }> = ({
   range,

--- a/frontend/web/components/experiments/results/ExperimentResultsAxisChart.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsAxisChart.tsx
@@ -1,7 +1,7 @@
 import { FC, useMemo } from 'react'
 import ColorSwatch from 'components/ColorSwatch'
 import { colorTextDanger, colorTextSuccess } from 'common/theme/tokens'
-import { BayesianMetricResult, ExpectedDirection } from 'common/types/responses'
+import { BayesianMetricResult } from 'common/types/responses'
 import {
   AxisRange,
   VariantIdentity,
@@ -11,8 +11,8 @@ import {
   valueToPercent,
 } from './derive'
 
-const getLiftColour = (lift: number, direction: ExpectedDirection): string =>
-  isLiftFavourable(lift, direction) ? colorTextSuccess : colorTextDanger
+const getLiftColour = (lift: number): string =>
+  isLiftFavourable(lift) ? colorTextSuccess : colorTextDanger
 
 const TickLines: FC<{ ticks: number[]; range: AxisRange }> = ({
   range,
@@ -35,12 +35,10 @@ type ExperimentResultsAxisChartProps = {
   identities: VariantIdentity[]
   metricName: string
   metricResult?: BayesianMetricResult
-  direction: ExpectedDirection
   range: AxisRange
 }
 
 const ExperimentResultsAxisChart: FC<ExperimentResultsAxisChartProps> = ({
-  direction,
   identities,
   metricName,
   metricResult,
@@ -93,7 +91,7 @@ const ExperimentResultsAxisChart: FC<ExperimentResultsAxisChartProps> = ({
               )
             }
             if (!inf) return null
-            const colour = getLiftColour(inf.lift, direction)
+            const colour = getLiftColour(inf.lift)
             const ciLeft = valueToPercent(inf.ci_low, range)
             const ciRight = valueToPercent(inf.ci_high, range)
             const dotPos = valueToPercent(inf.lift, range)

--- a/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
@@ -4,7 +4,6 @@ import Icon from 'components/icons/Icon'
 import Tooltip from 'components/Tooltip'
 import {
   colorIconSecondary,
-  colorTextDanger,
   colorTextSecondary,
   colorTextSuccess,
 } from 'common/theme/tokens'
@@ -18,7 +17,7 @@ import {
 import {
   VariantIdentity,
   formatLiftPct,
-  isLiftFavourable,
+  getLiftColour,
   liftToPercent,
 } from './derive'
 
@@ -40,9 +39,6 @@ const renderMetricValue = (
   if (aggregation === 'occurrence') return `${(mean * 100).toFixed(1)}%`
   return mean.toFixed(2)
 }
-
-const getLiftColour = (lift: number): string =>
-  isLiftFavourable(lift) ? colorTextSuccess : colorTextDanger
 
 const renderLift = (
   identity: VariantIdentity,

--- a/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsScorecardTable.tsx
@@ -10,7 +10,6 @@ import {
 } from 'common/theme/tokens'
 import {
   BayesianMetricResult,
-  ExpectedDirection,
   ExperimentMetric,
   Inference,
   MetricAggregation,
@@ -42,13 +41,12 @@ const renderMetricValue = (
   return mean.toFixed(2)
 }
 
-const getLiftColour = (lift: number, direction: ExpectedDirection): string =>
-  isLiftFavourable(lift, direction) ? colorTextSuccess : colorTextDanger
+const getLiftColour = (lift: number): string =>
+  isLiftFavourable(lift) ? colorTextSuccess : colorTextDanger
 
 const renderLift = (
   identity: VariantIdentity,
   inference: Inference | null,
-  direction: ExpectedDirection,
   liftRange: number,
 ): ReactNode => {
   if (identity.isControl) {
@@ -57,7 +55,7 @@ const renderLift = (
   if (!inference) {
     return <span className='text-secondary fs-caption'>Collecting data…</span>
   }
-  const colour = getLiftColour(inference.lift, direction)
+  const colour = getLiftColour(inference.lift)
   const left = liftToPercent(inference.ci_low, liftRange)
   const right = liftToPercent(inference.ci_high, liftRange)
   const dotPos = liftToPercent(inference.lift, liftRange)
@@ -201,14 +199,7 @@ const ExperimentResultsScorecardTable: FC<
                 </td>
                 <td>{stats ? stats.n.toLocaleString() : '—'}</td>
                 <td>{renderMetricValue(stats, metric.aggregation)}</td>
-                <td>
-                  {renderLift(
-                    v,
-                    inference,
-                    metric.expected_direction,
-                    liftRange,
-                  )}
-                </td>
+                <td>{renderLift(v, inference, liftRange)}</td>
                 <td>{renderCI(v, inference)}</td>
                 <td>
                   {renderWinProbability(v, inference, v.key === winnerKey)}

--- a/frontend/web/components/experiments/results/ExperimentSummaryScorecard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentSummaryScorecard.tsx
@@ -1,58 +1,13 @@
 import { FC, useMemo } from 'react'
 import InfoMessage from 'components/InfoMessage'
 import { BayesianResultsSummary, Experiment } from 'common/types/responses'
-import { getPrimaryMetric } from 'components/experiments/constants'
-import {
-  formatLiftPct,
-  getMetricResult,
-  getVariantIdentities,
-  getWinningVariant,
-  isLiftFavourable,
-} from './derive'
+import { deriveSummary } from './derive'
 import StatCard from './StatCard'
 
 type ExperimentSummaryScorecardProps = {
   usersEnrolled: number | null
   experiment?: Experiment
   results?: BayesianResultsSummary
-}
-
-export type SummaryStats = {
-  winnerName: string
-  winnerColour: string
-  controlColour: string
-  chanceToBest: string
-  liftVsControl: string
-  liftFavourable: boolean
-}
-
-export const deriveSummary = (
-  experiment: Experiment,
-  results: BayesianResultsSummary,
-): SummaryStats | null => {
-  const metric = getPrimaryMetric(experiment)
-  if (!metric) return null
-  const metricResult = getMetricResult(results, metric.metric)
-  if (!metricResult) return null
-
-  const identities = getVariantIdentities(experiment.feature)
-  const winner = getWinningVariant(metricResult, identities)
-  if (!winner) return null
-
-  const winnerIdentity = identities.find((v) => v.key === winner.key)
-  const controlIdentity = identities.find((v) => v.isControl)
-
-  return {
-    chanceToBest: `${Math.round(winner.chanceToWin * 100)}%`,
-    controlColour: controlIdentity?.colour ?? '',
-    liftFavourable: isLiftFavourable(
-      winner.inference.lift,
-      metric.expected_direction,
-    ),
-    liftVsControl: formatLiftPct(winner.inference.lift),
-    winnerColour: winnerIdentity?.colour ?? '',
-    winnerName: winner.name,
-  }
 }
 
 const ExperimentSummaryScorecard: FC<ExperimentSummaryScorecardProps> = ({
@@ -65,6 +20,11 @@ const ExperimentSummaryScorecard: FC<ExperimentSummaryScorecardProps> = ({
     [experiment, results],
   )
   const hasResults = !!results
+
+  let liftClassName: string | undefined
+  if (summary && !summary.controlWins) {
+    liftClassName = summary.liftFavourable ? 'text-success' : 'text-danger'
+  }
 
   return (
     <>
@@ -88,7 +48,11 @@ const ExperimentSummaryScorecard: FC<ExperimentSummaryScorecardProps> = ({
             loading={!hasResults}
             value={
               summary?.winnerName ? (
-                <span className='text-success'>{summary.winnerName}</span>
+                <span
+                  className={summary.controlWins ? undefined : 'text-success'}
+                >
+                  {summary.winnerName}
+                </span>
               ) : undefined
             }
           />
@@ -106,13 +70,7 @@ const ExperimentSummaryScorecard: FC<ExperimentSummaryScorecardProps> = ({
             loading={!hasResults}
             value={
               summary?.liftVsControl ? (
-                <span
-                  className={
-                    summary.liftFavourable ? 'text-success' : 'text-danger'
-                  }
-                >
-                  {summary.liftVsControl}
-                </span>
+                <span className={liftClassName}>{summary.liftVsControl}</span>
               ) : undefined
             }
           />

--- a/frontend/web/components/experiments/results/__tests__/derive.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/derive.test.ts
@@ -4,15 +4,19 @@ import {
   computeLiftRange,
   computeAxisRange,
   buildExposuresChartData,
+  deriveSummary,
   formatBucketLabel,
   getHeadlineTotal,
   getVariantIdentities,
   getVariantTotals,
+  getWinningVariant,
   liftToPercent,
   valueToPercent,
 } from 'components/experiments/results/derive'
 import {
   BayesianMetricResult,
+  BayesianResultsSummary,
+  Experiment,
   ExperimentFeature,
   ExposuresSummary,
   MultivariateOption,
@@ -243,6 +247,95 @@ describe('liftToPercent', () => {
     expect(liftToPercent(0.15, 0.3)).toBe(75)
     expect(liftToPercent(-0.6, 0.3)).toBe(0)
     expect(liftToPercent(0.6, 0.3)).toBe(100)
+  })
+})
+
+const losingMetricResult: BayesianMetricResult = {
+  ...metricResult,
+  inference: {
+    b: { chance_to_win: 0.05, ci_high: 0.02, ci_low: -0.3, lift: -0.15 },
+    c: { chance_to_win: 0.1, ci_high: 0.04, ci_low: -0.2, lift: -0.09 },
+  },
+}
+
+describe('getWinningVariant', () => {
+  it('returns the treatment with the highest chance of beating control', () => {
+    expect(getWinningVariant(metricResult, identities)).toMatchObject({
+      chanceToWin: 0.75,
+      isControl: false,
+      key: 'b',
+    })
+  })
+
+  it('returns control when no treatment is likely to beat it', () => {
+    expect(getWinningVariant(losingMetricResult, identities)).toMatchObject({
+      chanceToWin: 0.85,
+      inference: null,
+      isControl: true,
+      key: CONTROL_VARIANT_KEY,
+      name: 'Control',
+    })
+  })
+
+  it('returns null when no treatment has inference data', () => {
+    expect(
+      getWinningVariant({ ...metricResult, inference: {} }, identities),
+    ).toBeNull()
+  })
+})
+
+describe('deriveSummary', () => {
+  const experiment: Experiment = {
+    created_at: '2026-06-01T00:00:00Z',
+    ended_at: null,
+    feature: feature({
+      multivariate_options: [
+        option({ id: 10, key: 'b', string_value: 'big' }),
+        option({ id: 11, key: 'c', string_value: 'huge' }),
+      ],
+    }),
+    hypothesis: '',
+    id: 1,
+    metrics: [
+      {
+        aggregation: 'occurrence',
+        created_at: '2026-06-01T00:00:00Z',
+        expected_direction: 'increase',
+        id: 1,
+        metric: 1,
+        metric_name: 'Signup',
+      },
+    ],
+    name: 'exp',
+    started_at: null,
+    status: 'running',
+    updated_at: '2026-06-01T00:00:00Z',
+  }
+  const results = (mr: BayesianMetricResult): BayesianResultsSummary => ({
+    metrics: [mr],
+    srm_p_value: null,
+  })
+
+  it('summarises the winning treatment with its lift vs control', () => {
+    expect(deriveSummary(experiment, results(metricResult))).toMatchObject({
+      chanceToBest: '75%',
+      controlWins: false,
+      liftFavourable: true,
+      liftVsControl: '+8.0%',
+      winnerName: 'b',
+    })
+  })
+
+  it('summarises control as the winner with a baseline lift', () => {
+    expect(
+      deriveSummary(experiment, results(losingMetricResult)),
+    ).toMatchObject({
+      chanceToBest: '85%',
+      controlWins: true,
+      liftFavourable: false,
+      liftVsControl: 'Baseline',
+      winnerName: 'Control',
+    })
   })
 })
 

--- a/frontend/web/components/experiments/results/derive.ts
+++ b/frontend/web/components/experiments/results/derive.ts
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import { ChartDataPoint, buildChartColorMap } from 'components/charts'
+import { colorTextDanger, colorTextSuccess } from 'common/theme/tokens'
 import {
   BayesianMetricResult,
   BayesianResultsSummary,
@@ -122,6 +123,9 @@ export const getResultsTotalUsers = (
 // Colour by sign only — expected_direction is not used reliably yet, so it
 // deliberately plays no part in lift colouring.
 export const isLiftFavourable = (lift: number): boolean => lift > 0
+
+export const getLiftColour = (lift: number): string =>
+  isLiftFavourable(lift) ? colorTextSuccess : colorTextDanger
 
 export const formatLiftPct = (lift: number): string => {
   const pct = lift * 100

--- a/frontend/web/components/experiments/results/derive.ts
+++ b/frontend/web/components/experiments/results/derive.ts
@@ -4,12 +4,14 @@ import {
   BayesianMetricResult,
   BayesianResultsSummary,
   ExpectedDirection,
+  Experiment,
   ExperimentFeature,
   ExposureGranularity,
   ExposuresSummary,
   Inference,
   MultivariateOption,
 } from 'common/types/responses'
+import { getPrimaryMetric } from 'components/experiments/constants'
 
 // Mirrors api/features/constants.py CONTROL_VARIANT_KEY.
 export const CONTROL_VARIANT_KEY = 'control'
@@ -141,28 +143,88 @@ export type WinningVariant = {
   key: string
   name: string
   chanceToWin: number
-  inference: Inference
+  inference: Inference | null
+  isControl: boolean
 }
 
+// chance_to_win is pairwise — P(variant beats control) — so chances don't sum
+// to 1 across arms. P(control is best) = P(no variant beats it); the Bonferroni
+// bound 1 - Σ chance_to_win is exact for one variant, conservative otherwise.
 export const getWinningVariant = (
   metricResult: BayesianMetricResult,
   identities: VariantIdentity[],
 ): WinningVariant | null => {
   let best: WinningVariant | null = null
-  identities.forEach((v) => {
-    if (v.isControl) return
+  let treatmentChancesTotal = 0
+  for (const v of identities) {
+    if (v.isControl) continue
     const inf = metricResult.inference[v.key]
-    if (!inf) return
+    if (!inf) continue
+    treatmentChancesTotal += inf.chance_to_win
     if (!best || inf.chance_to_win > best.chanceToWin) {
       best = {
         chanceToWin: inf.chance_to_win,
         inference: inf,
+        isControl: false,
         key: v.key,
         name: v.name,
       }
     }
-  })
+  }
+  if (!best) return null
+  const control = identities.find((v) => v.isControl)
+  const controlChance = Math.max(0, 1 - treatmentChancesTotal)
+  if (control && controlChance > best.chanceToWin) {
+    return {
+      chanceToWin: controlChance,
+      inference: null,
+      isControl: true,
+      key: control.key,
+      name: control.name,
+    }
+  }
   return best
+}
+
+export type SummaryStats = {
+  winnerName: string
+  winnerColour: string
+  controlColour: string
+  controlWins: boolean
+  chanceToBest: string
+  liftVsControl: string
+  liftFavourable: boolean
+}
+
+export const deriveSummary = (
+  experiment: Experiment,
+  results: BayesianResultsSummary,
+): SummaryStats | null => {
+  const metric = getPrimaryMetric(experiment)
+  if (!metric) return null
+  const metricResult = getMetricResult(results, metric.metric)
+  if (!metricResult) return null
+
+  const identities = getVariantIdentities(experiment.feature)
+  const winner = getWinningVariant(metricResult, identities)
+  if (!winner) return null
+
+  const winnerIdentity = identities.find((v) => v.key === winner.key)
+  const controlIdentity = identities.find((v) => v.isControl)
+
+  return {
+    chanceToBest: `${Math.round(winner.chanceToWin * 100)}%`,
+    controlColour: controlIdentity?.colour ?? '',
+    controlWins: winner.isControl,
+    liftFavourable: winner.inference
+      ? isLiftFavourable(winner.inference.lift, metric.expected_direction)
+      : false,
+    liftVsControl: winner.inference
+      ? formatLiftPct(winner.inference.lift)
+      : 'Baseline',
+    winnerColour: winnerIdentity?.colour ?? '',
+    winnerName: winner.name,
+  }
 }
 
 export type AxisRange = { min: number; max: number }

--- a/frontend/web/components/experiments/results/derive.ts
+++ b/frontend/web/components/experiments/results/derive.ts
@@ -3,7 +3,6 @@ import { ChartDataPoint, buildChartColorMap } from 'components/charts'
 import {
   BayesianMetricResult,
   BayesianResultsSummary,
-  ExpectedDirection,
   Experiment,
   ExperimentFeature,
   ExposureGranularity,
@@ -120,13 +119,9 @@ export const getResultsTotalUsers = (
   return Object.values(firstMetric.variants).reduce((sum, v) => sum + v.n, 0)
 }
 
-export const isLiftFavourable = (
-  lift: number,
-  direction: ExpectedDirection,
-): boolean => {
-  if (direction === 'increase' || direction === 'not_decrease') return lift > 0
-  return lift < 0
-}
+// Colour by sign only — expected_direction is not used reliably yet, so it
+// deliberately plays no part in lift colouring.
+export const isLiftFavourable = (lift: number): boolean => lift > 0
 
 export const formatLiftPct = (lift: number): string => {
   const pct = lift * 100
@@ -217,7 +212,7 @@ export const deriveSummary = (
     controlColour: controlIdentity?.colour ?? '',
     controlWins: winner.isControl,
     liftFavourable: winner.inference
-      ? isLiftFavourable(winner.inference.lift, metric.expected_direction)
+      ? isLiftFavourable(winner.inference.lift)
       : false,
     liftVsControl: winner.inference
       ? formatLiftPct(winner.inference.lift)

--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -81,6 +81,14 @@
       color: $text-icon-light;
     }
   }
+  .alert-success {
+    .title {
+      color: $text-icon-light;
+    }
+    strong {
+      color: $text-icon-light;
+    }
+  }
   .alert-warning {
     background-color: $warning-solid-dark-alert;
   }

--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -91,6 +91,9 @@
   }
   .alert-warning {
     background-color: $warning-solid-dark-alert;
+    strong {
+      color: $text-icon-light;
+    }
   }
   .alert-danger{
     background-color: $danger-solid-dark-alert


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

UI fixes for the experiment results page:

- Control can now win: when no variant is likely to beat it, the banner turns into a warning ("Control is the winner"), the winning variation card shows Control, and lift shows "Baseline".
- Lift colours are sign-based only (positive green, negative red) — `expected_direction` no longer affects colouring.
- Fixed unreadable variant names in the banner in dark mode (`.alert-success strong` had no dark override).
- Hypothesis: standard title colour, edit button next to the title, full-width text.

## How did you test this code?

Unit tests for the winner/summary derivation; manually checked the control-wins state, negative lift colours, and dark mode.


**Before**
<img width="1160" height="883" alt="image" src="https://github.com/user-attachments/assets/ea959e68-d901-4806-83e3-5daa22c0b3a7" />


**After**
<img width="1117" height="850" alt="image" src="https://github.com/user-attachments/assets/f8a653aa-733a-4b6a-b431-a371cee40a14" />
