### PR TITLE
fix(docs): Google Tag Manager is not loading

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -41,6 +41,9 @@ const config: Config = {
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),
                 },
+                googleTagManager: {
+                  containerId: 'GTM-5ZV5K5G',
+                },
             } satisfies Preset.Options,
         ],
     ],
@@ -57,9 +60,6 @@ const config: Config = {
             // Public API key: it is safe to commit it
             apiKey: '00987f2d774d7787dcae25294463294c',
             indexName: 'flagsmith',
-        },
-        tagManager: {
-            trackingID: 'GTM-5ZV5K5G',
         },
         navbar: {
             title: 'Flagsmith',


### PR DESCRIPTION
Fixes #8095

Move the GTM configuration into the Docusaurus classic preset using the supported googleTagManager.containerId option, and remove the unsupported themeConfig.tagManager configuration.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to  docs.flagsmith.com

See https://github.com/Flagsmith/flagsmith/issues/8095

<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue. 
Leave "Contributes to" if the changes need to be released first. -->

_Please describe._

## How did you test this code?

I haven't tested this code, beyond using an LLM to help me confirm it's correct

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
