### PR TITLE
perf(SDK): Decouple SDK identity request cost from version history

### DIFF
--- a/api/environments/identities/managers.py
+++ b/api/environments/identities/managers.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING
 
 from django.db.models import Manager
 
+from environments.identities.services import replace_identity_environment
+
 if TYPE_CHECKING:
     from typing import Iterable
 
@@ -28,7 +30,7 @@ class IdentityManager(Manager["Identity"]):
             identifier=identifier,
             environment=environment,
         )
-        identity.environment = environment
+        replace_identity_environment(identity, environment)
         return identity, created
 
     def with_traits(

--- a/api/environments/identities/managers.py
+++ b/api/environments/identities/managers.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
     from environments.identities.models import Identity
     from environments.models import Environment
-    from integrations.integration import IntegrationConfig
 
 
 class IdentityManager(Manager["Identity"]):
@@ -25,28 +24,18 @@ class IdentityManager(Manager["Identity"]):
         identifier: str,
         environment: "Environment",
     ) -> "tuple[Identity, bool]":
-        return self.with_context().get_or_create(
+        identity, created = self.with_traits().get_or_create(
             identifier=identifier,
             environment=environment,
         )
+        identity.environment = environment
+        return identity, created
 
-    def with_context(
+    def with_traits(
         self,
-        integrations: "Iterable[IntegrationConfig] | None" = None,
-        extra_select_related: "Iterable[str] | None" = None,
         extra_prefetch_related: "Iterable[str | Prefetch] | None" = None,  # type: ignore[type-arg]
     ) -> "QuerySet[Identity]":
-        from integrations.integration import IDENTITY_INTEGRATIONS
-
-        return self.select_related(
-            "environment",
-            "environment__project",
-            *(
-                f"environment__{integration['relation_name']}"
-                for integration in (integrations or IDENTITY_INTEGRATIONS)
-            ),
-            *(extra_select_related or []),
-        ).prefetch_related(
+        return self.prefetch_related(
             "identity_traits",
             *(extra_prefetch_related or []),
         )

--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -98,7 +98,6 @@ class Identity(models.Model):
             environment=self.environment,
             feature_name=feature_name,
             additional_filters=full_query,
-            additional_select_related_args=["feature_segment__segment", "identity"],
             additional_prefetch_related_args=[
                 Prefetch(
                     "multivariate_feature_state_values",
@@ -255,11 +254,17 @@ class Identity(models.Model):
 
             if trait_key in current_traits:
                 current_trait = current_traits[trait_key]
-                # Don't update the trait if the value hasn't changed
-                if current_trait.trait_value == trait_value:
+                trait_value_data = Trait.generate_trait_value_data(trait_value)
+                # Don't update the trait if the value hasn't changed. Note that the
+                # incoming value may be raw or in `SDKTraitValueData` form, so compare
+                # the stored fields rather than the values directly.
+                if all(
+                    getattr(current_trait, attr) == value
+                    for attr, value in trait_value_data.items()
+                ):
                     continue
 
-                for attr, value in Trait.generate_trait_value_data(trait_value).items():
+                for attr, value in trait_value_data.items():
                     setattr(current_trait, attr, value)
                 updated_traits.append(current_trait)
                 continue

--- a/api/environments/identities/services.py
+++ b/api/environments/identities/services.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from environments.identities.models import Identity
+    from environments.models import Environment
+
+
+def replace_identity_environment(
+    identity: "Identity",
+    environment: "Environment",
+) -> None:
+    """
+    Replace the environment relation on an identity model instance.
+
+    Used for optimisation on SDK request paths, where identities are fetched
+    without joining the environment: assigning the relation keeps
+    `identity.environment` accesses from querying the database, and an
+    environment instance sourced from the environment cache already carries
+    its related project, organisation, and integration configurations.
+    """
+    identity.environment = environment

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -27,6 +27,7 @@ from environments.identities.serializers import (
     IdentitySerializer,
     SDKIdentitiesQuerySerializer,
 )
+from environments.identities.services import replace_identity_environment
 from environments.models import Environment
 from environments.permissions.permissions import NestedEnvironmentPermissions
 from environments.sdk.serializers import (
@@ -124,7 +125,7 @@ class SDKIdentitiesDeprecated(SDKAPIView):
                 .with_traits()
                 .get(id=identity.id)
             )
-            identity.environment = request.environment
+            replace_identity_environment(identity, request.environment)
 
         traits_data = identity.get_all_user_traits()  # type: ignore[no-untyped-call]
 
@@ -193,7 +194,7 @@ class SDKIdentities(SDKAPIView):
                 .with_traits()
                 .get(id=identity.id)
             )
-            identity.environment = request.environment
+            replace_identity_environment(identity, request.environment)
 
         self.identity = identity
 

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -121,9 +121,10 @@ class SDKIdentitiesDeprecated(SDKAPIView):
         if not is_new_identity and is_database_replica_setup():
             identity = (
                 using_database_replica(Identity.objects)
-                .with_context()
+                .with_traits()
                 .get(id=identity.id)
             )
+            identity.environment = request.environment
 
         traits_data = identity.get_all_user_traits()  # type: ignore[no-untyped-call]
 
@@ -189,9 +190,10 @@ class SDKIdentities(SDKAPIView):
         if not is_new_identity and is_database_replica_setup():
             identity = (
                 using_database_replica(Identity.objects)
-                .with_context()
+                .with_traits()
                 .get(id=identity.id)
             )
+            identity.environment = request.environment
 
         self.identity = identity
 

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -535,10 +535,10 @@ class Environment(
         if not segments:
             segments = list(
                 Segment.live_objects.filter(
-                    feature_segments__feature_states__environment=self
-                )
-                .distinct()
-                .prefetch_related(
+                    id__in=FeatureSegment.objects.filter(
+                        feature_states__environment=self
+                    ).values("segment_id")
+                ).prefetch_related(
                     "rules",
                     "rules__conditions",
                     "rules__rules",

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -536,7 +536,9 @@ class Environment(
             segments = list(
                 Segment.live_objects.filter(
                     feature_segments__feature_states__environment=self
-                ).prefetch_related(
+                )
+                .distinct()
+                .prefetch_related(
                     "rules",
                     "rules__conditions",
                     "rules__rules",

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -49,6 +49,7 @@ def get_identified_transient_identity_and_traits(
         environment=environment,
         identifier=identifier,
     ).first():
+        identity.environment = environment
         return identity, identity.update_traits(sdk_trait_data)
     return (
         identity := _get_transient_identity(
@@ -72,6 +73,7 @@ def get_persisted_identity_and_traits(
         environment=environment,
         identifier=identifier,
     )
+    identity.environment = environment
     persist_trait_data = environment.project.organisation.persist_trait_data
     if created:
         return identity, identity.generate_traits(

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -7,6 +7,7 @@ from typing import TypeAlias
 from django.utils import timezone
 
 from environments.identities.models import Identity
+from environments.identities.services import replace_identity_environment
 from environments.identities.traits.models import Trait
 from environments.models import Environment
 from environments.sdk.types import SDKTraitData
@@ -49,7 +50,7 @@ def get_identified_transient_identity_and_traits(
         environment=environment,
         identifier=identifier,
     ).first():
-        identity.environment = environment
+        replace_identity_environment(identity, environment)
         return identity, identity.update_traits(sdk_trait_data)
     return (
         identity := _get_transient_identity(
@@ -73,7 +74,7 @@ def get_persisted_identity_and_traits(
         environment=environment,
         identifier=identifier,
     )
-    identity.environment = environment
+    replace_identity_environment(identity, environment)
     persist_trait_data = environment.project.organisation.persist_trait_data
     if created:
         return identity, identity.generate_traits(

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -609,7 +609,7 @@ def _get_feature_states_queryset(
     ).prefetch_related(*additional_prefetch_related_args)
 
 
-def _exclude_superseded_versions(
+def _exclude_superseded_versions(  # TODO incorporate into get_live_feature_states https://github.com/Flagsmith/flagsmith/issues/8127
     queryset: QuerySet[FeatureState],
 ) -> QuerySet[FeatureState]:
     """

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -1,7 +1,8 @@
 import typing
 
 from common.core.utils import using_database_replica
-from django.db.models import Prefetch, Q, QuerySet
+from django.db.models import F, Prefetch, Q, QuerySet, Value, Window
+from django.db.models.functions import Coalesce, RowNumber
 from django.utils import timezone
 from rest_framework.exceptions import NotFound, ValidationError
 
@@ -108,6 +109,10 @@ def get_environment_flags_dict(
     # for each feature.
     feature_states_dict = {}  # type: ignore[var-annotated]
     for feature_state in feature_states:
+        # Every feature state in the queryset belongs to `environment`;
+        # populating the relation up front keeps `feature_state.environment`
+        # accesses from querying the database.
+        feature_state.environment = environment
         key = key_function(feature_state)
         current_feature_state = feature_states_dict.get(key)
         if not current_feature_state or feature_state > current_feature_state:
@@ -584,26 +589,44 @@ def _get_feature_states_queryset(
     if from_replica:
         feature_state_manager = using_database_replica(FeatureState.objects)
 
-    queryset = (
-        feature_state_manager.get_live_feature_states(
-            environment=environment,
-            additional_filters=additional_filters,
-        )
-        .select_related(
-            "environment",
-            "feature",
-            "feature_state_value",
-            "environment_feature_version",
-            "feature_segment",
-            *additional_select_related_args,
-        )
-        .prefetch_related(*additional_prefetch_related_args)
+    queryset = feature_state_manager.get_live_feature_states(
+        environment=environment,
+        additional_filters=additional_filters,
     )
 
     if feature_name:
         queryset = queryset.filter(feature__name__iexact=feature_name)
 
-    return queryset
+    if not environment.use_v2_feature_versioning:
+        queryset = _exclude_superseded_versions(queryset)
+
+    return queryset.select_related(
+        "feature",
+        "feature_state_value",
+        "environment_feature_version",
+        "feature_segment",
+        *additional_select_related_args,
+    ).prefetch_related(*additional_prefetch_related_args)
+
+
+def _exclude_superseded_versions(
+    queryset: QuerySet[FeatureState],
+) -> QuerySet[FeatureState]:
+    """
+    Exclude feature states superseded by a newer live version of the same
+    environment default, segment override, or identity override.
+    """
+    return queryset.annotate(
+        version_rank=Window(
+            expression=RowNumber(),
+            partition_by=[
+                F("feature_id"),
+                Coalesce("feature_segment_id", Value(0)),
+                Coalesce("identity_id", Value(0)),
+            ],
+            order_by=[F("live_from").desc(), F("version").desc()],
+        ),
+    ).filter(version_rank=1)
 
 
 def _get_distinct_key(

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -1122,9 +1122,10 @@ class SDKFeatureStates(GenericAPIView):  # type: ignore[type-arg]
         if not is_new_identity and is_database_replica_setup():
             identity = (
                 using_database_replica(Identity.objects)
-                .with_context()
+                .with_traits()
                 .get(id=identity.id)
             )
+        identity.environment = request.environment
 
         if feature_name := request.GET.get("feature"):
             feature_states = identity.get_all_feature_states(feature_name=feature_name)

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -55,6 +55,7 @@ from environments.identities.serializers import (
     IdentityAllFeatureStatesSerializer,
     IdentitySourceIdentityRequestSerializer,
 )
+from environments.identities.services import replace_identity_environment
 from environments.models import Environment
 from environments.onboarding.services import record_environment_first_evaluation
 from environments.permissions.permissions import (
@@ -1125,7 +1126,7 @@ class SDKFeatureStates(GenericAPIView):  # type: ignore[type-arg]
                 .with_traits()
                 .get(id=identity.id)
             )
-        identity.environment = request.environment
+        replace_identity_environment(identity, request.environment)
 
         if feature_name := request.GET.get("feature"):
             feature_states = identity.get_all_feature_states(feature_name=feature_name)

--- a/api/tests/unit/environments/identities/test_unit_identities_models.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_models.py
@@ -921,6 +921,24 @@ def test_update_traits__unchanged_value__makes_single_query(  # type: ignore[no-
     assert True  # verified by django_assert_num_queries context manager above
 
 
+def test_update_traits__unchanged_sdk_trait_value_data__makes_single_query(
+    identity: Identity,
+    django_assert_num_queries: DjangoAssertNumQueries,
+    trait: Trait,
+) -> None:
+    # Given
+    trait_data_items = [
+        generate_trait_data_item(
+            trait_key=trait.trait_key,
+            trait_value={"type": trait.value_type, "value": trait.trait_value},
+        ),
+    ]
+
+    # When / Then
+    with django_assert_num_queries(1):
+        identity.update_traits(trait_data_items)
+
+
 @pytest.mark.parametrize(
     "environment_value, project_value, disabled_flag_returned",
     (

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -742,7 +742,7 @@ def test_sdk_feature_states_get__no_identifier__returns_feature_list(
     ["use_replica", "is_new_identity", "num_queries"],
     [
         pytest.param(False, True, 9, id="default_database,new_identity"),
-        pytest.param(False, False, 8, id="default_database,existing_identity"),
+        pytest.param(False, False, 6, id="default_database,existing_identity"),
         pytest.param(True, True, 9, id="replica_database,new_identity"),
         pytest.param(True, False, 7, id="replica_database,existing_identity"),
     ],
@@ -795,7 +795,7 @@ def test_SDKFeatureStates_get__given_identifier__responds_200_with_feature_list(
     ["use_replica", "is_new_identity", "num_queries"],
     [
         pytest.param(False, True, 9, id="default_database,new_identity"),
-        pytest.param(False, False, 8, id="default_database,existing_identity"),
+        pytest.param(False, False, 6, id="default_database,existing_identity"),
         pytest.param(True, True, 9, id="replica_database,new_identity"),
         pytest.param(True, False, 7, id="replica_database,existing_identity"),
     ],
@@ -846,7 +846,7 @@ def test_sdk_feature_states_get__identifier_and_existing_feature__returns_featur
     ["use_replica", "is_new_identity", "num_queries"],
     [
         pytest.param(False, True, 8, id="default_database,new_identity"),
-        pytest.param(False, False, 7, id="default_database,existing_identity"),
+        pytest.param(False, False, 5, id="default_database,existing_identity"),
         pytest.param(True, True, 8, id="replica_database,new_identity"),
         pytest.param(True, False, 6, id="replica_database,existing_identity"),
     ],

--- a/api/tests/unit/features/versioning/test_unit_versioning_versioning_service.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_versioning_service.py
@@ -136,6 +136,114 @@ def test_get_environment_flags_list__multiple_versions_and_identities__returns_l
     }
 
 
+def test_get_environment_flags_list__segment_override_multiple_versions__returns_latest_live(
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    segment: Segment,
+) -> None:
+    # Given
+    environment_default_feature_state = FeatureState.objects.get(
+        feature=feature, environment=environment, feature_segment=None, identity=None
+    )
+    feature_segment = FeatureSegment.objects.create(
+        feature=feature, segment=segment, environment=environment
+    )
+    FeatureState.objects.create(
+        feature=feature,
+        environment=environment,
+        feature_segment=feature_segment,
+        enabled=False,
+        version=1,
+        live_from=timezone.now() - timedelta(days=1),
+    )
+    segment_override_v2_feature_state = FeatureState.objects.create(
+        feature=feature,
+        environment=environment,
+        feature_segment=feature_segment,
+        enabled=True,
+        version=2,
+        live_from=timezone.now(),
+    )
+
+    # When
+    environment_feature_states = get_environment_flags_list(environment=environment)
+
+    # Then
+    assert set(environment_feature_states) == {
+        environment_default_feature_state,
+        segment_override_v2_feature_state,
+    }
+
+
+def test_get_environment_flags_list__identity_override_multiple_versions__returns_latest_live(
+    environment: Environment,
+    feature: Feature,
+    identity: Identity,
+) -> None:
+    # Given
+    environment_default_feature_state = FeatureState.objects.get(
+        feature=feature, environment=environment, feature_segment=None, identity=None
+    )
+    FeatureState.objects.create(
+        feature=feature,
+        environment=environment,
+        identity=identity,
+        enabled=False,
+        version=1,
+        live_from=timezone.now() - timedelta(days=1),
+    )
+    identity_override_v2_feature_state = FeatureState.objects.create(
+        feature=feature,
+        environment=environment,
+        identity=identity,
+        enabled=True,
+        version=2,
+        live_from=timezone.now(),
+    )
+
+    # When
+    environment_feature_states = get_environment_flags_list(environment=environment)
+
+    # Then
+    assert set(environment_feature_states) == {
+        environment_default_feature_state,
+        identity_override_v2_feature_state,
+    }
+
+
+def test_get_environment_flags_list__filter_excludes_latest_version__returns_latest_matching(
+    environment: Environment,
+    feature: Feature,
+) -> None:
+    # Given
+    # the latest committed version of a flag is disabled,
+    # with an earlier enabled version behind it
+    enabled_v2_feature_state = FeatureState.objects.get(
+        feature=feature, environment=environment, feature_segment=None, identity=None
+    )
+    enabled_v2_feature_state.version = 2
+    enabled_v2_feature_state.enabled = True
+    enabled_v2_feature_state.save()
+    FeatureState.objects.create(
+        feature=feature,
+        environment=environment,
+        enabled=False,
+        version=3,
+        live_from=timezone.now(),
+    )
+
+    # When
+    environment_feature_states = get_environment_flags_list(
+        environment=environment,
+        additional_filters=Q(enabled=True),
+    )
+
+    # Then
+    # the latest version that matches the filters is returned
+    assert environment_feature_states == [enabled_v2_feature_state]
+
+
 def test_get_environment_flags_list__v2_versioning_with_published_version__returns_latest_live(
     project: Project,
     environment_v2_versioning: Environment,


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The `GET`/`POST /api/v1/identities/` hot path had several costs, some of which grow with environment size and age:

1. In v1-versioning environments, flag evaluation fetched every committed version of every feature state. Version selection now happens in SQL with a `ROW_NUMBER()` window over `(feature, feature_segment, identity)` ordered by `(live_from, version)`, replicating `FeatureState.__gt__`. The Python dedup still runs on the reduced set to make sure the logic is unchanged. The `additional_filters` logic is preserved, and v2-versioning environments are unaffected.

2. Every `POST` with traits wrote unchanged traits. `update_traits` compared the stored scalar against the SDK-deserialised dict, which never matches. This is now fixed.

3. The wide `Environment` join happened multiple times. We're now making sure it's done once per request. This also benefits `GET /api/v1/flags`. There were also some unused joins: `identity` and `feature_segment__segment`, that are now removed.

4. No `.distinct()` on the environment segments queryset meant a more expensive dedup on the Python side. Implemented as a semi-join to keep Oracle compat.

Benchmarked with [this script](https://gist.github.com/khvn26/18ff3c56b5f2cdc0f3a51f67f16950ce) (100 features, 20 segments overriding 5 features each, 5 committed versions per override, 10 traits):

| | before | after |
|---|---|---|
| `GET` mean latency | 174 ms | 60 ms |
| `POST` mean latency | 179 ms | 57 ms |
| `POST` queries (writes) | 19 (1) | 10 (0) |

Real deployments should see a larger gain as latency climbed along with version counts.

## How did you test this code?

- Added `test_update_traits__unchanged_sdk_trait_value_data__makes_single_query` pinning the no-write behaviour for SDK-shaped trait values.
- Updated three deprecated-endpoint query count assertions downwards (8→6, 8→6, 7→5).
- Benchmark linked above.

