### PR TITLE
fix: consolidate copy field pattern usage

### DIFF
--- a/frontend/documentation/components/CopyField.stories.tsx
+++ b/frontend/documentation/components/CopyField.stories.tsx
@@ -57,3 +57,15 @@ export const LongValue: Story = {
     </Container>
   ),
 }
+
+export const WithLabel: Story = {
+  render: () => (
+    <Container>
+      <CopyField
+        value='https://app.flagsmith.com/api/v1/auth/saml/my-org/response/'
+        title='Assertion Consumer Service (ACS) URL'
+        tooltip='Your identity provider posts SAML responses to this URL.'
+      />
+    </Container>
+  ),
+}

--- a/frontend/web/components/CopyField.tsx
+++ b/frontend/web/components/CopyField.tsx
@@ -1,33 +1,41 @@
-import React, { FC } from 'react'
+import React, { FC, useId } from 'react'
 import Button from './base/forms/Button'
 import Flex from './base/grid/Flex'
+import FieldLabel from './base/forms/FieldLabel'
 import Icon from './icons/Icon'
 import Input from './base/forms/Input'
 import Row from './base/grid/Row'
+import { TooltipProps } from './Tooltip'
 import Utils from 'common/utils/utils'
 
-// Minimal read-only input + icon-only Copy button pattern. The codebase has
-// half a dozen consumers rolling this inline (CreateSAML's ACS URL, SDK
-// keys, webhook URLs, etc.) — they should all migrate here in a follow-up.
-// Keep the API tight for now to avoid pre-committing to choices that don't
-// fit every existing consumer.
+// Read-only input + icon-only Copy button. Optionally renders a wired label
+// (with tooltip) above the row — use `title` + `tooltip` for that, matching
+// InputGroup's prop naming convention.
 type CopyFieldProps = {
   value: string
   className?: string
   'data-test'?: string
+  title?: string
+  tooltip?: string
+  tooltipPlace?: TooltipProps['place']
 }
 
 const CopyField: FC<CopyFieldProps> = ({
   className,
   'data-test': dataTest,
+  title,
+  tooltip,
+  tooltipPlace,
   value,
 }) => {
   const onCopy = () => Utils.copyToClipboard(value)
+  const inputId = useId()
 
-  return (
+  const row = (
     <Row className='gap-2 align-items-center'>
       <Flex>
         <Input
+          id={inputId}
           value={value}
           readOnly
           className={className}
@@ -43,6 +51,21 @@ const CopyField: FC<CopyFieldProps> = ({
         <Icon name='copy' width={20} />
       </Button>
     </Row>
+  )
+
+  if (!title) return row
+
+  return (
+    <div>
+      <FieldLabel
+        htmlFor={inputId}
+        tooltip={tooltip}
+        tooltipPlace={tooltipPlace}
+      >
+        {title}
+      </FieldLabel>
+      {row}
+    </div>
   )
 }
 

--- a/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
@@ -21,8 +21,7 @@ import Tabs from 'components/navigation/TabMenu/Tabs'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import { AttributeName } from 'common/types/responses'
 import SAMLAttributeMappingTable from 'components/pages/organisation-settings/tabs/sso/saml/SAMLAttributeMappingTable'
-import Input from 'components/base/forms/Input'
-import Icon from 'components/icons/Icon'
+import CopyField from 'components/CopyField'
 import Project from 'common/project'
 
 type CreateSAML = {
@@ -59,9 +58,6 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
     `./auth/saml/${name}/response/`,
     new Request(Project.api).url, // Project.api can be relative, e.g. /api/v1/
   ).href
-  const copyAcsUrl = () => {
-    Utils.copyToClipboard(acsUrl)
-  }
 
   useEffect(() => {
     if (isSuccess && data) {
@@ -214,32 +210,15 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
         </div>
       )}
       {isEdit && (
-        <div className='mt-12'>
-          <Tooltip
-            title={
-              <label>
-                Assertion Consumer Service (ACS) URL
-                <Icon name='info-outlined' />
-              </label>
-            }
-          >
-            Also known as sign-on URL. Your identity provider needs to know this
-            URL to send SAML responses to it.
-          </Tooltip>
-          <div
-            onClick={(e) => e.stopPropagation()}
-            className='flex flex-row gap-2'
-          >
-            <Input className='w-full flex-1' value={acsUrl} readOnly />
-            <Button
-              onClick={() => {
-                copyAcsUrl()
-              }}
-              className='me-2 btn-with-icon'
-            >
-              <Icon name='copy' width={20} />
-            </Button>
-          </div>
+        // stopPropagation: prevent clicks on the read-only input from
+        // bubbling into the parent Tabs panel.
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+        <div className='mt-12' onClick={(e) => e.stopPropagation()}>
+          <CopyField
+            value={acsUrl}
+            title='Assertion Consumer Service (ACS) URL'
+            tooltip='Also known as sign-on URL. Your identity provider needs to know this URL to send SAML responses to it.'
+          />
         </div>
       )}
       <div className='text-right py-2'>

--- a/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/sso/saml/modals/CreateSAML.tsx
@@ -212,7 +212,6 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
       {isEdit && (
         // stopPropagation: prevent clicks on the read-only input from
         // bubbling into the parent Tabs panel.
-        // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
         <div className='mt-12' onClick={(e) => e.stopPropagation()}>
           <CopyField
             value={acsUrl}

--- a/frontend/web/components/pages/sdk-keys/SDKKeysPage.tsx
+++ b/frontend/web/components/pages/sdk-keys/SDKKeysPage.tsx
@@ -1,9 +1,7 @@
 import React, { FC } from 'react'
-import Button from 'components/base/forms/Button'
-import Input from 'components/base/forms/Input'
-import Icon from 'components/icons/Icon'
+import CopyField from 'components/CopyField'
 import PageTitle from 'components/PageTitle'
-import Utils from 'common/utils/utils'
+import Button from 'components/base/forms/Button'
 import { useRouteMatch } from 'react-router-dom'
 import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import { ServerSideSDKKeys } from './components'
@@ -27,8 +25,6 @@ const SDKKeysPage: FC = () => {
     environments?.results?.find((env) => env.api_key === environmentId)?.name ??
     ''
 
-  const handleCopy = () => Utils.copyToClipboard(environmentId)
-
   return (
     <div
       data-test='sdk-keys-page'
@@ -47,22 +43,7 @@ const SDKKeysPage: FC = () => {
         SDKs.
       </PageTitle>
       <div className='col-md-6'>
-        <Row>
-          <Flex>
-            <Input
-              value={environmentId}
-              inputClassName='input input--wide'
-              type='text'
-              placeholder='Client-side Environment Key'
-            />
-          </Flex>
-          <Button
-            onClick={handleCopy}
-            className='ml-2 btn-with-icon icon-default'
-          >
-            <Icon name='copy' width={20} />
-          </Button>
-        </Row>
+        <CopyField value={environmentId} />
       </div>
       <hr className='py-0 my-4' />
       <ServerSideSDKKeys


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8125 

This PR standardizes the "read-only input + icon-only copy button" pattern by leveraging the `CopyField` component that was originally shipped with the SCIM work.

- Enhanced `<CopyField>` to support an optional wired label via the `title`, `tooltip`, and `tooltipPlace` props, passing through to `<FieldLabel>`.
- Generates stable, unique DOM ids using `useId()` for accessibility (`htmlFor`).
- Migrated the ACS URL field in `CreateSAML.tsx` from an ad-hoc layout to `<CopyField>`, preserving its tooltip and `stopPropagation` behaviour.
- Migrated the Environment Key field in `SDKKeysPage.tsx` to use `<CopyField>`.
- Removed the dead `w-full` CSS class usage from `CreateSAML.tsx` (the class had no corresponding rule).
- Added a `WithLabel` story to `CopyField.stories.tsx` to document the new props.

*Note: Other candidates like `ServerSideKeyRow`, `Token`, `UsersAndPermissionsPage`, and `EditHealthProvider` were evaluated but explicitly excluded because they represent different patterns (e.g. table rows with multiple actions, masked secret tokens, non-input text display).*

## How did you test this code?

- **Manually via Storybook**: Verified the new `WithLabel` story renders correctly with the tooltip on the info icon.
- **Manually**: Navigated to Organisation Settings -> SSO -> SAML (Edit Mode) to ensure the ACS URL field renders correctly, the tooltip works, and the input value can be copied.
- **Manually**: Navigated to an Environment's SDK Keys page to ensure the Client-side Environment Key field renders as expected and copies correctly.
- **TypeScript**: Ran a full `tsc --noEmit` check to ensure the changes are fully type-safe.
