### PR TITLE
feat(api): Support confidential clients in OAuth dynamic client registration

### DIFF
--- a/api/oauth2_metadata/dataclasses.py
+++ b/api/oauth2_metadata/dataclasses.py
@@ -4,6 +4,15 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.conf import settings
+from oauth2_provider.models import Application
+
+
+@dataclass(frozen=True)
+class RegisteredClient:
+    """An application created via dynamic client registration."""
+
+    application: Application
+    client_secret: str
 
 
 @dataclass(frozen=True)

--- a/api/oauth2_metadata/metrics.py
+++ b/api/oauth2_metadata/metrics.py
@@ -1,0 +1,9 @@
+import prometheus_client
+
+flagsmith_oauth2_dcr_registrations_total = prometheus_client.Counter(
+    "flagsmith_oauth2_dcr_registrations_total",
+    "Total OAuth2 dynamic client registration requests, labelled by the "
+    "requested token endpoint auth method and whether the registration "
+    "was accepted or rejected.",
+    ["token_endpoint_auth_method", "outcome"],
+)

--- a/api/oauth2_metadata/serializers.py
+++ b/api/oauth2_metadata/serializers.py
@@ -23,6 +23,9 @@ _CLIENT_NAME_RE = re.compile(r"^[\w\s.\-()]+$", re.ASCII)
 
 DEFAULT_CLIENT_NAME = "MCP client"
 
+# Matches token_endpoint_auth_methods_supported in the RFC 8414 metadata.
+TOKEN_ENDPOINT_AUTH_METHODS = ["client_secret_basic", "client_secret_post", "none"]
+
 
 class DCRRequestSerializer(serializers.Serializer[None]):
     # Optional per RFC 7591 §2; null, blank and absent all mean "unnamed".
@@ -49,7 +52,8 @@ class DCRRequestSerializer(serializers.Serializer[None]):
         required=False,
         default=["code"],
     )
-    token_endpoint_auth_method = serializers.CharField(
+    token_endpoint_auth_method = serializers.ChoiceField(
+        choices=TOKEN_ENDPOINT_AUTH_METHODS,
         required=False,
         default="none",
     )
@@ -73,14 +77,6 @@ class DCRRequestSerializer(serializers.Serializer[None]):
                 errors.append(str(e.message))
         if errors:
             raise serializers.ValidationError(errors)
-        return value
-
-    def validate_token_endpoint_auth_method(self, value: str) -> str:
-        if value != "none":
-            raise serializers.ValidationError(
-                "Only public clients are supported; "
-                "token_endpoint_auth_method must be 'none'."
-            )
         return value
 
     def validate_grant_types(self, value: list[str]) -> list[str]:

--- a/api/oauth2_metadata/services.py
+++ b/api/oauth2_metadata/services.py
@@ -2,7 +2,10 @@ import logging
 from urllib.parse import urlparse
 
 from django.core.exceptions import ValidationError
+from oauth2_provider.generators import generate_client_secret
 from oauth2_provider.models import Application
+
+from oauth2_metadata.dataclasses import RegisteredClient
 
 logger = logging.getLogger(__name__)
 
@@ -64,19 +67,27 @@ def create_oauth2_application(
     *,
     client_name: str,
     redirect_uris: list[str],
-) -> Application:
-    """Create a public OAuth2 application for dynamic client registration."""
+    token_endpoint_auth_method: str = "none",
+) -> RegisteredClient:
+    """Create an OAuth2 application for dynamic client registration."""
+    client_secret = ""
+    client_type = Application.CLIENT_PUBLIC
+    if token_endpoint_auth_method != "none":
+        client_secret = generate_client_secret()
+        client_type = Application.CLIENT_CONFIDENTIAL
+
     application: Application = Application.objects.create(
         name=client_name,
-        client_type=Application.CLIENT_PUBLIC,
+        client_type=client_type,
         authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-        client_secret="",
+        client_secret=client_secret,
         redirect_uris=" ".join(redirect_uris),
         skip_authorization=False,
     )
     logger.info(
-        "OAuth2 DCR: registered application %s (client_id=%s).",
+        "OAuth2 DCR: registered application %s (client_id=%s, client_type=%s).",
         client_name,
         application.client_id,
+        client_type,
     )
-    return application
+    return RegisteredClient(application=application, client_secret=client_secret)

--- a/api/oauth2_metadata/views.py
+++ b/api/oauth2_metadata/views.py
@@ -19,7 +19,12 @@ from rest_framework.views import APIView
 
 from oauth2_metadata.dataclasses import OAuthConfig
 from oauth2_metadata.mappers import map_drf_error_to_rfc7591_error_body
-from oauth2_metadata.serializers import DCRRequestSerializer, OAuthConsentSerializer
+from oauth2_metadata.metrics import flagsmith_oauth2_dcr_registrations_total
+from oauth2_metadata.serializers import (
+    TOKEN_ENDPOINT_AUTH_METHODS,
+    DCRRequestSerializer,
+    OAuthConsentSerializer,
+)
 from oauth2_metadata.services import create_oauth2_application
 
 logger = structlog.get_logger("oauth2_metadata")
@@ -160,6 +165,9 @@ class DynamicClientRegistrationView(APIView):
         if not serializer.is_valid():
             error_body = map_drf_error_to_rfc7591_error_body(serializer.errors)
             payload = request.data if isinstance(request.data, dict) else {}
+            self._count_registration(
+                payload.get("token_endpoint_auth_method"), outcome="rejected"
+            )
             logger.error(
                 "registration.rejected",
                 error=error_body["error"],
@@ -175,20 +183,39 @@ class DynamicClientRegistrationView(APIView):
 
         data = serializer.validated_data
 
-        application = create_oauth2_application(
+        registered = create_oauth2_application(
             client_name=data["client_name"],
             redirect_uris=data["redirect_uris"],
+            token_endpoint_auth_method=data["token_endpoint_auth_method"],
+        )
+        self._count_registration(
+            data["token_endpoint_auth_method"], outcome="registered"
         )
 
-        return Response(
-            {
-                "client_id": application.client_id,
-                "client_name": application.name,
-                "redirect_uris": data["redirect_uris"],
-                "grant_types": data["grant_types"],
-                "response_types": data["response_types"],
-                "token_endpoint_auth_method": data["token_endpoint_auth_method"],
-                "client_id_issued_at": int(application.created.timestamp()),
-            },
-            status=drf_status.HTTP_201_CREATED,
-        )
+        application = registered.application
+        response_body: dict[str, Any] = {
+            "client_id": application.client_id,
+            "client_name": application.name,
+            "redirect_uris": data["redirect_uris"],
+            "grant_types": data["grant_types"],
+            "response_types": data["response_types"],
+            "token_endpoint_auth_method": data["token_endpoint_auth_method"],
+            "client_id_issued_at": int(application.created.timestamp()),
+        }
+        if registered.client_secret:
+            response_body["client_secret"] = registered.client_secret
+            # 0 means the secret never expires, per RFC 7591 §3.2.1.
+            response_body["client_secret_expires_at"] = 0
+
+        return Response(response_body, status=drf_status.HTTP_201_CREATED)
+
+    def _count_registration(self, auth_method: Any, outcome: str) -> None:
+        # Requested method is client input; collapse unknown values to keep
+        # metric cardinality bounded.
+        if auth_method is None:
+            auth_method = "none"
+        if auth_method not in TOKEN_ENDPOINT_AUTH_METHODS:
+            auth_method = "other"
+        flagsmith_oauth2_dcr_registrations_total.labels(
+            token_endpoint_auth_method=auth_method, outcome=outcome
+        ).inc()

--- a/api/tests/unit/oauth2_metadata/test_dcr.py
+++ b/api/tests/unit/oauth2_metadata/test_dcr.py
@@ -188,6 +188,7 @@ def test_dcr_register__invalid_redirect_uris__returns_rfc7591_error(
 def test_dcr_register__confidential_client__returns_201_with_secret(
     api_client: APIClient,
     auth_method: str,
+    assert_metric: AssertMetricFixture,
 ) -> None:
     # Given
     payload = _valid_payload(token_endpoint_auth_method=auth_method)
@@ -206,6 +207,12 @@ def test_dcr_register__confidential_client__returns_201_with_secret(
     assert application.client_type == Application.CLIENT_CONFIDENTIAL
     # The secret is hashed at rest; only the response carries the plaintext.
     assert application.client_secret != data["client_secret"]
+
+    assert_metric(
+        name="flagsmith_oauth2_dcr_registrations_total",
+        labels={"token_endpoint_auth_method": auth_method, "outcome": "registered"},
+        value=1,
+    )
 
 
 @pytest.mark.django_db()

--- a/api/tests/unit/oauth2_metadata/test_dcr.py
+++ b/api/tests/unit/oauth2_metadata/test_dcr.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from common.test_tools import AssertMetricFixture
+from django.contrib.auth.hashers import check_password
 from django.urls import reverse
 from oauth2_provider.models import Application
 from pytest_structlog import StructuredLogCapture
@@ -206,7 +207,9 @@ def test_dcr_register__confidential_client__returns_201_with_secret(
     application = Application.objects.get(client_id=data["client_id"])
     assert application.client_type == Application.CLIENT_CONFIDENTIAL
     # The secret is hashed at rest; only the response carries the plaintext.
+    # check_password is the same verification the token endpoint performs.
     assert application.client_secret != data["client_secret"]
+    assert check_password(data["client_secret"], application.client_secret)
 
     assert_metric(
         name="flagsmith_oauth2_dcr_registrations_total",

--- a/api/tests/unit/oauth2_metadata/test_dcr.py
+++ b/api/tests/unit/oauth2_metadata/test_dcr.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from common.test_tools import AssertMetricFixture
 from django.urls import reverse
 from oauth2_provider.models import Application
 from pytest_structlog import StructuredLogCapture
@@ -44,6 +45,8 @@ def test_dcr_register__valid_request__returns_201_with_client_id(
     assert data["response_types"] == ["code"]
     assert data["token_endpoint_auth_method"] == "none"
     assert isinstance(data["client_id_issued_at"], int)
+    assert "client_secret" not in data
+    assert "client_secret_expires_at" not in data
 
 
 @pytest.mark.django_db()
@@ -177,6 +180,69 @@ def test_dcr_register__invalid_redirect_uris__returns_rfc7591_error(
     assert expected_fragment.lower() in data["error_description"].lower()
 
 
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "auth_method",
+    ["client_secret_basic", "client_secret_post"],
+)
+def test_dcr_register__confidential_client__returns_201_with_secret(
+    api_client: APIClient,
+    auth_method: str,
+) -> None:
+    # Given
+    payload = _valid_payload(token_endpoint_auth_method=auth_method)
+
+    # When
+    response = api_client.post(DCR_URL, data=payload, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["token_endpoint_auth_method"] == auth_method
+    assert data["client_secret"]
+    assert data["client_secret_expires_at"] == 0
+
+    application = Application.objects.get(client_id=data["client_id"])
+    assert application.client_type == Application.CLIENT_CONFIDENTIAL
+    # The secret is hashed at rest; only the response carries the plaintext.
+    assert application.client_secret != data["client_secret"]
+
+
+@pytest.mark.django_db()
+def test_dcr_register__valid_request__increments_registration_metric(
+    api_client: APIClient,
+    assert_metric: AssertMetricFixture,
+) -> None:
+    # Given / When
+    api_client.post(DCR_URL, data=_valid_payload(), format="json")
+
+    # Then
+    assert_metric(
+        name="flagsmith_oauth2_dcr_registrations_total",
+        labels={"token_endpoint_auth_method": "none", "outcome": "registered"},
+        value=1,
+    )
+
+
+def test_dcr_register__invalid_auth_method__increments_rejection_metric(
+    api_client: APIClient,
+    assert_metric: AssertMetricFixture,
+) -> None:
+    # Given / When - an unsupported method is collapsed to "other".
+    api_client.post(
+        DCR_URL,
+        data=_valid_payload(token_endpoint_auth_method="private_key_jwt"),
+        format="json",
+    )
+
+    # Then
+    assert_metric(
+        name="flagsmith_oauth2_dcr_registrations_total",
+        labels={"token_endpoint_auth_method": "other", "outcome": "rejected"},
+        value=1,
+    )
+
+
 @pytest.mark.parametrize(
     "invalid_uri",
     ["javascript:alert(1)", ""],
@@ -208,7 +274,7 @@ def test_dcr_register__invalid_redirect_uri_after_valid_one__returns_rfc7591_err
         ({"client_name": "<script>alert(1)</script>"}, "letters"),
         ({"grant_types": ["implicit"]}, "grant type"),
         ({"response_types": ["token"]}, "response type"),
-        ({"token_endpoint_auth_method": "client_secret_basic"}, "public clients"),
+        ({"token_endpoint_auth_method": "private_key_jwt"}, "not a valid choice"),
     ],
     ids=[
         "xss-client-name",

--- a/api/tests/unit/oauth2_metadata/test_scopes.py
+++ b/api/tests/unit/oauth2_metadata/test_scopes.py
@@ -35,13 +35,13 @@ def test_get_available_scopes__dcr_registered_application__excludes_admin_api(
     db: None,
 ) -> None:
     # Given
-    application = create_oauth2_application(
+    registered = create_oauth2_application(
         client_name="Third Party App",
         redirect_uris=["https://example.com/callback"],
     )
 
     # When
-    scopes = FlagsmithScopes().get_available_scopes(application=application)
+    scopes = FlagsmithScopes().get_available_scopes(application=registered.application)
 
     # Then
     assert set(scopes) == {SCOPE_MCP}
@@ -72,13 +72,13 @@ def test_get_default_scopes__dcr_registered_application__defaults_to_mcp(
     db: None,
 ) -> None:
     # Given
-    application = create_oauth2_application(
+    registered = create_oauth2_application(
         client_name="Third Party App",
         redirect_uris=["https://example.com/callback"],
     )
 
     # When
-    scopes = FlagsmithScopes().get_default_scopes(application=application)
+    scopes = FlagsmithScopes().get_default_scopes(application=registered.application)
 
     # Then
     assert scopes == [SCOPE_MCP]

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -425,7 +425,7 @@ Attributes:
 ### `oauth2_metadata.registration.rejected`
 
 Logged at `error` from:
- - `api/oauth2_metadata/views.py:163`
+ - `api/oauth2_metadata/views.py:171`
 
 Attributes:
  - `client.name`

--- a/docs/docs/deployment-self-hosting/observability/_metrics-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_metrics-catalogue.md
@@ -79,6 +79,16 @@ Labels:
  - `method`
  - `response_status`
 
+### `flagsmith_oauth2_dcr_registrations`
+
+Counter.
+
+Total OAuth2 dynamic client registration requests, labelled by the requested token endpoint auth method and whether the registration was accepted or rejected.
+
+Labels:
+ - `token_endpoint_auth_method`
+ - `outcome`
+
 ### `flagsmith_segment_membership_backfill_duration_seconds`
 
 Histogram.


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8113.

Claude's MCP connector requests `token_endpoint_auth_method: client_secret_post`, and our DCR endpoint only accepted public clients. Our RFC 8414 metadata has advertised the `client_secret_*` methods all along, so clients choosing them is legitimate.

In this PR, we:

1. Accept `client_secret_basic` and `client_secret_post` in dynamic client registration. Such applications are created as confidential, and the response carries the generated `client_secret` with `client_secret_expires_at: 0` per RFC 7591 §3.2.1. django-oauth-toolkit hashes the secret at rest and already authenticates both methods at the token endpoint. PKCE remains required for all clients, and DCR applications keep `skip_authorization=False`.

2. Add a `flagsmith_oauth2_dcr_registrations_total` counter, labelled by requested auth method (collapsed to `other` for unsupported values) and outcome, so registration traffic is no longer invisible.

3. Return a `RegisteredClient` dataclass from `create_oauth2_application`, as the plaintext secret only exists at creation time.

## How did you test this code?

Added unit tests.
