### PR TITLE
feat(onboarding): wire the verify console to the real first-evaluation signal

### DIFF
--- a/frontend/common/services/useEnvironmentOnboardingStatus.ts
+++ b/frontend/common/services/useEnvironmentOnboardingStatus.ts
@@ -1,0 +1,50 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const environmentOnboardingStatusService = service
+  .enhanceEndpoints({ addTagTypes: ['EnvironmentOnboardingStatus'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      getEnvironmentOnboardingStatus: builder.query<
+        Res['environmentOnboardingStatus'],
+        Req['getEnvironmentOnboardingStatus']
+      >({
+        providesTags: (res, err, req) => [
+          { id: req.environmentKey, type: 'EnvironmentOnboardingStatus' },
+        ],
+        // Unauthenticated Core endpoint keyed by the environment's client-side
+        // API key. Served by Core, not the edge/CDN host.
+        query: (query: Req['getEnvironmentOnboardingStatus']) => ({
+          url: `environments/${query.environmentKey}/onboarding-status/`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function getEnvironmentOnboardingStatus(
+  store: any,
+  data: Req['getEnvironmentOnboardingStatus'],
+  options?: Parameters<
+    typeof environmentOnboardingStatusService.endpoints.getEnvironmentOnboardingStatus.initiate
+  >[1],
+) {
+  return store.dispatch(
+    environmentOnboardingStatusService.endpoints.getEnvironmentOnboardingStatus.initiate(
+      data,
+      options,
+    ),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useGetEnvironmentOnboardingStatusQuery,
+  // END OF EXPORTS
+} = environmentOnboardingStatusService
+
+/* Usage examples:
+const { data, isLoading } = useGetEnvironmentOnboardingStatusQuery({ environmentKey: 'abc' }, {}) //get hook
+environmentOnboardingStatusService.endpoints.getEnvironmentOnboardingStatus.select({ environmentKey: 'abc' })(store.getState()) //access data from any function
+*/

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -874,6 +874,7 @@ export type Req = {
   getBuildVersion: {}
   createOnboardingSupportOptIn: {}
   getEnvironmentMetrics: { id: number }
+  getEnvironmentOnboardingStatus: { environmentKey: string }
   getUserEnvironmentPermissions: {
     environmentId: string
     userId: number

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1441,6 +1441,12 @@ export type Res = {
       rank: number
     }[]
   }
+  environmentOnboardingStatus: {
+    // Null until the environment's first SDK evaluation is reported by Edge.
+    first_evaluated_at: string | null
+    // A Core `KnownSDK` label (e.g. 'flagsmith-js-sdk') or 'unknown'.
+    first_evaluated_sdk_label: string | null
+  }
   profile: User
   onboarding: {}
   userPermissions: UserPermission[]

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -20,11 +20,30 @@ test.describe('Onboarding', () => {
 
     await addErrorLogging();
 
+    // Drive the verify console's real first-evaluation signal: Edge
+    // reports to Core, which the page polls at onboarding-status/. Flip
+    // firstEvaluated to simulate that landing (there's no real SDK eval here).
+    let firstEvaluated = false;
+    await page.route(/onboarding-status\//, (route) =>
+      route.fulfill({
+        json: {
+          first_evaluated_at: firstEvaluated ? '2024-01-01T00:00:00Z' : null,
+          first_evaluated_sdk_label: firstEvaluated ? 'flagsmith-js-sdk' : null,
+        },
+      }),
+    );
+
     // The welcome heading means bootstrap settled (loader, then heading/error).
     const flowReady = async () =>
       page
         .getByRole('heading', { name: /Welcome/ })
         .waitFor({ state: 'visible', timeout: 30000 });
+
+    // The console polls every few seconds, so LIVE lands shortly after the flip.
+    const waitConnected = () =>
+      expect(page.getByText('LIVE', { exact: true })).toBeVisible({
+        timeout: 15000,
+      });
 
     // The features page syncs the slideout state to the URL with
     // history.replace, which aborts a full navigation that is still in
@@ -32,7 +51,7 @@ test.describe('Onboarding', () => {
     const gotoOnboarding = async () => {
       for (let attempt = 0; ; attempt++) {
         try {
-          await page.goto('/getting-started?connected');
+          await page.goto('/getting-started');
           return;
         } catch (e) {
           if (attempt >= 2) throw e;
@@ -74,12 +93,11 @@ test.describe('Onboarding', () => {
     await page.getByRole('button', { name: 'Copy code snippet' }).click();
     await expect(page.getByText('Copy code snippet')).toContainText('✓');
 
-    // No real first evaluation in a test, so force the connected state via
-    // ?connected (the #7767 stub); that unlocks the toggle and flips LIVE.
-    log('Force the connected state');
-    await gotoOnboarding();
-    await flowReady();
-    await expect(page.getByText('LIVE', { exact: true })).toBeVisible();
+    // The first evaluation lands; the console polls onboarding-status/ and
+    // flips to LIVE on its own - no reload needed.
+    log('First evaluation received, console flips to LIVE');
+    firstEvaluated = true;
+    await waitConnected();
 
     // Two switches on the page (theme + flag), so scope to the flags region.
     log('Toggle the flag');
@@ -129,6 +147,7 @@ test.describe('Onboarding', () => {
       page.getByRole('heading', { name: 'Choose your next quest' }),
     ).toBeVisible();
 
+    await waitConnected();
     await page.getByRole('button', { name: /Gradual rollout/ }).click();
     await expect(page).toHaveURL(
       /\/features\?feature=\d+&tab=segment-overrides/,
@@ -136,11 +155,13 @@ test.describe('Onboarding', () => {
 
     await gotoOnboarding();
     await flowReady();
+    await waitConnected();
     await page.getByRole('button', { name: /Remote config/ }).click();
     await expect(page).toHaveURL(/\/features\?feature=\d+&tab=value/);
 
     await gotoOnboarding();
     await flowReady();
+    await waitConnected();
     await page.getByRole('button', { name: /Experiment/ }).click();
     await expect(page).toHaveURL(/\/experiments$/);
   });

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -138,6 +138,10 @@ test.describe('Onboarding', () => {
         .getByRole('region', { name: 'Your flags' })
         .getByText('Onboarding', { exact: true }),
     ).toBeVisible();
+    // The reload dropped the connected latch, so wait for the console to flip
+    // back before snapshotting: the badge state would otherwise race the first
+    // poll and diff against the baseline.
+    await waitConnected();
     await visualSnapshot(page, 'onboarding-renamed', testInfo);
 
     // The next-quest cards unlock once connected, each deep-linking to the
@@ -147,7 +151,6 @@ test.describe('Onboarding', () => {
       page.getByRole('heading', { name: 'Choose your next quest' }),
     ).toBeVisible();
 
-    await waitConnected();
     await page.getByRole('button', { name: /Gradual rollout/ }).click();
     await expect(page).toHaveURL(
       /\/features\?feature=\d+&tab=segment-overrides/,

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -64,8 +64,9 @@ const OnboardingFlow: FC = () => {
     projectId,
   })
 
-  // Connection is stubbed until #7767 (useOnboardingConnection); the toggle is real.
-  const connection = useOnboardingConnection()
+  // Real first-evaluation signal: polls the environment's onboarding
+  // status until Edge reports its first SDK evaluation.
+  const connection = useOnboardingConnection(environmentKey)
   // Session-only: a reload resets the checklist. Fine for onboarding.
   const [installCopied, setInstallCopied] = useState(false)
   const [snippetCopied, setSnippetCopied] = useState(false)

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
@@ -1,13 +1,34 @@
-import { useLocation } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { useGetEnvironmentOnboardingStatusQuery } from 'common/services/useEnvironmentOnboardingStatus'
 
 export type OnboardingConnectionStatus = 'listening' | 'connected'
 
-// Connection status for the verify console. Reports the pre-connection state
-// with a `?connected` query-param hatch to exercise the connected UI.
-// TODO(#7767): replace with the real first-evaluation signal.
-export const useOnboardingConnection = (): OnboardingConnectionStatus => {
-  const { search } = useLocation()
-  return new URLSearchParams(search).has('connected')
-    ? 'connected'
-    : 'listening'
+// Edge reports the first evaluation asynchronously after the SDK's first
+// request, so the flip isn't instant — poll until it lands.
+const POLL_INTERVAL_MS = 3000
+
+// Connection status for the verify console, driven by the real first-evaluation
+// signal: Edge reports the first SDK evaluation to Core, exposed at
+// GET environments/{key}/onboarding-status/. `first_evaluated_at` flips from
+// null to a timestamp once received; it never reverts, so we stop polling then.
+export const useOnboardingConnection = (
+  environmentKey: string,
+): OnboardingConnectionStatus => {
+  const [firstEvaluated, setFirstEvaluated] = useState(false)
+
+  const { data } = useGetEnvironmentOnboardingStatusQuery(
+    { environmentKey },
+    {
+      pollingInterval: POLL_INTERVAL_MS,
+      skip: firstEvaluated || !environmentKey,
+    },
+  )
+
+  useEffect(() => {
+    if (data?.first_evaluated_at) {
+      setFirstEvaluated(true)
+    }
+  }, [data])
+
+  return firstEvaluated ? 'connected' : 'listening'
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #7767, consuming the first-evaluation signal from #7623.

The verify console was stubbed: it read a `?connected` query param, so the connected state could be faked from the URL. It now reflects the real signal.

- New RTK Query service `useEnvironmentOnboardingStatus`, calling `GET environments/{key}/onboarding-status/`. Unauthenticated, keyed by the environment's client-side API key, served by Core rather than the edge host.
- `useOnboardingConnection` takes the environment key and polls that endpoint every 3s, flipping to `connected` once `first_evaluated_at` is no longer null. Edge reports the first evaluation asynchronously after the SDK's first request, so the flip is not instant; the value never reverts, so polling stops once it lands.
- The `?connected` hatch is gone.

## How did you test this code?

The e2e test (`onboarding-tests.pw.ts`) mocks `onboarding-status/` and flips `first_evaluated_at` mid-test, so it now asserts through the real polling path rather than the query param.

Manually verified with the `onboarding_quickstart_flow` flag on:

- [x] `/getting-started` holds on "listening" while nothing has evaluated
- [x] Running the snippet in a scratch app flips the console to LIVE within a few seconds, no reload needed
- [x] `?connected` on the URL no longer does anything

`tsc` and `eslint` are clean on the changed files.
