### PR TITLE
fix(onboarding): stop polling while the verify console is hidden

### DIFF
--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingConnection.ts
@@ -5,26 +5,19 @@ export type OnboardingConnectionStatus = 'listening' | 'connected'
 
 export type OnboardingConnection = {
   status: OnboardingConnectionStatus
-  // Which SDK reported the first evaluation, e.g. 'flagsmith-python-sdk'. Null
-  // until the signal lands, and also when Core could not identify the SDK from
-  // the user agent (it sends 'unknown', which is nothing to show a user).
-  sdkLabel: string | null
+  sdkLabel: string | null // null until the signal lands, or if unidentified
 }
 
-// Edge reports the first evaluation asynchronously after the SDK's first
-// request, so the flip isn't instant — poll until it lands.
-const POLL_INTERVAL_MS = 3000
+const POLL_INTERVAL_MS = 5000
 
-const UNIDENTIFIED_SDK = 'unknown'
+const UNIDENTIFIED_SDK = 'unknown' // what Core sends for an unknown user agent
 
-// Connection status for the verify console, driven by the real first-evaluation
-// signal: Edge reports the first SDK evaluation to Core, exposed at
-// GET environments/{key}/onboarding-status/. `first_evaluated_at` flips from
-// null to a timestamp once received; it never reverts, so we stop polling then.
-// The signal is latched into state because skipping the query drops `data`.
+// Polls onboarding-status/ until Core reports the first SDK evaluation.
 export const useOnboardingConnection = (
   environmentKey: string,
 ): OnboardingConnection => {
+  // Kept in state, not read from `data`: the query is skipped once the signal
+  // lands, and a skipped query has no data to read.
   const [firstEvaluation, setFirstEvaluation] = useState<{
     sdkLabel: string | null
   } | null>(null)
@@ -34,6 +27,7 @@ export const useOnboardingConnection = (
     {
       pollingInterval: POLL_INTERVAL_MS,
       skip: !!firstEvaluation || !environmentKey,
+      skipPollingIfUnfocused: true, // pauses when hidden; visibilitychange, not blur
     },
   )
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8154.

The verify console polled `onboarding-status/` every 3s for as long as `/getting-started` was open, so a tab left open without an SDK wired up cost roughly 1,200 requests an hour.

- `skipPollingIfUnfocused: true`, available since #8139 put us on RTK 2. It pauses while the tab is hidden and resumes on return. It keys off `visibilitychange` rather than window blur, so a browser visible on a second screen keeps polling and can't show a stale "listening" badge to someone watching the page.
- `pollingInterval` 3s → 5s, as @Zaimwa9 suggested on #8132.

Also corrects a comment that credited Edge with recording the first evaluation. Core does it, in `features/views.py` on `GET /flags/`.

## How did you test this code?

- [x] `typecheck` passes, which is what proves the option exists (it doesn't on RTK 1.9)
- [x] `test:unit` (348) and `lint` clean

Worth watching on CI: the onboarding e2e test waits up to 15s for the LIVE badge, so a 5s interval is within tolerance. `skipPollingIfUnfocused` should be a no-op there, since RTK treats the page as focused until a `visibilitychange` or blur event says otherwise, and a Playwright page is visible. If that assumption is wrong the test will time out rather than fail subtly.

Manual pass:

- [ ] `/getting-started` open in the foreground: `onboarding-status/` requests every 5s in the network tab
- [ ] Switch to another tab: requests stop. Switch back: a request fires immediately
- [ ] Browser visible on a second screen but not focused: requests continue
- [ ] Run an SDK against the environment: the console still flips to LIVE without a reload
