### PR TITLE
fix(API): _validate_owner_removal counts non-existent group IDs as removals

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -448,8 +448,7 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         serializer.is_valid(raise_exception=True)
         self._validate_owner_removal(
             feature,
-            owners_to_remove=0,
-            group_owners_to_remove=len(serializer.validated_data["group_ids"]),
+            group_ids_to_remove=serializer.validated_data["group_ids"],
         )
         serializer.remove_group_owners(feature)
         response = Response(self.get_serializer(instance=feature).data)
@@ -486,8 +485,7 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         feature = self.get_object()
         self._validate_owner_removal(
             feature,
-            owners_to_remove=len(serializer.validated_data["user_ids"]),
-            group_owners_to_remove=0,
+            user_ids_to_remove=serializer.validated_data["user_ids"],
         )
         serializer.remove_users(feature)
 
@@ -496,11 +494,15 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     def _validate_owner_removal(
         self,
         feature: Feature,
-        owners_to_remove: int,
-        group_owners_to_remove: int,
+        user_ids_to_remove: typing.Iterable[int] = (),
+        group_ids_to_remove: typing.Iterable[int] = (),
     ) -> None:
         if not feature.project.enforce_feature_owners:
             return
+        owners_to_remove = feature.owners.filter(id__in=user_ids_to_remove).count()
+        group_owners_to_remove = feature.group_owners.filter(
+            id__in=group_ids_to_remove
+        ).count()
         remaining = (
             feature.owners.count()
             - owners_to_remove

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -5468,3 +5468,40 @@ def test_remove_group_owners__enforce_owners_user_owners_remain__returns_200(
     feature.refresh_from_db()
     assert group not in feature.group_owners.all()
     assert admin_user in feature.owners.all()
+
+
+def test_remove_group_owners__enforce_owners_nonexistent_group_id_in_request__returns_200(
+    admin_client_new: APIClient,
+    project: Project,
+    feature: Feature,
+    admin_user: FFAdminUser,
+    organisation: Organisation,
+) -> None:
+    # Given
+    project.enforce_feature_owners = True
+    project.save()
+    group = UserPermissionGroup.objects.create(
+        name="Test Group", organisation=organisation
+    )
+    feature.owners.add(admin_user)
+    feature.group_owners.add(group)
+    nonexistent_group_id = group.id + 9999
+
+    url = reverse(
+        "api-v1:projects:project-features-remove-group-owners",
+        args=[project.id, feature.id],
+    )
+    # A stale/non-existent group ID alongside a real one should not inflate
+    # the removal count and block a legitimate removal.
+    data = {"group_ids": [group.id, nonexistent_group_id]}
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    feature.refresh_from_db()
+    assert group not in feature.group_owners.all()
+    assert admin_user in feature.owners.all()


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

When `enforce_feature_owners` is on, removing group owners from a feature could be wrongly rejected with a 400 if the request included a stale or non-existent group ID alongside a real one. The validation counted every ID in the request as a removal, instead of only the IDs that were actually current owners, so a harmless extra ID could make it look like the last owner was being removed.

Contributes to https://github.com/Flagsmith/flagsmith/issues/8038

- [x] `_validate_owner_removal` now counts only the requested IDs that are actually current owners/group owners of the feature, instead of trusting the request's ID count.

## How did you test this code?

Added a regression test (`test_remove_group_owners__enforce_owners_nonexistent_group_id_in_request__returns_200`) reproducing the issue's exact scenario: a feature with one user owner and one group owner, removing the group owner while also passing a non-existent group ID. Verified it fails with `400` against the old code and passes with the fix. Ran the full `test_unit_features_views.py` suite (298 passed, 2 pre-existing skips), plus `mypy` and the project's lint/format pre-commit hooks, all clean.

Review effort: 1/5