### PR TITLE
infra: Fix API boot failure in SaaS

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-admin-api.json
@@ -7,9 +7,10 @@
         {
             "name": "flagsmith-api",
             "command": [
-                "serve",
+                "start",
                 "--keep-alive",
-                "75"
+                "75",
+                "api"
             ],
             "cpu": 0,
             "portMappings": [

--- a/infrastructure/aws/production/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/production/ecs-task-definition-sdk-api.json
@@ -7,9 +7,10 @@
         {
             "name": "flagsmith-api",
             "command": [
-                "serve",
+                "start",
                 "--keep-alive",
-                "75"
+                "75",
+                "api"
             ],
             "cpu": 0,
             "portMappings": [

--- a/infrastructure/aws/staging/ecs-task-definition-admin-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-admin-api.json
@@ -7,9 +7,10 @@
         {
             "name": "flagsmith-api",
             "command": [
-                "serve",
+                "start",
                 "--keep-alive",
-                "75"
+                "75",
+                "api"
             ],
             "cpu": 0,
             "portMappings": [

--- a/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
+++ b/infrastructure/aws/staging/ecs-task-definition-sdk-api.json
@@ -7,9 +7,10 @@
         {
             "name": "flagsmith-api",
             "command": [
-                "serve",
+                "start",
                 "--keep-alive",
-                "75"
+                "75",
+                "api"
             ],
             "cpu": 0,
             "portMappings": [


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Move away from `serve` to fully utilise flagsmith-common's gunicorn compatibility, and fix `error: unrecognized arguments`.

## How did you test this code?

Parsed both orderings through the real `start` command locally:

- `start --keep-alive 75 api` → `keepalive = 75`, dispatches to `handle_api` (which starts Gunicorn with that config).
- `start api --keep-alive 75` → `unrecognized arguments: --keep-alive 75`, reproducing the production failure exactly.
