### PR TITLE
fix: send falsy variant values to Mixpanel and Rudderstack integrations

### DIFF
--- a/api/integrations/mixpanel/mixpanel.py
+++ b/api/integrations/mixpanel/mixpanel.py
@@ -46,6 +46,9 @@ class MixpanelWrapper(AbstractBaseIdentityIntegrationWrapper[MixpanelUserData]):
 
         for feature_state in feature_states:
             value = feature_state.get_feature_state_value(identity=identity)
+            # enabled + value set (incl. falsy like 0 or "") -> value
+            # enabled + value is None -> True
+            # disabled -> False
             feature_properties[feature_state.feature.name] = (
                 value
                 if (feature_state.enabled and value is not None)

--- a/api/integrations/mixpanel/mixpanel.py
+++ b/api/integrations/mixpanel/mixpanel.py
@@ -47,7 +47,9 @@ class MixpanelWrapper(AbstractBaseIdentityIntegrationWrapper[MixpanelUserData]):
         for feature_state in feature_states:
             value = feature_state.get_feature_state_value(identity=identity)
             feature_properties[feature_state.feature.name] = (
-                value if (feature_state.enabled and value) else feature_state.enabled
+                value
+                if (feature_state.enabled and value is not None)
+                else feature_state.enabled
             )
 
         return [

--- a/api/integrations/rudderstack/rudderstack.py
+++ b/api/integrations/rudderstack/rudderstack.py
@@ -32,7 +32,9 @@ class RudderstackWrapper(AbstractBaseIdentityIntegrationWrapper):  # type: ignor
         for feature_state in feature_states:
             value = feature_state.get_feature_state_value(identity=identity)
             feature_properties[feature_state.feature.name] = (
-                value if (feature_state.enabled and value) else feature_state.enabled
+                value
+                if (feature_state.enabled and value is not None)
+                else feature_state.enabled
             )
 
         return {

--- a/api/integrations/rudderstack/rudderstack.py
+++ b/api/integrations/rudderstack/rudderstack.py
@@ -31,6 +31,9 @@ class RudderstackWrapper(AbstractBaseIdentityIntegrationWrapper):  # type: ignor
 
         for feature_state in feature_states:
             value = feature_state.get_feature_state_value(identity=identity)
+            # enabled + value set (incl. falsy like 0 or "") -> value
+            # enabled + value is None -> True
+            # disabled -> False
             feature_properties[feature_state.feature.name] = (
                 value
                 if (feature_state.enabled and value is not None)

--- a/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
+++ b/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
@@ -207,7 +207,7 @@ def test_identify_integrations__mixpanel_configured__posts_to_expected_url(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "feature_state_with_value,expected_property_value",
-    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
+    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), (None, True)],
     indirect=["feature_state_with_value"],
 )
 def test_mixpanel_generate_user_data__falsy_values__returns_value_not_enabled_state(

--- a/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
+++ b/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
@@ -207,7 +207,15 @@ def test_identify_integrations__mixpanel_configured__posts_to_expected_url(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "feature_state_with_value,expected_property_value",
-    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), ("", ""), (None, True)],
+    [
+        (False, False),
+        (True, True),
+        ("foo", "foo"),
+        (1, 1),
+        (0, 0),
+        ("", ""),
+        (None, True),
+    ],
     indirect=["feature_state_with_value"],
 )
 def test_mixpanel_generate_user_data__falsy_values__returns_value_not_enabled_state(

--- a/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
+++ b/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
@@ -207,7 +207,7 @@ def test_identify_integrations__mixpanel_configured__posts_to_expected_url(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "feature_state_with_value,expected_property_value",
-    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), (None, True)],
+    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), ("", ""), (None, True)],
     indirect=["feature_state_with_value"],
 )
 def test_mixpanel_generate_user_data__falsy_values__returns_value_not_enabled_state(

--- a/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
+++ b/api/tests/unit/integrations/mixpanel/test_unit_mixpanel.py
@@ -1,3 +1,4 @@
+import typing
 from logging import DEBUG
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
 
     from environments.identities.models import Identity
     from environments.models import Environment
-    from features.models import Feature
+    from features.models import Feature, FeatureState
     from projects.models import Project
 
 
@@ -140,7 +141,9 @@ def test_mixpanel_generate_user_data__identity_with_features__returns_expected_f
     for feature_state in feature_states:
         value = feature_state.get_feature_state_value()
         feature_properties[feature_state.feature.name] = (
-            value if (feature_state.enabled and value) else feature_state.enabled
+            value
+            if (feature_state.enabled and value is not None)
+            else feature_state.enabled
         )
 
     expected_user_data = [
@@ -199,3 +202,65 @@ def test_identify_integrations__mixpanel_configured__posts_to_expected_url(
     # Then
     assert mocked_post.call_args.args[0] == expected_url
     assert mocked_post.call_args.kwargs["json"][0]["$token"] == api_key
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "feature_state_with_value,expected_property_value",
+    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
+    indirect=["feature_state_with_value"],
+)
+def test_mixpanel_generate_user_data__falsy_values__returns_value_not_enabled_state(
+    expected_property_value: typing.Any,
+    environment: "Environment",
+    feature_state: "FeatureState",
+    feature_state_with_value: "FeatureState",
+    identity: "Identity",
+) -> None:
+    # Given
+    config = MixpanelConfiguration(api_key="123key")
+    mixpanel = MixpanelWrapper(config)
+
+    # When
+    user_data = mixpanel.generate_user_data(
+        identity=identity,
+        feature_states=[feature_state, feature_state_with_value],
+        trait_models=[],
+    )
+
+    # Then
+    expected_user_data = [
+        {
+            "$token": config.api_key,
+            "$distinct_id": identity.identifier,
+            "$set": {
+                feature_state.feature.name: feature_state.enabled,
+                feature_state_with_value.feature.name: expected_property_value,
+            },
+            "$ip": "0",
+        }
+    ]
+    assert user_data == expected_user_data
+
+
+@pytest.mark.django_db
+def test_mixpanel_generate_user_data__disabled_flag__returns_enabled_state(
+    feature: "Feature",
+    environment: "Environment",
+    identity: "Identity",
+) -> None:
+    # Given
+    config = MixpanelConfiguration(api_key="123key")
+    mixpanel = MixpanelWrapper(config)
+    feature_states = [*feature.feature_states.all()]
+
+    # When
+    user_data = mixpanel.generate_user_data(
+        identity=identity,
+        feature_states=feature_states,
+        trait_models=[],
+    )
+
+    # Then
+    # Default feature is not enabled, so the value should be False
+    assert user_data[0]["$set"][feature.name] is False

--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
@@ -36,7 +36,7 @@ def test_rudderstack_generate_user_data__valid_identity__returns_expected_data( 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "feature_state_with_value,expected_property_value",
-    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
+    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), (None, True)],
     indirect=["feature_state_with_value"],
 )
 def test_rudderstack_generate_user_data__falsy_values__returns_value_not_enabled_state(

--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
@@ -36,7 +36,7 @@ def test_rudderstack_generate_user_data__valid_identity__returns_expected_data( 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "feature_state_with_value,expected_property_value",
-    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), (None, True)],
+    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), ("", ""), (None, True)],
     indirect=["feature_state_with_value"],
 )
 def test_rudderstack_generate_user_data__falsy_values__returns_value_not_enabled_state(

--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
@@ -1,3 +1,7 @@
+import typing
+
+import pytest
+
 from environments.identities.models import Identity
 from environments.models import Environment
 from features.models import Feature, FeatureState
@@ -26,4 +30,39 @@ def test_rudderstack_generate_user_data__valid_identity__returns_expected_data( 
     assert user_data == {
         "user_id": identity.identifier,
         "traits": {feature.name: False},
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "feature_state_with_value,expected_property_value",
+    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0)],
+    indirect=["feature_state_with_value"],
+)
+def test_rudderstack_generate_user_data__falsy_values__returns_value_not_enabled_state(
+    expected_property_value: typing.Any,
+    environment: Environment,
+    feature_state: FeatureState,
+    feature_state_with_value: FeatureState,
+    identity: Identity,
+) -> None:
+    # Given
+    config = RudderstackConfiguration(
+        api_key="123key", base_url="https://api.rudderstack.com/"
+    )
+    rudderstack_wrapper = RudderstackWrapper(config)
+
+    # When
+    user_data = rudderstack_wrapper.generate_user_data(
+        identity=identity,
+        feature_states=[feature_state, feature_state_with_value],
+    )
+
+    # Then
+    assert user_data == {
+        "user_id": identity.identifier,
+        "traits": {
+            feature_state.feature.name: feature_state.enabled,
+            feature_state_with_value.feature.name: expected_property_value,
+        },
     }

--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack.py
@@ -36,7 +36,15 @@ def test_rudderstack_generate_user_data__valid_identity__returns_expected_data( 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "feature_state_with_value,expected_property_value",
-    [(False, False), (True, True), ("foo", "foo"), (1, 1), (0, 0), ("", ""), (None, True)],
+    [
+        (False, False),
+        (True, True),
+        ("foo", "foo"),
+        (1, 1),
+        (0, 0),
+        ("", ""),
+        (None, True),
+    ],
     indirect=["feature_state_with_value"],
 )
 def test_rudderstack_generate_user_data__falsy_values__returns_value_not_enabled_state(


### PR DESCRIPTION
### Describe the pull request
This PR fixes a bug in the Mixpanel and Rudderstack integrations where falsy variant values (like `False`, `0`, or `""`) were being incorrectly dropped and replaced with the feature's `enabled` state (usually `True`).

**Root cause:**
The integrations used the ternary expression:
value if (feature_state.enabled and value) else feature_state.enabled
Because `False`, `0`, and `""` are falsy in Python, the `and value` condition failed, causing the code to fall back to `feature_state.enabled`.

**Fix:**
Updated the logic to check for `value is not None`, matching the correct pattern already used in the Amplitude and Heap integrations:
value if (feature_state.enabled and value is not None) else feature_state.enabled

I also updated the existing unit tests and added new parametrized tests (matching the Heap integration test pattern) to explicitly verify that falsy values (`False`, `0`, `""`) are sent correctly to both Mixpanel and Rudderstack.

### Link to the issue
Closes #7701
