### PR TITLE
fix(LaunchDarkly): resolve served variation for boolean flag import

### DIFF
--- a/api/integrations/launch_darkly/services.py
+++ b/api/integrations/launch_darkly/services.py
@@ -663,13 +663,33 @@ def _create_boolean_feature_states_with_segments_identities(
     environments_by_ld_environment_key: dict[str, Environment],
     segments_by_ld_key: dict[str, Segment],
 ) -> None:
+    variations_by_idx = {
+        str(idx): variation for idx, variation in enumerate(ld_flag["variations"])
+    }
+
     for ld_environment_key, environment in environments_by_ld_environment_key.items():
         ld_flag_config = ld_flag["environments"][ld_environment_key]
+
+        # LD separates "is the flag on" from "what does it serve" (the fallthrough
+        # variation when on, or the off variation when off). Flagsmith's `enabled`
+        # is the served value, so resolve it the same way the string factory does,
+        # instead of taking the `on` toggle at face value.
+        is_flag_on = ld_flag_config["on"]
+        variation_config_key = "isFallthrough" if is_flag_on else "isOff"
+        enabled = is_flag_on
+
+        if ld_flag_config_summary := ld_flag_config.get("_summary"):
+            enabled_variations = ld_flag_config_summary.get("variations") or {}
+            for idx, variation_config in enabled_variations.items():
+                if variation_config.get(variation_config_key):
+                    enabled = bool(variations_by_idx[idx]["value"])
+                    break
+
         feature_state, _ = FeatureState.objects.update_or_create(
             feature=feature,
             feature_segment=None,
             environment=environment,
-            defaults={"enabled": ld_flag_config["on"]},
+            defaults={"enabled": enabled},
         )
 
         FeatureStateValue.objects.update_or_create(

--- a/api/tests/unit/integrations/launch_darkly/client_responses/get_flags.json
+++ b/api/tests/unit/integrations/launch_darkly/client_responses/get_flags.json
@@ -48,13 +48,13 @@
           "prerequisites": 0,
           "variations": {
             "0": {
-              "isFallthrough": true,
+              "isOff": true,
               "nullRules": 0,
               "rules": 0,
               "targets": 0
             },
             "1": {
-              "isOff": true,
+              "isFallthrough": true,
               "nullRules": 0,
               "rules": 0,
               "targets": 0
@@ -80,13 +80,13 @@
           "prerequisites": 0,
           "variations": {
             "0": {
-              "isFallthrough": true,
+              "isOff": true,
               "nullRules": 0,
               "rules": 0,
               "targets": 0
             },
             "1": {
-              "isOff": true,
+              "isFallthrough": true,
               "nullRules": 0,
               "rules": 0,
               "targets": 0

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -169,13 +169,16 @@ def test_process_import_request__success__expected_status(  # type: ignore[no-un
     assert deprecated_feature.is_archived is True
 
     # Standard feature states have expected values.
+    # flag1 is "on" in Test but its fallthrough serves the "false" variation, and
+    # "off" in Production but its off variation serves "true" -- `enabled` should
+    # follow the served variation, not the raw LD `on` toggle.
     boolean_standard_feature = Feature.objects.get(project=project, name="flag1")
     boolean_standard_feature_states_by_env_name = {
         fs.environment.name: fs
         for fs in FeatureState.objects.filter(feature=boolean_standard_feature)
     }
-    boolean_standard_feature_states_by_env_name["Test"].enabled is True
-    boolean_standard_feature_states_by_env_name["Production"].enabled is False
+    assert boolean_standard_feature_states_by_env_name["Test"].enabled is False
+    assert boolean_standard_feature_states_by_env_name["Production"].enabled is True
 
     string_standard_feature = Feature.objects.get(project=project, name="flag2_value")
     string_standard_feature_states_by_env_name = {


### PR DESCRIPTION
Boolean flags imported from LaunchDarkly can evaluate to the opposite of what they do in LD. LD separates "is the flag on" from "what does it serve" (the fallthrough variation when on, or the off variation when off), but the importer mapped the raw `on` toggle straight to Flagsmith's `enabled` state. Any project using the common "flag on, default off, enable via targeting/segments" pattern imports with an inverted default, silently, since nothing is written to `error_messages` and the import still reports success.

## Changes
- [x] Boolean flag import now resolves the actual served variation (fallthrough when on, off variation when off) from LD's per-flag `_summary`, matching how the existing string/multivariate import paths already resolve their served value, instead of taking the `on` toggle at face value.
- [x] Added a regression test reproducing both directions of the bug (on-but-serving-false, and off-but-serving-true).

Contributes to #8047

## How did you test this code?
- Added `test_process_import_request__success__expected_status` coverage: the `flag1` fixture now has a boolean flag that is `on` in one environment but resolves to the `false` variation, and `off` in another environment but resolves to `true`. Confirmed the test fails on the old code and passes with the fix.
- Ran the full `tests/unit/integrations/launch_darkly` suite (47 passed).
- `make lint` (pre-commit) and `mypy` pass on the changed files.

Review effort: 2/5