### PR TITLE
feat: ClickHouse database setup SQL on the warehouse card and docs

### DIFF
--- a/docs/docs/experimentation/connect-a-warehouse.md
+++ b/docs/docs/experimentation/connect-a-warehouse.md
@@ -52,43 +52,45 @@ The current status is shown on the warehouse card in **Environment Settings > Wa
 
 ## Bring your own ClickHouse
 
-Instead of the managed Flagsmith warehouse, you can store experiment events in your own **ClickHouse** instance, so
-experiment data never leaves your data platform.
+Instead of the managed Flagsmith warehouse, you can store experiment events in your own **ClickHouse** instance.
 
-1. Create the database and events table by running the following against your ClickHouse instance. This is a one-off
-   setup step; the same SQL is available to copy from the warehouse card in the Flagsmith dashboard.
+1. Create the database and events table by running the following against your ClickHouse instance, using an
+   administrative user (the statements require `CREATE DATABASE` and `CREATE TABLE` privileges). This is a one-off setup
+   step; the same SQL is available to copy from the warehouse card in the Flagsmith dashboard, adjusted to the database
+   name you configure.
 
-```sql
-CREATE DATABASE IF NOT EXISTS flagsmith_exp;
+   ```sql
+   CREATE DATABASE IF NOT EXISTS flagsmith_exp;
 
-CREATE TABLE IF NOT EXISTS flagsmith_exp.events
-(
-    environment_key      LowCardinality(String),
-    event                LowCardinality(String),
-    feature_name         LowCardinality(String),
-    timestamp            DateTime64(3),
-    collected_at         DateTime64(3),
-    identifier           String,
-    value                String                          CODEC(ZSTD(3)),
-    traits               String                          CODEC(ZSTD(3)),
-    metadata             String                          CODEC(ZSTD(3)),
-    sdk_language         LowCardinality(String),
-    sdk_version          LowCardinality(String),
+   CREATE TABLE IF NOT EXISTS flagsmith_exp.events
+   (
+       environment_key      LowCardinality(String),
+       event                LowCardinality(String),
+       feature_name         LowCardinality(String),
+       timestamp            DateTime64(3),
+       collected_at         DateTime64(3),
+       identifier           String,
+       value                String                          CODEC(ZSTD(3)),
+       traits               String                          CODEC(ZSTD(3)),
+       metadata             String                          CODEC(ZSTD(3)),
+       sdk_language         LowCardinality(String),
+       sdk_version          LowCardinality(String),
 
-    INDEX idx_identity identifier TYPE bloom_filter GRANULARITY 4,
+       INDEX idx_identity identifier TYPE bloom_filter GRANULARITY 4,
 
-    CONSTRAINT environment_key_not_empty CHECK environment_key != '',
-    CONSTRAINT event_not_empty           CHECK event != '',
-    CONSTRAINT timestamp_sane            CHECK timestamp > toDateTime64('2020-01-01 00:00:00', 3)
-)
-ENGINE = MergeTree
-PARTITION BY toYYYYMMDD(timestamp)
-ORDER BY (environment_key, event, feature_name, timestamp, identifier);
-```
+       CONSTRAINT environment_key_not_empty CHECK environment_key != '',
+       CONSTRAINT event_not_empty           CHECK event != '',
+       CONSTRAINT timestamp_sane            CHECK timestamp > toDateTime64('2020-01-01 00:00:00', 3)
+   )
+   ENGINE = MergeTree
+   PARTITION BY toYYYYMMDD(timestamp)
+   ORDER BY (environment_key, event, feature_name, timestamp, identifier);
+   ```
 
 2. Go to **Environment Settings > Warehouse**, select **ClickHouse** and enter your connection details: host, port (9440
-   by default, the native protocol port), database, username and password. The configured user needs `INSERT` permission
-   on `flagsmith_exp.events`.
+   by default, the native protocol port), database (`flagsmith_exp` by default), username and password. Use a
+   least-privileged runtime user rather than the administrative one — it needs `INSERT` and `SELECT` on the `events`
+   table in the configured database.
 3. Click **Test connection**. Once the test succeeds, save the connection.
 
 Connections use the ClickHouse native protocol, with TLS enabled by default.

--- a/docs/docs/experimentation/connect-a-warehouse.md
+++ b/docs/docs/experimentation/connect-a-warehouse.md
@@ -55,16 +55,19 @@ The current status is shown on the warehouse card in **Environment Settings > Wa
 Instead of the managed Flagsmith warehouse, you can store experiment events in your own **ClickHouse** instance.
 
 1. Configure your instance by running the following against it, using an administrative user (the statements require
-   `CREATE USER`, `GRANT`, `CREATE DATABASE` and `CREATE TABLE` privileges). Replace `<USERNAME>` and
-   `<YOUR_SECURED_PASSWORD>` with your own values. This is a one-off setup step; the same SQL is available to copy from
-   the Flagsmith dashboard.
+   `CREATE USER`, `GRANT`, `CREATE DATABASE` and `CREATE TABLE` privileges). Replace `<USER>` and `<CHANGE_ME_PASSWORD>`
+   with your own values. This is a one-off setup step; the same SQL is available to copy from the Flagsmith dashboard.
 
    ```sql
    -- Create a dedicated user for Flagsmith
-   CREATE USER IF NOT EXISTS <USERNAME> IDENTIFIED BY '<YOUR_SECURED_PASSWORD>';
+   CREATE USER IF NOT EXISTS <USER>
+       IDENTIFIED WITH sha256_password BY '<CHANGE_ME_PASSWORD>';
 
    -- Allow it to write and read experiment events
-   GRANT INSERT, SELECT ON flagsmith_exp.* TO <USERNAME>;
+   GRANT SELECT, INSERT ON flagsmith_exp.events TO <USER>;
+
+   -- Allow it to check the events table exists
+   GRANT SHOW TABLES, SHOW COLUMNS ON flagsmith_exp.* TO <USER>;
 
    -- Create the database and events table
    CREATE DATABASE IF NOT EXISTS flagsmith_exp;

--- a/docs/docs/experimentation/connect-a-warehouse.md
+++ b/docs/docs/experimentation/connect-a-warehouse.md
@@ -50,6 +50,49 @@ The current status is shown on the warehouse card in **Environment Settings > Wa
 - **Connected**: events have been received; you are ready to run experiments.
 - **Errored**: something went wrong; [contact support](/support/).
 
+## Bring your own ClickHouse
+
+Instead of the managed Flagsmith warehouse, you can store experiment events in your own **ClickHouse** instance, so
+experiment data never leaves your data platform.
+
+1. Create the database and events table by running the following against your ClickHouse instance. This is a one-off
+   setup step; the same SQL is available to copy from the warehouse card in the Flagsmith dashboard.
+
+```sql
+CREATE DATABASE IF NOT EXISTS flagsmith_exp;
+
+CREATE TABLE IF NOT EXISTS flagsmith_exp.events
+(
+    environment_key      LowCardinality(String),
+    event                LowCardinality(String),
+    feature_name         LowCardinality(String),
+    timestamp            DateTime64(3),
+    collected_at         DateTime64(3),
+    identifier           String,
+    value                String                          CODEC(ZSTD(3)),
+    traits               String                          CODEC(ZSTD(3)),
+    metadata             String                          CODEC(ZSTD(3)),
+    sdk_language         LowCardinality(String),
+    sdk_version          LowCardinality(String),
+
+    INDEX idx_identity identifier TYPE bloom_filter GRANULARITY 4,
+
+    CONSTRAINT environment_key_not_empty CHECK environment_key != '',
+    CONSTRAINT event_not_empty           CHECK event != '',
+    CONSTRAINT timestamp_sane            CHECK timestamp > toDateTime64('2020-01-01 00:00:00', 3)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(timestamp)
+ORDER BY (environment_key, event, feature_name, timestamp, identifier);
+```
+
+2. Go to **Environment Settings > Warehouse**, select **ClickHouse** and enter your connection details: host, port (9440
+   by default, the native protocol port), database, username and password. The configured user needs `INSERT` permission
+   on `flagsmith_exp.events`.
+3. Click **Test connection**. Once the test succeeds, save the connection.
+
+Connections use the ClickHouse native protocol, with TLS enabled by default.
+
 ## Coming soon
 
 Bring your own warehouse: connections for **Snowflake**, **BigQuery** and **Databricks**, so experiment results are

--- a/docs/docs/experimentation/connect-a-warehouse.md
+++ b/docs/docs/experimentation/connect-a-warehouse.md
@@ -54,12 +54,19 @@ The current status is shown on the warehouse card in **Environment Settings > Wa
 
 Instead of the managed Flagsmith warehouse, you can store experiment events in your own **ClickHouse** instance.
 
-1. Create the database and events table by running the following against your ClickHouse instance, using an
-   administrative user (the statements require `CREATE DATABASE` and `CREATE TABLE` privileges). This is a one-off setup
-   step; the same SQL is available to copy from the warehouse card in the Flagsmith dashboard, adjusted to the database
-   name you configure.
+1. Configure your instance by running the following against it, using an administrative user (the statements require
+   `CREATE USER`, `GRANT`, `CREATE DATABASE` and `CREATE TABLE` privileges). Replace `<USERNAME>` and
+   `<YOUR_SECURED_PASSWORD>` with your own values. This is a one-off setup step; the same SQL is available to copy from
+   the Flagsmith dashboard.
 
    ```sql
+   -- Create a dedicated user for Flagsmith
+   CREATE USER IF NOT EXISTS <USERNAME> IDENTIFIED BY '<YOUR_SECURED_PASSWORD>';
+
+   -- Allow it to write and read experiment events
+   GRANT INSERT, SELECT ON flagsmith_exp.* TO <USERNAME>;
+
+   -- Create the database and events table
    CREATE DATABASE IF NOT EXISTS flagsmith_exp;
 
    CREATE TABLE IF NOT EXISTS flagsmith_exp.events
@@ -88,10 +95,11 @@ Instead of the managed Flagsmith warehouse, you can store experiment events in y
    ```
 
 2. Go to **Environment Settings > Warehouse**, select **ClickHouse** and enter your connection details: host, port (9440
-   by default, the native protocol port), database (`flagsmith_exp` by default), username and password. Use a
-   least-privileged runtime user rather than the administrative one — it needs `INSERT` and `SELECT` on the `events`
-   table in the configured database.
+   by default, the native protocol port), database (`flagsmith_exp` by default), and the username and password of the
+   user you created in step 1.
 3. Click **Test connection**. Once the test succeeds, save the connection.
+4. Click **Send your first event** on the connection card to verify events are arriving in your warehouse; the button
+   disappears once the first event is received.
 
 Connections use the ClickHouse native protocol, with TLS enabled by default.
 

--- a/docs/docs/experimentation/connect-a-warehouse.md
+++ b/docs/docs/experimentation/connect-a-warehouse.md
@@ -95,6 +95,9 @@ Instead of the managed Flagsmith warehouse, you can store experiment events in y
 
 Connections use the ClickHouse native protocol, with TLS enabled by default.
 
+Experiment results and exposure queries are currently computed from the managed Flagsmith warehouse; serving results
+directly from your own ClickHouse instance is not supported yet.
+
 ## Coming soon
 
 Bring your own warehouse: connections for **Snowflake**, **BigQuery** and **Databricks**, so experiment results are

--- a/frontend/web/components/CalloutBar.tsx
+++ b/frontend/web/components/CalloutBar.tsx
@@ -5,7 +5,7 @@ export type CalloutBarTheme = 'light' | 'dark'
 
 type CalloutBarProps = {
   theme?: CalloutBarTheme
-  icon: ReactNode
+  icon?: ReactNode
   prefix: ReactNode
   label: ReactNode
   expanded?: boolean
@@ -14,7 +14,7 @@ type CalloutBarProps = {
 
 const CalloutBar: FC<CalloutBarProps> = ({
   expanded,
-  icon,
+  icon = <>{'<>'}</>,
   label,
   onClick,
   prefix,

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -233,6 +233,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
 
         <WarehouseSetupSqlHelp
           database={database.trim() || CLICKHOUSE_DEFAULTS.database}
+          showInitially={!isEdit}
         />
 
         {error && <ErrorMessage error={getWarehouseErrorMessage(isEdit)} />}

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -233,7 +233,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
 
         <WarehouseSetupSqlHelp
           database={database.trim() || CLICKHOUSE_DEFAULTS.database}
-          showInitially={!isEdit}
+          showInitially={!isEdit || testState === 'errored'}
         />
 
         {error && <ErrorMessage error={getWarehouseErrorMessage(isEdit)} />}

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -4,6 +4,7 @@ import Input from 'components/base/forms/Input'
 import Switch from 'components/Switch'
 import ErrorMessage from 'components/ErrorMessage'
 import FieldError from 'components/base/forms/FieldError'
+import WarehouseSetupSqlHelp from './WarehouseSetupSqlHelp'
 import WarningMessage from 'components/WarningMessage'
 import { ClickHouseConfig } from 'common/types/responses'
 import { useTestWarehouseConnectionConfigMutation } from 'common/services/useWarehouseConnection'
@@ -185,7 +186,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setField(setDatabase)(e.target.value)
               }
-              placeholder='flagsmith'
+              placeholder='flagsmith_exp'
             />
           </div>
         </div>
@@ -229,6 +230,10 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
             </label>
           </div>
         </div>
+
+        <WarehouseSetupSqlHelp
+          database={database.trim() || CLICKHOUSE_DEFAULTS.database}
+        />
 
         {error && <ErrorMessage error={getWarehouseErrorMessage(isEdit)} />}
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -22,6 +22,7 @@ import {
   getButtonLabel,
   getTestFailureWarning,
   getWarehouseErrorMessage,
+  isMissingEventsTableDetail,
 } from './warehouseFormUtils'
 import './ConfigForm.scss'
 
@@ -56,6 +57,9 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
   const [error, setError] = useState(false)
   const [testState, setTestState] = useState<TestState>('idle')
   const [testDetail, setTestDetail] = useState<string | null>(null)
+  // Sticky: the setup SQL stays offered once a test reports the table missing,
+  // even while the user edits fields (which resets the live test state).
+  const [showSetupSql, setShowSetupSql] = useState(false)
   const testRevision = useRef(0)
 
   const [testConnectionConfig, { isLoading: isTesting }] =
@@ -105,6 +109,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
       } else {
         setTestState('errored')
         setTestDetail(result.status_detail)
+        setShowSetupSql(isMissingEventsTableDetail(result.status_detail))
       }
     } catch {
       if (revision !== testRevision.current) return
@@ -234,7 +239,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         {isEdit && (
           <WarehouseSetupSqlHelp
             database={database.trim() || CLICKHOUSE_DEFAULTS.database}
-            showInitially={testState === 'errored'}
+            showInitially={showSetupSql}
           />
         )}
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -51,7 +51,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
   const [database, setDatabase] = useState(defaults.database)
   const [username, setUsername] = useState(defaults.username)
   const [password, setPassword] = useState('')
-  const [secure, setSecure] = useState(defaults.secure)
+  const [secure] = useState(defaults.secure)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState(false)
   const [testState, setTestState] = useState<TestState>('idle')
@@ -148,7 +148,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
         </div>
 
         <div className='wh-config-form__field'>
-          <label className='wh-config-form__label'>Name</label>
+          <label className='wh-config-form__label'>Name this warehouse</label>
           <Input
             value={name}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -180,7 +180,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
             />
           </div>
           <div className='wh-config-form__field'>
-            <label className='wh-config-form__label'>Database</label>
+            <label className='wh-config-form__label'>Database Name</label>
             <Input
               value={database}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -198,7 +198,7 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               setField(setUsername)(e.target.value)
             }
-            placeholder='default'
+            placeholder='The user from the setup script'
           />
         </div>
 
@@ -224,17 +224,19 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
 
         <div className='wh-config-form__field'>
           <div className='d-flex flex-row align-items-center gap-2'>
-            <Switch checked={secure} onChange={setField(setSecure)} />
+            <Switch checked={secure} disabled />
             <label className='wh-config-form__label mb-0'>
               Secure connection (TLS)
             </label>
           </div>
         </div>
 
-        <WarehouseSetupSqlHelp
-          database={database.trim() || CLICKHOUSE_DEFAULTS.database}
-          showInitially={!isEdit || testState === 'errored'}
-        />
+        {isEdit && (
+          <WarehouseSetupSqlHelp
+            database={database.trim() || CLICKHOUSE_DEFAULTS.database}
+            showInitially={testState === 'errored'}
+          />
+        )}
 
         {error && <ErrorMessage error={getWarehouseErrorMessage(isEdit)} />}
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -59,6 +59,11 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
   const isFlagsmith = connection.warehouse_type === 'flagsmith'
   const isPending = connection.status === 'pending_connection'
   const isConnected = connection.status === 'connected'
+  // ClickHouse connections are born connected, so the first-event nudge stays
+  // until events actually arrive in the customer's warehouse.
+  const showSendFirstEvent = isFlagsmith
+    ? !isPending && !isConnected
+    : !connection.total_events_received
 
   const handleDelete = () => {
     openConfirm({
@@ -170,7 +175,7 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
             {isSendingTestEvent ? 'Testing...' : 'Test connection'}
           </Button>
         )}
-        {isFlagsmith && !isPending && !isConnected && (
+        {showSendFirstEvent && (
           <Button
             id='warehouse-send-first-event'
             theme='primary'

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -9,6 +9,7 @@ import Tooltip from 'components/Tooltip'
 import Icon from 'components/icons/Icon'
 import Button from 'components/base/forms/Button'
 import WarehouseEventCodeHelp from './WarehouseEventCodeHelp'
+import WarehouseSetupSqlHelp from './WarehouseSetupSqlHelp'
 import WarehouseStats from './WarehouseStats'
 
 type WarehouseConnectionCardProps = {
@@ -140,6 +141,11 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
             Your test event is on its way. It can take up to a few hours to
             process the first event.
           </span>
+        </div>
+      )}
+      {connection.warehouse_type === 'clickhouse' && (
+        <div className='mb-3'>
+          <WarehouseSetupSqlHelp showInitially={!isConnected} />
         </div>
       )}
       <WarehouseEventCodeHelp />

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -63,7 +63,8 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
   // until events actually arrive in the customer's warehouse.
   const showSendFirstEvent = isFlagsmith
     ? !isPending && !isConnected
-    : !connection.total_events_received
+    : connection.warehouse_type === 'clickhouse' &&
+      !connection.total_events_received
 
   const handleDelete = () => {
     openConfirm({
@@ -149,8 +150,9 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
           </span>
         </div>
       )}
+      <WarehouseEventCodeHelp />
       {connection.warehouse_type === 'clickhouse' && (
-        <div className='mb-3'>
+        <div className='mt-3'>
           <WarehouseSetupSqlHelp
             database={
               (connection.config &&
@@ -158,13 +160,11 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
                 connection.config.database) ||
               CLICKHOUSE_DEFAULTS.database
             }
-            showInitially={!connection.total_events_received}
           />
         </div>
       )}
-      <WarehouseEventCodeHelp />
       <div className='d-flex justify-content-end mt-3'>
-        {onTestConnection && (
+        {onTestConnection && !isConnected && (
           <Button
             id='warehouse-connection-test'
             theme='outline'

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -10,6 +10,7 @@ import Icon from 'components/icons/Icon'
 import Button from 'components/base/forms/Button'
 import WarehouseEventCodeHelp from './WarehouseEventCodeHelp'
 import WarehouseSetupSqlHelp from './WarehouseSetupSqlHelp'
+import { CLICKHOUSE_DEFAULTS } from './clickhouseConfig'
 import WarehouseStats from './WarehouseStats'
 
 type WarehouseConnectionCardProps = {
@@ -146,6 +147,12 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
       {connection.warehouse_type === 'clickhouse' && (
         <div className='mb-3'>
           <WarehouseSetupSqlHelp
+            database={
+              (connection.config &&
+                'database' in connection.config &&
+                connection.config.database) ||
+              CLICKHOUSE_DEFAULTS.database
+            }
             showInitially={!connection.total_events_received}
           />
         </div>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseConnectionCard.tsx
@@ -145,7 +145,9 @@ const WarehouseConnectionCard: FC<WarehouseConnectionCardProps> = ({
       )}
       {connection.warehouse_type === 'clickhouse' && (
         <div className='mb-3'>
-          <WarehouseSetupSqlHelp showInitially={!isConnected} />
+          <WarehouseSetupSqlHelp
+            showInitially={!connection.total_events_received}
+          />
         </div>
       )}
       <WarehouseEventCodeHelp />

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.scss
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.scss
@@ -80,12 +80,7 @@
 
   &__step-toggle {
     display: flex;
-    align-items: center;
     gap: 8px;
-    padding: 0;
-    border: none;
-    background: none;
-    text-align: left;
   }
 
   &__step-content {

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.scss
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.scss
@@ -37,6 +37,62 @@
     border-radius: var(--radius-lg);
   }
 
+  &__steps {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__step {
+    display: flex;
+    gap: 16px;
+
+    &:not(:last-child) &-content {
+      padding-bottom: 32px;
+    }
+  }
+
+  &__step-rail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__step-marker {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border: 1px solid var(--color-border-default);
+    border-radius: 50%;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-secondary);
+    background: var(--color-surface-subtle);
+  }
+
+  &__step-connector {
+    flex: 1;
+    width: 1px;
+    background: var(--color-border-default);
+  }
+
+  &__step-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0;
+    border: none;
+    background: none;
+    text-align: left;
+  }
+
+  &__step-content {
+    flex: 1;
+    min-width: 0;
+  }
+
   &__flagsmith-description {
     font-size: 16px;
     font-weight: 700;

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
@@ -7,6 +7,8 @@ import SelectableCard from 'components/base/SelectableCard'
 import ConfigForm from './ConfigForm'
 import Utils from 'common/utils/utils'
 import ClickHouseConfigForm from './ClickHouseConfigForm'
+import WarehouseSqlSnippet from './WarehouseSqlSnippet'
+import { getClickHouseOnboardingSql } from './clickhouseSetupSql'
 import { ClickHouseFormData } from './clickhouseConfig'
 import './WarehouseSetup.scss'
 
@@ -29,6 +31,7 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
 }) => {
   const [selectedType, setSelectedType] =
     useState<WarehouseTypeOption>('flagsmith')
+  const [sqlExpanded, setSqlExpanded] = useState(true)
   const clickhouseEnabled = Utils.getFlagsmithHasFeature('clickhouse_warehouse')
   const configurableTypes: WarehouseTypeOption[] = clickhouseEnabled
     ? ['flagsmith', 'clickhouse']
@@ -132,10 +135,56 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
       )}
 
       {selectedType === 'clickhouse' && (
-        <ClickHouseConfigForm
-          environmentId={environmentId}
-          onSave={onCreateClickHouse}
-        />
+        <div className='warehouse-setup__steps'>
+          <div className='warehouse-setup__step'>
+            <div className='warehouse-setup__step-rail'>
+              <div className='warehouse-setup__step-marker'>1</div>
+              <div className='warehouse-setup__step-connector' />
+            </div>
+            <div className='warehouse-setup__step-content'>
+              <button
+                type='button'
+                className='warehouse-setup__step-toggle mb-2'
+                aria-expanded={sqlExpanded}
+                onClick={() => setSqlExpanded(!sqlExpanded)}
+              >
+                <h6 className='mb-0'>
+                  Configure your warehouse for experimentation
+                </h6>
+                <Icon
+                  name={sqlExpanded ? 'chevron-up' : 'chevron-down'}
+                  width={22}
+                  fill='#656D7B'
+                />
+              </button>
+              {sqlExpanded && (
+                <>
+                  <p className='text-muted mb-3'>
+                    Run this once against your ClickHouse instance using an
+                    administrative user. Replace {'<USERNAME>'} and{' '}
+                    {'<YOUR_SECURED_PASSWORD>'} with your own values.
+                  </p>
+                  <WarehouseSqlSnippet sql={getClickHouseOnboardingSql()} />
+                </>
+              )}
+            </div>
+          </div>
+          <div className='warehouse-setup__step'>
+            <div className='warehouse-setup__step-rail'>
+              <div className='warehouse-setup__step-marker'>2</div>
+            </div>
+            <div className='warehouse-setup__step-content'>
+              <h6 className='mb-2'>Connect your warehouse</h6>
+              <p className='text-muted mb-3'>
+                Enter the connection details for the user you created in step 1.
+              </p>
+              <ClickHouseConfigForm
+                environmentId={environmentId}
+                onSave={onCreateClickHouse}
+              />
+            </div>
+          </div>
+        </div>
       )}
 
       {!configurableTypes.includes(selectedType) && (

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from 'react'
 import Icon from 'components/icons/Icon'
 import Button from 'components/base/forms/Button'
+import BareButton from 'components/base/forms/BareButton'
 import { WarehouseType } from 'common/types/responses'
 import { ConfigFormData } from './ConfigForm'
 import SelectableCard from 'components/base/SelectableCard'
@@ -142,8 +143,7 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
               <div className='warehouse-setup__step-connector' />
             </div>
             <div className='warehouse-setup__step-content'>
-              <button
-                type='button'
+              <BareButton
                 className='warehouse-setup__step-toggle mb-2'
                 aria-expanded={sqlExpanded}
                 onClick={() => setSqlExpanded(!sqlExpanded)}
@@ -156,7 +156,7 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
                   width={22}
                   fill='#656D7B'
                 />
-              </button>
+              </BareButton>
               {sqlExpanded && (
                 <>
                   <p className='text-muted mb-3'>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetup.tsx
@@ -161,8 +161,8 @@ const WarehouseSetup: FC<WarehouseSetupProps> = ({
                 <>
                   <p className='text-muted mb-3'>
                     Run this once against your ClickHouse instance using an
-                    administrative user. Replace {'<USERNAME>'} and{' '}
-                    {'<YOUR_SECURED_PASSWORD>'} with your own values.
+                    administrative user. Replace {'<USER>'} and{' '}
+                    {'<CHANGE_ME_PASSWORD>'} with your own values.
                   </p>
                   <WarehouseSqlSnippet sql={getClickHouseOnboardingSql()} />
                 </>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
@@ -20,7 +20,6 @@ const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
   return (
     <div>
       <CalloutBar
-        icon={<>{'<>'}</>}
         prefix='Database setup:'
         label='Run once against your ClickHouse instance to create the events table'
         expanded={visible}

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
@@ -1,0 +1,49 @@
+import React, { FC, useState } from 'react'
+import Button from 'components/base/forms/Button'
+import CalloutBar from 'components/CalloutBar'
+import Highlight from 'components/Highlight'
+import Icon from 'components/icons/Icon'
+import Utils from 'common/utils/utils'
+import { CLICKHOUSE_SETUP_SQL } from './clickhouseSetupSql'
+
+type WarehouseSetupSqlHelpProps = {
+  showInitially?: boolean
+}
+
+const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
+  showInitially,
+}) => {
+  const [visible, setVisible] = useState(!!showInitially)
+
+  return (
+    <div>
+      <CalloutBar
+        icon={<>{'<>'}</>}
+        prefix='Database setup:'
+        label='Run once against your ClickHouse instance to create the events table'
+        expanded={visible}
+        onClick={() => setVisible(!visible)}
+      />
+      {visible && (
+        <div className='hljs-container mt-2 mb-2'>
+          <Highlight forceExpanded preventEscape className='sql'>
+            {CLICKHOUSE_SETUP_SQL}
+          </Highlight>
+          <div className='flex-column hljs-docs'>
+            <Button
+              onClick={() => Utils.copyToClipboard(CLICKHOUSE_SETUP_SQL)}
+              theme='primary'
+              size='xSmall'
+            >
+              <Icon name='copy' width={16} fill='white' />
+              Copy Code
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+WarehouseSetupSqlHelp.displayName = 'WarehouseSetupSqlHelp'
+export default WarehouseSetupSqlHelp

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
@@ -1,9 +1,6 @@
 import React, { FC, useState } from 'react'
-import Button from 'components/base/forms/Button'
 import CalloutBar from 'components/CalloutBar'
-import Highlight from 'components/Highlight'
-import Icon from 'components/icons/Icon'
-import Utils from 'common/utils/utils'
+import WarehouseSqlSnippet from './WarehouseSqlSnippet'
 import { getClickHouseSetupSql } from './clickhouseSetupSql'
 
 type WarehouseSetupSqlHelpProps = {
@@ -19,7 +16,6 @@ const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
   // then stays authoritative across re-renders.
   const [override, setOverride] = useState<boolean | null>(null)
   const visible = override ?? !!showInitially
-  const sql = getClickHouseSetupSql(database)
 
   return (
     <div>
@@ -30,23 +26,7 @@ const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
         expanded={visible}
         onClick={() => setOverride(!visible)}
       />
-      {visible && (
-        <div className='hljs-container mt-2 mb-2'>
-          <Highlight forceExpanded preventEscape className='sql'>
-            {sql}
-          </Highlight>
-          <div className='flex-column hljs-docs'>
-            <Button
-              onClick={() => Utils.copyToClipboard(sql)}
-              theme='primary'
-              size='xSmall'
-            >
-              <Icon name='copy' width={16} fill='white' />
-              Copy Code
-            </Button>
-          </div>
-        </div>
-      )}
+      {visible && <WarehouseSqlSnippet sql={getClickHouseSetupSql(database)} />}
     </div>
   )
 }

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
@@ -15,7 +15,10 @@ const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
   database,
   showInitially,
 }) => {
-  const [visible, setVisible] = useState(!!showInitially)
+  // Visibility follows showInitially until the user toggles; their choice
+  // then stays authoritative across re-renders.
+  const [override, setOverride] = useState<boolean | null>(null)
+  const visible = override ?? !!showInitially
   const sql = getClickHouseSetupSql(database)
 
   return (
@@ -25,7 +28,7 @@ const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
         prefix='Database setup:'
         label='Run once against your ClickHouse instance to create the events table'
         expanded={visible}
-        onClick={() => setVisible(!visible)}
+        onClick={() => setOverride(!visible)}
       />
       {visible && (
         <div className='hljs-container mt-2 mb-2'>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSetupSqlHelp.tsx
@@ -4,16 +4,19 @@ import CalloutBar from 'components/CalloutBar'
 import Highlight from 'components/Highlight'
 import Icon from 'components/icons/Icon'
 import Utils from 'common/utils/utils'
-import { CLICKHOUSE_SETUP_SQL } from './clickhouseSetupSql'
+import { getClickHouseSetupSql } from './clickhouseSetupSql'
 
 type WarehouseSetupSqlHelpProps = {
+  database: string
   showInitially?: boolean
 }
 
 const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
+  database,
   showInitially,
 }) => {
   const [visible, setVisible] = useState(!!showInitially)
+  const sql = getClickHouseSetupSql(database)
 
   return (
     <div>
@@ -27,11 +30,11 @@ const WarehouseSetupSqlHelp: FC<WarehouseSetupSqlHelpProps> = ({
       {visible && (
         <div className='hljs-container mt-2 mb-2'>
           <Highlight forceExpanded preventEscape className='sql'>
-            {CLICKHOUSE_SETUP_SQL}
+            {sql}
           </Highlight>
           <div className='flex-column hljs-docs'>
             <Button
-              onClick={() => Utils.copyToClipboard(CLICKHOUSE_SETUP_SQL)}
+              onClick={() => Utils.copyToClipboard(sql)}
               theme='primary'
               size='xSmall'
             >

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSqlSnippet.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSqlSnippet.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react'
+import Button from 'components/base/forms/Button'
+import Highlight from 'components/Highlight'
+import Icon from 'components/icons/Icon'
+import Utils from 'common/utils/utils'
+
+type WarehouseSqlSnippetProps = {
+  sql: string
+}
+
+const WarehouseSqlSnippet: FC<WarehouseSqlSnippetProps> = ({ sql }) => (
+  <div className='hljs-container mt-2 mb-2'>
+    <Highlight forceExpanded className='sql'>
+      {sql}
+    </Highlight>
+    <div className='flex-column hljs-docs'>
+      <Button
+        onClick={() => Utils.copyToClipboard(sql)}
+        theme='primary'
+        size='xSmall'
+      >
+        <Icon name='copy' width={16} fill='white' />
+        Copy Code
+      </Button>
+    </div>
+  </div>
+)
+
+WarehouseSqlSnippet.displayName = 'WarehouseSqlSnippet'
+export default WarehouseSqlSnippet

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSqlSnippet.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/WarehouseSqlSnippet.tsx
@@ -19,7 +19,7 @@ const WarehouseSqlSnippet: FC<WarehouseSqlSnippetProps> = ({ sql }) => (
         theme='primary'
         size='xSmall'
       >
-        <Icon name='copy' width={16} fill='white' />
+        <Icon name='copy' width={16} />
         Copy Code
       </Button>
     </div>

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
@@ -1,0 +1,18 @@
+import { CLICKHOUSE_DEFAULTS } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig'
+import { getClickHouseSetupSql } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql'
+
+describe('getClickHouseSetupSql', () => {
+  it('interpolates the configured database into both statements', () => {
+    const sql = getClickHouseSetupSql('analytics')
+
+    expect(sql).toContain('CREATE DATABASE IF NOT EXISTS analytics;')
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS analytics.events')
+    expect(sql).not.toContain('flagsmith_exp')
+  })
+
+  it('matches the form default database', () => {
+    expect(getClickHouseSetupSql(CLICKHOUSE_DEFAULTS.database)).toContain(
+      'CREATE TABLE IF NOT EXISTS flagsmith_exp.events',
+    )
+  })
+})

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
@@ -26,11 +26,15 @@ describe('getClickHouseOnboardingSql', () => {
   it('creates a placeholder user, grants it access, and includes the DDL', () => {
     const sql = getClickHouseOnboardingSql()
 
+    expect(sql).toContain('CREATE USER IF NOT EXISTS <USER>')
     expect(sql).toContain(
-      "CREATE USER IF NOT EXISTS <USERNAME> IDENTIFIED BY '<YOUR_SECURED_PASSWORD>';",
+      "IDENTIFIED WITH sha256_password BY '<CHANGE_ME_PASSWORD>';",
     )
     expect(sql).toContain(
-      'GRANT INSERT, SELECT ON flagsmith_exp.* TO <USERNAME>;',
+      'GRANT SELECT, INSERT ON flagsmith_exp.events TO <USER>;',
+    )
+    expect(sql).toContain(
+      'GRANT SHOW TABLES, SHOW COLUMNS ON flagsmith_exp.* TO <USER>;',
     )
     expect(sql).toContain(getClickHouseSetupSql('flagsmith_exp'))
   })

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import { CLICKHOUSE_DEFAULTS } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig'
 import { getClickHouseSetupSql } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql'
 
@@ -14,5 +16,23 @@ describe('getClickHouseSetupSql', () => {
     expect(getClickHouseSetupSql(CLICKHOUSE_DEFAULTS.database)).toContain(
       'CREATE TABLE IF NOT EXISTS flagsmith_exp.events',
     )
+  })
+
+  it('matches the copy of the DDL in the documentation', () => {
+    const doc = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../../../../../../../../docs/docs/experimentation/connect-a-warehouse.md',
+      ),
+      'utf8',
+    )
+    const fencedSql = doc.match(/```sql\n([\s\S]*?)```/)?.[1] ?? ''
+    const dedented = fencedSql
+      .split('\n')
+      .map((line) => line.replace(/^ {3}/, ''))
+      .join('\n')
+      .trim()
+
+    expect(dedented).toEqual(getClickHouseSetupSql('flagsmith_exp'))
   })
 })

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseSetupSql.test.ts
@@ -1,7 +1,10 @@
 import fs from 'fs'
 import path from 'path'
 import { CLICKHOUSE_DEFAULTS } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig'
-import { getClickHouseSetupSql } from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql'
+import {
+  getClickHouseOnboardingSql,
+  getClickHouseSetupSql,
+} from 'components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql'
 
 describe('getClickHouseSetupSql', () => {
   it('interpolates the configured database into both statements', () => {
@@ -17,8 +20,22 @@ describe('getClickHouseSetupSql', () => {
       'CREATE TABLE IF NOT EXISTS flagsmith_exp.events',
     )
   })
+})
 
-  it('matches the copy of the DDL in the documentation', () => {
+describe('getClickHouseOnboardingSql', () => {
+  it('creates a placeholder user, grants it access, and includes the DDL', () => {
+    const sql = getClickHouseOnboardingSql()
+
+    expect(sql).toContain(
+      "CREATE USER IF NOT EXISTS <USERNAME> IDENTIFIED BY '<YOUR_SECURED_PASSWORD>';",
+    )
+    expect(sql).toContain(
+      'GRANT INSERT, SELECT ON flagsmith_exp.* TO <USERNAME>;',
+    )
+    expect(sql).toContain(getClickHouseSetupSql('flagsmith_exp'))
+  })
+
+  it('matches the copy of the script in the documentation', () => {
     const doc = fs.readFileSync(
       path.join(
         __dirname,
@@ -33,6 +50,6 @@ describe('getClickHouseSetupSql', () => {
       .join('\n')
       .trim()
 
-    expect(dedented).toEqual(getClickHouseSetupSql('flagsmith_exp'))
+    expect(dedented).toEqual(getClickHouseOnboardingSql())
   })
 })

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehouseFormUtils.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehouseFormUtils.test.ts
@@ -22,4 +22,10 @@ describe('getTestFailureWarning', () => {
       "events won't be delivered until the table exists",
     )
   })
+
+  it('keeps the sentence boundary when the missing-table detail lacks punctuation', () => {
+    expect(getTestFailureWarning('Events table not found')).toContain(
+      'Events table not found. You can save anyway',
+    )
+  })
 })

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehouseFormUtils.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/warehouseFormUtils.test.ts
@@ -9,4 +9,17 @@ describe('getTestFailureWarning', () => {
   ])('formats detail %p with a single sentence break', (detail, expected) => {
     expect(getTestFailureWarning(detail)).toContain(expected)
   })
+
+  it('does not claim a failed connection when only the events table is missing', () => {
+    const detail =
+      'Events table not found in the configured database. Run the setup SQL to create it.'
+
+    const warning = getTestFailureWarning(detail)
+
+    expect(warning).not.toContain("couldn't establish a connection")
+    expect(warning).toContain(detail)
+    expect(warning).toContain(
+      "events won't be delivered until the table exists",
+    )
+  })
 })

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
@@ -1,7 +1,7 @@
 import { ClickHouseConfig } from 'common/types/responses'
 
 export const CLICKHOUSE_DEFAULTS: ClickHouseConfig = {
-  database: 'flagsmith',
+  database: 'flagsmith_exp',
   host: '',
   port: 9440,
   secure: true,

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
@@ -5,7 +5,7 @@ export const CLICKHOUSE_DEFAULTS: ClickHouseConfig = {
   host: '',
   port: 9440,
   secure: true,
-  username: 'default',
+  username: '',
 }
 
 export type ClickHouseFormState = {

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
@@ -1,6 +1,8 @@
-export const CLICKHOUSE_SETUP_SQL = `CREATE DATABASE IF NOT EXISTS flagsmith_exp;
+export const getClickHouseSetupSql = (
+  database: string,
+): string => `CREATE DATABASE IF NOT EXISTS ${database};
 
-CREATE TABLE IF NOT EXISTS flagsmith_exp.events
+CREATE TABLE IF NOT EXISTS ${database}.events
 (
     environment_key      LowCardinality(String),
     event                LowCardinality(String),

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
@@ -1,0 +1,25 @@
+export const CLICKHOUSE_SETUP_SQL = `CREATE DATABASE IF NOT EXISTS flagsmith_exp;
+
+CREATE TABLE IF NOT EXISTS flagsmith_exp.events
+(
+    environment_key      LowCardinality(String),
+    event                LowCardinality(String),
+    feature_name         LowCardinality(String),
+    timestamp            DateTime64(3),
+    collected_at         DateTime64(3),
+    identifier           String,
+    value                String                          CODEC(ZSTD(3)),
+    traits               String                          CODEC(ZSTD(3)),
+    metadata             String                          CODEC(ZSTD(3)),
+    sdk_language         LowCardinality(String),
+    sdk_version          LowCardinality(String),
+
+    INDEX idx_identity identifier TYPE bloom_filter GRANULARITY 4,
+
+    CONSTRAINT environment_key_not_empty CHECK environment_key != '',
+    CONSTRAINT event_not_empty           CHECK event != '',
+    CONSTRAINT timestamp_sane            CHECK timestamp > toDateTime64('2020-01-01 00:00:00', 3)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(timestamp)
+ORDER BY (environment_key, event, feature_name, timestamp, identifier);`

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
@@ -25,3 +25,13 @@ CREATE TABLE IF NOT EXISTS ${database}.events
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(timestamp)
 ORDER BY (environment_key, event, feature_name, timestamp, identifier);`
+
+export const getClickHouseOnboardingSql =
+  (): string => `-- Create a dedicated user for Flagsmith
+CREATE USER IF NOT EXISTS <USERNAME> IDENTIFIED BY '<YOUR_SECURED_PASSWORD>';
+
+-- Allow it to write and read experiment events
+GRANT INSERT, SELECT ON flagsmith_exp.* TO <USERNAME>;
+
+-- Create the database and events table
+${getClickHouseSetupSql('flagsmith_exp')}`

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseSetupSql.ts
@@ -28,10 +28,14 @@ ORDER BY (environment_key, event, feature_name, timestamp, identifier);`
 
 export const getClickHouseOnboardingSql =
   (): string => `-- Create a dedicated user for Flagsmith
-CREATE USER IF NOT EXISTS <USERNAME> IDENTIFIED BY '<YOUR_SECURED_PASSWORD>';
+CREATE USER IF NOT EXISTS <USER>
+    IDENTIFIED WITH sha256_password BY '<CHANGE_ME_PASSWORD>';
 
 -- Allow it to write and read experiment events
-GRANT INSERT, SELECT ON flagsmith_exp.* TO <USERNAME>;
+GRANT SELECT, INSERT ON flagsmith_exp.events TO <USER>;
+
+-- Allow it to check the events table exists
+GRANT SHOW TABLES, SHOW COLUMNS ON flagsmith_exp.* TO <USER>;
 
 -- Create the database and events table
 ${getClickHouseSetupSql('flagsmith_exp')}`

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
@@ -8,12 +8,20 @@ export const getWarehouseErrorMessage = (isEdit: boolean): string =>
     isEdit ? 'update' : 'create'
   } warehouse connection. Please try again.`
 
+export const isMissingEventsTableDetail = (detail: string | null): boolean =>
+  !!detail?.startsWith('Events table not found')
+
+const punctuate = (detail: string): string =>
+  `${detail}${/[.!?]$/.test(detail) ? '' : '.'}`
+
 export const getTestFailureWarning = (detail: string | null): string => {
   // The missing-table detail means the connection itself succeeded, so the
   // "couldn't establish a connection" lead-in would be wrong.
-  if (detail?.startsWith('Events table not found')) {
-    return `${detail} You can save anyway and test again later, but events won't be delivered until the table exists.`
+  if (detail && isMissingEventsTableDetail(detail)) {
+    return `${punctuate(
+      detail,
+    )} You can save anyway and test again later, but events won't be delivered until the table exists.`
   }
-  const reason = detail ? `: ${detail}${/[.!?]$/.test(detail) ? '' : '.'}` : '.'
+  const reason = detail ? `: ${punctuate(detail)}` : '.'
   return `We couldn't establish a connection${reason} You can save anyway and test again later, but events won't be delivered until the connection succeeds.`
 }

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/warehouseFormUtils.ts
@@ -9,6 +9,11 @@ export const getWarehouseErrorMessage = (isEdit: boolean): string =>
   } warehouse connection. Please try again.`
 
 export const getTestFailureWarning = (detail: string | null): string => {
+  // The missing-table detail means the connection itself succeeded, so the
+  // "couldn't establish a connection" lead-in would be wrong.
+  if (detail?.startsWith('Events table not found')) {
+    return `${detail} You can save anyway and test again later, but events won't be delivered until the table exists.`
+  }
   const reason = detail ? `: ${detail}${/[.!?]$/.test(detail) ? '' : '.'}` : '.'
   return `We couldn't establish a connection${reason} You can save anyway and test again later, but events won't be delivered until the connection succeeds.`
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Surfaces the one-off ClickHouse database setup SQL (`events` table DDL):

- Collapsible "Database setup" section on the warehouse connection card (ClickHouse only), with syntax highlighting and a copy button. The SQL interpolates the connection's configured database, so the copied statements always match what was saved. Starts expanded until the connection has received its first event, then collapses to a one-line header. (`total_events_received` is currently always null for ClickHouse connections — a backend follow-up will extend event stats to ClickHouse so the collapse becomes effective.)
- The same section, collapsed, inside the create/edit form — interpolating the live Database field — so users can run the setup and test the connection in one sitting.
- Canonical database name is `flagsmith_exp`: form default and placeholder updated (backend default to follow in the backend PR).
- New "Bring your own ClickHouse" section in the [Connect a Warehouse](https://docs.flagsmith.com/experimentation/connect-a-warehouse) docs with the same SQL, setup steps, and separate admin (setup) vs runtime (INSERT/SELECT) permissions guidance.

## How did you test this code?

Unit tests (including snippet interpolation pinned to the form's default database), lint, typecheck (no new errors against the baseline). Manually: checked the section renders on card and form for ClickHouse only, interpolates the Database field value, copies the SQL, and collapses/expands on click.


<img width="784" height="649" alt="image" src="https://github.com/user-attachments/assets/765ee134-a626-4ac3-af5f-79b900039e84" />

<img width="982" height="922" alt="image" src="https://github.com/user-attachments/assets/fde56d3f-5ad6-4679-9977-502a6ae04c54" />

<img width="891" height="500" alt="image" src="https://github.com/user-attachments/assets/fe4db13a-9c2a-4cd1-831b-a658ea3e3b5f" />
