### PR TITLE
feat(ds): add Link for navigation

### DIFF
--- a/frontend/documentation/components/Link.stories.tsx
+++ b/frontend/documentation/components/Link.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import type { Meta, StoryObj } from 'storybook'
+
+import Link from 'components/base/link'
+import Button from 'components/base/forms/Button'
+import { Icon } from 'components/icons'
+import { withRouter } from './_decorators'
+
+const meta: Meta<typeof Link> = {
+  component: Link,
+  decorators: [withRouter],
+  parameters: { layout: 'padded' },
+  title: 'Components/Link',
+}
+export default meta
+
+type Story = StoryObj<typeof Link>
+
+// An in-app route. No page load, so app state survives the navigation.
+export const InApp: Story = {
+  render: () => <Link to='/organisations'>Switch organisation</Link>,
+}
+
+// Anything outside the app, which needs a real document load.
+export const External: Story = {
+  render: () => <Link href='https://docs.flagsmith.com'>Read the docs</Link>,
+}
+
+// rel is set for you, so a new tab cannot reach back into this one.
+export const NewTab: Story = {
+  render: () => (
+    <Link href='https://docs.flagsmith.com' target='_blank'>
+      Read the docs
+    </Link>
+  ),
+}
+
+// The reason vertical-align matters: a link in prose has to sit on the same
+// baseline as the text around it.
+export const InSentence: Story = {
+  render: () => (
+    <p>
+      Invites are managed from your{' '}
+      <Link to='/organisations'>organisation settings</Link>, where you can also
+      revoke one that has not been accepted.
+    </p>
+  ),
+}
+
+// Children are laid out with a gap, so an icon needs no spacing of its own.
+export const WithIcon: Story = {
+  render: () => (
+    <Link to='/projects'>
+      Continue
+      <Icon name='arrow-right' width={16} />
+    </Link>
+  ),
+}
+
+// The distinction the component exists for. The link goes somewhere, the button
+// does something, and each carries the element that means that.
+export const AlongsideAButton: Story = {
+  render: () => (
+    <div className='d-flex align-items-center gap-3'>
+      <Button onClick={() => undefined}>Create project</Button>
+      <Link to='/projects'>View all projects</Link>
+    </div>
+  ),
+}

--- a/frontend/documentation/components/Link.stories.tsx
+++ b/frontend/documentation/components/Link.stories.tsx
@@ -16,17 +16,14 @@ export default meta
 
 type Story = StoryObj<typeof Link>
 
-// An in-app route. No page load, so app state survives the navigation.
 export const InApp: Story = {
   render: () => <Link to='/organisations'>Switch organisation</Link>,
 }
 
-// Anything outside the app, which needs a real document load.
 export const External: Story = {
   render: () => <Link href='https://docs.flagsmith.com'>Read the docs</Link>,
 }
 
-// rel is set for you, so a new tab cannot reach back into this one.
 export const NewTab: Story = {
   render: () => (
     <Link href='https://docs.flagsmith.com' target='_blank'>
@@ -35,8 +32,7 @@ export const NewTab: Story = {
   ),
 }
 
-// The reason vertical-align matters: a link in prose has to sit on the same
-// baseline as the text around it.
+// Checks the baseline sits right mid-sentence.
 export const InSentence: Story = {
   render: () => (
     <p>
@@ -47,7 +43,7 @@ export const InSentence: Story = {
   ),
 }
 
-// Children are laid out with a gap, so an icon needs no spacing of its own.
+// Checks the gap, so an icon needs no spacing of its own.
 export const WithIcon: Story = {
   render: () => (
     <Link to='/projects'>
@@ -57,8 +53,6 @@ export const WithIcon: Story = {
   ),
 }
 
-// The distinction the component exists for. The link goes somewhere, the button
-// does something, and each carries the element that means that.
 export const AlongsideAButton: Story = {
   render: () => (
     <div className='d-flex align-items-center gap-3'>

--- a/frontend/documentation/components/Link.stories.tsx
+++ b/frontend/documentation/components/Link.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { Meta, StoryObj } from 'storybook'
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
 import Link from 'components/base/link'
 import Button from 'components/base/forms/Button'

--- a/frontend/web/components/base/link/Link.scss
+++ b/frontend/web/components/base/link/Link.scss
@@ -1,9 +1,7 @@
-// Light mode is the same #6837fc as btn-link, so those call sites will not
-// shift when they move over. Dark deliberately differs: `.dark .btn-link` keeps
-// that same purple, this takes a lighter one for contrast on dark backgrounds.
-// `body.dark a` in styles.scss colours every anchor and outranks a bare .link,
-// so dark is repeated to beat it, the same way `.dark .btn-link` does. Both go
-// away if that global rule moves to a token.
+// Same token as btn-link since #8181, so call sites do not shift when they move
+// over. `body.dark a` in styles.scss colours every anchor and outranks a bare
+// .link, so dark is repeated to beat it. That goes away if the global rule moves
+// to a token too.
 .link,
 .dark .link {
   display: inline-flex;

--- a/frontend/web/components/base/link/Link.scss
+++ b/frontend/web/components/base/link/Link.scss
@@ -1,6 +1,6 @@
-// Reproduces what btn-link renders today, so links that move onto this
-// component do not shift. The colour token resolves to the same purple in light
-// mode and a lighter one in dark, where btn-link had no dark treatment.
+// Matches btn-link so the call sites that move onto this do not shift. The
+// token is the same purple in light mode and a lighter one in dark, which
+// btn-link had no treatment for.
 .link {
   display: inline-flex;
   align-items: center;

--- a/frontend/web/components/base/link/Link.scss
+++ b/frontend/web/components/base/link/Link.scss
@@ -1,7 +1,12 @@
 // Matches btn-link so the call sites that move onto this do not shift. The
 // token is the same purple in light mode and a lighter one in dark, which
 // btn-link had no treatment for.
-.link {
+//
+// `body.dark a` in styles.scss colours every anchor and outranks a bare .link,
+// so dark is repeated to beat it, the same way .dark .btn-link does. Both go
+// away if that global rule moves to a token.
+.link,
+.dark .link {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;

--- a/frontend/web/components/base/link/Link.scss
+++ b/frontend/web/components/base/link/Link.scss
@@ -1,8 +1,6 @@
 // Light mode is the same #6837fc as btn-link, so those call sites will not
 // shift when they move over. Dark deliberately differs: `.dark .btn-link` keeps
-// that same purple, this takes a lighter one for contrast on dark backgrounds,
-// so moving a link over is a visible change there.
-//
+// that same purple, this takes a lighter one for contrast on dark backgrounds.
 // `body.dark a` in styles.scss colours every anchor and outranks a bare .link,
 // so dark is repeated to beat it, the same way `.dark .btn-link` does. Both go
 // away if that global rule moves to a token.

--- a/frontend/web/components/base/link/Link.scss
+++ b/frontend/web/components/base/link/Link.scss
@@ -1,0 +1,19 @@
+// Reproduces what btn-link renders today, so links that move onto this
+// component do not shift. The colour token resolves to the same purple in light
+// mode and a lighter one in dark, where btn-link had no dark treatment.
+.link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  vertical-align: baseline;
+  color: var(--color-text-action);
+  font-weight: var(--font-weight-medium);
+  text-decoration: none;
+  transition: all 200ms;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-text-action);
+    text-decoration: underline;
+  }
+}

--- a/frontend/web/components/base/link/Link.scss
+++ b/frontend/web/components/base/link/Link.scss
@@ -1,9 +1,10 @@
-// Matches btn-link so the call sites that move onto this do not shift. The
-// token is the same purple in light mode and a lighter one in dark, which
-// btn-link had no treatment for.
+// Light mode is the same #6837fc as btn-link, so those call sites will not
+// shift when they move over. Dark deliberately differs: `.dark .btn-link` keeps
+// that same purple, this takes a lighter one for contrast on dark backgrounds,
+// so moving a link over is a visible change there.
 //
 // `body.dark a` in styles.scss colours every anchor and outranks a bare .link,
-// so dark is repeated to beat it, the same way .dark .btn-link does. Both go
+// so dark is repeated to beat it, the same way `.dark .btn-link` does. Both go
 // away if that global rule moves to a token.
 .link,
 .dark .link {

--- a/frontend/web/components/base/link/Link.tsx
+++ b/frontend/web/components/base/link/Link.tsx
@@ -1,10 +1,12 @@
-import React, { AnchorHTMLAttributes, ReactNode } from 'react'
+import React, { AnchorHTMLAttributes, ReactNode, Ref } from 'react'
 import cn from 'classnames'
 import { Link as RouterLink } from 'react-router-dom'
 import './Link.scss'
 
 type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   children: ReactNode
+  // React 19 ref-as-prop, no forwardRef.
+  ref?: Ref<HTMLAnchorElement>
 }
 
 // Exactly one destination, so a link can never render without one. `to` is an
@@ -14,33 +16,40 @@ export type LinkProps = LinkBaseProps &
 
 // A navigation control. Use this wherever the job is to go somewhere, and
 // Button wherever the job is to do something.
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ children, className, href, rel, target, to, ...rest }, ref) => {
-    const classes = cn('link', className)
+const Link: React.FC<LinkProps> = ({
+  children,
+  className,
+  href,
+  ref,
+  rel,
+  target,
+  to,
+  ...rest
+}) => {
+  const classes = cn('link', className)
 
-    if (to) {
-      return (
-        <RouterLink {...rest} className={classes} to={to} ref={ref}>
-          {children}
-        </RouterLink>
-      )
-    }
-
+  if (to) {
     return (
-      <a
-        {...rest}
-        className={classes}
-        href={href}
-        target={target}
-        // Stops the new tab getting a handle on this one.
-        rel={target === '_blank' ? rel ?? 'noreferrer' : rel}
-        ref={ref}
-      >
+      <RouterLink {...rest} className={classes} to={to} ref={ref}>
         {children}
-      </a>
+      </RouterLink>
     )
-  },
-)
+  }
+
+  return (
+    <a
+      {...rest}
+      className={classes}
+      href={href}
+      target={target}
+      // Stops the new tab getting a handle on this one.
+      rel={target === '_blank' ? rel ?? 'noreferrer' : rel}
+      ref={ref}
+    >
+      {children}
+    </a>
+  )
+}
 
 Link.displayName = 'Link'
 export default Link

--- a/frontend/web/components/base/link/Link.tsx
+++ b/frontend/web/components/base/link/Link.tsx
@@ -13,8 +13,11 @@ type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 
 // `to` stays in the app and does not reload it, `href` leaves. `to` takes the
 // router's own type, so the object form carrying search or state works here too.
-export type LinkProps = LinkBaseProps &
-  ({ to: RouterLinkProps['to']; href?: never } | { href: string; to?: never })
+type LinkDestination =
+  | { to: RouterLinkProps['to']; href?: never }
+  | { href: string; to?: never }
+
+export type LinkProps = LinkBaseProps & LinkDestination
 
 // Use this to go somewhere and Button to do something.
 const Link: React.FC<LinkProps> = ({
@@ -28,10 +31,19 @@ const Link: React.FC<LinkProps> = ({
   ...rest
 }) => {
   const classes = cn('link', className)
+  // Stops a new tab getting a handle on this one.
+  const safeRel = target === '_blank' ? rel ?? 'noreferrer' : rel
 
   if (to) {
     return (
-      <RouterLink {...rest} className={classes} to={to} ref={ref}>
+      <RouterLink
+        {...rest}
+        className={classes}
+        to={to}
+        target={target}
+        rel={safeRel}
+        ref={ref}
+      >
         {children}
       </RouterLink>
     )
@@ -43,8 +55,7 @@ const Link: React.FC<LinkProps> = ({
       className={classes}
       href={href}
       target={target}
-      // Stops the new tab getting a handle on this one.
-      rel={target === '_blank' ? rel ?? 'noreferrer' : rel}
+      rel={safeRel}
       ref={ref}
     >
       {children}

--- a/frontend/web/components/base/link/Link.tsx
+++ b/frontend/web/components/base/link/Link.tsx
@@ -1,0 +1,46 @@
+import React, { AnchorHTMLAttributes, ReactNode } from 'react'
+import cn from 'classnames'
+import { Link as RouterLink } from 'react-router-dom'
+import './Link.scss'
+
+type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children: ReactNode
+}
+
+// Exactly one destination, so a link can never render without one. `to` is an
+// in-app route and does not reload the app; `href` is for anything outside it.
+export type LinkProps = LinkBaseProps &
+  ({ to: string; href?: never } | { href: string; to?: never })
+
+// A navigation control. Use this wherever the job is to go somewhere, and
+// Button wherever the job is to do something.
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ children, className, href, rel, target, to, ...rest }, ref) => {
+    const classes = cn('link', className)
+
+    if (to) {
+      return (
+        <RouterLink {...rest} className={classes} to={to} ref={ref}>
+          {children}
+        </RouterLink>
+      )
+    }
+
+    return (
+      <a
+        {...rest}
+        className={classes}
+        href={href}
+        target={target}
+        // Stops the new tab getting a handle on this one.
+        rel={target === '_blank' ? rel ?? 'noreferrer' : rel}
+        ref={ref}
+      >
+        {children}
+      </a>
+    )
+  },
+)
+
+Link.displayName = 'Link'
+export default Link

--- a/frontend/web/components/base/link/Link.tsx
+++ b/frontend/web/components/base/link/Link.tsx
@@ -34,7 +34,8 @@ const Link: React.FC<LinkProps> = ({
   // Stops a new tab getting a handle on this one.
   const safeRel = target === '_blank' ? rel ?? 'noreferrer' : rel
 
-  if (to) {
+  // Not truthiness: `to=''` would render an anchor with no href.
+  if (to !== undefined) {
     return (
       <RouterLink
         {...rest}

--- a/frontend/web/components/base/link/Link.tsx
+++ b/frontend/web/components/base/link/Link.tsx
@@ -5,17 +5,14 @@ import './Link.scss'
 
 type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   children: ReactNode
-  // React 19 ref-as-prop, no forwardRef.
   ref?: Ref<HTMLAnchorElement>
 }
 
-// Exactly one destination, so a link can never render without one. `to` is an
-// in-app route and does not reload the app; `href` is for anything outside it.
+// `to` stays in the app and does not reload it, `href` leaves.
 export type LinkProps = LinkBaseProps &
   ({ to: string; href?: never } | { href: string; to?: never })
 
-// A navigation control. Use this wherever the job is to go somewhere, and
-// Button wherever the job is to do something.
+// Use this to go somewhere and Button to do something.
 const Link: React.FC<LinkProps> = ({
   children,
   className,

--- a/frontend/web/components/base/link/Link.tsx
+++ b/frontend/web/components/base/link/Link.tsx
@@ -1,6 +1,9 @@
 import React, { AnchorHTMLAttributes, ReactNode, Ref } from 'react'
 import cn from 'classnames'
-import { Link as RouterLink } from 'react-router-dom'
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+} from 'react-router-dom'
 import './Link.scss'
 
 type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
@@ -8,9 +11,10 @@ type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   ref?: Ref<HTMLAnchorElement>
 }
 
-// `to` stays in the app and does not reload it, `href` leaves.
+// `to` stays in the app and does not reload it, `href` leaves. `to` takes the
+// router's own type, so the object form carrying search or state works here too.
 export type LinkProps = LinkBaseProps &
-  ({ to: string; href?: never } | { href: string; to?: never })
+  ({ to: RouterLinkProps['to']; href?: never } | { href: string; to?: never })
 
 // Use this to go somewhere and Button to do something.
 const Link: React.FC<LinkProps> = ({

--- a/frontend/web/components/base/link/index.ts
+++ b/frontend/web/components/base/link/index.ts
@@ -1,2 +1,2 @@
-export { default, Link } from './Link'
+export { default } from './Link'
 export type { LinkProps } from './Link'

--- a/frontend/web/components/base/link/index.ts
+++ b/frontend/web/components/base/link/index.ts
@@ -1,0 +1,2 @@
+export { default, Link } from './Link'
+export type { LinkProps } from './Link'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8178 (epic #5746)

The goal is that in-app navigation goes through react-router's `Link` wherever it can, so the app does not reload, and that **one component decides that** rather than every call site choosing for itself. Today `Button` renders an `<a>` whenever it is given `href`, which it is at 30 sites, so the name tells you nothing about what you get and each one is a full page load whether it needs to be or not.

- **`to` is the default**, rendering a router link. `href` is for leaving the app. The type permits exactly one, so a link cannot render without a destination and passing both is a compile error rather than one silently winning.
- **Owns its styling** in `Link.scss` and imports nothing from `Button`. In light mode it is the same `#6837fc` as `btn-link` (`$link-color` resolves to `$primary`), so those call sites will not shift when they move over.
- **Dark mode deliberately differs.** `.dark .btn-link` keeps that same purple; this takes `--purple-400`, which is lighter and holds up better on a dark background. Moving a link over is therefore a visible change in dark mode, not a no-op.
- **`.link` repeats itself under `.dark`.** `body.dark a` in `styles.scss` colours every anchor at higher specificity than a bare `.link`, so the token never applied and links rendered as body text. `.dark .btn-link` already exists for the same reason. Both disappear if that global rule moves to a token.
- **Six stories rather than a controls playground**, so each variant snapshots. In-prose and with-icon earn their place: `.link` is `inline-flex` with a `gap`, so baseline alignment mid-sentence and icon spacing are what would break unnoticed.

Not in scope here: nothing uses it yet, deliberately, so this lands on its own. Adoption of the 30 `Button href` sites follows in batches under #8178, after which `Button` can drop its anchor branch and only ever render `<button>`. Roughly 20 of those are external, a handful are internal routes that become `to`, and about 6 are `href='#'` with an `onClick`, which are not navigation and want a real button.

## How did you test this code?

- `tsc`: 0 new errors vs `main`.
- `eslint`: clean on all changed files.
- Storybook: six stories added under `Components/Link`.

Nobody has looked at it rendered, hence draft. Smoke test (light + dark):

- [ ] `InSentence` beside a `btn-link` elsewhere in the app: colour and weight match, baseline sits right mid-paragraph
- [ ] `WithIcon`: `gap: 0.25rem` spacing between icon and text
- [ ] Dark theme toggle: the one place behaviour differs from `btn-link`
- [ ] `InApp`: clicking navigates without a page reload
- [ ] `NewTab`: opens a new tab and `rel="noreferrer"` is set
- [ ] `AlongsideAButton`: the link and the button read as different things
