### PR TITLE
fix(SDK): Flag fetches fail when replica databases are configured

### DIFF
--- a/api/app/routers.py
+++ b/api/app/routers.py
@@ -1,9 +1,13 @@
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
+from common.core.utils import ReplicaNamePrefix
 from django.db.models import Model
 
 AnalyticsDatabaseName = Literal["analytics"]
 ClickHouseDatabaseName = Literal["clickhouse"]
+
+PRIMARY_DATABASE_NAME = "default"
+REPLICA_NAME_PREFIXES: tuple[str, ...] = get_args(ReplicaNamePrefix)
 
 
 class AnalyticsRouter:
@@ -73,4 +77,33 @@ class ClickHouseRouter:
             return app_label in self.route_app_labels
         if app_label in self.route_app_labels:
             return False
+        return None
+
+
+class ReplicaRouter:
+    """
+    Treat the primary database and its read replicas as one logical database.
+
+    Replicas hold copies of the primary's data, so an object read from a replica
+    can legitimately be related to an object read from the primary.
+
+    Only `allow_relation` is implemented.
+
+    This router must be registered last so that the restrictions of other routers
+    keep taking precedence.
+    """
+
+    def allow_relation(self, obj1: Model, obj2: Model, **hints: Any) -> bool | None:
+        databases = (obj1._state.db, obj2._state.db)
+        if all(
+            database is not None
+            and (
+                database == PRIMARY_DATABASE_NAME
+                or database.startswith(REPLICA_NAME_PREFIXES)
+            )
+            for database in databases
+        ):
+            return True
+        # Defer to the remaining routers for anything
+        # that isn't the primary or one of its replicas.
         return None

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1543,6 +1543,9 @@ SEGMENT_MEMBERSHIP_DELETE_REFRESH_DELAY_SECONDS = env.int(
 # the default Postgres database whether or not a CH alias is configured.
 DATABASE_ROUTERS.append("app.routers.ClickHouseRouter")
 
+# Should be registered last.
+DATABASE_ROUTERS.append("app.routers.ReplicaRouter")
+
 if CLICKHOUSE_ENABLED:
     _clickhouse_db: dict[str, Any] = {
         "ENGINE": "core.db_backends.clickhouse",

--- a/api/tests/unit/app/test_unit_app_routers.py
+++ b/api/tests/unit/app/test_unit_app_routers.py
@@ -5,6 +5,8 @@ from django.apps import apps
 from django.db import models
 
 from app import routers
+from environments.models import Environment
+from features.models import Feature, FeatureState
 
 
 @pytest.fixture(autouse=True)
@@ -235,3 +237,65 @@ def test_clickhouse_router_allow_migrate__given_db_and_app_label__returns_expect
 
     # Then
     assert result is expected
+
+
+@pytest.mark.parametrize(
+    ["db1", "db2", "expected"],
+    [
+        ("default", "default", True),
+        ("default", "replica_1", True),
+        ("replica_1", "default", True),
+        ("replica_1", "replica_2", True),
+        ("default", "cross_region_replica_1", True),
+        ("replica_1", "cross_region_replica_1", True),
+        ("default", None, None),
+        (None, None, None),
+        ("default", "analytics", None),
+        ("analytics", "analytics", None),
+        ("replica_1", "task_processor", None),
+    ],
+)
+def test_replica_router_allow_relation__given_databases__returns_expected(
+    db1: str | None,
+    db2: str | None,
+    expected: bool | None,
+) -> None:
+    # Given
+    class SomeModel(models.Model):
+        class Meta:
+            app_label = "some_app"
+
+    obj1, obj2 = SomeModel(), SomeModel()
+    obj1._state.db = db1
+    obj2._state.db = db2
+
+    router = routers.ReplicaRouter()
+
+    # When
+    result = router.allow_relation(obj1, obj2)
+
+    # Then
+    assert result is expected
+
+
+def test_replica_router_allow_relation__replica_instance__allows_primary_assignment(
+    environment: Environment,
+    feature: Feature,
+) -> None:
+    """
+    Regression test for https://github.com/Flagsmith/flagsmith/issues/8167 —
+    the SDK flags endpoint reads feature states from a replica, then primes the
+    `environment` foreign key with the primary-loaded environment.
+    """
+    # Given
+    feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment=None, identity=None
+    )
+    # Simulate a feature state loaded via `using_database_replica`
+    feature_state._state.db = "replica_1"
+
+    # When
+    feature_state.environment = environment
+
+    # Then
+    assert feature_state.environment is environment


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8167.

In this PR, we allow relations between all read objects by adding a custom `ReplicaRouter`.

## How did you test this code?

Added unit tests:

- Parametrised coverage of `ReplicaRouter.allow_relation` across primary/replica, replica/replica, cross-region replica, unsaved, `analytics` and `task_processor` combinations.
- A regression test that loads a `FeatureState`, marks it as replica-loaded, and assigns the primary-loaded `Environment`.
