### PR TITLE
deps(frontend): bump immutable, postcss, fast-uri and rspack [security]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4086,13 +4086,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -5896,27 +5896,29 @@
       ]
     },
     "node_modules/@rspack/binding": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-2.0.5.tgz",
-      "integrity": "sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-2.1.7.tgz",
+      "integrity": "sha512-wYqi8TY30hsIzLry503o/Uqu7y9Ec7pEwN5TVmB7Pb3xHrR2eHsQPzdpF/GkCLUjQSgD2Es3CDVV1mr6zO/78g==",
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "2.0.5",
-        "@rspack/binding-darwin-x64": "2.0.5",
-        "@rspack/binding-linux-arm64-gnu": "2.0.5",
-        "@rspack/binding-linux-arm64-musl": "2.0.5",
-        "@rspack/binding-linux-x64-gnu": "2.0.5",
-        "@rspack/binding-linux-x64-musl": "2.0.5",
-        "@rspack/binding-wasm32-wasi": "2.0.5",
-        "@rspack/binding-win32-arm64-msvc": "2.0.5",
-        "@rspack/binding-win32-ia32-msvc": "2.0.5",
-        "@rspack/binding-win32-x64-msvc": "2.0.5"
+        "@rspack/binding-darwin-arm64": "2.1.7",
+        "@rspack/binding-darwin-x64": "2.1.7",
+        "@rspack/binding-linux-arm64-gnu": "2.1.7",
+        "@rspack/binding-linux-arm64-musl": "2.1.7",
+        "@rspack/binding-linux-riscv64-gnu": "2.1.7",
+        "@rspack/binding-linux-riscv64-musl": "2.1.7",
+        "@rspack/binding-linux-x64-gnu": "2.1.7",
+        "@rspack/binding-linux-x64-musl": "2.1.7",
+        "@rspack/binding-wasm32-wasi": "2.1.7",
+        "@rspack/binding-win32-arm64-msvc": "2.1.7",
+        "@rspack/binding-win32-ia32-msvc": "2.1.7",
+        "@rspack/binding-win32-x64-msvc": "2.1.7"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-2.0.5.tgz",
-      "integrity": "sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-2.1.7.tgz",
+      "integrity": "sha512-DwxzrXRctueP/3Pyom9JHcIsRShuEAlHb+mrE5OPT+4cdHI1UnJpbzEvEDLTo4IKJhDb3vjXdHLtjqtL0SYbeA==",
       "cpu": [
         "arm64"
       ],
@@ -5927,9 +5929,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-2.0.5.tgz",
-      "integrity": "sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-2.1.7.tgz",
+      "integrity": "sha512-kPbrYvR/XUHfAMgRVq3QnC71DW/qjwsPj+3hEUuEnRmlploPNy9u8Szf1IHKSVUSrVZBTgDyMoZQdxYLfhResw==",
       "cpu": [
         "x64"
       ],
@@ -5940,9 +5942,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-2.0.5.tgz",
-      "integrity": "sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-2.1.7.tgz",
+      "integrity": "sha512-VFB+YXM3kZ6IIuLV64H3vgnwqvQIIaqfR/aeGwuxYvwcZsrgblSBmXMeDULdgDjqP8Yr0VaFMBBiD9OtG5KdFw==",
       "cpu": [
         "arm64"
       ],
@@ -5953,9 +5955,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-2.0.5.tgz",
-      "integrity": "sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-2.1.7.tgz",
+      "integrity": "sha512-Mzbxyg0aJ+ITj526Iuz0enEDYY6WxhFIwEKXqwjQh+Vpd5v/+aPzPo83sSQVX/3puBV1sbmviTURbh6N9e1fvA==",
       "cpu": [
         "arm64"
       ],
@@ -5965,10 +5967,36 @@
         "linux"
       ]
     },
+    "node_modules/@rspack/binding-linux-riscv64-gnu": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-2.1.7.tgz",
+      "integrity": "sha512-mpazwgT/Pse1720mvEJsoXfPkJ+enj0xUqpbe/wL6aedwjGT+9jJNB8HTJXE4XBX0UO7umGqcJMeKA6YsD2CDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-riscv64-musl": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-2.1.7.tgz",
+      "integrity": "sha512-oU/l3soPRsDEWn7KZic+npyTMM2N1kRdHjoJ+L5IUBXs8bjdTXPLoyTbTdIOza5ZSoT4+UeEiEryj4BB0tQE5w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-2.0.5.tgz",
-      "integrity": "sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-2.1.7.tgz",
+      "integrity": "sha512-7Gtpl3h3jtnOpk1mYQE8mRndXAO2ibI8mnAbs7klevdKey+ZHneWMoMi2yOMQhhI/ifWEFxDzyGJ8bdxo0XTsA==",
       "cpu": [
         "x64"
       ],
@@ -5979,9 +6007,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-2.0.5.tgz",
-      "integrity": "sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-2.1.7.tgz",
+      "integrity": "sha512-w+whI2Uy+DYkGN+MVkzMFWweL7B/s1gMqX+nvTE1vhOy3hGV0VyA9H6lqWjSD3I+eGkpYhN9Pr244cYnLpZOUQ==",
       "cpu": [
         "x64"
       ],
@@ -5992,24 +6020,55 @@
       ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-2.0.5.tgz",
-      "integrity": "sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-2.1.7.tgz",
+      "integrity": "sha512-cDVgvzRdTgxaeM+a5Lx0+7/VAvunvwO0wNtQ3ATQGOtFCW5b7cUzhNPcytH5ZSJTnFWuxinlGwtar5yfcnkdZQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "1.1.4"
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "1.1.6"
+      }
+    },
+    "node_modules/@rspack/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rspack/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rspack/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-2.0.5.tgz",
-      "integrity": "sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-2.1.7.tgz",
+      "integrity": "sha512-JDd85+iYwUvaG9Zrt5X7oIxRZRiTW+76FwkRakoXNy/5VAWQW32Jq4ESjSVz6l6mh0KnZxPq3TLMugacCPnLjw==",
       "cpu": [
         "arm64"
       ],
@@ -6020,9 +6079,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-2.0.5.tgz",
-      "integrity": "sha512-nMJGIY7kvgbyMolEE7tXDe+Z9jSItDshTIqMQQkkD3WTHdjlBQozHxk4kBtKLsunO+3NkCLe5Oa3hXg1yyStIg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-2.1.7.tgz",
+      "integrity": "sha512-y9PKEs6v9BLHV0i/4eaIRtxpATvSgcf/VYQkMT8mp+qWlPjUwDQNwU2ueWVGpff6INO+YAa7zobzziNFRgO7Lg==",
       "cpu": [
         "ia32"
       ],
@@ -6033,9 +6092,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-2.0.5.tgz",
-      "integrity": "sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-2.1.7.tgz",
+      "integrity": "sha512-BjkOzcPY/K8YlRRvyywz0mDWk89MMxqAMhDmgBXCWorh1IjgKTsWDJ2lCGIM8M9CZXUG3khom8AfrOGwRT2I+g==",
       "cpu": [
         "x64"
       ],
@@ -6046,9 +6105,9 @@
       ]
     },
     "node_modules/@rspack/cli": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-2.0.5.tgz",
-      "integrity": "sha512-AAyuY/8sfegb0IcsFEhn5gLOTxy1uDmwjP49RY81PENz2pCk/7NU0zDdt0ke5wmpOH5s6IxS+Kw4aWdvl8FGpQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-2.1.7.tgz",
+      "integrity": "sha512-1hmCC6OsJM4zJC7gWi122/kbl2h7lxZl4Wi1kdPYak0pqth6FGTmyHV+bwB+3yzAb6e/B2ttNqvXU1Zbj+Z+gQ==",
       "license": "MIT",
       "bin": {
         "rspack": "bin/rspack.js"
@@ -6064,12 +6123,12 @@
       }
     },
     "node_modules/@rspack/core": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-2.0.5.tgz",
-      "integrity": "sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-2.1.7.tgz",
+      "integrity": "sha512-d5Ju3zXzGgbqQWvlMlLUtek2eFPIzsFe2QOF4nwTAknxo/4OZ64t+kPT9nM6fr3aZX93VK0R3v02/kZYIRrV9Q==",
       "license": "MIT",
       "dependencies": {
-        "@rspack/binding": "2.0.5"
+        "@rspack/binding": "2.1.7"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -6088,15 +6147,15 @@
       }
     },
     "node_modules/@rspack/dev-middleware": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rspack/dev-middleware/-/dev-middleware-2.0.2.tgz",
-      "integrity": "sha512-vYdJq4AEEOxeTvlr8tEqgcVrNm0JOiOalmB6fc63Obu3RKYD4JAWj9oR+n7/nAd1x4GXjyGWivfel+/jZ+olvQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/dev-middleware/-/dev-middleware-2.0.3.tgz",
+      "integrity": "sha512-GxnGj9jy76G3eCPyZei81fwKLAMLZaPEEqFz1/QDYquhwi/qYZX5fekFJ1XVpuwxGEK9KSX3hxZylfwrs4cmLA==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@rspack/core": "^2.0.0-0"
+        "@rspack/core": "^2.0.0"
       },
       "peerDependenciesMeta": {
         "@rspack/core": {
@@ -6105,18 +6164,18 @@
       }
     },
     "node_modules/@rspack/dev-server": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.0.3.tgz",
-      "integrity": "sha512-S29nOxXQS9o+0uGNe7SgND2dAKnte5ZTD5tiT3/B4lKbviqpXD4tbH7NZWA3hGwlSkmOIbFlysYPL1bVHuBcSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.1.0.tgz",
+      "integrity": "sha512-WkCi6bWThVX5Ziv04srPaRoCoUY5FJolO4gqzE7xPO0XbXShsGnwn0vGD0DFfnYFcw9VSsxlmeCDV799lNYclA==",
       "license": "MIT",
       "dependencies": {
-        "@rspack/dev-middleware": "^2.0.1"
+        "@rspack/dev-middleware": "^2.0.3"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@rspack/core": "^2.0.0-0",
+        "@rspack/core": "^2.0.0",
         "selfsigned": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -6126,12 +6185,12 @@
       }
     },
     "node_modules/@rspack/plugin-react-refresh": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-2.0.1.tgz",
-      "integrity": "sha512-rYmxHJeDhN9/neZJgEjSFqG20A2Mu1mKv8+15kgwyuIDFSd3cgP3OVxwXLz5UmZSmWAfSzayDmmU1tBT0j1Nxw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-2.0.2.tgz",
+      "integrity": "sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==",
       "license": "MIT",
       "peerDependencies": {
-        "@rspack/core": "^2.0.0-0",
+        "@rspack/core": "^2.0.0",
         "react-refresh": ">=0.10.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -7499,9 +7558,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12896,9 +12955,9 @@
       }
     },
     "node_modules/express-handlebars/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -12937,9 +12996,9 @@
       }
     },
     "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -13110,9 +13169,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -13845,15 +13904,15 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/lru-cache": {
@@ -14501,9 +14560,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -17904,9 +17963,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -19103,9 +19162,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -19122,7 +19181,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Clears five High advisories flagged against the `flagsmith-frontend` image on 2.256.0 and 2.257.0. All five were already open Trivy alerts on `main` — `trivy.yaml` sets `exit-code: 0`, so they never blocked a build.

Lockfile only: every range in `package.json` already permitted the patched versions, so no manifest changes are needed.

| Advisory | The hole | Impact on Flagsmith | Fixed in |
| --- | --- | --- | --- |
| CVE-2026-59880 (immutable) | Hash collisions in `Map`/`Set` degrade insert/lookup to a CPU DoS when an attacker controls keys. | None reachable. `immutable` is a transitive dep of `sass` only, used to compile SCSS at build time; no app code imports it. | `immutable` 5.1.9 |
| CVE-2026-59879 (immutable) | `List` indices between 2^30 and 2^31 cause infinite loops, unbounded allocation or silent wraparound. | None reachable. Same build-time-only path as above. | `immutable` 5.1.9 |
| GHSA-r28c-9q8g-f849 (postcss) | `sourceMappingURL` comments are followed without sandboxing `..`, disclosing arbitrary `.map` files. | None reachable. `postcss` comes in via `css-loader`; it only ever processes our own CSS during `npm run bundle`, never untrusted input at runtime. | `postcss` 8.5.25 |
| CVE-2026-16221 (fast-uri) | A literal backslash is not treated as an authority delimiter, so host allowlists and SSRF filters can be bypassed. | None reachable. `fast-uri` comes in via `ajv`, used by rspack/webpack/terser to validate their own config schemas — never for host decisions. | `fast-uri` 3.1.4 |
| CVE-2026-13676 (fast-uri) | Failed IDN canonicalisation allows the same host confusion via Unicode hostnames. Not in the original scan, fixed by the same bump. | None reachable. Same build-time-only path as above. | `fast-uri` 3.1.4 |
| CVE-2026-55603 (http-proxy-middleware) | Unescaped CRLF in `fixRequestBody` lets an attacker inject `multipart/form-data` fields, desynchronising the proxy from the backend. | Not our direct dependency — we pin 3.0.7, which is already patched. The hit is a **vendored copy at `@rspack/core/compiled/http-proxy-middleware@4.0.0`**, invisible to `npm audit`. Dev-server only; the runtime image never loads it. | `@rspack/*` 2.1.7, vendoring 4.2.0 |

Also picks up `body-parser` 1.20.6 (GHSA-v422-hmwv-36x6) and `brace-expansion` 2.1.3/5.0.8 (GHSA-3jxr-9vmj-r5cp).

So the exposure is nil in a deployed container — all six are build tooling that ships inside the image because `oss-frontend` copies the whole `/build/frontend/` (including `node_modules`) and the build deps live in `dependencies` rather than `devDependencies`. Only `flagsmith-frontend` is affected; the API and unified images carry the compiled bundle only, no npm packages. Splitting build from runtime deps so the toolchain stops shipping is a follow-up.

Known remaining High in the production tree: `brace-expansion` via `express-handlebars@6` → `glob` → `minimatch`. That line has no patch; clearing it needs `express-handlebars@8`, a breaking major, so it is left for a separate PR.

## How did you test this code?

- `npm audit --omit=dev` no longer reports any of the six; the only High left is the `express-handlebars` chain noted above.
- Confirmed the fifth CVE at its real location: `@rspack/core@2.0.5` vendors `compiled/http-proxy-middleware@4.0.0`, and 2.1.7 vendors 4.2.0.
- `ENV=selfhosted npm run bundle` compiles clean on rspack 2.1.7 — 0 errors, 24 pre-existing sass deprecation warnings.
- `npm run test:unit` — 25 suites, 284 tests, all passing.
- `git diff frontend/package.json` is empty, confirming the bumps sit inside the declared ranges.
