### PR TITLE
fix(api): DCR rejects registrations without a client_name

### DIFF
--- a/api/oauth2_metadata/serializers.py
+++ b/api/oauth2_metadata/serializers.py
@@ -23,7 +23,12 @@ _CLIENT_NAME_RE = re.compile(r"^[\w\s.\-()]+$", re.ASCII)
 
 
 class DCRRequestSerializer(serializers.Serializer[None]):
-    client_name = serializers.CharField(max_length=255, required=True)
+    # Optional per RFC 7591 §2; some MCP clients register without a name.
+    client_name = serializers.CharField(
+        max_length=255,
+        required=False,
+        default="MCP client",
+    )
     redirect_uris = serializers.ListField(
         child=serializers.CharField(max_length=2000),
         min_length=1,

--- a/api/oauth2_metadata/serializers.py
+++ b/api/oauth2_metadata/serializers.py
@@ -21,13 +21,17 @@ class OAuthConsentSerializer(serializers.Serializer):  # type: ignore[type-arg]
 # ASCII-only to prevent Unicode homoglyph spoofing on the consent screen.
 _CLIENT_NAME_RE = re.compile(r"^[\w\s.\-()]+$", re.ASCII)
 
+DEFAULT_CLIENT_NAME = "MCP client"
+
 
 class DCRRequestSerializer(serializers.Serializer[None]):
-    # Optional per RFC 7591 §2; some MCP clients register without a name.
+    # Optional per RFC 7591 §2; null, blank and absent all mean "unnamed".
     client_name = serializers.CharField(
         max_length=255,
         required=False,
-        default="MCP client",
+        allow_blank=True,
+        allow_null=True,
+        default=DEFAULT_CLIENT_NAME,
     )
     redirect_uris = serializers.ListField(
         child=serializers.CharField(max_length=2000),
@@ -50,7 +54,9 @@ class DCRRequestSerializer(serializers.Serializer[None]):
         default="none",
     )
 
-    def validate_client_name(self, value: str) -> str:
+    def validate_client_name(self, value: str | None) -> str:
+        if not value or not value.strip():
+            return DEFAULT_CLIENT_NAME
         if not _CLIENT_NAME_RE.match(value):
             raise serializers.ValidationError(
                 "Client name may only contain letters, digits, spaces, "

--- a/api/oauth2_metadata/views.py
+++ b/api/oauth2_metadata/views.py
@@ -160,7 +160,7 @@ class DynamicClientRegistrationView(APIView):
         if not serializer.is_valid():
             error_body = map_drf_error_to_rfc7591_error_body(serializer.errors)
             payload = request.data if isinstance(request.data, dict) else {}
-            logger.info(
+            logger.error(
                 "registration.rejected",
                 error=error_body["error"],
                 error_description=error_body["error_description"],

--- a/api/oauth2_metadata/views.py
+++ b/api/oauth2_metadata/views.py
@@ -1,6 +1,7 @@
 from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
 
+import structlog
 from django.http import HttpRequest, JsonResponse, QueryDict
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
@@ -20,6 +21,8 @@ from oauth2_metadata.dataclasses import OAuthConfig
 from oauth2_metadata.mappers import map_drf_error_to_rfc7591_error_body
 from oauth2_metadata.serializers import DCRRequestSerializer, OAuthConsentSerializer
 from oauth2_metadata.services import create_oauth2_application
+
+logger = structlog.get_logger("oauth2_metadata")
 
 
 @csrf_exempt
@@ -155,8 +158,18 @@ class DynamicClientRegistrationView(APIView):
     def post(self, request: Request) -> Response:
         serializer = DCRRequestSerializer(data=request.data)
         if not serializer.is_valid():
+            error_body = map_drf_error_to_rfc7591_error_body(serializer.errors)
+            payload = request.data if isinstance(request.data, dict) else {}
+            logger.info(
+                "registration.rejected",
+                error=error_body["error"],
+                error_description=error_body["error_description"],
+                client__name=payload.get("client_name"),
+                redirect_uris=payload.get("redirect_uris"),
+                user_agent=request.headers.get("User-Agent", ""),
+            )
             return Response(
-                map_drf_error_to_rfc7591_error_body(serializer.errors),
+                error_body,
                 status=drf_status.HTTP_400_BAD_REQUEST,
             )
 

--- a/api/tests/unit/oauth2_metadata/test_dcr.py
+++ b/api/tests/unit/oauth2_metadata/test_dcr.py
@@ -286,7 +286,7 @@ def test_dcr_register__invalid_request__logs_rejection(
     # Then
     assert log.events == [
         {
-            "level": "info",
+            "level": "error",
             "event": "registration.rejected",
             "error": "invalid_redirect_uri",
             "error_description": (

--- a/api/tests/unit/oauth2_metadata/test_dcr.py
+++ b/api/tests/unit/oauth2_metadata/test_dcr.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 from oauth2_provider.models import Application
+from pytest_structlog import StructuredLogCapture
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -236,33 +237,69 @@ def test_dcr_register__invalid_client_metadata__returns_rfc7591_error(
     assert expected_fragment.lower() in data["error_description"].lower()
 
 
-@pytest.mark.parametrize(
-    ("payload", "expected_error"),
-    [
-        (
-            {"redirect_uris": ["https://example.com/callback"]},
-            "invalid_client_metadata",
-        ),
-        (
-            {"client_name": "Test"},
-            "invalid_redirect_uri",
-        ),
-    ],
-    ids=["missing-client-name", "missing-redirect-uris"],
-)
-def test_dcr_register__missing_required_field__returns_rfc7591_error(
+@pytest.mark.django_db()
+def test_dcr_register__no_client_name__returns_201_with_default_name(
     api_client: APIClient,
-    payload: dict[str, object],
-    expected_error: str,
+) -> None:
+    # Given - client_name is optional per RFC 7591 section 2.
+    payload = {"redirect_uris": ["https://example.com/callback"]}
+
+    # When
+    response = api_client.post(DCR_URL, data=payload, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["client_name"] == "MCP client"
+
+
+def test_dcr_register__missing_redirect_uris__returns_rfc7591_error(
+    api_client: APIClient,
 ) -> None:
     # Given / When
-    response = api_client.post(DCR_URL, data=payload, format="json")
+    response = api_client.post(DCR_URL, data={"client_name": "Test"}, format="json")
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["error"] == expected_error
+    assert data["error"] == "invalid_redirect_uri"
     assert "error_description" in data
+
+
+def test_dcr_register__invalid_request__logs_rejection(
+    api_client: APIClient,
+    log: StructuredLogCapture,
+) -> None:
+    # Given
+    payload = _valid_payload(
+        client_name="Claude Desktop",
+        redirect_uris=["https://example.com/callback", "javascript:alert(1)"],
+    )
+
+    # When
+    api_client.post(
+        DCR_URL,
+        data=payload,
+        format="json",
+        HTTP_USER_AGENT="Claude-Desktop/1.0",
+    )
+
+    # Then
+    assert log.events == [
+        {
+            "level": "info",
+            "event": "registration.rejected",
+            "error": "invalid_redirect_uri",
+            "error_description": (
+                "Scheme is not permitted in redirect URIs: javascript:alert(1)"
+            ),
+            "client__name": "Claude Desktop",
+            "redirect_uris": [
+                "https://example.com/callback",
+                "javascript:alert(1)",
+            ],
+            "user_agent": "Claude-Desktop/1.0",
+        }
+    ]
 
 
 def test_dcr_register__get_request__returns_405(

--- a/api/tests/unit/oauth2_metadata/test_dcr.py
+++ b/api/tests/unit/oauth2_metadata/test_dcr.py
@@ -206,14 +206,12 @@ def test_dcr_register__invalid_redirect_uri_after_valid_one__returns_rfc7591_err
     ("overrides", "expected_fragment"),
     [
         ({"client_name": "<script>alert(1)</script>"}, "letters"),
-        ({"client_name": "   "}, "blank"),
         ({"grant_types": ["implicit"]}, "grant type"),
         ({"response_types": ["token"]}, "response type"),
         ({"token_endpoint_auth_method": "client_secret_basic"}, "public clients"),
     ],
     ids=[
         "xss-client-name",
-        "blank-client-name",
         "bad-grant-type",
         "bad-response-type",
         "bad-auth-method",
@@ -238,11 +236,22 @@ def test_dcr_register__invalid_client_metadata__returns_rfc7591_error(
 
 
 @pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"redirect_uris": ["https://example.com/callback"]},
+        {"client_name": None, "redirect_uris": ["https://example.com/callback"]},
+        {"client_name": "", "redirect_uris": ["https://example.com/callback"]},
+        {"client_name": "   ", "redirect_uris": ["https://example.com/callback"]},
+    ],
+    ids=["absent", "null", "blank", "whitespace-only"],
+)
 def test_dcr_register__no_client_name__returns_201_with_default_name(
     api_client: APIClient,
+    payload: dict[str, object],
 ) -> None:
-    # Given - client_name is optional per RFC 7591 section 2.
-    payload = {"redirect_uris": ["https://example.com/callback"]}
+    # Given - client_name is optional per RFC 7591 section 2; null and
+    # blank values are treated the same as an absent one.
 
     # When
     response = api_client.post(DCR_URL, data=payload, format="json")

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -424,7 +424,7 @@ Attributes:
 
 ### `oauth2_metadata.registration.rejected`
 
-Logged at `info` from:
+Logged at `error` from:
  - `api/oauth2_metadata/views.py:163`
 
 Attributes:

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -422,6 +422,18 @@ Logged at `info` from:
 Attributes:
  - `organisation.id`
 
+### `oauth2_metadata.registration.rejected`
+
+Logged at `info` from:
+ - `api/oauth2_metadata/views.py:163`
+
+Attributes:
+ - `client.name`
+ - `error`
+ - `error_description`
+ - `redirect_uris`
+ - `user_agent`
+
 ### `onboarding.environment.already_evaluated`
 
 Logged at `info` from:


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Claude Desktop still cannot register with `POST /o/register/` after #8114. The failure is now a clean 400, which leaves no Sentry trace, so we cannot tell which validation trips it.

In this PR, we:

1. Make `client_name` optional with a default of "MCP client". RFC 7591 §2 makes it optional and some MCP clients omit it. This is one of the candidate causes of the Claude Desktop failure.

2. Log every rejected registration as a `oauth2_metadata.registration.rejected` event carrying the error code, description, and user agent. The next rejected attempt will identify the failing validation and client from logs.

## How did you test this code?

Added unit tests.
