### PR TITLE
feat(onboarding): name the SDK that reported the first evaluation

### DIFF
--- a/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
+++ b/frontend/documentation/pages/onboarding/OnboardingTerminal.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof OnboardingTerminal> = {
     docs: {
       description: {
         component:
-          'The onboarding verify console. The checklist ticks as the user acts (copy install, copy snippet), and the first evaluation flips the badge to LIVE and prints the connection receipt. Always dark, since a terminal reads the same in light and dark mode.',
+          'The onboarding verify console. The checklist ticks as the user acts (copy install, copy snippet), and the first evaluation flips the badge to LIVE and prints the connection receipt, naming the SDK that reported it when Core could identify it. Always dark, since a terminal reads the same in light and dark mode.',
       },
     },
     layout: 'padded',
@@ -37,4 +37,14 @@ export const SnippetsCopied: Story = {
 
 export const Connected: Story = {
   args: { connected: true, installCopied: true, snippetCopied: true },
+}
+
+// Core identifies the SDK from the user agent, so the receipt can name it.
+export const ConnectedWithSdkLabel: Story = {
+  args: {
+    connected: true,
+    installCopied: true,
+    sdkLabel: 'flagsmith-python-sdk',
+    snippetCopied: true,
+  },
 }

--- a/frontend/e2e/tests/onboarding-tests.pw.ts
+++ b/frontend/e2e/tests/onboarding-tests.pw.ts
@@ -99,6 +99,10 @@ test.describe('Onboarding', () => {
     firstEvaluated = true;
     await waitConnected();
 
+    // The console names the SDK that reported the evaluation, from the mocked
+    // first_evaluated_sdk_label above.
+    await expect(page.getByText(/flagsmith-js-sdk/)).toBeVisible();
+
     // Two switches on the page (theme + flag), so scope to the flags region.
     log('Toggle the flag');
     const flagsTable = page.getByRole('region', { name: 'Your flags' });

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -222,10 +222,11 @@ const OnboardingFlow: FC = () => {
         featureName={featureName}
         installCopied={installCopied}
         snippetCopied={snippetCopied}
-        connected={connection === 'connected'}
+        connected={connection.status === 'connected'}
+        sdkLabel={connection.sdkLabel}
       />
       <OnboardingFlagsTable
-        status={connection === 'connected' ? 'connected' : 'waiting'}
+        status={connection.status === 'connected' ? 'connected' : 'waiting'}
         flags={[
           {
             description: 'Controls the demo button shown to your users',
@@ -239,7 +240,7 @@ const OnboardingFlow: FC = () => {
         togglesReady={flagStateReady}
       />
       <OnboardingNextSteps
-        locked={connection !== 'connected'}
+        locked={connection.status !== 'connected'}
         onSelect={goToNextStep}
       />
       <div className='d-flex justify-content-end'>

--- a/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingTerminal/OnboardingTerminal.tsx
@@ -8,6 +8,8 @@ export type OnboardingTerminalProps = {
   snippetCopied: boolean
   // First evaluation received (#7767).
   connected: boolean
+  // Which SDK reported that evaluation, when Core could identify it.
+  sdkLabel?: string | null
 }
 
 // Verify console. Always dark (a terminal reads the same in both modes), so it
@@ -16,6 +18,7 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
   connected,
   featureName,
   installCopied,
+  sdkLabel,
   snippetCopied,
 }) => {
   const steps = [
@@ -74,7 +77,7 @@ const OnboardingTerminal: FC<OnboardingTerminalProps> = ({
         {connected ? (
           <>
             <p className='onboarding-terminal__line onboarding-terminal__line--dim'>
-              SDK initialized · flags loaded · {featureName}: true
+              {sdkLabel ? `${sdkLabel} · ` : ''}first evaluation received
             </p>
             <p className='onboarding-terminal__line onboarding-terminal__line--ok onboarding-terminal__line--strong'>
               ✓ Connected

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
@@ -3,32 +3,50 @@ import { useGetEnvironmentOnboardingStatusQuery } from 'common/services/useEnvir
 
 export type OnboardingConnectionStatus = 'listening' | 'connected'
 
+export type OnboardingConnection = {
+  status: OnboardingConnectionStatus
+  // Which SDK reported the first evaluation, e.g. 'flagsmith-python-sdk'. Null
+  // until the signal lands, and also when Core could not identify the SDK from
+  // the user agent (it sends 'unknown', which is nothing to show a user).
+  sdkLabel: string | null
+}
+
 // Edge reports the first evaluation asynchronously after the SDK's first
 // request, so the flip isn't instant — poll until it lands.
 const POLL_INTERVAL_MS = 3000
+
+const UNIDENTIFIED_SDK = 'unknown'
 
 // Connection status for the verify console, driven by the real first-evaluation
 // signal: Edge reports the first SDK evaluation to Core, exposed at
 // GET environments/{key}/onboarding-status/. `first_evaluated_at` flips from
 // null to a timestamp once received; it never reverts, so we stop polling then.
+// The signal is latched into state because skipping the query drops `data`.
 export const useOnboardingConnection = (
   environmentKey: string,
-): OnboardingConnectionStatus => {
-  const [firstEvaluated, setFirstEvaluated] = useState(false)
+): OnboardingConnection => {
+  const [firstEvaluation, setFirstEvaluation] = useState<{
+    sdkLabel: string | null
+  } | null>(null)
 
   const { data } = useGetEnvironmentOnboardingStatusQuery(
     { environmentKey },
     {
       pollingInterval: POLL_INTERVAL_MS,
-      skip: firstEvaluated || !environmentKey,
+      skip: !!firstEvaluation || !environmentKey,
     },
   )
 
   useEffect(() => {
-    if (data?.first_evaluated_at) {
-      setFirstEvaluated(true)
-    }
+    if (!data?.first_evaluated_at) return
+    const label = data.first_evaluated_sdk_label
+    setFirstEvaluation({
+      sdkLabel: label && label !== UNIDENTIFIED_SDK ? label : null,
+    })
   }, [data])
 
-  return firstEvaluated ? 'connected' : 'listening'
+  return {
+    sdkLabel: firstEvaluation?.sdkLabel ?? null,
+    status: firstEvaluation ? 'connected' : 'listening',
+  }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Stacked on #8145, so the snippets a reviewer copies from the preview are the fixed ones. Follows @Zaimwa9's suggestion on #8132: `first_evaluated_sdk_label` arrives in the onboarding-status response and nothing used it.

The console's receipt line was invented, and asserted a flag value nothing had checked:

```
SDK initialized · flags loaded · show_demo_flag: true
```

It now reports what actually happened:

```
flagsmith-python-sdk · first evaluation received
```

That's the one thing the console couldn't tell you before: whether the evaluation came from the user's own app rather than something else hitting the environment.

- Core sends `'unknown'` when it can't identify the SDK from the user agent. The hook normalises that to null and the line falls back to `first evaluation received`.
- `useOnboardingConnection` returns `{ status, sdkLabel }` instead of a bare status string. The label is latched alongside the status, since skipping the query drops `data`.

Not in scope, still open from the same review: the poll ignores `isError`, so a 404 or 500 renders identically to "still listening".

## How did you test this code?

The e2e mock already returned `flagsmith-js-sdk`, so `onboarding-tests.pw.ts` now asserts the console names it after the flip.

- [x] `typecheck` and `lint` clean on the changed files
- [x] Storybook: added a `ConnectedWithSdkLabel` variant next to `Connected`
- [ ] Onboarding → run an SDK against the environment: the receipt names that SDK, e.g. `flagsmith-python-sdk · first evaluation received`
- [x] Verified end to end on staging: ran the Python snippet, then `GET environments/{key}/onboarding-status/` returned `first_evaluated_sdk_label: "flagsmith-python-sdk"`

Note on the null-label path: `features/views.py:1040` only records the evaluation when `map_request_to_sdk_label` recognises the user agent, so `'unknown'` never reaches this endpoint from the SDK flow. The normalisation is defensive, and not reachable by hitting the API with plain `curl`.

## Screenshots

| | Before (main) | After |
|---|---|---|
| Console receipt, connected | | |
| Console receipt, SDK not identified | n/a | |
