### PR TITLE
fix(code-help): correct the identity and segment snippets

### DIFF
--- a/frontend/common/code-help/create-user/create-user-ios.js
+++ b/frontend/common/code-help/create-user/create-user-ios.js
@@ -11,8 +11,9 @@ func application(_ application: UIApplication,
   [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
   Flagsmith.shared.apiKey = "${envId}"${
-  Constants.isCustomFlagsmithUrl() &&
-  `\n  Flagsmith.shared.baseURL = "${Constants.getFlagsmithSDKUrl()}"\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `\n  Flagsmith.shared.baseURL = "${Constants.getFlagsmithSDKUrl()}"\n`
+    : ''
 }
 
   // This will create a user in the dashboard if they don't already exist

--- a/frontend/common/code-help/create-user/create-user-java.js
+++ b/frontend/common/code-help/create-user/create-user-java.js
@@ -7,10 +7,11 @@ export default (
 ) => `${LIB_NAME_JAVA} ${LIB_NAME} = ${LIB_NAME_JAVA}
     .newBuilder()
     .setApiKey("${envId}")${
-  Constants.isCustomFlagsmithUrl() &&
-  `\n    .withConfiguration(FlagsmithConfig.builder()
+  Constants.isCustomFlagsmithUrl()
+    ? `\n    .withConfiguration(FlagsmithConfig.builder()
         .baseUri("${Constants.getFlagsmithSDKUrl()}")
         .build())`
+    : ''
 }
     .build();
 

--- a/frontend/common/code-help/create-user/create-user-node.js
+++ b/frontend/common/code-help/create-user/create-user-node.js
@@ -11,7 +11,7 @@ export default (
     USER_ID,
   },
   userId,
-) => `import Flagsmith from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
+) => `import { Flagsmith } from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
 
 const ${LIB_NAME} = new Flagsmith({${
   Constants.isCustomFlagsmithUrl()

--- a/frontend/common/code-help/create-user/create-user-php.js
+++ b/frontend/common/code-help/create-user/create-user-php.js
@@ -7,8 +7,9 @@ export default (
 ) => `use Flagsmith\\Flagsmith;
 
 $flagsmith = new Flagsmith('${envId}'${
-  Constants.isCustomFlagsmithUrl() &&
-  `,\n  '${Constants.getFlagsmithSDKUrl()}'\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `,\n  '${Constants.getFlagsmithSDKUrl()}'\n`
+    : ''
 });
 
 // Identify the user

--- a/frontend/common/code-help/create-user/create-user-ruby.js
+++ b/frontend/common/code-help/create-user/create-user-ruby.js
@@ -8,8 +8,9 @@ export default (
 
 $flagsmith = Flagsmith::Client.new(
     environment_key="${envId}"${
-  Constants.isCustomFlagsmithUrl() &&
-  `,\n    api_url="${Constants.getFlagsmithSDKUrl()}"\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `,\n    api_url="${Constants.getFlagsmithSDKUrl()}"\n`
+    : ''
 })
 
 // Identify the user

--- a/frontend/common/code-help/create-user/create-user-rust.js
+++ b/frontend/common/code-help/create-user/create-user-rust.js
@@ -1,15 +1,12 @@
 import Constants from 'common/constants'
 
-export default (
-  envId,
-  { FEATURE_NAME, FEATURE_NAME_ALT, USER_ID },
-  userId,
-) => `
+export default (envId, { FEATURE_NAME, FEATURE_NAME_ALT, USER_ID }, userId) => `
 use flagsmith::{Flag, Flagsmith, FlagsmithOptions};
 
 let options = FlagsmithOptions {${
-  Constants.isCustomFlagsmithUrl() &&
-  `api_url: "${Constants.getFlagsmithSDKUrl()}".to_string(),\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `api_url: "${Constants.getFlagsmithSDKUrl()}".to_string(),\n`
+    : ''
 }..Default::default()};
 let flagsmith = Flagsmith::new(
     "${envId}".to_string(),

--- a/frontend/common/code-help/traits/traits-java.js
+++ b/frontend/common/code-help/traits/traits-java.js
@@ -7,10 +7,11 @@ export default (
 ) => `${LIB_NAME_JAVA} ${LIB_NAME} = ${LIB_NAME_JAVA}
 .newBuilder()
 .setApiKey("${envId}")${
-  Constants.isCustomFlagsmithUrl() &&
-  `\n    .withConfiguration(FlagsmithConfig.builder()
+  Constants.isCustomFlagsmithUrl()
+    ? `\n    .withConfiguration(FlagsmithConfig.builder()
         .baseUri("${Constants.getFlagsmithSDKUrl()}")
         .build())`
+    : ''
 }
 .build();
 

--- a/frontend/common/code-help/traits/traits-node.js
+++ b/frontend/common/code-help/traits/traits-node.js
@@ -4,11 +4,12 @@ export default (
   envId,
   { FEATURE_NAME, LIB_NAME, NPM_NODE_CLIENT, TRAIT_NAME, USER_ID },
   userId,
-) => `import Flagsmith from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
+) => `import { Flagsmith } from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
 
 const ${LIB_NAME} = new Flagsmith({${
-  Constants.isCustomFlagsmithUrl() &&
-  `\n    apiUrl: '${Constants.getFlagsmithSDKUrl()}',`
+  Constants.isCustomFlagsmithUrl()
+    ? `\n    apiUrl: '${Constants.getFlagsmithSDKUrl()}',`
+    : ''
 }
     environmentKey: '${envId}'
 });

--- a/frontend/common/code-help/traits/traits-php.js
+++ b/frontend/common/code-help/traits/traits-php.js
@@ -2,8 +2,9 @@ import Constants from 'common/constants'
 export default (envId, { TRAIT_NAME }, userId) => `use Flagsmith\\Flagsmith;
 
 $flagsmith = new Flagsmith('${envId}'${
-  Constants.isCustomFlagsmithUrl() &&
-  `,\n  '${Constants.getFlagsmithSDKUrl()}'\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `,\n  '${Constants.getFlagsmithSDKUrl()}'\n`
+    : ''
 });
 
 $traits = (object) [ '${TRAIT_NAME}' => 42 ];

--- a/frontend/common/code-help/traits/traits-ruby.js
+++ b/frontend/common/code-help/traits/traits-ruby.js
@@ -4,8 +4,9 @@ export default (envId, { TRAIT_NAME }, userId) => `require "flagsmith"
 
 $flagsmith = Flagsmith::Client.new(
     environment_key="${envId}"${
-  Constants.isCustomFlagsmithUrl() &&
-  `,\n    api_url="${Constants.getFlagsmithSDKUrl()}"\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `,\n    api_url="${Constants.getFlagsmithSDKUrl()}"\n`
+    : ''
 })
 
 traits = {"${TRAIT_NAME}": 42}

--- a/frontend/common/code-help/traits/traits-rust.js
+++ b/frontend/common/code-help/traits/traits-rust.js
@@ -6,8 +6,9 @@ use flagsmith_flag_engine::types::{FlagsmithValue, FlagsmithValueType};
 use flagsmith_flag_engine::identities::Trait;
 
 let options = FlagsmithOptions {${
-  Constants.isCustomFlagsmithUrl() &&
-  `api_url: "${Constants.getFlagsmithSDKUrl()}".to_string(),\n`
+  Constants.isCustomFlagsmithUrl()
+    ? `api_url: "${Constants.getFlagsmithSDKUrl()}".to_string(),\n`
+    : ''
 }..Default::default()};
 let flagsmith = Flagsmith::new(
     "${envId}".to_string(),


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Split out of #8145, which fixes the same class of bug in the snippets the onboarding renders. These eleven render on the Identity, Identities and Segments pages instead.

Two bugs:

- **A stray `false` in the output.** Ten templates used `${cond && \`…\`}` inside a template literal, which renders the string `false` when `cond` is false, i.e. on SaaS. The iOS snippet read `Flagsmith.shared.apiKey = "KEY"false`. Now a ternary with an empty fallback.
- **The Node snippets don't run.** They import a default export `@flagsmith/nodejs` doesn't have, so the first line throws `SyntaxError: The requested module '@flagsmith/nodejs' does not provide an export named 'default'`. It's `import { Flagsmith }`, which is what `docs/integrating-with-flagsmith/sdks/server-side.mdx:257` already shows.

## How did you test this code?

The Node import is verified in #8145, where the same fix to `init-node.js` was executed against `@flagsmith/nodejs@9`: it throws before the change and reaches the network call after.

The `false` fix is verified by rendering: every template was rendered with a non-custom API URL and checked for a boolean glued onto the preceding value. #8145 adds a unit test asserting exactly that for the init snippets.

- [ ] Identity page → the traits snippets for Java, Node, PHP, Ruby and Rust contain no stray `false`
- [ ] Identities page → the create-user snippets for iOS, Java, Node, PHP, Ruby and Rust contain no stray `false`
- [ ] Segments page → the traits snippets render the same
- [ ] Node snippet on either page starts with `import { Flagsmith } from "@flagsmith/nodejs"`
