### PR TITLE
fix(code-help): make the SDK snippets runnable

### DIFF
--- a/frontend/common/code-help/__tests__/init-snippets.test.ts
+++ b/frontend/common/code-help/__tests__/init-snippets.test.ts
@@ -1,0 +1,173 @@
+// The templates only need `Constants` for the custom-URL branch. Mocking it
+// keeps the legacy Flux stores (which touch `window`) out of this test.
+jest.mock('common/constants', () => ({
+  __esModule: true,
+  default: {
+    getFlagsmithSDKUrl: () => 'https://edge.api.flagsmith.com/api/v1/',
+    isCustomFlagsmithUrl: () => false,
+  },
+}))
+
+import initDotnet from 'common/code-help/init/init-dotnet'
+import initFlutter from 'common/code-help/init/init-flutter'
+import initGo from 'common/code-help/init/init-go'
+import initIos from 'common/code-help/init/init-ios'
+import initJava from 'common/code-help/init/init-java'
+import initJs from 'common/code-help/init/init-js'
+import initNextAppRouter from 'common/code-help/init/init-next-app-router'
+import initNextPagesRouter from 'common/code-help/init/init-next-pages-router'
+import initNode from 'common/code-help/init/init-node'
+import initPhp from 'common/code-help/init/init-php'
+import initPython from 'common/code-help/init/init-python'
+import initReact from 'common/code-help/init/init-react'
+import initReactNative from 'common/code-help/init/init-react-native'
+import initRuby from 'common/code-help/init/init-ruby'
+import initRust from 'common/code-help/init/init-rust'
+
+const ENV_ID = 'test-environment-key'
+
+// Deliberately not a valid identifier in any of the target languages: the
+// onboarding lets the user name the flag, and nothing sanitises it.
+const FEATURE_NAME = 'show banner-v2'
+
+// Mirrors the subset of `Constants`' keywords the init templates read. Anything
+// a template expects but this omits renders as "undefined", which the stray
+// interpolation test below catches.
+const keywords = {
+  FEATURE_NAME,
+  // Empty means "one flag only", which is what the onboarding passes.
+  FEATURE_NAME_ALT: '',
+  LIB_NAME: 'flagsmith',
+  LIB_NAME_JAVA: 'FlagsmithClient',
+  NPM_CLIENT: '@flagsmith/flagsmith',
+  NPM_NODE_CLIENT: '@flagsmith/nodejs',
+}
+
+// The Features page keeps two placeholder flags: one for the enabled check, one
+// for the value.
+const twoFlagKeywords = { ...keywords, FEATURE_NAME_ALT: 'banner_size' }
+
+const snippets: Record<string, string> = {
+  '.NET': initDotnet(ENV_ID, keywords),
+  'Flutter': initFlutter(ENV_ID, keywords),
+  'Go': initGo(ENV_ID, keywords),
+  'Java': initJava(ENV_ID, keywords),
+  'JavaScript': initJs(ENV_ID, keywords),
+  'Next.js (app router)': initNextAppRouter(ENV_ID, keywords),
+  'Next.js (pages router)': initNextPagesRouter(ENV_ID, keywords),
+  'Node JS': initNode(ENV_ID, keywords),
+  'PHP': initPhp(ENV_ID, keywords),
+  'Python': initPython(ENV_ID, keywords),
+  'React': initReact(ENV_ID, keywords),
+  'React Native': initReactNative(ENV_ID, keywords),
+  'Ruby': initRuby(ENV_ID, keywords),
+  'Rust': initRust(ENV_ID, keywords),
+  'iOS': initIos(ENV_ID, keywords),
+}
+
+const twoFlagSnippets: Record<string, string> = {
+  'JavaScript': initJs(ENV_ID, twoFlagKeywords),
+  'Next.js (app router)': initNextAppRouter(ENV_ID, twoFlagKeywords),
+  'Node JS': initNode(ENV_ID, twoFlagKeywords),
+  'Python': initPython(ENV_ID, twoFlagKeywords),
+  'React': initReact(ENV_ID, twoFlagKeywords),
+  'Ruby': initRuby(ENV_ID, twoFlagKeywords),
+}
+
+const languages = Object.keys(snippets)
+
+describe('code-help init snippets', () => {
+  it.each(languages)('%s references only the given flag', (language) => {
+    expect(snippets[language]).toContain(FEATURE_NAME)
+    expect(snippets[language]).not.toContain('banner_size')
+  })
+
+  it.each(languages)('%s interpolates no stray value', (language) => {
+    // `${cond && `...`}` renders "false" straight into the snippet when cond is
+    // false, e.g. `apiKey = "KEY"false`. A boolean preceded by `: `, `= `, `(`
+    // or a comma is a real argument, so only flag the glued-on case.
+    expect(snippets[language]).not.toMatch(/[^\s:=(,[]false/)
+    // A keyword the template expects but the caller omits renders as undefined.
+    expect(snippets[language]).not.toContain('undefined')
+  })
+
+  it.each(languages)('%s names no variable after the flag', (language) => {
+    // A flag name with a space or hyphen cannot be an identifier.
+    expect(snippets[language]).not.toMatch(
+      new RegExp(`(const|let|var|final|bool)\\s+${FEATURE_NAME}`),
+    )
+  })
+
+  it('reads the Python value without json.loads', () => {
+    // json.loads needs an import, and throws on a plain string value.
+    expect(snippets.Python).not.toContain('json.loads')
+  })
+
+  it('defines the flags variable it reads in PHP', () => {
+    expect(snippets.PHP).toContain('$flags = $flagsmith->getEnvironmentFlags')
+  })
+
+  it('comments Ruby with # rather than //', () => {
+    expect(snippets.Ruby).not.toContain('//')
+  })
+
+  it('comments .NET with // rather than #', () => {
+    expect(snippets['.NET']).not.toContain('#')
+  })
+
+  it('passes the Go environment key as a string, not a rune', () => {
+    expect(snippets.Go).toContain(`NewClient("${ENV_ID}"`)
+  })
+
+  it('renders React Native with View/Text, not web elements', () => {
+    // <div>/<p> do not exist in React Native.
+    expect(snippets['React Native']).not.toMatch(/<div>|<p>/)
+    expect(snippets['React Native']).toContain('<View>')
+    expect(snippets['React Native']).toContain('<Text>')
+    expect(snippets['React Native']).toContain("from 'react-native'")
+  })
+
+  it('gives Go a compilable program', () => {
+    // Go rejects unused variables, so reading a flag without printing it does
+    // not compile, and a fragment has no package or imports at all.
+    expect(snippets.Go).toContain('package main')
+    expect(snippets.Go).toContain('func main() {')
+    expect(snippets.Go).toContain(
+      'flagsmith "github.com/Flagsmith/flagsmith-go-client/v5"',
+    )
+    expect(snippets.Go).toContain('fmt.Println')
+    // v5 takes the context as an argument.
+    expect(snippets.Go).toContain('GetEnvironmentFlags(ctx)')
+  })
+
+  describe('with a second flag, as the Features page renders it', () => {
+    const twoFlagLanguages = Object.keys(twoFlagSnippets)
+
+    it.each(twoFlagLanguages)('%s reads the value off it', (language) => {
+      expect(twoFlagSnippets[language]).toContain('banner_size')
+    })
+
+    it('subscribes React to both flags', () => {
+      expect(twoFlagSnippets.React).toContain(
+        `useFlags(['${FEATURE_NAME}', 'banner_size'])`,
+      )
+      expect(twoFlagSnippets.React).toContain(`flags['banner_size'].value`)
+    })
+
+    it.each(['Python', 'Ruby', 'Node JS', 'JavaScript'])(
+      '%s labels the printed value with the flag it read',
+      (language) => {
+        // The value comes off the second flag, so labelling it with the first
+        // would tell the reader the wrong flag produced it.
+        const printed = twoFlagSnippets[language]
+        expect(printed).not.toMatch(/my_cool_feature value/)
+        expect(printed).toMatch(/banner_size value/)
+      },
+    )
+
+    it('still subscribes React to one flag when there is no second', () => {
+      expect(snippets.React).toContain(`useFlags(['${FEATURE_NAME}'])`)
+      expect(snippets.React).toContain(`flags['${FEATURE_NAME}'].value`)
+    })
+  })
+})

--- a/frontend/common/code-help/init/init-dotnet.js
+++ b/frontend/common/code-help/init/init-dotnet.js
@@ -1,28 +1,27 @@
 import Constants from 'common/constants'
 
-export default (
-  envId,
-  { FEATURE_NAME, FEATURE_NAME_ALT },
-  customFeature,
-) => `using Flagsmith;
+// FlagsmithClient takes a FlagsmithConfiguration, not an environment key, and
+// top-level statements reject `static` on a declaration (error CS0106).
+export default (envId, { FEATURE_NAME, FEATURE_NAME_ALT }) => `using Flagsmith;
 
-static FlagsmithClient _flagsmithClient;
-
-_flagsmithClient = new("${envId}"${
+var flagsmithClient = new FlagsmithClient(new FlagsmithConfiguration
+{
+    EnvironmentKey = "${envId}",${
   Constants.isCustomFlagsmithUrl()
-    ? `, apiUrl: "${Constants.getFlagsmithSDKUrl()}"`
+    ? `\n    ApiUri = new Uri("${Constants.getFlagsmithSDKUrl()}"),`
     : ''
+}
 });
 
-var flags = await _flagsmithClient.GetEnvironmentFlags();  # This method triggers a network request
+// The method below triggers a network request
+var flags = await flagsmithClient.GetEnvironmentFlags();
 
-// Check for a feature
-var isEnabled = await flags.IsFeatureEnabled("${
-  customFeature || FEATURE_NAME
-}");
-
-// Or, use the value of a feature
+// Check whether the feature is enabled, or read its value
+var isEnabled = await flags.IsFeatureEnabled("${FEATURE_NAME}");
 var featureValue = await flags.GetFeatureValue("${
-  customFeature || FEATURE_NAME_ALT
+  FEATURE_NAME_ALT || FEATURE_NAME
 }");
+
+Console.WriteLine($"${FEATURE_NAME} enabled: {isEnabled}");
+Console.WriteLine($"${FEATURE_NAME_ALT || FEATURE_NAME} value: {featureValue}");
 `

--- a/frontend/common/code-help/init/init-flutter.js
+++ b/frontend/common/code-help/init/init-flutter.js
@@ -1,40 +1,29 @@
 import Constants from 'common/constants'
+
+// baseURI belongs to FlagsmithConfig; FlagsmithClient itself only takes
+// `apiKey` (plus optional config, seeds and storage).
 export default (
   envId,
   { FEATURE_NAME, FEATURE_NAME_ALT },
-) => `//In your application, initialise the Flagsmith client with your API key:
+) => `import 'package:flagsmith/flagsmith.dart';
 
 final flagsmithClient = FlagsmithClient(
-        apiKey: '${envId}',${
+  apiKey: '${envId}',${
   Constants.isCustomFlagsmithUrl()
-    ? `\n        baseURI: '${Constants.getFlagsmithSDKUrl()}',`
+    ? `\n  config: FlagsmithConfig(baseURI: '${Constants.getFlagsmithSDKUrl()}'),`
     : ''
 }
-        config: config,
-        seeds: <Flag>[
-            Flag.seed('feature', enabled: true),
-        ],
-    );
+);
 
-//if you prefer async initialization then you should use
-//final flagsmithClient = await FlagsmithClient.init(
-//        apiKey: '${envId}',${
-  Constants.isCustomFlagsmithUrl()
-    ? `\n//        baseURI: '${Constants.getFlagsmithSDKUrl()}',`
-    : ''
-}
-//        config: config,
-//        seeds: <Flag>[
-//            Flag.seed('feature', enabled: true),
-//        ],
-//        update: false,
-//    );
+// The method below triggers a network request
+await flagsmithClient.getFeatureFlags();
 
-await flagsmithClient.getFeatureFlags(reload: true) // fetch updates from api
+// Check whether the feature is enabled, or read its value
+final isEnabled = await flagsmithClient.hasFeatureFlag('${FEATURE_NAME}');
+final featureValue = await flagsmithClient.getFeatureFlagValue('${
+  FEATURE_NAME_ALT || FEATURE_NAME
+}');
 
-// Check for a feature
-bool ${FEATURE_NAME} = await flagsmithClient.hasFeatureFlag("${FEATURE_NAME}");
-
-// Or, use the value of a feature
-final ${FEATURE_NAME_ALT} = await flagsmithClient.getFeatureFlagValue("${FEATURE_NAME_ALT}");
+print('${FEATURE_NAME} enabled: $isEnabled');
+print('${FEATURE_NAME_ALT || FEATURE_NAME} value: $featureValue');
 `

--- a/frontend/common/code-help/init/init-go.js
+++ b/frontend/common/code-help/init/init-go.js
@@ -1,18 +1,34 @@
 import Constants from 'common/constants'
 
-export default (envId, { FEATURE_NAME, FEATURE_NAME_ALT }, customFeature) => `
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
+// A complete program: Go rejects unused variables, so a fragment that reads
+// flags without printing them does not compile.
+export default (envId, { FEATURE_NAME, FEATURE_NAME_ALT }) => `package main
 
-// Initialise the Flagsmith client
-client := flagsmith.NewClient('${envId}',${
+import (
+	"context"
+	"fmt"
+	flagsmith "github.com/Flagsmith/flagsmith-go-client/v5"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Initialise the Flagsmith client
+	client := flagsmith.NewClient("${envId}"${
   Constants.isCustomFlagsmithUrl()
-    ? `\n    flagsmith.WithBaseURL("${Constants.getFlagsmithSDKUrl()}"),\n`
-    : '\n'
-}    flagsmith.WithContext(ctx))
+    ? `,\n\t\tflagsmith.WithBaseURL("${Constants.getFlagsmithSDKUrl()}")`
+    : ''
+})
 
-// The method below triggers a network request
-flags, _ := client.GetEnvironmentFlags()
-isEnabled, _ := flags.IsFeatureEnabled("${customFeature || FEATURE_NAME}")
-featureValue, _ := flags.GetFeatureValue("${customFeature || FEATURE_NAME_ALT}")
+	// The method below triggers a network request
+	flags, _ := client.GetEnvironmentFlags(ctx)
+
+	// Check whether the feature is enabled, or read its value
+	isEnabled, _ := flags.IsFeatureEnabled("${FEATURE_NAME}")
+	featureValue, _ := flags.GetFeatureValue("${FEATURE_NAME_ALT || FEATURE_NAME}")
+
+	fmt.Println("${FEATURE_NAME} enabled:", isEnabled)
+	fmt.Println("${FEATURE_NAME_ALT || FEATURE_NAME} value:", featureValue)
+}
 `

--- a/frontend/common/code-help/init/init-ios.js
+++ b/frontend/common/code-help/init/init-ios.js
@@ -9,8 +9,10 @@ func application(_ application: UIApplication,
  didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
   Flagsmith.shared.apiKey = "${envId}"${
-  Constants.isCustomFlagsmithUrl() &&
-  `\n  Flagsmith.shared.baseURL = "${Constants.getFlagsmithSDKUrl()}"\n`
+  // `&&` here would interpolate the literal string "false" into the snippet.
+  Constants.isCustomFlagsmithUrl()
+    ? `\n  Flagsmith.shared.baseURL = "${Constants.getFlagsmithSDKUrl()}"\n`
+    : ''
 }
   // Check for a feature
   Flagsmith.shared
@@ -20,7 +22,9 @@ func application(_ application: UIApplication,
 
   // Or, use the value of a feature
   Flagsmith.shared
-  .getFeatureValue(withID: "${FEATURE_NAME_ALT}", forIdentity: nil) { (result) in
+  .getFeatureValue(withID: "${
+    FEATURE_NAME_ALT || FEATURE_NAME
+  }", forIdentity: nil) { (result) in
       switch result {
       case .success(let value):
           print(value ?? "nil")

--- a/frontend/common/code-help/init/init-java.js
+++ b/frontend/common/code-help/init/init-java.js
@@ -2,7 +2,6 @@ import Constants from 'common/constants'
 export default (
   envId,
   { FEATURE_NAME, FEATURE_NAME_ALT, LIB_NAME, LIB_NAME_JAVA },
-  customFeature,
 ) => `${LIB_NAME_JAVA} ${LIB_NAME} = ${LIB_NAME_JAVA}
     .newBuilder()
     .setApiKey("${envId}")${
@@ -14,13 +13,12 @@ export default (
 }
     .build();
 
-Flags flags = flagsmith.getEnvironmentFlags();
+// The method below triggers a network request
+Flags flags = ${LIB_NAME}.getEnvironmentFlags();
 
-// Check for a feature
-boolean isEnabled = flags.isFeatureEnabled("${customFeature || FEATURE_NAME}");
-
-// Or, use the value of a feature
+// Check whether the feature is enabled, or read its value
+boolean isEnabled = flags.isFeatureEnabled("${FEATURE_NAME}");
 Object featureValue = flags.getFeatureValue("${
-  customFeature || FEATURE_NAME_ALT
+  FEATURE_NAME_ALT || FEATURE_NAME
 }");
 `

--- a/frontend/common/code-help/init/init-js.js
+++ b/frontend/common/code-help/init/init-js.js
@@ -1,8 +1,9 @@
 import Constants from 'common/constants'
+// Flag names are user-defined and need not be valid JS identifiers, so the
+// snippet reads flags by key and keeps its own local variable names.
 export default (
   envId,
-  { FEATURE_FUNCTION, FEATURE_NAME, FEATURE_NAME_ALT, LIB_NAME, NPM_CLIENT },
-  customFeature,
+  { FEATURE_NAME, FEATURE_NAME_ALT, LIB_NAME, NPM_CLIENT },
 ) => `import ${LIB_NAME} from "${NPM_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
 
 ${LIB_NAME}.init({
@@ -15,23 +16,19 @@ ${LIB_NAME}.init({
         // Determines if the update came from the server or local cached storage
         const { isFromServer } = params;
 
-        // Check for a feature
-        if (${LIB_NAME}.hasFeature("${customFeature || FEATURE_NAME}")) {
-            ${FEATURE_FUNCTION}();
-        }
-
-        // Or, use the value of a feature
-        const ${FEATURE_NAME_ALT} = ${LIB_NAME}.getValue("${
-  customFeature || FEATURE_NAME_ALT
+        // Check whether the feature is enabled, or read its value
+        const isEnabled = ${LIB_NAME}.hasFeature("${FEATURE_NAME}");
+        const featureValue = ${LIB_NAME}.getValue("${
+  FEATURE_NAME_ALT || FEATURE_NAME
 }");
+        console.log("${FEATURE_NAME} enabled:", isEnabled, { isFromServer });
+        console.log("${FEATURE_NAME_ALT || FEATURE_NAME} value:", featureValue);
 
-        // Check whether value has changed
-        const ${FEATURE_NAME_ALT}Old = oldFlags["${
-  customFeature || FEATURE_NAME_ALT
-}"]
-        && oldFlags["${customFeature || FEATURE_NAME_ALT}"].value;
+        // Check whether the value has changed
+        const previousValue = oldFlags["${FEATURE_NAME_ALT || FEATURE_NAME}"]
+            && oldFlags["${FEATURE_NAME_ALT || FEATURE_NAME}"].value;
 
-        if (${FEATURE_NAME_ALT} !== ${FEATURE_NAME_ALT}Old) {
+        if (featureValue !== previousValue) {
             // Value has changed, do something here
         }
     }

--- a/frontend/common/code-help/init/init-next-app-router.js
+++ b/frontend/common/code-help/init/init-next-app-router.js
@@ -64,11 +64,19 @@ export const FeatureFlagProvider = ({
 import { useFlags } from '@flagsmith/flagsmith/react';
 
 export default function HomePage() {
-  const flags = useFlags(['${FEATURE_NAME}','${FEATURE_NAME_ALT}']); // only causes re-render if specified flag values / traits change
-  const ${FEATURE_NAME} = flags.${FEATURE_NAME}.enabled
-  const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
+  // Only re-renders when the listed flag values / traits change
+  const flags = useFlags([${
+    FEATURE_NAME_ALT
+      ? `'${FEATURE_NAME}', '${FEATURE_NAME_ALT}'`
+      : `'${FEATURE_NAME}'`
+  }]);
+  const isEnabled = flags['${FEATURE_NAME}'].enabled;
+  const featureValue = flags['${FEATURE_NAME_ALT || FEATURE_NAME}'].value;
   
   return (
-    <>{...}</>
+    <div>
+      <p>${FEATURE_NAME} enabled: {String(isEnabled)}</p>
+      <p>${FEATURE_NAME_ALT || FEATURE_NAME} value: {String(featureValue)}</p>
+    </div>
   );
 }`

--- a/frontend/common/code-help/init/init-next-pages-router.js
+++ b/frontend/common/code-help/init/init-next-pages-router.js
@@ -6,7 +6,7 @@ export default (
 import ${LIB_NAME} from "${NPM_CLIENT}/isomorphic";
 import { FlagsmithProvider } from '@flagsmith/flagsmith/react';
 
-export default function App({ Component, pageProps, flagsmithState } {
+export default function App({ Component, pageProps, flagsmithState }) {
   return (
     <FlagsmithProvider
       serverState={flagsmithState}
@@ -39,10 +39,18 @@ import flagsmith from '@flagsmith/flagsmith/isomorphic';
 import { useFlags, useFlagsmith } from '@flagsmith/flagsmith/react';
 
 export default function HomePage() {
-  const flags = useFlags(['${FEATURE_NAME}','${FEATURE_NAME_ALT}']); // only causes re-render if specified flag values / traits change
-  const ${FEATURE_NAME} = flags.${FEATURE_NAME}.enabled
-  const ${FEATURE_NAME_ALT} = flags.${FEATURE_NAME_ALT}.value
+  // Only re-renders when the listed flag values / traits change
+  const flags = useFlags([${
+    FEATURE_NAME_ALT
+      ? `'${FEATURE_NAME}', '${FEATURE_NAME_ALT}'`
+      : `'${FEATURE_NAME}'`
+  }]);
+  const isEnabled = flags['${FEATURE_NAME}'].enabled;
+  const featureValue = flags['${FEATURE_NAME_ALT || FEATURE_NAME}'].value;
   return (
-    <>{...}</>
+    <div>
+      <p>${FEATURE_NAME} enabled: {String(isEnabled)}</p>
+      <p>${FEATURE_NAME_ALT || FEATURE_NAME} value: {String(featureValue)}</p>
+    </div>
   );
 }`

--- a/frontend/common/code-help/init/init-node.js
+++ b/frontend/common/code-help/init/init-node.js
@@ -3,8 +3,7 @@ import Constants from 'common/constants'
 export default (
   envId,
   { FEATURE_NAME, FEATURE_NAME_ALT, LIB_NAME, NPM_NODE_CLIENT },
-  customFeature,
-) => `import Flagsmith from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
+) => `import { Flagsmith } from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
 
 const ${LIB_NAME} = new Flagsmith({${
   Constants.isCustomFlagsmithUrl()
@@ -14,13 +13,14 @@ const ${LIB_NAME} = new Flagsmith({${
     environmentKey: '${envId}'
 });
 
-const flags = await flagsmith.getEnvironmentFlags();
+// The method below triggers a network request
+const flags = await ${LIB_NAME}.getEnvironmentFlags();
 
-// Check for a feature
-var isEnabled = flags.isFeatureEnabled("${customFeature || FEATURE_NAME}")
-
-// Or, use the value of a feature
-var featureValue = flags.getFeatureValue('${
-  customFeature || FEATURE_NAME_ALT
-}');
+// Check whether the feature is enabled, or read its value
+const isEnabled = flags.isFeatureEnabled("${FEATURE_NAME}");
+const featureValue = flags.getFeatureValue("${
+  FEATURE_NAME_ALT || FEATURE_NAME
+}");
+console.log("${FEATURE_NAME} enabled:", isEnabled);
+console.log("${FEATURE_NAME_ALT || FEATURE_NAME} value:", featureValue);
 `

--- a/frontend/common/code-help/init/init-php.js
+++ b/frontend/common/code-help/init/init-php.js
@@ -1,8 +1,7 @@
 import Constants from 'common/constants'
-export default (
-  envId,
-  { FEATURE_NAME, FEATURE_NAME_ALT },
-) => `use Flagsmith\\Flagsmith;
+export default (envId, { FEATURE_NAME, FEATURE_NAME_ALT }) => `<?php
+
+use Flagsmith\\Flagsmith;
 
 $flagsmith = new Flagsmith('${envId}'${
   Constants.isCustomFlagsmithUrl()
@@ -10,9 +9,10 @@ $flagsmith = new Flagsmith('${envId}'${
     : ''
 });
 
-// Check for a feature
-$${FEATURE_NAME} = $flags->isFeatureEnabled('${FEATURE_NAME}');
+// The method below triggers a network request
+$flags = $flagsmith->getEnvironmentFlags();
 
-// Or use the value of a feature
-$${FEATURE_NAME_ALT} = $flags->getFeatureValue('${FEATURE_NAME_ALT}')
+// Check whether the feature is enabled, or read its value
+$isEnabled = $flags->isFeatureEnabled('${FEATURE_NAME}');
+$featureValue = $flags->getFeatureValue('${FEATURE_NAME_ALT || FEATURE_NAME}');
 `

--- a/frontend/common/code-help/init/init-python.js
+++ b/frontend/common/code-help/init/init-python.js
@@ -14,9 +14,11 @@ flagsmith = Flagsmith(\n    environment_key="${envId}"${
 # The method below triggers a network request
 flags = flagsmith.get_environment_flags()
 
-# Check for a feature
+# Check whether the feature is enabled
 is_enabled = flags.is_feature_enabled("${FEATURE_NAME}")
+print("${FEATURE_NAME} enabled:", is_enabled)
 
-# Or, use the value of a feature
-feature_value = json.loads(flags.get_feature_value("${FEATURE_NAME_ALT}"))
+# Or read its value
+feature_value = flags.get_feature_value("${FEATURE_NAME_ALT || FEATURE_NAME}")
+print("${FEATURE_NAME_ALT || FEATURE_NAME} value:", feature_value)
 `

--- a/frontend/common/code-help/init/init-react-native.js
+++ b/frontend/common/code-help/init/init-react-native.js
@@ -1,12 +1,14 @@
 import Constants from 'common/constants'
 
-// Flag names are user-defined and need not be valid JS identifiers, so the
-// snippet reads flags by key and keeps its own local variable names.
+// Same shape as the React snippet, but React Native has no <div>/<p>, so this
+// renders View/Text. Flag names are user-defined and need not be valid JS
+// identifiers, so flags are read by key with local variable names.
 export default (
   envId,
   { FEATURE_NAME, FEATURE_NAME_ALT, LIB_NAME, NPM_CLIENT },
 ) => `import ${LIB_NAME} from "${NPM_CLIENT}";
 import { FlagsmithProvider, useFlags } from '${NPM_CLIENT}/react';
+import { View, Text } from 'react-native';
 
 export function HomePage() {
   // Only re-renders when the listed flag values / traits change
@@ -19,10 +21,12 @@ export function HomePage() {
   const featureValue = flags['${FEATURE_NAME_ALT || FEATURE_NAME}'].value;
 
   return (
-    <div>
-      <p>${FEATURE_NAME} enabled: {String(isEnabled)}</p>
-      <p>${FEATURE_NAME_ALT || FEATURE_NAME} value: {String(featureValue)}</p>
-    </div>
+    <View>
+      <Text>${FEATURE_NAME} enabled: {String(isEnabled)}</Text>
+      <Text>${
+        FEATURE_NAME_ALT || FEATURE_NAME
+      } value: {String(featureValue)}</Text>
+    </View>
   );
 }
 

--- a/frontend/common/code-help/init/init-ruby.js
+++ b/frontend/common/code-help/init/init-ruby.js
@@ -3,7 +3,6 @@ import Constants from 'common/constants'
 export default (
   envId,
   { FEATURE_NAME, FEATURE_NAME_ALT },
-  customFeature,
 ) => `require "flagsmith"
 
 $flagsmith = Flagsmith::Client.new(
@@ -13,14 +12,13 @@ $flagsmith = Flagsmith::Client.new(
     : '\n'
 })
 
-// Load the environment's flags locally
+# Load the environment's flags
 $flags = $flagsmith.get_environment_flags
 
-// Check for a feature
-$is_enabled = $flags.is_feature_enabled('${customFeature || FEATURE_NAME}')
+# Check whether the feature is enabled, or read its value
+$is_enabled = $flags.is_feature_enabled('${FEATURE_NAME}')
+$feature_value = $flags.get_feature_value('${FEATURE_NAME_ALT || FEATURE_NAME}')
 
-// Or, use the value of a feature
-$feature_value = $flags.get_feature_value('${
-  customFeature || FEATURE_NAME_ALT
-}')
+puts "${FEATURE_NAME} enabled: #{$is_enabled}"
+puts "${FEATURE_NAME_ALT || FEATURE_NAME} value: #{$feature_value}"
 `

--- a/frontend/common/code-help/init/init-rust.js
+++ b/frontend/common/code-help/init/init-rust.js
@@ -1,13 +1,18 @@
 import Constants from 'common/constants'
 
 export default (envId, { FEATURE_NAME, FEATURE_NAME_ALT }) => `
-use flagsmith::{Flag, Flagsmith, FlagsmithOptions};
+use flagsmith::{Flagsmith, FlagsmithOptions};
 
-let options = FlagsmithOptions {${
+${
+  // rustfmt splits a struct literal that doesn't fit on one line, and the API
+  // URL makes this one long.
   Constants.isCustomFlagsmithUrl()
-    ? `api_url: "${Constants.getFlagsmithSDKUrl()}".to_string(), `
-    : ''
-}..Default::default()};
+    ? `let options = FlagsmithOptions {
+    api_url: "${Constants.getFlagsmithSDKUrl()}".to_string(),
+    ..Default::default()
+};`
+    : `let options = FlagsmithOptions { ..Default::default() };`
+}
 let flagsmith = Flagsmith::new(
     "${envId}".to_string(),
     options,
@@ -16,8 +21,11 @@ let flagsmith = Flagsmith::new(
 // The method below triggers a network request
 let flags = flagsmith.get_environment_flags().unwrap();
 
-// Check for a feature
-let show_button = flags.is_feature_enabled("${FEATURE_NAME}").unwrap();
-
-let button_data = flags.get_feature_value_as_string("${FEATURE_NAME_ALT}").unwrap();
+// Check whether the feature is enabled, or read its value
+let is_enabled = flags.is_feature_enabled("${FEATURE_NAME}").unwrap();
+let feature_value = flags.get_feature_value_as_string("${
+  FEATURE_NAME_ALT || FEATURE_NAME
+}").unwrap();
+println!("${FEATURE_NAME} enabled: {}", is_enabled);
+println!("${FEATURE_NAME_ALT || FEATURE_NAME} value: {}", feature_value);
 `

--- a/frontend/common/code-help/install/install-flutter.js
+++ b/frontend/common/code-help/install/install-flutter.js
@@ -1,5 +1,2 @@
-export default () => `The client library is available from the https://pub.dev/packages/flagsmith:
-
-dependencies:
-  flagsmith:
+export default () => `flutter pub add flagsmith
 `

--- a/frontend/common/code-help/install/install-php.js
+++ b/frontend/common/code-help/install/install-php.js
@@ -1,2 +1,2 @@
-export default () => `composer require flagsmith/flagsmith-php-client
+export default () => `composer require flagsmith/flagsmith-php-client guzzlehttp/guzzle symfony/cache
 `

--- a/frontend/common/code-help/install/install-rust.js
+++ b/frontend/common/code-help/install/install-rust.js
@@ -1,2 +1,2 @@
-export default () =>
-  'The package can be found at https://crates.io/crates/flagsmith;'
+export default () => `cargo add flagsmith
+`

--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -38,6 +38,7 @@ import initNode from './code-help/init/init-node'
 import initPhp from './code-help/init/init-php'
 import initPython from './code-help/init/init-python'
 import initReact from './code-help/init/init-react'
+import initReactNative from './code-help/init/init-react-native'
 import initRuby from './code-help/init/init-ruby'
 import initRust from './code-help/init/init-rust'
 import installCurl from './code-help/install/install-curl'
@@ -111,24 +112,39 @@ const Constants = {
       'iOS': createUserIos(envId, keywords, userId),
     }),
 
-    'INIT': (envId: string) => ({
-      '.NET': initDotnet(envId, keywords),
-      'Flutter': initFlutter(envId, keywords),
-      'Go': initGo(envId, keywords),
-      'Java': initJava(envId, keywords),
-      'JavaScript': initJs(envId, keywords),
-      'Next.js (app router)': initNextAppRouter(envId, keywords),
-      'Next.js (pages router)': initNextPagesRouter(envId, keywords),
-      'Node JS': initNode(envId, keywords),
-      'PHP': initPhp(envId, keywords),
-      'Python': initPython(envId, keywords),
-      'React': initReact(envId, keywords),
-      'React Native': initReact(envId, keywordsReactNative),
-      'Ruby': initRuby(envId, keywords),
-      'Rust': initRust(envId, keywords),
-      'curl': initCurl(envId),
-      'iOS': initIos(envId, keywords),
-    }),
+    // Pass `featureName` to build the snippets around one real flag, as the
+    // onboarding does. Without it the snippets illustrate two placeholder flags:
+    // one for the enabled check, one for the value.
+    'INIT': (envId: string, featureName?: string) => {
+      const kw = featureName
+        ? { ...keywords, FEATURE_NAME: featureName, FEATURE_NAME_ALT: '' }
+        : keywords
+      const kwNative = featureName
+        ? {
+            ...keywordsReactNative,
+            FEATURE_NAME: featureName,
+            FEATURE_NAME_ALT: '',
+          }
+        : keywordsReactNative
+      return {
+        '.NET': initDotnet(envId, kw),
+        'Flutter': initFlutter(envId, kw),
+        'Go': initGo(envId, kw),
+        'Java': initJava(envId, kw),
+        'JavaScript': initJs(envId, kw),
+        'Next.js (app router)': initNextAppRouter(envId, kw),
+        'Next.js (pages router)': initNextPagesRouter(envId, kw),
+        'Node JS': initNode(envId, kw),
+        'PHP': initPhp(envId, kw),
+        'Python': initPython(envId, kw),
+        'React': initReact(envId, kw),
+        'React Native': initReactNative(envId, kwNative),
+        'Ruby': initRuby(envId, kw),
+        'Rust': initRust(envId, kw),
+        'curl': initCurl(envId),
+        'iOS': initIos(envId, kw),
+      }
+    },
 
     'INSTALL': {
       '.NET': installDotnet(),

--- a/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
+++ b/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof OnboardingTerminal> = {
     docs: {
       description: {
         component:
-          'The onboarding verify console. The checklist ticks as the user acts (copy install, copy snippet), and the first evaluation flips the badge to LIVE and prints the connection receipt. Always dark, since a terminal reads the same in light and dark mode.',
+          'The onboarding verify console. The checklist ticks as the user acts (copy install, copy snippet), and the first evaluation flips the badge to LIVE and prints the connection receipt, naming the SDK that reported it when Core could identify it. Always dark, since a terminal reads the same in light and dark mode.',
       },
     },
     layout: 'padded',
@@ -37,4 +37,14 @@ export const SnippetsCopied: Story = {
 
 export const Connected: Story = {
   args: { connected: true, installCopied: true, snippetCopied: true },
+}
+
+// Core identifies the SDK from the user agent, so the receipt can name it.
+export const ConnectedWithSdkLabel: Story = {
+  args: {
+    connected: true,
+    installCopied: true,
+    sdkLabel: 'flagsmith-python-sdk',
+    snippetCopied: true,
+  },
 }

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -99,6 +99,10 @@ test.describe('Onboarding', () => {
     firstEvaluated = true;
     await waitConnected();
 
+    // The console names the SDK that reported the evaluation, from the mocked
+    // first_evaluated_sdk_label above.
+    await expect(page.getByText(/flagsmith-js-sdk/)).toBeVisible();
+
     // Two switches on the page (theme + flag), so scope to the flags region.
     log('Toggle the flag');
     const flagsTable = page.getByRole('region', { name: 'Your flags' });

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -19,14 +19,15 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   transform: {
-    '^.+\\.(ts|tsx)$': [
+    // Code-help snippet templates are ESM .js, so they need transforming too.
+    // node_modules stays untransformed, hence the ignore pattern below.
+    '^.+\\.(js|jsx|ts|tsx)$': [
       'ts-jest',
       {
         tsconfig: 'tsconfig.jest.json',
       },
     ],
   },
-  // Skip transforming JS files - they're ES5 compatible and don't need Babel
-  transformIgnorePatterns: [],
+  transformIgnorePatterns: ['/node_modules/'],
   verbose: true,
 }

--- a/frontend/web/components/pages/onboarding/OnboardingConnectPanel/sdkSnippets.ts
+++ b/frontend/web/components/pages/onboarding/OnboardingConnectPanel/sdkSnippets.ts
@@ -1,15 +1,10 @@
 // Snippets for every SDK we support, sourced from the maintained
 // `Constants.codeHelp` (the same install/init the rest of the app uses, so
-// they don't drift). One adaptation for this page: codeHelp uses a placeholder
-// flag name; we swap it for the user's real flag, so the snippet references
-// the flag this onboarding actually created.
+// they don't drift). We pass the flag this onboarding created, which builds the
+// snippets around that one flag rather than codeHelp's two placeholders.
 // The SDK list itself (labels, logos, codeHelp keys) lives in ./sdkLangs.
 import Constants from 'common/constants'
 import { SdkLang } from './sdkLangs'
-
-// Mirrors Constants' `keywords.FEATURE_NAME`. Kept local (keywords isn't
-// exported); if that placeholder ever changes, update this too.
-const PLACEHOLDER_FLAG = 'my_cool_feature'
 
 export type SdkSnippet = {
   install: string
@@ -40,16 +35,13 @@ export const getSdkSnippet = (
   featureName: string,
 ): SdkSnippet => {
   const installs = Constants.codeHelp.INSTALL as Record<string, string>
-  const inits = Constants.codeHelp.INIT(environmentKey) as Record<
+  const inits = Constants.codeHelp.INIT(environmentKey, featureName) as Record<
     string,
     string
   >
-  const wire = (inits[lang.initKey ?? lang.codeHelpKey] ?? '')
-    .split(PLACEHOLDER_FLAG)
-    .join(featureName)
   return {
     language: lang.language,
     ...parseInstall(installs[lang.codeHelpKey] ?? ''),
-    wire: wire.trim(),
+    wire: (inits[lang.initKey ?? lang.codeHelpKey] ?? '').trim(),
   }
 }

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -222,10 +222,11 @@ const OnboardingFlow: FC = () => {
         featureName={featureName}
         installCopied={installCopied}
         snippetCopied={snippetCopied}
-        connected={connection === 'connected'}
+        connected={connection.status === 'connected'}
+        sdkLabel={connection.sdkLabel}
       />
       <OnboardingFlagsTable
-        status={connection === 'connected' ? 'connected' : 'waiting'}
+        status={connection.status === 'connected' ? 'connected' : 'waiting'}
         flags={[
           {
             description: 'Controls the demo button shown to your users',
@@ -239,7 +240,7 @@ const OnboardingFlow: FC = () => {
         togglesReady={flagStateReady}
       />
       <OnboardingNextSteps
-        locked={connection !== 'connected'}
+        locked={connection.status !== 'connected'}
         onSelect={goToNextStep}
       />
       <div className='d-flex justify-content-end'>

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
@@ -8,6 +8,8 @@ export type OnboardingTerminalProps = {
   snippetCopied: boolean
   // First evaluation received (#7767).
   connected: boolean
+  // Which SDK reported that evaluation, when Core could identify it.
+  sdkLabel?: string | null
 }
 
 // Verify console. Always dark (a terminal reads the same in both modes), so it
@@ -16,6 +18,7 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
   connected,
   featureName,
   installCopied,
+  sdkLabel,
   snippetCopied,
 }) => {
   const steps = [
@@ -74,7 +77,7 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
         {connected ? (
           <>
             <p className='onboarding-terminal__line onboarding-terminal__line--dim'>
-              SDK initialized · flags loaded · {featureName}: true
+              {sdkLabel ? `${sdkLabel} · ` : ''}first evaluation received
             </p>
             <p className='onboarding-terminal__line onboarding-terminal__line--ok onboarding-terminal__line--strong'>
               ✓ Connected

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
@@ -3,32 +3,50 @@ import { useGetEnvironmentOnboardingStatusQuery } from 'common/services/useEnvir
 
 export type OnboardingConnectionStatus = 'listening' | 'connected'
 
+export type OnboardingConnection = {
+  status: OnboardingConnectionStatus
+  // Which SDK reported the first evaluation, e.g. 'flagsmith-python-sdk'. Null
+  // until the signal lands, and also when Core could not identify the SDK from
+  // the user agent (it sends 'unknown', which is nothing to show a user).
+  sdkLabel: string | null
+}
+
 // Edge reports the first evaluation asynchronously after the SDK's first
 // request, so the flip isn't instant — poll until it lands.
 const POLL_INTERVAL_MS = 3000
+
+const UNIDENTIFIED_SDK = 'unknown'
 
 // Connection status for the verify console, driven by the real first-evaluation
 // signal: Edge reports the first SDK evaluation to Core, exposed at
 // GET environments/{key}/onboarding-status/. `first_evaluated_at` flips from
 // null to a timestamp once received; it never reverts, so we stop polling then.
+// The signal is latched into state because skipping the query drops `data`.
 export const useOnboardingConnection = (
   environmentKey: string,
-): OnboardingConnectionStatus => {
-  const [firstEvaluated, setFirstEvaluated] = useState(false)
+): OnboardingConnection => {
+  const [firstEvaluation, setFirstEvaluation] = useState<{
+    sdkLabel: string | null
+  } | null>(null)
 
   const { data } = useGetEnvironmentOnboardingStatusQuery(
     { environmentKey },
     {
       pollingInterval: POLL_INTERVAL_MS,
-      skip: firstEvaluated || !environmentKey,
+      skip: !!firstEvaluation || !environmentKey,
     },
   )
 
   useEffect(() => {
-    if (data?.first_evaluated_at) {
-      setFirstEvaluated(true)
-    }
+    if (!data?.first_evaluated_at) return
+    const label = data.first_evaluated_sdk_label
+    setFirstEvaluation({
+      sdkLabel: label && label !== UNIDENTIFIED_SDK ? label : null,
+    })
   }, [data])
 
-  return firstEvaluated ? 'connected' : 'listening'
+  return {
+    sdkLabel: firstEvaluation?.sdkLabel ?? null,
+    status: firstEvaluation ? 'connected' : 'listening',
+  }
 }

--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -1,6 +1,6 @@
 @import '../mixins/custom-scrollbar';
 .custom-scroll {
-  @include customScroll()
+  @include customScroll();
 }
 @mixin transition($transition...) {
   -moz-transition: $transition;
@@ -97,6 +97,7 @@
   font-size: 17px;
   display: block;
   overflow-x: auto;
+  tab-size: 2;
   @include customScrollDark();
   @include hljsScrollbar();
   padding: 0.5em;


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #8132. The onboarding's Python snippet failed on copy-paste, so I ran every snippet through its real toolchain. Most were broken:

- **Didn't compile:** .NET (`static` on a top-level declaration, and the constructor takes a `FlagsmithConfiguration`), Go (rune-literal key, `GetEnvironmentFlags` missing its `ctx`, no `package`/`main`), Next.js (missing paren, `<>{...}</>`).
- **Didn't run:** Python (`json.loads` with no import), Node (imports a default export the SDK lacks), PHP (undefined `$flags`, no `<?php`, install omitted the required PSR-18 client), Flutter (undefined `config`, `baseURI` passed to the wrong class), React Native (rendered `<div>`/`<p>`, which don't exist in RN), JavaScript (called a function the user doesn't have).
- **Wrong output:** Ruby commented with `//`, .NET with `#`, iOS printed the literal string `false`. The Rust and Flutter installs were prose, not commands.

Snippets now print their result, and code blocks get `tab-size` so Go's tabs don't render 8 columns wide.

`codeHelp.INIT` takes an optional feature name. The onboarding passes the flag it created, so the snippet stops referencing `banner_size`, a flag nobody has; the Features page passes nothing and keeps both placeholders as today. Flag names are no longer interpolated into variable names, since a user-chosen name with a space or hyphen broke the JS snippets.

Identity and segment snippets are in #8146.

## How did you test this code?

A test covers all 15 init snippets in both shapes (368 unit tests). It needed `.js` in the Jest transform, with `node_modules` excluded again; the suite still runs in ~1s.

Then each snippet through its toolchain, in Docker where needed:

| Snippet | Result |
| --- | --- |
| Python, Node.js | Executed |
| Go | `go build`, `go run`, gofmt-clean |
| .NET | `dotnet build` succeeded, ran |
| Java | `mvn compile` succeeded |
| Rust | `cargo build`, no warnings |
| PHP | `php -l`, composer, executed |
| Flutter | `dart analyze`, no issues |
| React, JavaScript | Bundled and loaded in a browser; React renders the flag values |
| React Native, Next.js (both routers) | Parsed |
| Ruby | `ruby -c` only, no gem installed |
| curl | Executed, clean 404 for a placeholder key |
| iOS | Not tested, needs Xcode |

All runs used a placeholder key, so this shows the code is valid and the SDK calls exist, not that a real flag value came back. Java, Rust and Flutter are fragments, compiled inside a minimal wrapper; Go and .NET are now complete programs because their compilers reject fragments.

- [ ] Features page → SDK integration: two placeholder flags as today, plus the fixes
- [ ] Onboarding → Connect your code: every language references only the created flag
