### PR TITLE
fix(Segments): delete_segment task crashes when segment already deleted

### DIFF
--- a/api/segments/tasks.py
+++ b/api/segments/tasks.py
@@ -11,7 +11,12 @@ from segments.models import Segment
 
 @register_task_handler()
 def delete_segment(segment_id: int) -> None:
-    Segment.objects.get(pk=segment_id).delete()
+    try:
+        Segment.objects.get(pk=segment_id).delete()
+    except Segment.DoesNotExist:
+        # Already deleted, e.g. by a cascading delete of its parent segment
+        # or feature, or a previous run of this task.
+        return
 
 
 @register_task_handler()

--- a/api/tests/unit/segments/test_unit_segments_tasks.py
+++ b/api/tests/unit/segments/test_unit_segments_tasks.py
@@ -1,0 +1,32 @@
+from projects.models import Project
+from segments.models import Segment
+from segments.tasks import delete_segment
+
+
+def test_delete_segment__segment_exists__soft_deletes_segment(
+    project: Project,
+) -> None:
+    # Given
+    segment = Segment.objects.create(name="Test Segment", project=project)
+
+    # When
+    delete_segment(segment_id=segment.id)
+
+    # Then
+    segment.refresh_from_db()
+    assert segment.deleted_at is not None
+
+
+def test_delete_segment__segment_already_deleted__does_not_raise(
+    project: Project,
+) -> None:
+    # Given
+    segment = Segment.objects.create(name="Test Segment", project=project)
+    segment_id = segment.id
+    segment.hard_delete()
+
+    # When
+    delete_segment(segment_id=segment_id)  # should not raise
+
+    # Then
+    assert not Segment.objects.all_with_deleted().filter(id=segment_id).exists()


### PR DESCRIPTION
The async delete_segment task fetches a segment by id and deletes it, but a concurrent delete of the same segment (e.g. a cascading project or feature delete racing with another delete of the same segment) can remove it first. The task then crashes with Segment.DoesNotExist instead of treating the segment as already gone.

## Changes
- [x] delete_segment task no longer crashes when the segment was already removed by a concurrent delete
- [x] Added regression tests covering both the normal delete and the already-deleted case

Closes https://github.com/Flagsmith/flagsmith/issues/7354

Review effort: 1/5