### PR TITLE
feat: show segment rule diffs in audit log change details

### DIFF
--- a/api/audit/serializers.py
+++ b/api/audit/serializers.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
 from audit.types import AuditLogChangeDetail, ChangeType
 from environments.serializers import EnvironmentSerializerLight
 from projects.serializers import ProjectListSerializer
@@ -74,8 +75,25 @@ class AuditLogRetrieveSerializer(serializers.ModelSerializer):  # type: ignore[t
     )
     def get_change_details(self, instance: AuditLog) -> list[AuditLogChangeDetail]:
         if history_record := instance.history_record:
+            changes = history_record.get_change_details()  # type: ignore[attr-defined]
+
+            # For segment updates, include rule/condition diffs.
+            if (
+                instance.related_object_type == RelatedObjectType.SEGMENT.name
+                and history_record.history_type == "~"  # type: ignore[attr-defined]
+                and getattr(history_record, "version", None)
+            ):
+                from segments.audit_helpers import (
+                    get_segment_rules_change_details,
+                )
+
+                changes = list(changes) + get_segment_rules_change_details(
+                    segment_id=instance.related_object_id,  # type: ignore[arg-type]
+                    current_version=history_record.version,  # type: ignore[attr-defined]
+                )
+
             return AuditLogChangeDetailsSerializer(  # type: ignore[return-value]
-                instance=history_record.get_change_details(),  # type: ignore[attr-defined]
+                instance=changes,
                 many=True,
             ).data
 

--- a/api/segments/audit_helpers.py
+++ b/api/segments/audit_helpers.py
@@ -1,0 +1,185 @@
+import typing
+from typing import Any
+
+from simple_history.models import ModelChange
+
+if typing.TYPE_CHECKING:
+    from segments.models import Condition, Segment, SegmentRule
+
+
+def get_segment_rules_data(segment: "Segment") -> list[dict[str, Any]]:
+    """
+    Serialize a segment's rules and conditions into a list of dicts
+    suitable for comparison in audit log change details.
+    """
+    from segments.models import Condition, SegmentRule
+
+    top_level_rules = list(SegmentRule.objects.filter(segment=segment).order_by("id"))
+    if not top_level_rules:
+        return []
+
+    # Collect all rule IDs level by level.
+    rule_id_to_children: dict[int, list["SegmentRule"]] = {}
+    current_level = top_level_rules
+
+    while current_level:
+        current_ids = [r.id for r in current_level]
+        nested = list(
+            SegmentRule.objects.filter(rule_id__in=current_ids).order_by("id")
+        )
+        for rule in nested:
+            parent_id: int = rule.rule_id  # type: ignore[assignment]
+            rule_id_to_children.setdefault(parent_id, []).append(rule)
+        current_level = nested
+
+    # Collect all conditions in one query.
+    all_rule_ids: set[int] = set()
+    _collect_rule_ids(top_level_rules, rule_id_to_children, all_rule_ids)
+    conditions = list(Condition.objects.filter(rule_id__in=all_rule_ids).order_by("id"))
+    rule_id_to_conditions: dict[int, list["Condition"]] = {}
+    for condition in conditions:
+        cond_rule_id: int = condition.rule_id
+        rule_id_to_conditions.setdefault(cond_rule_id, []).append(condition)
+
+    return [
+        _serialize_rule(rule, rule_id_to_children, rule_id_to_conditions)
+        for rule in top_level_rules
+    ]
+
+
+def _collect_rule_ids(
+    rules: list[Any],
+    rule_id_to_children: dict[int, list[Any]],
+    result: set[int],
+) -> None:
+    for rule in rules:
+        result.add(rule.id)
+        children = rule_id_to_children.get(rule.id, [])
+        _collect_rule_ids(children, rule_id_to_children, result)
+
+
+def _serialize_rule(
+    rule: "SegmentRule",
+    rule_id_to_children: dict[int, list[Any]],
+    rule_id_to_conditions: dict[int, list[Any]],
+) -> dict[str, Any]:
+    conditions = rule_id_to_conditions.get(rule.id, [])
+    children = rule_id_to_children.get(rule.id, [])
+    data: dict[str, Any] = {"type": rule.type}
+    if conditions:
+        data["conditions"] = [_serialize_condition(c) for c in conditions]
+    if children:
+        data["rules"] = [
+            _serialize_rule(child, rule_id_to_children, rule_id_to_conditions)
+            for child in children
+        ]
+    return data
+
+
+def _serialize_condition(condition: "Condition") -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "operator": condition.operator,
+    }
+    if condition.property:
+        data["property"] = condition.property
+    if condition.value is not None:
+        data["value"] = condition.value
+    return data
+
+
+def get_segment_rules_change_details(
+    segment_id: int,
+    current_version: int,
+) -> list[ModelChange]:
+    """
+    Compute rule change details for a segment update by comparing
+    the previous revision's rules against the current version's rules.
+
+    Uses revision records for both old and new state so that historical
+    audit entries remain accurate even after further updates.
+
+    Only called from the retrieve serializer (single object), not the
+    list endpoint, so the extra queries are bounded.
+    """
+    from segments.models import Segment
+
+    # The "old" state is the revision with version = current_version - 1.
+    previous_revision = (
+        Segment.objects.filter(
+            version_of_id=segment_id,
+            version=current_version - 1,
+        )
+        .order_by("-id")
+        .first()
+    )
+
+    if previous_revision is None:
+        return []
+
+    # The "new" state: look for a revision that captured this version
+    # (created by the next update). If none exists, the live segment
+    # is still at this version and we use it directly.
+    current_revision = (
+        Segment.objects.filter(
+            version_of_id=segment_id,
+            version=current_version,
+        )
+        .order_by("-id")
+        .first()
+    )
+
+    if current_revision is None:
+        # This is the latest update; use the live segment.
+        try:
+            current_segment = Segment.objects.get(id=segment_id)
+        except Segment.DoesNotExist:
+            return []
+        new_rules = get_segment_rules_data(current_segment)
+    else:
+        new_rules = get_segment_rules_data(current_revision)
+
+    old_rules = get_segment_rules_data(previous_revision)
+
+    if old_rules == new_rules:
+        return []
+
+    return [
+        ModelChange(
+            "rules",
+            _format_rules_for_display(old_rules),
+            _format_rules_for_display(new_rules),
+        )
+    ]
+
+
+def _format_rules_for_display(rules_data: list[dict[str, Any]]) -> str:
+    """Format rules data into a human-readable string for the audit log."""
+    if not rules_data:
+        return "(empty)"
+
+    parts = []
+    for rule in rules_data:
+        parts.append(_format_rule(rule))
+    return "; ".join(parts)
+
+
+def _format_rule(rule: dict[str, Any]) -> str:
+    rule_type = rule["type"]
+    conditions: list[dict[str, Any]] = rule.get("conditions", [])
+    sub_rules: list[dict[str, Any]] = rule.get("rules", [])
+
+    condition_strs = []
+    for c in conditions:
+        prop = c.get("property", "")
+        op = c["operator"]
+        val = c.get("value", "")
+        condition_strs.append(f"{prop} {op} {val}".strip())
+
+    sub_rule_strs = [_format_rule(r) for r in sub_rules]
+
+    all_parts = condition_strs + sub_rule_strs
+    if not all_parts:
+        return f"{rule_type}()"
+
+    joiner = f" {rule_type} "
+    return f"({joiner.join(all_parts)})"

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -80,7 +80,10 @@ class SegmentConditionManager(ConfiguredOrderManager["Condition"]):
 class Segment(
     LifecycleModelMixin,  # type: ignore[misc]
     SoftDeleteExportableModel,
-    abstract_base_auditable_model_factory(["uuid"]),  # type: ignore[misc]
+    abstract_base_auditable_model_factory(  # type: ignore[misc]
+        ["uuid"],
+        change_details_excluded_fields=["version"],
+    ),
 ):
     history_record_class_path = "segments.models.HistoricalSegment"
     related_object_type = RelatedObjectType.SEGMENT

--- a/api/tests/unit/segments/test_unit_segments_audit_helpers.py
+++ b/api/tests/unit/segments/test_unit_segments_audit_helpers.py
@@ -1,0 +1,315 @@
+from flag_engine.segments.constants import EQUAL, GREATER_THAN
+
+from segments.audit_helpers import (
+    _format_rules_for_display,
+    get_segment_rules_change_details,
+    get_segment_rules_data,
+)
+from segments.models import Condition, Segment, SegmentRule
+
+
+def test_get_segment_rules_data__no_rules__returns_empty_list(
+    segment: Segment,
+) -> None:
+    # Given - segment with no rules
+    # When
+    result = get_segment_rules_data(segment)
+    # Then
+    assert result == []
+
+
+def test_get_segment_rules_data__single_rule__returns_serialized_conditions(
+    segment: Segment,
+) -> None:
+    # Given
+    rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator=EQUAL, property="age", value="25")
+
+    # When
+    result = get_segment_rules_data(segment)
+
+    # Then
+    assert result == [
+        {
+            "type": "ALL",
+            "conditions": [{"operator": EQUAL, "property": "age", "value": "25"}],
+        }
+    ]
+
+
+def test_get_segment_rules_data__nested_rules__returns_nested_structure(
+    segment: Segment,
+) -> None:
+    # Given
+    top_rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    nested_rule = SegmentRule.objects.create(rule=top_rule, type=SegmentRule.ANY_RULE)
+    Condition.objects.create(
+        rule=nested_rule, operator=EQUAL, property="country", value="US"
+    )
+    Condition.objects.create(
+        rule=nested_rule, operator=EQUAL, property="country", value="UK"
+    )
+
+    # When
+    result = get_segment_rules_data(segment)
+
+    # Then
+    assert result == [
+        {
+            "type": "ALL",
+            "rules": [
+                {
+                    "type": "ANY",
+                    "conditions": [
+                        {"operator": EQUAL, "property": "country", "value": "US"},
+                        {"operator": EQUAL, "property": "country", "value": "UK"},
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+def test_get_segment_rules_data__multiple_top_rules__returns_all_rules(
+    segment: Segment,
+) -> None:
+    # Given
+    rule1 = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    rule2 = SegmentRule.objects.create(segment=segment, type=SegmentRule.ANY_RULE)
+    Condition.objects.create(rule=rule1, operator=EQUAL, property="plan", value="pro")
+    Condition.objects.create(
+        rule=rule2, operator=GREATER_THAN, property="age", value="18"
+    )
+
+    # When
+    result = get_segment_rules_data(segment)
+
+    # Then
+    assert len(result) == 2
+    assert result[0]["type"] == "ALL"
+    assert result[0]["conditions"] == [
+        {"operator": EQUAL, "property": "plan", "value": "pro"}
+    ]
+    assert result[1]["type"] == "ANY"
+    assert result[1]["conditions"] == [
+        {"operator": GREATER_THAN, "property": "age", "value": "18"}
+    ]
+
+
+def test_get_segment_rules_data__no_property_condition__omits_property_key(
+    segment: Segment,
+) -> None:
+    # Given - percentage split condition has no property
+    rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator="PERCENTAGE_SPLIT", value="50")
+
+    # When
+    result = get_segment_rules_data(segment)
+
+    # Then
+    assert result == [
+        {
+            "type": "ALL",
+            "conditions": [{"operator": "PERCENTAGE_SPLIT", "value": "50"}],
+        }
+    ]
+
+
+def test_get_segment_rules_change_details__rules_changed__returns_diff(
+    project,
+) -> None:
+    # Given
+    segment = Segment.objects.create(name="test", project=project)
+    rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator=EQUAL, property="age", value="25")
+    segment.clone(is_revision=True)
+
+    Condition.objects.filter(rule__segment=segment).delete()
+    SegmentRule.objects.filter(segment=segment).delete()
+    new_rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(
+        rule=new_rule, operator=GREATER_THAN, property="age", value="30"
+    )
+
+    # When
+    result = get_segment_rules_change_details(
+        segment_id=segment.id,
+        current_version=segment.version,
+    )
+
+    # Then
+    assert len(result) == 1
+    assert result[0].field == "rules"
+    assert "age EQUAL 25" in result[0].old
+    assert "age GREATER_THAN 30" in result[0].new
+
+
+def test_get_segment_rules_change_details__rules_unchanged__returns_empty_list(
+    project,
+) -> None:
+    # Given
+    segment = Segment.objects.create(name="test", project=project)
+    rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator=EQUAL, property="age", value="25")
+    segment.clone(is_revision=True)
+
+    # When
+    result = get_segment_rules_change_details(
+        segment_id=segment.id,
+        current_version=segment.version,
+    )
+
+    # Then
+    assert result == []
+
+
+def test_get_segment_rules_change_details__no_previous_revision__returns_empty_list(
+    project,
+) -> None:
+    # Given
+    segment = Segment.objects.create(name="test", project=project)
+    rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator=EQUAL, property="age", value="25")
+
+    # When
+    result = get_segment_rules_change_details(
+        segment_id=segment.id,
+        current_version=1,
+    )
+
+    # Then
+    assert result == []
+
+
+def test_get_segment_rules_change_details__segment_deleted__returns_empty_list(
+    project,
+) -> None:
+    # Given - non-existent segment
+    # When
+    result = get_segment_rules_change_details(
+        segment_id=99999,
+        current_version=2,
+    )
+
+    # Then
+    assert result == []
+
+
+def test_get_segment_rules_change_details__two_updates__shows_correct_diff_for_first(
+    project,
+) -> None:
+    # Given - segment updated twice
+    segment = Segment.objects.create(name="test", project=project)
+    rule = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator=EQUAL, property="age", value="25")
+
+    # First update: rules change from [age=25] to [age=30]
+    segment.clone(is_revision=True)
+    Condition.objects.filter(rule__segment=segment).delete()
+    SegmentRule.objects.filter(segment=segment).delete()
+    rule2 = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(
+        rule=rule2, operator=GREATER_THAN, property="age", value="30"
+    )
+    first_update_version = segment.version  # version=2
+
+    # Second update: rules change from [age>30] to [plan=pro]
+    segment.clone(is_revision=True)
+    Condition.objects.filter(rule__segment=segment).delete()
+    SegmentRule.objects.filter(segment=segment).delete()
+    rule3 = SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule3, operator=EQUAL, property="plan", value="pro")
+    second_update_version = segment.version  # version=3
+
+    # When - check the diff for the FIRST update
+    result_first = get_segment_rules_change_details(
+        segment_id=segment.id,
+        current_version=first_update_version,
+    )
+
+    # Then - should show [age=25] -> [age>30], NOT [age=25] -> [plan=pro]
+    assert len(result_first) == 1
+    assert "age EQUAL 25" in result_first[0].old
+    assert "age GREATER_THAN 30" in result_first[0].new
+    assert "plan" not in result_first[0].new
+
+    # When - check the diff for the SECOND update
+    result_second = get_segment_rules_change_details(
+        segment_id=segment.id,
+        current_version=second_update_version,
+    )
+
+    # Then - should show [age>30] -> [plan=pro]
+    assert len(result_second) == 1
+    assert "age GREATER_THAN 30" in result_second[0].old
+    assert "plan EQUAL pro" in result_second[0].new
+
+
+def test_format_rules_for_display__empty_rules__returns_empty_marker() -> None:
+    # Given
+    rules: list = []
+
+    # When
+    result = _format_rules_for_display(rules)
+
+    # Then
+    assert result == "(empty)"
+
+
+def test_format_rules_for_display__single_condition__returns_flat_expression() -> None:
+    # Given
+    rules = [
+        {
+            "type": "ALL",
+            "conditions": [{"operator": "EQUAL", "property": "x", "value": "1"}],
+        }
+    ]
+
+    # When
+    result = _format_rules_for_display(rules)
+
+    # Then
+    assert result == "(x EQUAL 1)"
+
+
+def test_format_rules_for_display__multiple_conditions__joins_with_type() -> None:
+    # Given
+    rules = [
+        {
+            "type": "ALL",
+            "conditions": [
+                {"operator": "EQUAL", "property": "x", "value": "1"},
+                {"operator": "GREATER_THAN", "property": "y", "value": "2"},
+            ],
+        }
+    ]
+
+    # When
+    result = _format_rules_for_display(rules)
+
+    # Then
+    assert result == "(x EQUAL 1 ALL y GREATER_THAN 2)"
+
+
+def test_format_rules_for_display__nested_rules__returns_nested_parentheses() -> None:
+    # Given
+    rules = [
+        {
+            "type": "ALL",
+            "rules": [
+                {
+                    "type": "ANY",
+                    "conditions": [
+                        {"operator": "EQUAL", "property": "a", "value": "1"},
+                        {"operator": "EQUAL", "property": "b", "value": "2"},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    # When
+    result = _format_rules_for_display(rules)
+
+    # Then
+    assert result == "((a EQUAL 1 ANY b EQUAL 2))"


### PR DESCRIPTION
Show segment rule diffs in the audit log detail view.

When a segment is updated, change_details now includes a "rules" field with the before/after state of rules and conditions in a readable format. Previously only "version: 1 -> 2" was shown.

Example response:

{"change_details": [{"field": "rules", "old": "(email EQUAL beta@test.com)", "new": "(email EQUAL beta@test.com ALL plan EQUAL pro)"}]}

How it works:
- The existing clone-before-update system already preserves old rules as revisions
- On audit log retrieval, we compare current rules against the previous revision
- If rules differ, a "rules" change entry is appended to change_details
- If rules are unchanged, nothing extra appears

Changes:
- api/segments/audit_helpers.py (new) - serialize rule tree and compute diffs
- api/audit/serializers.py - enrich segment update records with rule diffs
- api/segments/models.py - exclude "version" from change_details (noise)
- api/tests/unit/segments/test_unit_segments_audit_helpers.py (new) - 13 tests

No migration. No frontend changes needed.

Closes #6726
