### PR TITLE
feat: Button loading state: aria, loadingLabel, link variant

### DIFF
--- a/frontend/documentation/components/Button.stories.tsx
+++ b/frontend/documentation/components/Button.stories.tsx
@@ -126,6 +126,80 @@ export const Disabled: Story = {
   ),
 }
 
+export const Loading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loading buttons auto-disable, announce via aria-busy, and show a spinner beside the label. `loadingLabel` swaps the label while loading.',
+      },
+    },
+  },
+  render: () => (
+    <div className='d-flex align-items-center flex-wrap gap-2'>
+      <Button theme='primary' isLoading>
+        Save
+      </Button>
+      <Button theme='secondary' isLoading>
+        Save
+      </Button>
+      <Button theme='danger' isLoading>
+        Delete
+      </Button>
+      <Button theme='primary' isLoading loadingLabel='Saving…'>
+        Save
+      </Button>
+    </div>
+  ),
+}
+
+export const LoadingSizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'The loading spinner across button sizes.',
+      },
+    },
+  },
+  render: () => (
+    <div className='d-flex align-items-center flex-wrap gap-2'>
+      <Button size='large' isLoading>
+        Large
+      </Button>
+      <Button size='default' isLoading>
+        Default
+      </Button>
+      <Button size='small' isLoading>
+        Small
+      </Button>
+      <Button size='xSmall' isLoading>
+        Extra Small
+      </Button>
+    </div>
+  ),
+}
+
+export const LoadingLink: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A loading link is non-interactive: pointer events are off, keyboard activation is guarded, and aria-disabled is set (anchors cannot be disabled natively).',
+      },
+    },
+  },
+  render: () => (
+    <div className='d-flex align-items-center flex-wrap gap-2'>
+      <Button href='https://docs.flagsmith.com' target='_blank'>
+        Idle link
+      </Button>
+      <Button href='https://docs.flagsmith.com' target='_blank' isLoading>
+        Loading link
+      </Button>
+    </div>
+  ),
+}
+
 export const WithIcons: Story = {
   parameters: {
     docs: {

--- a/frontend/web/components/base/forms/Button.tsx
+++ b/frontend/web/components/base/forms/Button.tsx
@@ -29,6 +29,9 @@ export type ButtonType = ButtonHTMLAttributes<HTMLButtonElement> & {
   theme?: keyof typeof themeClassNames
   size?: keyof typeof sizeClassNames
   isLoading?: boolean
+  // Replaces children while loading (e.g. 'Saving…'). Omit to keep the
+  // label beside the spinner, the existing behaviour at adopted sites.
+  loadingLabel?: string
 }
 
 export const Button = React.forwardRef<
@@ -42,6 +45,7 @@ export const Button = React.forwardRef<
       disabled,
       href,
       isLoading = false,
+      loadingLabel,
       onMouseUp,
       size = 'default',
       target,
@@ -58,16 +62,32 @@ export const Button = React.forwardRef<
       sizeClassNames[size],
       isLoading && 'd-inline-flex align-items-center gap-2',
     )
+    const content = (
+      <>
+        {isLoading && <Loader width='15px' height='15px' />}
+        {isLoading && loadingLabel ? loadingLabel : children}
+      </>
+    )
     return href ? (
+      // Anchors cannot be disabled, so a loading link gets Bootstrap's
+      // .disabled (pointer-events: none) plus a click guard for keyboard
+      // activation, and the same aria state as the button variant.
       <a
-        onClick={rest.onClick as React.MouseEventHandler}
-        className={classes}
+        onClick={
+          isLoading
+            ? (e) => e.preventDefault()
+            : (rest.onClick as React.MouseEventHandler)
+        }
+        className={cn(classes, isLoading && 'disabled')}
         target={target}
         href={href}
         rel='noreferrer'
+        aria-disabled={isLoading || undefined}
+        aria-busy={isLoading || undefined}
+        aria-live='polite'
         ref={ref as React.RefObject<HTMLAnchorElement>}
       >
-        {children}
+        {content}
       </a>
     ) : (
       <button
@@ -76,10 +96,11 @@ export const Button = React.forwardRef<
         type={type}
         onMouseUp={onMouseUp}
         className={classes}
+        aria-busy={isLoading || undefined}
+        aria-live='polite'
         ref={ref as React.RefObject<HTMLButtonElement>}
       >
-        {isLoading && <Loader width='15px' height='15px' />}
-        {children}
+        {content}
       </button>
     )
   },

--- a/frontend/web/components/modals/CreateGroup.tsx
+++ b/frontend/web/components/modals/CreateGroup.tsx
@@ -147,7 +147,7 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
         usersToAddAdmin: (usersToAddAdmin || []).map((user) => user.id),
         usersToRemove: getUsersToRemove(groupData!.users).map((v) => v.id),
         usersToRemoveAdmin: (usersToRemoveAdmin || []).map((user) => user.id),
-      }).then((data) => {
+      }).then((data: { data?: unknown; error?: unknown }) => {
         // @ts-ignore
         if (!data.error) {
           toast('Updated Group')
@@ -165,7 +165,7 @@ const CreateGroup: FC<CreateGroupType> = ({ group, orgId, roles }) => {
         orgId,
         users: users as any,
         usersToAddAdmin: (usersToAddAdmin || []).map((user) => user.id),
-      }).then((data) => {
+      }).then((data: { data?: unknown; error?: unknown }) => {
         // @ts-ignore
         if (!data.error) {
           toast('Created Group')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7384. Revives the deltas from #7393 on top of the `isLoading` that shipped since (thanks @Zaimwa9), without changing its behaviour at adopted sites.

- `aria-busy` while loading, `aria-live='polite'` so the transition is announced.
- Optional `loadingLabel` swaps the label while loading; omitting it keeps the current spinner-beside-label default.
- The link variant question answered: a loading `href` Button becomes non-interactive (Bootstrap `.disabled`, click guard for keyboard activation, `aria-disabled`), since anchors cannot be disabled. Previously it silently ignored `isLoading`.
- Storybook: `Loading`, `LoadingSizes`, `LoadingLink` stories, the loading state had no visual coverage.

Out of scope: migrating the 14 files still hand-rolling `isSaving` ternaries (tracked in #7384), and a size-aware spinner (currently 15px at every size, visible in the `LoadingSizes` story).

## How did you test this code?

- `tsc`: 0 new errors vs `main`.
- `eslint`: clean on changed files.
- Storybook: the three new stories cover themes, sizes and the link variant.
- Manual QA pending: a real async save (e.g. the ClickHouse form, the one adopted site) and a screen reader pass on the announcement.
