### PR TITLE
refactor(styles): semantic colors on links

### DIFF
--- a/frontend/web/styles/components/_list-item.scss
+++ b/frontend/web/styles/components/_list-item.scss
@@ -35,7 +35,7 @@
   }
   a:hover svg {
     path {
-      fill: $primary;
+      fill: var(--color-text-action);
     }
   }
 }
@@ -43,14 +43,8 @@
 .dark {
   .list-item {
     color: $text-icon-light;
-    &.clickable:hover .btn-link {
-      color: $primary400;
-    }
-      .btn-link {
-      color: $primary400;
-      path {
-        fill: $primary400;
-      }
+    .btn-link path {
+      fill: var(--color-text-action);
     }
   }
 }

--- a/frontend/web/styles/components/_panel.scss
+++ b/frontend/web/styles/components/_panel.scss
@@ -121,8 +121,9 @@
         }
       }
     }
-    .list-item:hover a,.btn-link {
-      color: $primary !important;
+    .list-item:hover a,
+    .btn-link {
+      color: var(--color-text-action) !important;
     }
 
     &.panel-integrations {

--- a/frontend/web/styles/components/_panel.scss
+++ b/frontend/web/styles/components/_panel.scss
@@ -121,6 +121,7 @@
         }
       }
     }
+
     // :hover is spelled out because `a:hover` above is also !important and
     // more specific, so a hovered link would otherwise still go near-white.
     .list-item:hover a,

--- a/frontend/web/styles/components/_panel.scss
+++ b/frontend/web/styles/components/_panel.scss
@@ -121,8 +121,11 @@
         }
       }
     }
+    // :hover is spelled out because `a:hover` above is also !important and
+    // more specific, so a hovered link would otherwise still go near-white.
     .list-item:hover a,
-    .btn-link {
+    .btn-link,
+    .btn-link:hover {
       color: var(--color-text-action) !important;
     }
 

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -20,7 +20,7 @@ button.btn {
       background: transparent;
     }
     &.btn:active {
-      color: $link-color;
+      color: var(--color-text-action);
       background: transparent;
     }
   }
@@ -286,7 +286,7 @@ button.btn-link {
   vertical-align: baseline;
   font-family: $font-family;
   background: transparent;
-  color: $link-color;
+  color: var(--color-text-action);
   @include transition(all 200ms);
   border: none;
   box-shadow: none;
@@ -297,7 +297,7 @@ button.btn-link {
   font-weight: 500;
   &:hover,
   &:focus {
-    color: $link-color;
+    color: var(--color-text-action);
     background: transparent;
     text-decoration: underline;
     border: none;
@@ -412,7 +412,6 @@ $add-btn-size: 34px;
       &:active,
       &:focus {
         background-color: transparent;
-        color: $dark-highlight-color;
       }
     }
     .btn-radio {
@@ -452,8 +451,5 @@ $add-btn-size: 34px;
         background-color: $danger-alfa-8;
       }
     }
-  }
-  .btn-link {
-    color: $primary;
   }
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8180

In dark mode a link was #906af6 inside a list item, #6837fc elsewhere, and #e1e1e1 on hover. Every link colour now reads `--color-text-action`, and the `.dark` blocks that only restated a value are gone.

Light mode is unchanged. Dark settles on #906af6, already what list items used.

- `_buttons.scss`: `.btn-link` base, hover, active. Dropped `.dark .btn-link` and the dark hover.
- `_list-item.scss`: the two `$primary400` rules and the icon fill.
- `_panel.scss`: the `!important` override keeps `!important`, value only.

Leaves the global `a` rule alone. #1E0D26 / #e1e1e1 is body text, not a link colour.

Makes #8178 safe: `.link` and `.btn-link` then match by construction, so migrating a call site is not a visual change.

## How did you test this code?

- `rspack build`: compiles, 24 pre-existing bootstrap warnings.
- Built CSS: `.btn-link` resolves to the token, nothing hardcodes the old dark purple.
- Brace balance checked against `main`, since whole rules were deleted.

Dark mode is the whole risk and wants a visual regression run. One screen per rule is enough:

- [ ] **Audit Log** — list item links, `_list-item.scss`
- [ ] **Integrations** — the `!important` override, `_panel.scss`
- [ ] **Login** — link-styled buttons, `.btn-link` base and hover

Watch for: links inside and outside a list item now matching, hover no longer going near-white, and light mode not moving.