### PR TITLE
fix(MCP): deploy the released image instead of redeploying the old one

### DIFF
--- a/.github/actions/mcp-deploy-ecs/action.yml
+++ b/.github/actions/mcp-deploy-ecs/action.yml
@@ -31,7 +31,7 @@ runs:
 
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
@@ -47,14 +47,14 @@ runs:
 
     - name: Render new image into task definition
       id: render
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
       with:
         task-definition: task-def.json
         container-name: ${{ inputs.container-name }}
         image: ${{ inputs.image }}
 
     - name: Deploy
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      uses: aws-actions/amazon-ecs-deploy-task-definition@c465972ecbd160473f22e683363b422a5412a3de # v2.6.3
       with:
         task-definition: ${{ steps.render.outputs.task-definition }}
         service: ${{ inputs.service }}

--- a/.github/actions/mcp-deploy-ecs/action.yml
+++ b/.github/actions/mcp-deploy-ecs/action.yml
@@ -1,0 +1,62 @@
+name: MCP Deploy to ECS
+description: >
+  Roll the MCP ECS service onto a specific image tag. The task definition is
+  owned by Pulumi (registered with track_latest), so this fetches the live
+  definition, swaps in the published image, and registers a new revision.
+
+inputs:
+  role-to-assume:
+    description: The AWS IAM role ARN to assume via OIDC.
+    required: true
+  aws-region:
+    description: The AWS region of the ECS cluster.
+    required: false
+    default: eu-west-2
+  cluster:
+    description: The name of the ECS cluster to deploy to.
+    required: true
+  service:
+    description: The name of the ECS service to deploy to.
+    required: true
+  container-name:
+    description: The container in the task definition to update.
+    required: false
+    default: mcp-server
+  image:
+    description: The fully-qualified image reference to deploy.
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Fetch current task definition
+      shell: bash
+      run: |
+        ARN=$(aws ecs describe-services \
+          --cluster "${{ inputs.cluster }}" --services "${{ inputs.service }}" \
+          --query 'services[0].taskDefinition' --output text)
+        aws ecs describe-task-definition --task-definition "$ARN" \
+          --query 'taskDefinition' --output json > task-def.json
+
+    - name: Render new image into task definition
+      id: render
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-def.json
+        container-name: ${{ inputs.container-name }}
+        image: ${{ inputs.image }}
+
+    - name: Deploy
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        task-definition: ${{ steps.render.outputs.task-definition }}
+        service: ${{ inputs.service }}
+        cluster: ${{ inputs.cluster }}
+        wait-for-service-stability: true

--- a/.github/workflows/mcp-docker-build-publish-deploy.yml
+++ b/.github/workflows/mcp-docker-build-publish-deploy.yml
@@ -65,6 +65,8 @@ jobs:
     runs-on: depot-ubuntu-latest
     # The OIDC role trusts jobs running in the staging environment.
     environment: staging
+    outputs:
+      image: ${{ vars.MCP_ECR_REPOSITORY_URL }}:${{ steps.meta.outputs.version }}
     permissions:
       contents: read
       packages: read
@@ -99,7 +101,7 @@ jobs:
           images: ${{ vars.MCP_ECR_REPOSITORY_URL }}
           tags: |
             type=ref,event=branch
-            type=sha
+            type=sha,priority=900
             type=raw,value=latest
 
       # Setup Docker buildx with Depot builder so imagetools have access to Depot cache
@@ -120,6 +122,8 @@ jobs:
     runs-on: depot-ubuntu-latest
     # The OIDC role trusts jobs running in the production environment.
     environment: production
+    outputs:
+      image: ${{ vars.MCP_ECR_REPOSITORY_URL }}:${{ steps.meta.outputs.version }}
     permissions:
       contents: read
       packages: read
@@ -176,20 +180,16 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Cloning repo
+        uses: actions/checkout@v5
+
+      - name: Deploy MCP to ECS
+        uses: ./.github/actions/mcp-deploy-ecs
         with:
           role-to-assume: ${{ vars.MCP_ECR_GITHUB_ROLE_ARN }}
-          aws-region: eu-west-2
-
-      - name: Roll the service onto the new image
-        run: |
-          aws ecs update-service \
-            --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment
-          aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE"
-        env:
-          CLUSTER: ${{ vars.AWS_ECS_CLUSTER_NAME }}
-          SERVICE: ${{ vars.AWS_ECS_MCP_SERVICE_NAME }}
+          cluster: ${{ vars.AWS_ECS_CLUSTER_NAME }}
+          service: ${{ vars.AWS_ECS_MCP_SERVICE_NAME }}
+          image: ${{ needs.docker-publish-ecr-staging-mcp.outputs.image }}
 
   deploy-ecr-mcp:
     name: Deploy MCP to production
@@ -202,17 +202,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Cloning repo
+        uses: actions/checkout@v5
+
+      - name: Deploy MCP to ECS
+        uses: ./.github/actions/mcp-deploy-ecs
         with:
           role-to-assume: ${{ vars.MCP_ECR_GITHUB_ROLE_ARN }}
-          aws-region: eu-west-2
-
-      - name: Roll the service onto the new image
-        run: |
-          aws ecs update-service \
-            --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment
-          aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE"
-        env:
-          CLUSTER: ${{ vars.AWS_ECS_CLUSTER_NAME }}
-          SERVICE: ${{ vars.AWS_ECS_MCP_SERVICE_NAME }}
+          cluster: ${{ vars.AWS_ECS_CLUSTER_NAME }}
+          service: ${{ vars.AWS_ECS_MCP_SERVICE_NAME }}
+          image: ${{ needs.docker-publish-ecr-mcp.outputs.image }}

--- a/.github/workflows/mcp-docker-build-publish-deploy.yml
+++ b/.github/workflows/mcp-docker-build-publish-deploy.yml
@@ -181,7 +181,9 @@ jobs:
       id-token: write
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Deploy MCP to ECS
         uses: ./.github/actions/mcp-deploy-ecs
@@ -203,7 +205,9 @@ jobs:
       id-token: write
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Deploy MCP to ECS
         uses: ./.github/actions/mcp-deploy-ecs


### PR DESCRIPTION
The MCP task definition now points at a fixed image version (set by Pulumi) instead of a moving `latest` tag. The old deploy step only forced a restart, so it kept running the same pinned version — new releases never went live. This makes the deploy step actually put the released image onto the service.

## Changes
- [x] Deploy now updates the service to run the newly released image
- [x] Shared the deploy steps between staging and production so they can't drift apart

## Before merge
- [ ] Needs the matching AWS permissions, added in Pulumi PR Flagsmith/pulumi#288. That must land first, or the deploy step will fail.

Review effort: 2/5
