### PR TITLE
feat(experiments): expose metric direction on experiment metrics API

### DIFF
--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -16,6 +16,7 @@ from experimentation.models import (
     ExperimentResults,
     ExperimentStatus,
     Metric,
+    MetricDirection,
     WarehouseConnection,
     WarehouseConnectionStatus,
     WarehouseType,
@@ -175,7 +176,11 @@ class ExperimentMetricSerializer(serializers.ModelSerializer):  # type: ignore[t
     )
     metric_name = serializers.CharField(source="metric.name", read_only=True)
     aggregation = serializers.CharField(source="metric.aggregation", read_only=True)
-    direction = serializers.CharField(source="metric.direction", read_only=True)
+    direction = serializers.ChoiceField(
+        choices=MetricDirection.choices,
+        source="metric.direction",
+        read_only=True,
+    )
 
     class Meta:
         model = ExperimentMetric

--- a/api/experimentation/serializers.py
+++ b/api/experimentation/serializers.py
@@ -175,6 +175,7 @@ class ExperimentMetricSerializer(serializers.ModelSerializer):  # type: ignore[t
     )
     metric_name = serializers.CharField(source="metric.name", read_only=True)
     aggregation = serializers.CharField(source="metric.aggregation", read_only=True)
+    direction = serializers.CharField(source="metric.direction", read_only=True)
 
     class Meta:
         model = ExperimentMetric
@@ -183,6 +184,7 @@ class ExperimentMetricSerializer(serializers.ModelSerializer):  # type: ignore[t
             "metric",
             "metric_name",
             "aggregation",
+            "direction",
             "expected_direction",
             "created_at",
         )

--- a/api/tests/unit/experimentation/test_experiment_metric_views.py
+++ b/api/tests/unit/experimentation/test_experiment_metric_views.py
@@ -64,6 +64,7 @@ def test_attach_metric__valid__returns_201(
     assert response.status_code == status.HTTP_201_CREATED
     data = response.json()
     assert data["metric_name"] == "Sessions per User"
+    assert data["direction"] == "up"
     assert data["expected_direction"] == "increase"
     assert ExperimentMetric.objects.filter(
         experiment=experiment, metric=metric

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -4535,6 +4535,10 @@
             "type": "string",
             "readOnly": true
           },
+          "direction": {
+            "type": "string",
+            "readOnly": true
+          },
           "expected_direction": {
             "$ref": "#/components/schemas/ExpectedDirectionEnum"
           },

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -4536,7 +4536,11 @@
             "readOnly": true
           },
           "direction": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DirectionEnum"
+              }
+            ],
             "readOnly": true
           },
           "expected_direction": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20182,6 +20182,9 @@ components:
         aggregation:
           type: string
           readOnly: true
+        direction:
+          type: string
+          readOnly: true
         expected_direction:
           $ref: '#/components/schemas/ExpectedDirectionEnum'
         created_at:
@@ -23685,6 +23688,9 @@ components:
           type: string
           readOnly: true
         aggregation:
+          type: string
+          readOnly: true
+        direction:
           type: string
           readOnly: true
         expected_direction:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20183,7 +20183,8 @@ components:
           type: string
           readOnly: true
         direction:
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/DirectionEnum'
           readOnly: true
         expected_direction:
           $ref: '#/components/schemas/ExpectedDirectionEnum'
@@ -23691,7 +23692,8 @@ components:
           type: string
           readOnly: true
         direction:
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/DirectionEnum'
           readOnly: true
         expected_direction:
           $ref: '#/components/schemas/ExpectedDirectionEnum'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Exposes the metric's inherent `direction` (`up` / `down` / `informational`) on the experiment metrics API, read-only from the related `Metric`. The frontend uses it to colour lift values by whether they move with or against the metric (follow-up to #8091).

## How did you test this code?

Extended the attach-metric view test to assert the new field; `tests/unit/experimentation/test_experiment_metric_views.py` passes (18 tests), mypy clean.
