### PR TITLE
fix(api): update-traits returns 400 for malformed request body

### DIFF
--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -176,6 +176,8 @@ class EdgeIdentityViewSet(
         if not environment.project.organisation.persist_trait_data:
             raise TraitPersistenceError()
         edge_identity = self.get_object()
+        if not isinstance(request.data, dict):
+            raise ValidationError({"detail": "Request data must be a JSON object."})
         try:
             trait = TraitModel(**request.data)
         except pydantic.ValidationError as validation_error:

--- a/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
@@ -696,3 +696,30 @@ def test_edge_identities_update_trait__persist_trait_data_disabled__returns_400(
     )
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_edge_identities_update_trait__malformed_payload__returns_400(  # type: ignore[no-untyped-def]
+    admin_client,
+    dynamo_enabled_environment,
+    environment_api_key,
+    identity_document,
+    edge_identity_dynamo_wrapper_mock,
+):
+    # Given
+    edge_identity_dynamo_wrapper_mock.get_item_from_uuid_or_404.return_value = (
+        identity_document
+    )
+    identity_uuid = identity_document["identity_uuid"]
+    url = reverse(
+        "api-v1:environments:environment-edge-identities-update-traits",
+        args=[environment_api_key, identity_uuid],
+    )
+    data = [{"trait_key": "some_trait_key", "trait_value": "some_trait_value"}]
+
+    # When
+    response = admin_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7951

The edge identity `update-traits` endpoint (`PUT /api/v1/environments/<api_key>/edge-identities/<uuid>/update-traits/`) crashed with a 500 error instead of returning a 400 when the request body wasn't a JSON object — for example, sending a JSON array as the payload.

This happened because the view unpacked the request body directly into a pydantic model (`TraitModel(**request.data)`). When `request.data` was a list, Python raised a `TypeError` on the `**` unpacking itself, before pydantic ever got a chance to validate anything, so the existing `except pydantic.ValidationError` handler never caught it.

The fix adds an explicit check that the request body is a JSON object before unpacking it, returning a standard 400 validation error otherwise — consistent with how the endpoint already reports other validation failures.

## How did you test this code?

Added a test (`test_edge_identities_update_trait__malformed_payload__returns_400`) that sends a JSON array as the request body to the update-traits endpoint and asserts a 400 response. I confirmed this test reproduces the original crash on the unpatched code (fails with the exact `TypeError` from the linked Sentry issue) and passes with the fix applied.

Ran the full test module for this view (`api/tests/integration/edge_api/identities/test_edge_identity_viewset.py`, 22 tests) against a local Postgres database — all passing. Also ran `ruff` (lint + format) and `mypy` on the changed files with no issues.