### PR TITLE
feat: Ask for the ClickHouse HTTPS port instead of inferring it from the native port

### DIFF
--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 import structlog
 from clickhouse_connect.driver.exceptions import ClickHouseError
 from clickhouse_driver import Client
-from clickhouse_driver import errors as clickhouse_errors
 from clickhouse_driver.util.helpers import parse_url
 from django.conf import settings
 from django.core.cache import cache
@@ -21,7 +20,6 @@ from rest_framework.exceptions import ValidationError
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from core.dataclasses import AuthorData
-from core.network import is_internal_address
 from environments.tasks import rebuild_environment_document
 from experimentation import warehouse_delivery_service
 from experimentation.constants import (
@@ -67,7 +65,6 @@ from experimentation.stats import (
     compare_to_control,
     srm_p_value,
 )
-from experimentation.types import ClickHouseConfig, ClickHouseCredentials
 from features.models import FeatureState
 from features.value_types import BOOLEAN, INTEGER, STRING
 from features.versioning.dataclasses import FlagChangeSet, MultivariateValueChangeSet
@@ -155,12 +152,17 @@ def get_unique_event_names(environment_key: str) -> list[str]:
     return [row[0] for row in rows]
 
 
-def _query_event_stats(client: Client, environment_key: str) -> WarehouseEventStats:
-    rows = client.execute(
-        "SELECT count() AS total, uniqExact(event) AS unique "
-        "FROM events WHERE environment_key = %(environment_key)s",
-        {"environment_key": environment_key},
-    )
+# Placeholder style is shared by clickhouse-driver and clickhouse-connect, so
+# the same query runs against the managed warehouse and customer instances.
+_EVENT_STATS_QUERY = (
+    "SELECT count() AS total, uniqExact(event) AS unique "
+    "FROM events WHERE environment_key = %(environment_key)s"
+)
+
+
+def _build_event_stats(
+    rows: Sequence[Sequence[typing.Any]],
+) -> WarehouseEventStats:
     total, unique = rows[0] if rows else (0, 0)
     return WarehouseEventStats(
         total_events_received=int(total),
@@ -170,7 +172,11 @@ def _query_event_stats(client: Client, environment_key: str) -> WarehouseEventSt
 
 def get_warehouse_event_stats(environment_key: str) -> WarehouseEventStats:
     """Return event counts recorded for `environment_key` in the warehouse."""
-    return _query_event_stats(_get_clickhouse_client(), environment_key)
+    rows = _get_clickhouse_client().execute(
+        _EVENT_STATS_QUERY,
+        {"environment_key": environment_key},
+    )
+    return _build_event_stats(rows)
 
 
 EXPOSURE_BUCKETS_QUERY = (
@@ -927,7 +933,7 @@ def deliver_warehouse_events(
         # blaming the customer's warehouse.
         mark_warehouse_delivery_failed(
             connection,
-            detail=warehouse_delivery_service.describe_delivery_error(exc),
+            detail=warehouse_delivery_service.describe_warehouse_error(exc),
         )
         flagsmith_experimentation_warehouse_delivery_runs_total.labels(
             result="failure"
@@ -967,81 +973,27 @@ def deliver_warehouse_events(
     )
 
 
-class InternalAddressError(Exception):
-    pass
-
-
-class MissingEventsTableError(Exception):
-    pass
-
-
-def _connect_customer_clickhouse(connection: WarehouseConnection) -> Client:
-    """Build a client for the customer's ClickHouse instance from stored
-    connection details, re-checking the host against internal address ranges
-    first: DNS may resolve differently than it did at validation time, and
-    rows may predate host validation."""
-    config = typing.cast(ClickHouseConfig, connection.config or {})
-    credentials = typing.cast(ClickHouseCredentials, connection.credentials or {})
-    if is_internal_address(config["host"], include_shared=True):
-        raise InternalAddressError(config["host"])
-    return Client(
-        config["host"],
-        port=config["port"],
-        user=config["username"],
-        password=credentials["password"],
-        database=config["database"],
-        secure=config["secure"],
-        connect_timeout=CLICKHOUSE_CONNECT_TIMEOUT_SECONDS,
-        send_receive_timeout=CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
-    )
-
-
-def _describe_verification_error(error: Exception) -> str:
-    if isinstance(error, clickhouse_errors.ServerException):
-        # 516 = AUTHENTICATION_FAILED (not in clickhouse_driver.errors.ErrorCodes)
-        if error.code == 516:
-            return "Authentication failed."
-        if error.code == clickhouse_errors.ErrorCodes.UNKNOWN_DATABASE:
-            return "Database does not exist."
-        return "The ClickHouse server rejected the request."
-    if isinstance(error, (clickhouse_errors.SocketTimeoutError, TimeoutError)):
-        return "The connection timed out."
-    if isinstance(error, clickhouse_errors.NetworkError):
-        return "Could not connect to the host."
-    if isinstance(error, InternalAddressError):
-        return "Host must not target internal or private network addresses."
-    if isinstance(error, MissingEventsTableError):
-        return (
-            "Events table not found in the configured database. "
-            "Run the setup SQL to create it."
-        )
-    if isinstance(error, KeyError):
-        return "Stored connection details are incomplete."
-    return "Verification failed."
-
-
 def verify_clickhouse_connection(
     connection: WarehouseConnection,
     persist: bool = True,
 ) -> None:
-    """Run SELECT 1 against the customer's ClickHouse, check the events table
-    exists, and set the status to connected or errored; never raises. With
-    persist=False, the status is only set on the in-memory instance, allowing
-    unsaved connections to be tested."""
+    """Run SELECT 1 against the customer's ClickHouse over the same client,
+    interface and port that delivery uses, and set the status to connected or
+    errored; never raises. With persist=False, the status is only set on the
+    in-memory instance, allowing unsaved connections to be tested."""
     log = logger.bind(environment__id=connection.environment_id)
     try:
         log = log.bind(organisation__id=connection.environment.project.organisation_id)
-        client = _connect_customer_clickhouse(connection)
-        try:
-            client.execute("SELECT 1")
-            rows = client.execute("EXISTS TABLE events")
-            if not rows[0][0]:
-                raise MissingEventsTableError()
-        finally:
-            client.disconnect()
+        with warehouse_delivery_service.delivery_client(
+            connection,
+            send_receive_timeout=CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
+        ) as client:
+            client.query("SELECT 1")
     except Exception as error:
         connection.status = WarehouseConnectionStatus.ERRORED
-        connection.status_detail = _describe_verification_error(error)
+        connection.status_detail = warehouse_delivery_service.describe_warehouse_error(
+            error
+        )
         if persist:
             connection.save(update_fields=["status", "status_detail"])
         flagsmith_experimentation_warehouse_connection_verifications_total.labels(
@@ -1120,11 +1072,15 @@ def _get_customer_warehouse_event_stats_cached(
     if cached == _CUSTOMER_EVENT_STATS_UNAVAILABLE:
         return None
     try:
-        client = _connect_customer_clickhouse(connection)
-        try:
-            stats = _query_event_stats(client, environment_key)
-        finally:
-            client.disconnect()
+        with warehouse_delivery_service.delivery_client(
+            connection,
+            send_receive_timeout=CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
+        ) as client:
+            rows = client.query(
+                _EVENT_STATS_QUERY,
+                parameters={"environment_key": environment_key},
+            ).result_rows
+        stats = _build_event_stats(rows)
     except Exception:
         cache.set(
             cache_key,

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -975,11 +975,11 @@ def verify_clickhouse_connection(
     connection: WarehouseConnection,
     persist: bool = True,
 ) -> None:
-    """Run SELECT 1 against the customer's ClickHouse over the same client,
-    interface and port that delivery uses, check the events table exists, and
-    set the status to connected or errored; never raises. With persist=False,
-    the status is only set on the in-memory instance, allowing unsaved
-    connections to be tested."""
+    """Check the customer's events table exists, connecting over the same
+    client, interface and port that delivery uses, and set the status to
+    connected or errored; never raises. With persist=False, the status is only
+    set on the in-memory instance, allowing unsaved connections to be
+    tested."""
     log = logger.bind(environment__id=connection.environment_id)
     try:
         log = log.bind(organisation__id=connection.environment.project.organisation_id)
@@ -987,7 +987,6 @@ def verify_clickhouse_connection(
             connection,
             send_receive_timeout=CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
         ) as client:
-            client.query("SELECT 1")
             warehouse_delivery_service.check_events_table_exists(client)
     except Exception as error:
         connection.status = WarehouseConnectionStatus.ERRORED

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -152,8 +152,6 @@ def get_unique_event_names(environment_key: str) -> list[str]:
     return [row[0] for row in rows]
 
 
-# Placeholder style is shared by clickhouse-driver and clickhouse-connect, so
-# the same query runs against the managed warehouse and customer instances.
 _EVENT_STATS_QUERY = (
     "SELECT count() AS total, uniqExact(event) AS unique "
     "FROM events WHERE environment_key = %(environment_key)s"

--- a/api/experimentation/services.py
+++ b/api/experimentation/services.py
@@ -976,9 +976,10 @@ def verify_clickhouse_connection(
     persist: bool = True,
 ) -> None:
     """Run SELECT 1 against the customer's ClickHouse over the same client,
-    interface and port that delivery uses, and set the status to connected or
-    errored; never raises. With persist=False, the status is only set on the
-    in-memory instance, allowing unsaved connections to be tested."""
+    interface and port that delivery uses, check the events table exists, and
+    set the status to connected or errored; never raises. With persist=False,
+    the status is only set on the in-memory instance, allowing unsaved
+    connections to be tested."""
     log = logger.bind(environment__id=connection.environment_id)
     try:
         log = log.bind(organisation__id=connection.environment.project.organisation_id)
@@ -987,6 +988,7 @@ def verify_clickhouse_connection(
             send_receive_timeout=CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
         ) as client:
             client.query("SELECT 1")
+            warehouse_delivery_service.check_events_table_exists(client)
     except Exception as error:
         connection.status = WarehouseConnectionStatus.ERRORED
         connection.status_detail = warehouse_delivery_service.describe_warehouse_error(

--- a/api/experimentation/types.py
+++ b/api/experimentation/types.py
@@ -48,6 +48,7 @@ SNOWFLAKE_DEFAULTS: SnowflakeConfig = {
 
 class ClickHouseConfig(TypedDict):
     host: str
+    # The HTTP(S) interface port, used for verification and delivery alike.
     port: int
     database: str
     username: str
@@ -56,7 +57,7 @@ class ClickHouseConfig(TypedDict):
 
 CLICKHOUSE_DEFAULTS: ClickHouseConfig = {
     "host": "",
-    "port": 9440,
+    "port": 8443,
     "database": "flagsmith_exp",
     "username": "default",
     "secure": True,

--- a/api/experimentation/warehouse_delivery_service.py
+++ b/api/experimentation/warehouse_delivery_service.py
@@ -74,8 +74,6 @@ class MissingEventsTableError(Exception):
     """The configured database has no events table to deliver into."""
 
 
-# The customer's fix is the same whether verification's existence check or a
-# delivery insert found the table missing.
 MISSING_EVENTS_TABLE_DETAIL = (
     "Events table not found in the configured database. Run the setup SQL to create it."
 )

--- a/api/experimentation/warehouse_delivery_service.py
+++ b/api/experimentation/warehouse_delivery_service.py
@@ -77,8 +77,7 @@ class MissingEventsTableError(Exception):
 # The customer's fix is the same whether verification's existence check or a
 # delivery insert found the table missing.
 MISSING_EVENTS_TABLE_DETAIL = (
-    "Events table not found in the configured database. "
-    "Run the setup SQL to create it."
+    "Events table not found in the configured database. Run the setup SQL to create it."
 )
 
 

--- a/api/experimentation/warehouse_delivery_service.py
+++ b/api/experimentation/warehouse_delivery_service.py
@@ -70,6 +70,10 @@ class ObjectRejectedError(Exception):
     unaffected, so the object is abandoned rather than retried."""
 
 
+class MissingEventsTableError(Exception):
+    """The configured database has no events table to deliver into."""
+
+
 # ClickHouse error codes raised by the object's own bytes: unparseable records,
 # values that do not fit the column, constraint violations. Anything else —
 # authentication (516), a missing table (60), an unreachable host — would fail
@@ -108,6 +112,11 @@ def describe_warehouse_error(error: Exception) -> str:
         if error.code == 60:
             return f"Table `{EVENTS_TABLE_NAME}` does not exist."
         return "The ClickHouse server rejected the request."
+    if isinstance(error, MissingEventsTableError):
+        return (
+            "Events table not found in the configured database. "
+            "Run the setup SQL to create it."
+        )
     return "Connection failed."
 
 
@@ -204,6 +213,14 @@ def delivery_client(
         yield client
     finally:
         client.close()
+
+
+def check_events_table_exists(client: "Client") -> None:
+    """Raise ``MissingEventsTableError`` if the connection's database has no
+    events table for delivery to insert into."""
+    rows = client.query(f"EXISTS TABLE {EVENTS_TABLE_NAME}").result_rows
+    if not rows[0][0]:
+        raise MissingEventsTableError()
 
 
 def deliver_object(client: "Client", bucket_name: str, s3_key: str) -> int:

--- a/api/experimentation/warehouse_delivery_service.py
+++ b/api/experimentation/warehouse_delivery_service.py
@@ -74,6 +74,14 @@ class MissingEventsTableError(Exception):
     """The configured database has no events table to deliver into."""
 
 
+# The customer's fix is the same whether verification's existence check or a
+# delivery insert found the table missing.
+MISSING_EVENTS_TABLE_DETAIL = (
+    "Events table not found in the configured database. "
+    "Run the setup SQL to create it."
+)
+
+
 # ClickHouse error codes raised by the object's own bytes: unparseable records,
 # values that do not fit the column, constraint violations. Anything else —
 # authentication (516), a missing table (60), an unreachable host — would fail
@@ -110,13 +118,10 @@ def describe_warehouse_error(error: Exception) -> str:
         if error.code == 81:
             return "Database does not exist."
         if error.code == 60:
-            return f"Table `{EVENTS_TABLE_NAME}` does not exist."
+            return MISSING_EVENTS_TABLE_DETAIL
         return "The ClickHouse server rejected the request."
     if isinstance(error, MissingEventsTableError):
-        return (
-            "Events table not found in the configured database. "
-            "Run the setup SQL to create it."
-        )
+        return MISSING_EVENTS_TABLE_DETAIL
     return "Connection failed."
 
 

--- a/api/experimentation/warehouse_delivery_service.py
+++ b/api/experimentation/warehouse_delivery_service.py
@@ -34,11 +34,6 @@ PENDING_PREFIX = "events/"
 ARCHIVE_PREFIX = "archive/"
 FAILED_PREFIX = "failed/"
 
-# The stored port is the native protocol port used by verification. Delivery
-# needs the HTTP interface, which listens on a different port; ClickHouse
-# exposes the two as a fixed pair, so it is inferred rather than asked for.
-NATIVE_TO_HTTP_PORT = {9440: 8443, 9000: 8123}
-
 CONNECT_TIMEOUT_SECONDS = 10
 INSERT_TIMEOUT_SECONDS = 300
 
@@ -95,23 +90,25 @@ OBJECT_LEVEL_ERROR_CODES = frozenset(
 )
 
 
-def describe_delivery_error(error: Exception) -> str:
-    """Return a user-facing description of a failed delivery run, suitable for
-    the connection's ``status_detail``. Raw exception text stays in the logs:
-    it can carry internal infrastructure details."""
+def describe_warehouse_error(error: Exception) -> str:
+    """Return a user-facing description of a failed verification or delivery
+    run, suitable for the connection's ``status_detail``. Raw exception text
+    stays in the logs: it can carry internal infrastructure details."""
     if isinstance(error, DeliveryConfigError):
         return str(error)
     # OperationalError subclasses DatabaseError, so it is matched first.
     if isinstance(error, OperationalError):
         return "Could not connect to the host."
     if isinstance(error, DatabaseError):
-        # 516 = AUTHENTICATION_FAILED, 60 = UNKNOWN_TABLE
+        # 516 = AUTHENTICATION_FAILED, 81 = UNKNOWN_DATABASE, 60 = UNKNOWN_TABLE
         if error.code == 516:
             return "Authentication failed."
+        if error.code == 81:
+            return "Database does not exist."
         if error.code == 60:
             return f"Table `{EVENTS_TABLE_NAME}` does not exist."
         return "The ClickHouse server rejected the request."
-    return "Delivery failed."
+    return "Connection failed."
 
 
 @lru_cache(maxsize=1)
@@ -159,9 +156,15 @@ def move_object(bucket_name: str, s3_key: str, *, to_prefix: str) -> str:
 
 
 @contextmanager
-def delivery_client(connection: "WarehouseConnection") -> "Iterator[Client]":
+def delivery_client(
+    connection: "WarehouseConnection",
+    *,
+    send_receive_timeout: int = INSERT_TIMEOUT_SECONDS,
+) -> "Iterator[Client]":
     """Yield a ClickHouse HTTP client for a connection, reusable across every
-    object delivered in one run.
+    object delivered in one run. Verification uses the same client, so a
+    connection that verifies is one that delivery can use, with a timeout
+    fitting its quick queries rather than a full insert.
 
     Raises ``DeliveryConfigError`` if the stored configuration cannot be turned
     into a usable client.
@@ -186,21 +189,15 @@ def delivery_client(connection: "WarehouseConnection") -> "Iterator[Client]":
             "Host must not target internal or private network addresses."
         )
 
-    if (http_port := NATIVE_TO_HTTP_PORT.get(port)) is None:
-        raise DeliveryConfigError(
-            f"No HTTP port is known for ClickHouse port {port}; "
-            f"expected one of {sorted(NATIVE_TO_HTTP_PORT)}."
-        )
-
     client = clickhouse_connect.get_client(
         host=host,
-        port=http_port,
+        port=port,
         username=username,
         password=password,
         database=database,
         secure=secure,
         connect_timeout=CONNECT_TIMEOUT_SECONDS,
-        send_receive_timeout=INSERT_TIMEOUT_SECONDS,
+        send_receive_timeout=send_receive_timeout,
         pool_mgr=_get_pool_manager(),
     )
     try:

--- a/api/tests/unit/experimentation/conftest.py
+++ b/api/tests/unit/experimentation/conftest.py
@@ -114,7 +114,7 @@ def clickhouse_connection(
         name="Production ClickHouse",
         config={
             "host": "ch.acme-corp.example",
-            "port": 9440,
+            "port": 8443,
             "database": "acme_dwh",
             "username": "acme_svc",
             "secure": True,

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -2053,10 +2053,7 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
         send_receive_timeout=services.CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
         pool_mgr=mocker.ANY,
     )
-    assert get_client.return_value.query.call_args_list == [
-        mocker.call("SELECT 1"),
-        mocker.call("EXISTS TABLE events"),
-    ]
+    get_client.return_value.query.assert_called_once_with("EXISTS TABLE events")
     get_client.return_value.close.assert_called_once_with()
     assert _verification_count("success") == success_count_before + 1
     assert {
@@ -2077,7 +2074,7 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
         ),
         (
             {"password": "hunter2"},
-            [[(1,)], [(0,)]],
+            [[(0,)]],
             "Events table not found in the configured database. "
             "Run the setup SQL to create it.",
         ),

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from clickhouse_driver import errors as clickhouse_errors
 from django.db.models import Q
 from flag_engine.segments.constants import PERCENTAGE_SPLIT
 from prometheus_client import REGISTRY
@@ -39,9 +38,6 @@ from experimentation.models import (
 )
 from experimentation.results_query import _MetricSlot
 from experimentation.services import (
-    InternalAddressError,
-    MissingEventsTableError,
-    _describe_verification_error,
     annotate_warehouse_event_stats,
     verify_clickhouse_connection,
 )
@@ -2032,8 +2028,9 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
     mocker: MockerFixture,
 ) -> None:
     # Given
-    mock_client = mocker.patch("experimentation.services.Client")
-    mock_client.return_value.execute.return_value = [(1,)]
+    get_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
     success_count_before = _verification_count("success")
     clickhouse_connection.status_detail = "stale detail"
     clickhouse_connection.save()
@@ -2041,25 +2038,23 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
     # When
     verify_clickhouse_connection(clickhouse_connection)
 
-    # Then
+    # Then the check ran over the same HTTP client delivery uses
     clickhouse_connection.refresh_from_db()
     assert clickhouse_connection.status == WarehouseConnectionStatus.CONNECTED
     assert clickhouse_connection.status_detail is None
-    mock_client.assert_called_once_with(
-        "ch.acme-corp.example",
-        port=9440,
-        user="acme_svc",
+    get_client.assert_called_once_with(
+        host="ch.acme-corp.example",
+        port=8443,
+        username="acme_svc",
         password="hunter2",
         database="acme_dwh",
         secure=True,
-        connect_timeout=5,
-        send_receive_timeout=5,
+        connect_timeout=10,
+        send_receive_timeout=services.CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
+        pool_mgr=mocker.ANY,
     )
-    assert mock_client.return_value.execute.call_args_list == [
-        mocker.call("SELECT 1"),
-        mocker.call("EXISTS TABLE events"),
-    ]
-    mock_client.return_value.disconnect.assert_called_once_with()
+    get_client.return_value.query.assert_called_once_with("SELECT 1")
+    get_client.return_value.close.assert_called_once_with()
     assert _verification_count("success") == success_count_before + 1
     assert {
         "level": "info",
@@ -2070,34 +2065,30 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
 
 
 @pytest.mark.parametrize(
-    "credentials, execute_side_effect, expected_detail",
+    "credentials, query_side_effect, expected_detail",
     [
         (
             {"password": "hunter2"},
             Exception("connection refused"),
-            "Verification failed.",
-        ),
-        (
-            {"password": "hunter2"},
-            [[(1,)], [(0,)]],
-            "Events table not found in the configured database. "
-            "Run the setup SQL to create it.",
+            "Connection failed.",
         ),
         (None, None, "Stored connection details are incomplete."),
     ],
-    ids=["driver_error", "missing_events_table", "missing_credentials"],
+    ids=["client_error", "missing_credentials"],
 )
 def test_verify_clickhouse_connection__failure__sets_errored_with_detail(
     clickhouse_connection: WarehouseConnection,
     credentials: dict[str, str] | None,
-    execute_side_effect: Exception | list[list[tuple[int]]] | None,
+    query_side_effect: Exception | None,
     expected_detail: str,
     log: StructuredLogCapture,
     mocker: MockerFixture,
 ) -> None:
     # Given
-    mock_client = mocker.patch("experimentation.services.Client")
-    mock_client.return_value.execute.side_effect = execute_side_effect
+    get_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
+    get_client.return_value.query.side_effect = query_side_effect
     clickhouse_connection.credentials = credentials
     clickhouse_connection.save()
     failure_count_before = _verification_count("failure")
@@ -2120,7 +2111,9 @@ def test_verify_clickhouse_connection__internal_host__sets_errored_without_conne
     mocker: MockerFixture,
 ) -> None:
     # Given
-    mock_client = mocker.patch("experimentation.services.Client")
+    get_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
     clickhouse_connection.config = {
         **(clickhouse_connection.config or {}),
         "host": "10.0.0.5",
@@ -2137,85 +2130,14 @@ def test_verify_clickhouse_connection__internal_host__sets_errored_without_conne
         clickhouse_connection.status_detail
         == "Host must not target internal or private network addresses."
     )
-    mock_client.assert_not_called()
+    get_client.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    "error,expected_detail",
+    "query_result, expected_stats",
     [
         (
-            clickhouse_errors.ServerException("Authentication failed", code=516),
-            "Authentication failed.",
-        ),
-        (
-            clickhouse_errors.ServerException(
-                "Database not_a_real_db does not exist", code=81
-            ),
-            "Database does not exist.",
-        ),
-        (
-            clickhouse_errors.ServerException("Some other server error", code=999),
-            "The ClickHouse server rejected the request.",
-        ),
-        (
-            clickhouse_errors.SocketTimeoutError("(10.255.255.1:9000)"),
-            "The connection timed out.",
-        ),
-        (
-            TimeoutError("timed out"),
-            "The connection timed out.",
-        ),
-        (
-            clickhouse_errors.NetworkError("Connection refused"),
-            "Could not connect to the host.",
-        ),
-        (
-            InternalAddressError("10.0.0.5"),
-            "Host must not target internal or private network addresses.",
-        ),
-        (
-            MissingEventsTableError(),
-            "Events table not found in the configured database. "
-            "Run the setup SQL to create it.",
-        ),
-        (
-            KeyError("host"),
-            "Stored connection details are incomplete.",
-        ),
-        (
-            ValueError("unexpected"),
-            "Verification failed.",
-        ),
-    ],
-    ids=[
-        "server_exception_auth_failure",
-        "server_exception_unknown_database",
-        "server_exception_other",
-        "socket_timeout_error",
-        "builtin_timeout_error",
-        "network_error",
-        "internal_address_error",
-        "missing_events_table_error",
-        "key_error",
-        "generic_exception",
-    ],
-)
-def test_describe_verification_error__known_error_types__returns_expected_detail(
-    error: Exception,
-    expected_detail: str,
-) -> None:
-    # Given / When
-    detail = _describe_verification_error(error)
-
-    # Then
-    assert detail == expected_detail
-
-
-@pytest.mark.parametrize(
-    "execute_side_effect, expected_stats",
-    [
-        (
-            [[(42, 7)]],
+            [(42, 7)],
             WarehouseEventStats(total_events_received=42, unique_events_count=7),
         ),
         (Exception("connection refused"), None),
@@ -2225,26 +2147,33 @@ def test_describe_verification_error__known_error_types__returns_expected_detail
 def test_annotate_warehouse_event_stats__clickhouse_connection__queries_customer_instance(
     clickhouse_connection: WarehouseConnection,
     reset_cache: None,
-    execute_side_effect: Exception | list[list[tuple[int, int]]],
+    query_result: Exception | list[tuple[int, int]],
     expected_stats: WarehouseEventStats | None,
     log: StructuredLogCapture,
     mocker: MockerFixture,
 ) -> None:
     # Given
-    mock_client = mocker.patch("experimentation.services.Client")
-    mock_client.return_value.execute.side_effect = execute_side_effect
+    get_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
+    if isinstance(query_result, Exception):
+        get_client.return_value.query.side_effect = query_result
+    else:
+        get_client.return_value.query.return_value = mocker.Mock(
+            result_rows=query_result
+        )
 
     # When
     annotate_warehouse_event_stats(clickhouse_connection, "test-env-key")
 
     # Then
     assert getattr(clickhouse_connection, "event_stats", None) == expected_stats
-    mock_client.return_value.execute.assert_called_once_with(
+    get_client.return_value.query.assert_called_once_with(
         "SELECT count() AS total, uniqExact(event) AS unique "
         "FROM events WHERE environment_key = %(environment_key)s",
-        {"environment_key": "test-env-key"},
+        parameters={"environment_key": "test-env-key"},
     )
-    mock_client.return_value.disconnect.assert_called_once_with()
+    get_client.return_value.close.assert_called_once_with()
     assert any(
         event["event"] == "connection.event_stats_failed" for event in log.events
     ) == (expected_stats is None)
@@ -2254,5 +2183,5 @@ def test_annotate_warehouse_event_stats__clickhouse_connection__queries_customer
     annotate_warehouse_event_stats(fresh_connection, "test-env-key")
 
     # Then
-    mock_client.assert_called_once()
+    get_client.assert_called_once()
     assert getattr(fresh_connection, "event_stats", None) == expected_stats

--- a/api/tests/unit/experimentation/test_services.py
+++ b/api/tests/unit/experimentation/test_services.py
@@ -2053,7 +2053,10 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
         send_receive_timeout=services.CLICKHOUSE_VERIFY_TIMEOUT_SECONDS,
         pool_mgr=mocker.ANY,
     )
-    get_client.return_value.query.assert_called_once_with("SELECT 1")
+    assert get_client.return_value.query.call_args_list == [
+        mocker.call("SELECT 1"),
+        mocker.call("EXISTS TABLE events"),
+    ]
     get_client.return_value.close.assert_called_once_with()
     assert _verification_count("success") == success_count_before + 1
     assert {
@@ -2065,21 +2068,27 @@ def test_verify_clickhouse_connection__reachable__sets_connected(
 
 
 @pytest.mark.parametrize(
-    "credentials, query_side_effect, expected_detail",
+    "credentials, query_results, expected_detail",
     [
         (
             {"password": "hunter2"},
             Exception("connection refused"),
             "Connection failed.",
         ),
+        (
+            {"password": "hunter2"},
+            [[(1,)], [(0,)]],
+            "Events table not found in the configured database. "
+            "Run the setup SQL to create it.",
+        ),
         (None, None, "Stored connection details are incomplete."),
     ],
-    ids=["client_error", "missing_credentials"],
+    ids=["client_error", "missing_events_table", "missing_credentials"],
 )
 def test_verify_clickhouse_connection__failure__sets_errored_with_detail(
     clickhouse_connection: WarehouseConnection,
     credentials: dict[str, str] | None,
-    query_side_effect: Exception | None,
+    query_results: Exception | list[list[tuple[int]]] | None,
     expected_detail: str,
     log: StructuredLogCapture,
     mocker: MockerFixture,
@@ -2088,7 +2097,12 @@ def test_verify_clickhouse_connection__failure__sets_errored_with_detail(
     get_client = mocker.patch(
         "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
     )
-    get_client.return_value.query.side_effect = query_side_effect
+    if isinstance(query_results, list):
+        get_client.return_value.query.side_effect = [
+            mocker.Mock(result_rows=rows) for rows in query_results
+        ]
+    else:
+        get_client.return_value.query.side_effect = query_results
     clickhouse_connection.credentials = credentials
     clickhouse_connection.save()
     failure_count_before = _verification_count("failure")

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -1,7 +1,7 @@
 import socket
 
 import pytest
-from clickhouse_driver import errors as clickhouse_errors
+from clickhouse_connect.driver.exceptions import OperationalError
 from django.urls import reverse
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
@@ -1225,7 +1225,9 @@ def test_post__clickhouse_minimal_payload__applies_defaults_and_generates_name(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    mocker.patch("experimentation.services.Client")
+    mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
 
     # When
     response = admin_client.post(
@@ -1242,7 +1244,7 @@ def test_post__clickhouse_minimal_payload__applies_defaults_and_generates_name(
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["config"] == {
         "host": "ch.example.com",
-        "port": 9440,
+        "port": 8443,
         "database": "flagsmith_exp",
         "username": "default",
         "secure": True,
@@ -1502,17 +1504,17 @@ def test_patch__flagsmith_to_clickhouse_without_credentials__returns_400(
 
 
 @pytest.mark.parametrize(
-    "execute_side_effect, expected_status, expected_detail",
+    "query_side_effect, expected_status, expected_detail",
     [
         (None, "connected", None),
-        (Exception("unreachable"), "errored", "Verification failed."),
+        (Exception("unreachable"), "errored", "Connection failed."),
     ],
     ids=["reachable", "unreachable"],
 )
 def test_post__clickhouse_verification_outcome__returns_201_with_status(
     admin_client: APIClient,
     enable_features: EnableFeaturesFixture,
-    execute_side_effect: Exception | None,
+    query_side_effect: Exception | None,
     expected_detail: str | None,
     expected_status: str,
     mocker: MockerFixture,
@@ -1520,8 +1522,10 @@ def test_post__clickhouse_verification_outcome__returns_201_with_status(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    mock_client = mocker.patch("experimentation.services.Client")
-    mock_client.return_value.execute.side_effect = execute_side_effect
+    mock_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
+    mock_client.return_value.query.side_effect = query_side_effect
 
     # When
     response = admin_client.post(
@@ -1540,7 +1544,7 @@ def test_post__clickhouse_verification_outcome__returns_201_with_status(
     assert response.json()["status"] == expected_status
     assert response.json()["status_detail"] == expected_detail
     assert "credentials" not in response.json()
-    assert mock_client.return_value.execute.call_args_list[0] == mocker.call("SELECT 1")
+    mock_client.return_value.query.assert_called_once_with("SELECT 1")
 
 
 def test_get__clickhouse__credentials_not_in_response(
@@ -1571,7 +1575,9 @@ def test_patch__clickhouse_config_without_credentials__keeps_stored_password(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    mock_client = mocker.patch("experimentation.services.Client")
+    mock_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
     url = reverse(
         "api-v1:environments:experimentation:warehouse-connections-detail",
         args=[environment.api_key, clickhouse_connection.id],
@@ -1580,7 +1586,7 @@ def test_patch__clickhouse_config_without_credentials__keeps_stored_password(
     # When
     response = admin_client.patch(
         url,
-        data={"config": {"host": "ch.example.com", "port": 9000}},
+        data={"config": {"host": "ch.example.com", "port": 8123}},
         format="json",
     )
 
@@ -1590,9 +1596,9 @@ def test_patch__clickhouse_config_without_credentials__keeps_stored_password(
     assert clickhouse_connection.credentials == {"password": "hunter2"}
     assert clickhouse_connection.config is not None
     assert clickhouse_connection.config.get("database") == "acme_dwh"
-    assert clickhouse_connection.config.get("port") == 9000
+    assert clickhouse_connection.config.get("port") == 8123
     assert mock_client.call_args.kwargs["password"] == "hunter2"
-    assert mock_client.call_args.kwargs["port"] == 9000
+    assert mock_client.call_args.kwargs["port"] == 8123
 
 
 def test_patch__clickhouse_name_only__does_not_reverify(
@@ -1604,7 +1610,9 @@ def test_patch__clickhouse_name_only__does_not_reverify(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    mock_client = mocker.patch("experimentation.services.Client")
+    mock_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
     url = reverse(
         "api-v1:environments:experimentation:warehouse-connections-detail",
         args=[environment.api_key, clickhouse_connection.id],
@@ -1627,7 +1635,9 @@ def test_put__clickhouse_name_only__preserves_config_and_credentials(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    mocker.patch("experimentation.services.Client")
+    mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
     url = reverse(
         "api-v1:environments:experimentation:warehouse-connections-detail",
         args=[environment.api_key, clickhouse_connection.id],
@@ -1661,7 +1671,9 @@ def test_test_warehouse_connection__clickhouse__reverifies_and_returns_status(
     enable_features("experimentation_warehouse_connection")
     clickhouse_connection.status = WarehouseConnectionStatus.ERRORED
     clickhouse_connection.save()
-    mocker.patch("experimentation.services.Client")
+    mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
     url = reverse(
         "api-v1:environments:experimentation:"
         "warehouse-connections-test-warehouse-connection",
@@ -1697,7 +1709,7 @@ CLICKHOUSE_TEST_PAYLOAD = {
         ),
         pytest.param(
             CLICKHOUSE_TEST_PAYLOAD,
-            clickhouse_errors.NetworkError("boom"),
+            OperationalError("boom"),
             status.HTTP_200_OK,
             {"status": "errored", "status_detail": "Could not connect to the host."},
             id="unreachable",
@@ -1730,7 +1742,10 @@ def test_test_warehouse_connection_config__payload__returns_expected_response(
 ) -> None:
     # Given
     enable_features("experimentation_warehouse_connection")
-    mocker.patch("experimentation.services.Client", side_effect=client_side_effect)
+    mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+        side_effect=client_side_effect,
+    )
     url = reverse(
         "api-v1:environments:experimentation:"
         "warehouse-connections-test-warehouse-connection-config",

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -1544,7 +1544,7 @@ def test_post__clickhouse_verification_outcome__returns_201_with_status(
     assert response.json()["status"] == expected_status
     assert response.json()["status_detail"] == expected_detail
     assert "credentials" not in response.json()
-    mock_client.return_value.query.assert_called_once_with("SELECT 1")
+    assert mock_client.return_value.query.call_args_list[0] == mocker.call("SELECT 1")
 
 
 def test_get__clickhouse__credentials_not_in_response(

--- a/api/tests/unit/experimentation/test_views.py
+++ b/api/tests/unit/experimentation/test_views.py
@@ -1544,7 +1544,7 @@ def test_post__clickhouse_verification_outcome__returns_201_with_status(
     assert response.json()["status"] == expected_status
     assert response.json()["status_detail"] == expected_detail
     assert "credentials" not in response.json()
-    assert mock_client.return_value.query.call_args_list[0] == mocker.call("SELECT 1")
+    mock_client.return_value.query.assert_called_once_with("EXISTS TABLE events")
 
 
 def test_get__clickhouse__credentials_not_in_response(

--- a/api/tests/unit/experimentation/test_warehouse_delivery_service.py
+++ b/api/tests/unit/experimentation/test_warehouse_delivery_service.py
@@ -349,7 +349,8 @@ def test_deliver_object__connection_level_error__reraises(
         ),
         pytest.param(
             DatabaseError("Code: 60. DB::Exception: no table", code=60),
-            "Table `events` does not exist.",
+            "Events table not found in the configured database. "
+            "Run the setup SQL to create it.",
             id="missing-table",
         ),
         pytest.param(

--- a/api/tests/unit/experimentation/test_warehouse_delivery_service.py
+++ b/api/tests/unit/experimentation/test_warehouse_delivery_service.py
@@ -216,6 +216,31 @@ def test_delivery_client__body_raises__still_closes_client(
     get_client.return_value.close.assert_called_once_with()
 
 
+@pytest.mark.parametrize(
+    "exists_result, expected_raise",
+    [
+        pytest.param([(1,)], False, id="table-exists"),
+        pytest.param([(0,)], True, id="table-missing"),
+    ],
+)
+def test_check_events_table_exists__exists_query_result__raises_only_when_missing(
+    exists_result: list[tuple[int]],
+    expected_raise: bool,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    client = mocker.MagicMock()
+    client.query.return_value = mocker.Mock(result_rows=exists_result)
+
+    # When / Then
+    if expected_raise:
+        with pytest.raises(warehouse_delivery_service.MissingEventsTableError):
+            warehouse_delivery_service.check_events_table_exists(client)
+    else:
+        warehouse_delivery_service.check_events_table_exists(client)
+    client.query.assert_called_once_with("EXISTS TABLE events")
+
+
 def test_deliver_object__valid_object__streams_body_and_returns_written_rows(
     events_bucket: Any,
     mocker: MockerFixture,
@@ -331,6 +356,12 @@ def test_deliver_object__connection_level_error__reraises(
             DatabaseError("Code: 241. DB::Exception: memory limit", code=241),
             "The ClickHouse server rejected the request.",
             id="other-server-error",
+        ),
+        pytest.param(
+            warehouse_delivery_service.MissingEventsTableError(),
+            "Events table not found in the configured database. "
+            "Run the setup SQL to create it.",
+            id="missing-events-table",
         ),
         pytest.param(
             ConnectionResetError("connection reset by peer"),

--- a/api/tests/unit/experimentation/test_warehouse_delivery_service.py
+++ b/api/tests/unit/experimentation/test_warehouse_delivery_service.py
@@ -141,21 +141,6 @@ def test_delivery_client__internal_host__raises_config_error(
             pass  # pragma: no cover
 
 
-def test_delivery_client__unmappable_port__raises_config_error(
-    clickhouse_connection: WarehouseConnection,
-) -> None:
-    # Given
-    clickhouse_connection.config["port"] = 1234  # type: ignore[index]
-
-    # When / Then
-    with pytest.raises(
-        warehouse_delivery_service.DeliveryConfigError,
-        match="No HTTP port is known for ClickHouse port 1234",
-    ):
-        with warehouse_delivery_service.delivery_client(clickhouse_connection):
-            pass  # pragma: no cover
-
-
 def test_delivery_client__valid_config__yields_http_client_and_closes(
     clickhouse_connection: WarehouseConnection,
     mocker: MockerFixture,
@@ -167,7 +152,7 @@ def test_delivery_client__valid_config__yields_http_client_and_closes(
 
     # When
     with warehouse_delivery_service.delivery_client(clickhouse_connection) as client:
-        # Then the native port is mapped to its HTTP counterpart
+        # Then the stored HTTP(S) port is used as-is
         assert client is get_client.return_value
         get_client.assert_called_once_with(
             host="ch.acme-corp.example",
@@ -190,6 +175,27 @@ def test_delivery_client__valid_config__yields_http_client_and_closes(
         get_client.return_value.close.assert_not_called()
 
     get_client.return_value.close.assert_called_once_with()
+
+
+def test_delivery_client__timeout_override__passed_through(
+    clickhouse_connection: WarehouseConnection,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    get_client = mocker.patch(
+        "experimentation.warehouse_delivery_service.clickhouse_connect.get_client",
+    )
+
+    # When a caller with quicker queries than an insert, such as verification,
+    # asks for a shorter timeout
+    with warehouse_delivery_service.delivery_client(
+        clickhouse_connection,
+        send_receive_timeout=5,
+    ):
+        pass
+
+    # Then
+    assert get_client.call_args.kwargs["send_receive_timeout"] == 5
 
 
 def test_delivery_client__body_raises__still_closes_client(
@@ -312,6 +318,11 @@ def test_deliver_object__connection_level_error__reraises(
             id="bad-auth",
         ),
         pytest.param(
+            DatabaseError("Code: 81. DB::Exception: no database", code=81),
+            "Database does not exist.",
+            id="missing-database",
+        ),
+        pytest.param(
             DatabaseError("Code: 60. DB::Exception: no table", code=60),
             "Table `events` does not exist.",
             id="missing-table",
@@ -323,19 +334,19 @@ def test_deliver_object__connection_level_error__reraises(
         ),
         pytest.param(
             ConnectionResetError("connection reset by peer"),
-            "Delivery failed.",
+            "Connection failed.",
             id="unexpected-error",
         ),
     ],
 )
-def test_describe_delivery_error__known_failures__returns_user_facing_detail(
+def test_describe_warehouse_error__known_failures__returns_user_facing_detail(
     error: Exception,
     expected_detail: str,
 ) -> None:
-    # Given a parametrised delivery failure
+    # Given a parametrised verification or delivery failure
 
     # When
-    detail = warehouse_delivery_service.describe_delivery_error(error)
+    detail = warehouse_delivery_service.describe_warehouse_error(error)
 
     # Then
     assert detail == expected_detail

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -631,7 +631,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1027`
+ - `api/experimentation/services.py:1025`
 
 Attributes:
  - `environment.id`
@@ -640,7 +640,7 @@ Attributes:
 ### `warehouse.connection.event_stats_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1090`
+ - `api/experimentation/services.py:1088`
 
 Attributes:
  - `environment.id`
@@ -649,7 +649,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:815`
+ - `api/experimentation/services.py:813`
 
 Attributes:
  - `environment.id`
@@ -658,7 +658,7 @@ Attributes:
 ### `warehouse.connection.verification_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1002`
+ - `api/experimentation/services.py:1000`
 
 Attributes:
  - `environment.id`
@@ -668,7 +668,7 @@ Attributes:
 ### `warehouse.connection.verification_succeeded`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1012`
+ - `api/experimentation/services.py:1010`
 
 Attributes:
  - `environment.id`
@@ -677,7 +677,7 @@ Attributes:
 ### `warehouse.delivery.all_objects_rejected`
 
 Logged at `error` from:
- - `api/experimentation/services.py:958`
+ - `api/experimentation/services.py:956`
 
 Attributes:
  - `connection.id`
@@ -688,7 +688,7 @@ Attributes:
 ### `warehouse.delivery.budget_exhausted`
 
 Logged at `info` from:
- - `api/experimentation/services.py:860`
+ - `api/experimentation/services.py:858`
 
 Attributes:
  - `connection.id`
@@ -699,7 +699,7 @@ Attributes:
 ### `warehouse.delivery.completed`
 
 Logged at `info` from:
- - `api/experimentation/services.py:968`
+ - `api/experimentation/services.py:966`
 
 Attributes:
  - `connection.id`
@@ -712,7 +712,7 @@ Attributes:
 ### `warehouse.delivery.failed`
 
 Logged at `error` from:
- - `api/experimentation/services.py:941`
+ - `api/experimentation/services.py:939`
 
 Attributes:
  - `connection.id`
@@ -723,7 +723,7 @@ Attributes:
 ### `warehouse.delivery.object_rejected`
 
 Logged at `error` from:
- - `api/experimentation/services.py:883`
+ - `api/experimentation/services.py:881`
 
 Attributes:
  - `connection.id`
@@ -735,7 +735,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:437`
+ - `api/experimentation/services.py:435`
 
 Attributes:
  - `environment.id`
@@ -745,7 +745,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:423`
+ - `api/experimentation/services.py:421`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -631,7 +631,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1075`
+ - `api/experimentation/services.py:1027`
 
 Attributes:
  - `environment.id`
@@ -640,7 +640,7 @@ Attributes:
 ### `warehouse.connection.event_stats_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1134`
+ - `api/experimentation/services.py:1090`
 
 Attributes:
  - `environment.id`
@@ -649,7 +649,7 @@ Attributes:
 ### `warehouse.connection.test_event_sent`
 
 Logged at `info` from:
- - `api/experimentation/services.py:809`
+ - `api/experimentation/services.py:815`
 
 Attributes:
  - `environment.id`
@@ -658,7 +658,7 @@ Attributes:
 ### `warehouse.connection.verification_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1050`
+ - `api/experimentation/services.py:1002`
 
 Attributes:
  - `environment.id`
@@ -668,7 +668,7 @@ Attributes:
 ### `warehouse.connection.verification_succeeded`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1060`
+ - `api/experimentation/services.py:1012`
 
 Attributes:
  - `environment.id`
@@ -677,7 +677,7 @@ Attributes:
 ### `warehouse.delivery.all_objects_rejected`
 
 Logged at `error` from:
- - `api/experimentation/services.py:952`
+ - `api/experimentation/services.py:958`
 
 Attributes:
  - `connection.id`
@@ -688,7 +688,7 @@ Attributes:
 ### `warehouse.delivery.budget_exhausted`
 
 Logged at `info` from:
- - `api/experimentation/services.py:854`
+ - `api/experimentation/services.py:860`
 
 Attributes:
  - `connection.id`
@@ -699,7 +699,7 @@ Attributes:
 ### `warehouse.delivery.completed`
 
 Logged at `info` from:
- - `api/experimentation/services.py:962`
+ - `api/experimentation/services.py:968`
 
 Attributes:
  - `connection.id`
@@ -712,7 +712,7 @@ Attributes:
 ### `warehouse.delivery.failed`
 
 Logged at `error` from:
- - `api/experimentation/services.py:935`
+ - `api/experimentation/services.py:941`
 
 Attributes:
  - `connection.id`
@@ -723,7 +723,7 @@ Attributes:
 ### `warehouse.delivery.object_rejected`
 
 Logged at `error` from:
- - `api/experimentation/services.py:877`
+ - `api/experimentation/services.py:883`
 
 Attributes:
  - `connection.id`
@@ -735,7 +735,7 @@ Attributes:
 ### `warehouse.srm.overallocated`
 
 Logged at `error` from:
- - `api/experimentation/services.py:431`
+ - `api/experimentation/services.py:437`
 
 Attributes:
  - `environment.id`
@@ -745,7 +745,7 @@ Attributes:
 ### `warehouse.srm.unkeyed_variant`
 
 Logged at `error` from:
- - `api/experimentation/services.py:417`
+ - `api/experimentation/services.py:423`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -631,7 +631,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1025`
+ - `api/experimentation/services.py:1027`
 
 Attributes:
  - `environment.id`
@@ -640,7 +640,7 @@ Attributes:
 ### `warehouse.connection.event_stats_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1088`
+ - `api/experimentation/services.py:1090`
 
 Attributes:
  - `environment.id`
@@ -658,7 +658,7 @@ Attributes:
 ### `warehouse.connection.verification_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1000`
+ - `api/experimentation/services.py:1002`
 
 Attributes:
  - `environment.id`
@@ -668,7 +668,7 @@ Attributes:
 ### `warehouse.connection.verification_succeeded`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1010`
+ - `api/experimentation/services.py:1012`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -631,7 +631,7 @@ Attributes:
 ### `warehouse.connection.connected`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1027`
+ - `api/experimentation/services.py:1026`
 
 Attributes:
  - `environment.id`
@@ -640,7 +640,7 @@ Attributes:
 ### `warehouse.connection.event_stats_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1090`
+ - `api/experimentation/services.py:1089`
 
 Attributes:
  - `environment.id`
@@ -658,7 +658,7 @@ Attributes:
 ### `warehouse.connection.verification_failed`
 
 Logged at `warning` from:
- - `api/experimentation/services.py:1002`
+ - `api/experimentation/services.py:1001`
 
 Attributes:
  - `environment.id`
@@ -668,7 +668,7 @@ Attributes:
 ### `warehouse.connection.verification_succeeded`
 
 Logged at `info` from:
- - `api/experimentation/services.py:1012`
+ - `api/experimentation/services.py:1011`
 
 Attributes:
  - `environment.id`

--- a/docs/docs/experimentation/connect-a-warehouse.md
+++ b/docs/docs/experimentation/connect-a-warehouse.md
@@ -97,14 +97,14 @@ Instead of the managed Flagsmith warehouse, you can store experiment events in y
    ORDER BY (environment_key, event, feature_name, timestamp, identifier);
    ```
 
-2. Go to **Environment Settings > Warehouse**, select **ClickHouse** and enter your connection details: host, port (9440
-   by default, the native protocol port), database (`flagsmith_exp` by default), and the username and password of the
-   user you created in step 1.
+2. Go to **Environment Settings > Warehouse**, select **ClickHouse** and enter your connection details: host, HTTPS port
+   (8443 by default), database (`flagsmith_exp` by default), and the username and password of the user you created in
+   step 1.
 3. Click **Test connection**. Once the test succeeds, save the connection.
 4. Click **Send your first event** on the connection card to verify events are arriving in your warehouse; the button
    disappears once the first event is received.
 
-Connections use the ClickHouse native protocol, with TLS enabled by default.
+Connections use the ClickHouse HTTP(S) interface, with TLS enabled by default.
 
 Experiment results and exposure queries are currently computed from the managed Flagsmith warehouse; serving results
 directly from your own ClickHouse instance is not supported yet.

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/ClickHouseConfigForm.tsx
@@ -165,13 +165,13 @@ const ClickHouseConfigForm: FC<ClickHouseConfigFormProps> = ({
 
         <div className='wh-config-form__row'>
           <div className='wh-config-form__field'>
-            <label className='wh-config-form__label'>Port</label>
+            <label className='wh-config-form__label'>HTTPS port</label>
             <Input
               value={port}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setField(setPort)(e.target.value)
               }
-              placeholder='9440'
+              placeholder='8443'
               aria-invalid={hasInvalidPort}
               aria-describedby={
                 hasInvalidPort ? 'warehouse-config-port-error' : undefined

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseConfig.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/clickhouseConfig.test.ts
@@ -12,7 +12,7 @@ const validForm: ClickHouseFormState = {
   host: 'ch.example.com',
   name: 'Production ClickHouse',
   password: 'hunter2',
-  port: '9440',
+  port: '8443',
   secure: true,
   username: 'default',
 }
@@ -20,12 +20,12 @@ const validForm: ClickHouseFormState = {
 describe('isValidPort', () => {
   it('accepts ports within 1-65535', () => {
     expect(isValidPort('1')).toBe(true)
-    expect(isValidPort('9440')).toBe(true)
+    expect(isValidPort('8443')).toBe(true)
     expect(isValidPort('65535')).toBe(true)
   })
 
   it('accepts a port with surrounding whitespace', () => {
-    expect(isValidPort(' 9440 ')).toBe(true)
+    expect(isValidPort(' 8443 ')).toBe(true)
   })
 
   it('rejects out-of-range or non-numeric ports', () => {
@@ -83,7 +83,7 @@ describe('isClickHouseConfigDirty', () => {
   const initialConfig = {
     database: 'flagsmith',
     host: 'ch.example.com',
-    port: 9440,
+    port: 8443,
     secure: true,
     username: 'default',
   }
@@ -95,7 +95,7 @@ describe('isClickHouseConfigDirty', () => {
   })
 
   it.each([
-    ['port', { port: '9000' }],
+    ['port', { port: '8123' }],
     ['database', { database: 'analytics' }],
     ['username', { username: 'svc' }],
     ['secure', { secure: false }],
@@ -112,7 +112,7 @@ describe('isClickHouseConfigDirty', () => {
   it('is clean when the port differs only in formatting', () => {
     expect(
       isClickHouseConfigDirty(
-        { ...validForm, password: '', port: '09440' },
+        { ...validForm, password: '', port: '08443' },
         initialConfig,
       ),
     ).toBe(false)
@@ -131,7 +131,7 @@ describe('buildClickHousePayload', () => {
       config: {
         database: 'flagsmith',
         host: 'ch.example.com',
-        port: 9440,
+        port: 8443,
         secure: true,
         username: 'default',
       },
@@ -154,14 +154,14 @@ describe('buildClickHousePayload', () => {
         host: ' ch.example.com ',
         name: ' Production ClickHouse ',
         password: ' hunter2 ',
-        port: ' 9440 ',
+        port: ' 8443 ',
         username: 'default ',
       }),
     ).toEqual({
       config: {
         database: 'flagsmith',
         host: 'ch.example.com',
-        port: 9440,
+        port: 8443,
         secure: true,
         username: 'default',
       },

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/clickhouseConfig.ts
@@ -3,7 +3,8 @@ import { ClickHouseConfig } from 'common/types/responses'
 export const CLICKHOUSE_DEFAULTS: ClickHouseConfig = {
   database: 'flagsmith_exp',
   host: '',
-  port: 9440,
+  // The HTTP(S) interface port, matching CLICKHOUSE_DEFAULTS in the API.
+  port: 8443,
   secure: true,
   username: '',
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8150

- The stored ClickHouse `port` now means the HTTP(S) interface port (default 8443) and delivery uses it directly, retiring `NATIVE_TO_HTTP_PORT`.
- Verification checks the events table exists over the same `clickhouse-connect` client, interface and port that delivery uses; customer event stats queries follow suit.
- The verification and delivery error mappers are collapsed into one `describe_warehouse_error`.
- The connection form field is relabelled "HTTPS port" with an 8443 placeholder and default.

No data migration for stored configs: the feature is not in production yet, and the few testing connections will be migrated manually.

Out of scope for now: verifying the events table schema, and moving the own-warehouse queries off `clickhouse-driver`.

## How did you test this code?

Unit tests updated for the new port semantics and client; 545 experimentation tests pass, plus the frontend config form tests.