### PR TITLE
fix(Utils): coerce non-string values before split in validateRule

### DIFF
--- a/frontend/common/utils/__tests__/utils.test.ts
+++ b/frontend/common/utils/__tests__/utils.test.ts
@@ -1,0 +1,96 @@
+// These stores pull in `window` globals (via the flux dispatcher) that
+// aren't available under the jest `node` test environment, so they're
+// mocked out to allow `common/utils/utils` to load for real.
+jest.mock('common/stores/account-store', () => ({}))
+jest.mock('common/stores/project-store', () => ({}))
+jest.mock('common/store', () => ({ getStore: () => ({}) }))
+jest.mock('@flagsmith/flagsmith', () => ({
+  getValue: (_key: string, opts: { fallback: unknown }) => opts.fallback,
+}))
+
+import Utils from 'common/utils/utils'
+import { SegmentCondition } from 'common/types/responses'
+
+const buildRule = (overrides: Partial<SegmentCondition>): SegmentCondition => ({
+  operator: 'EQUAL',
+  property: 'trait',
+  value: '',
+  ...overrides,
+})
+
+describe('validateRule', () => {
+  it('returns false for a falsy rule', () => {
+    expect(Utils.validateRule(undefined as unknown as SegmentCondition)).toBe(
+      false,
+    )
+  })
+
+  it('returns true for a rule marked as deleted regardless of its value', () => {
+    const rule = buildRule({
+      delete: true,
+      operator: 'MODULO',
+      value: undefined as unknown as string,
+    })
+    expect(() => Utils.validateRule(rule)).not.toThrow()
+    expect(Utils.validateRule(rule)).toBe(true)
+  })
+
+  describe('does not throw and returns false when value is missing', () => {
+    it.each<[string, SegmentCondition['value']]>([
+      ['undefined', undefined as unknown as string],
+      ['null', null],
+      ['empty string', ''],
+    ])('MODULO with %s value', (_label, value) => {
+      const rule = buildRule({ operator: 'MODULO', value })
+      expect(() => Utils.validateRule(rule)).not.toThrow()
+      expect(Utils.validateRule(rule)).toBe(false)
+    })
+
+    it.each<[string, SegmentCondition['value']]>([
+      ['undefined', undefined as unknown as string],
+      ['null', null],
+      ['empty string', ''],
+    ])('semver operator with %s value', (_label, value) => {
+      const rule = buildRule({ operator: 'GREATER_THAN:semver', value })
+      expect(() => Utils.validateRule(rule)).not.toThrow()
+      expect(Utils.validateRule(rule)).toBe(false)
+    })
+  })
+
+  it('does not throw when value is a non-string type for MODULO', () => {
+    const rule = buildRule({ operator: 'MODULO', value: true })
+    expect(() => Utils.validateRule(rule)).not.toThrow()
+  })
+
+  it('does not throw when value is a non-string type for a semver operator', () => {
+    const rule = buildRule({ operator: 'GREATER_THAN:semver', value: true })
+    expect(() => Utils.validateRule(rule)).not.toThrow()
+  })
+
+  it('is valid for a hideValue operator (e.g. IS_SET) even with a null value', () => {
+    const rule = buildRule({ operator: 'IS_SET', value: null })
+    expect(() => Utils.validateRule(rule)).not.toThrow()
+    expect(Utils.validateRule(rule)).toBe(true)
+  })
+
+  it('validates a correct MODULO value', () => {
+    const rule = buildRule({ operator: 'MODULO', value: '2|1' })
+    expect(Utils.validateRule(rule)).toBe(true)
+  })
+
+  it('validates a correct semver value', () => {
+    const rule = buildRule({
+      operator: 'GREATER_THAN:semver',
+      value: '1.0.0:semver',
+    })
+    expect(Utils.validateRule(rule)).toBe(true)
+  })
+
+  it('rejects an invalid semver value', () => {
+    const rule = buildRule({
+      operator: 'GREATER_THAN:semver',
+      value: 'not-a-version',
+    })
+    expect(Utils.validateRule(rule)).toBe(false)
+  })
+})

--- a/frontend/common/utils/__tests__/utils.test.ts
+++ b/frontend/common/utils/__tests__/utils.test.ts
@@ -60,11 +60,13 @@ describe('validateRule', () => {
   it('does not throw when value is a non-string type for MODULO', () => {
     const rule = buildRule({ operator: 'MODULO', value: true })
     expect(() => Utils.validateRule(rule)).not.toThrow()
+    expect(Utils.validateRule(rule)).toBe(false)
   })
 
   it('does not throw when value is a non-string type for a semver operator', () => {
     const rule = buildRule({ operator: 'GREATER_THAN:semver', value: true })
     expect(() => Utils.validateRule(rule)).not.toThrow()
+    expect(Utils.validateRule(rule)).toBe(false)
   })
 
   it('is valid for a hideValue operator (e.g. IS_SET) even with a null value', () => {

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -823,7 +823,7 @@ const Utils = Object.assign({}, BaseUtils, {
       if (!rule.value) {
         return false
       }
-      return !!semver.valid(`${rule.value.split(':')[0]}`)
+      return !!semver.valid(`${rule.value}`.split(':')[0])
     }
 
     switch (rule.operator) {
@@ -846,7 +846,7 @@ const Utils = Object.assign({}, BaseUtils, {
         if (!rule.value) {
           return false
         }
-        const valueSplit = rule.value.split('|')
+        const valueSplit = `${rule.value}`.split('|')
         if (valueSplit.length === 2) {
           const [divisor, remainder] = [
             parseFloat(valueSplit[0]),


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7536

`Utils.validateRule` (used by both the create-segment and edit-segment forms to decide whether a condition row is valid) crashes with `TypeError: Cannot read properties of undefined (reading 'split')` for some segment conditions.

#7779 previously added a guard so a missing (`null`/`undefined`) condition value returns `false` instead of crashing for the semver and Modulo operators. That guard only covers a *missing* value, though — it still calls `.split()` directly on `rule.value` once the value is present. If a condition reaches `validateRule` with a truthy value that isn't a string (for example a boolean, which can happen while a condition row's value is mid-update), `.split` doesn't exist on it and the same class of crash occurs, which is why this issue stayed open after #7779 merged.

This PR coerces the value to a string (`` `${rule.value}` ``) before calling `.split()` in both the semver and Modulo branches, so `validateRule` never throws regardless of what type the value happens to be, while keeping the existing pass/fail validation behaviour for well-formed input unchanged.

## How did you test this code?

Added unit tests in `frontend/common/utils/__tests__/utils.test.ts` covering `validateRule` for the Modulo and semver operators with missing (`undefined`/`null`/empty string) and non-string (boolean) values, plus the `IS_SET`/`IS_NOT_SET` "hideValue" operator, and existing valid/invalid value cases. The two non-string-value tests fail on the code prior to this fix (confirmed by reverting the fix locally and re-running) and pass afterwards.

Ran the full frontend unit test suite (`npm run test:unit`): 368 tests passed across 28 suites. Also ran `npx eslint` and `npm run typecheck` against the changed files — no new lint or type errors introduced.