### PR TITLE
fix(auth): disable Google sign-in button until OAuth script is ready

### DIFF
--- a/frontend/web/components/GoogleButton.tsx
+++ b/frontend/web/components/GoogleButton.tsx
@@ -5,6 +5,7 @@ import { Icon } from './icons'
 
 type GoogleButtonProps = {
   className?: string
+  ready?: boolean
   onSuccess?: (
     tokenResponse: Omit<
       TokenResponse,
@@ -12,7 +13,11 @@ type GoogleButtonProps = {
     >,
   ) => void
 }
-const GoogleButton: FC<GoogleButtonProps> = ({ className, onSuccess }) => {
+const GoogleButton: FC<GoogleButtonProps> = ({
+  className,
+  onSuccess,
+  ready,
+}) => {
   const login = useGoogleLogin({
     onSuccess: (tokenResponse) => {
       onSuccess?.(tokenResponse)
@@ -24,7 +29,8 @@ const GoogleButton: FC<GoogleButtonProps> = ({ className, onSuccess }) => {
       className={className}
       theme='secondary'
       key='google'
-      onClick={() => login()}
+      disabled={!ready}
+      onClick={() => ready && login()}
     >
       <Icon name='google' />
       Google

--- a/frontend/web/components/GoogleButton.tsx
+++ b/frontend/web/components/GoogleButton.tsx
@@ -5,7 +5,7 @@ import { Icon } from './icons'
 
 type GoogleButtonProps = {
   className?: string
-  ready?: boolean
+  ready: boolean
   onSuccess?: (
     tokenResponse: Omit<
       TokenResponse,

--- a/frontend/web/components/pages/HomePage.tsx
+++ b/frontend/web/components/pages/HomePage.tsx
@@ -36,6 +36,7 @@ import useSignupExperiment from 'common/useSignupExperiment'
 const HomePage: React.FC = () => {
   const history = useHistory()
   const location = useLocation()
+  const [googleReady, setGoogleReady] = useState(false)
   const [allRequirementsMet, setAllRequirementsMet] = useState(false)
   const [email, setEmail] = useState('')
   const [firstName, setFirstName] = useState('')
@@ -231,9 +232,12 @@ const HomePage: React.FC = () => {
             clientId={
               JSON.parse(Utils.getFlagsmithValue('oauth_google')).clientId
             }
+            onScriptLoadSuccess={() => setGoogleReady(true)}
+            onScriptLoadError={() => setGoogleReady(false)}
           >
             <GoogleButton
               className='w-100'
+              ready={googleReady}
               onSuccess={(e) => {
                 document.location.href = `${
                   document.location.origin


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6554

`GoogleButton` called `login()` from `useGoogleLogin` unconditionally on click. On slow connections, the Google Identity Services script hasn't loaded yet, so the internal token client `useGoogleLogin` depends on isn't ready, and clicking throws `TypeError: Cannot read properties of undefined (reading 'requestAccessToken')`.

`useGoogleLogin` in the installed version of `@react-oauth/google` (`^0.2.8`) only returns the login callback — it doesn't expose a readiness flag itself. `GoogleOAuthProvider` does expose `onScriptLoadSuccess`/`onScriptLoadError` callbacks, so `HomePage` now tracks script-load state via those and passes it down to `GoogleButton` as a `ready` prop, which disables the button (and no-ops the click handler defensively) until the script has actually loaded.

## How did you test this code?

Manually, since this needs a real network to reproduce (slow connection to Google's GSI script). Verified via code reading that:
- `useGoogleLogin`'s real type signature (checked `node_modules/@react-oauth/google/dist/index.d.ts`) only returns the callback, confirming the issue's originally suggested `{ login, ready }` destructure doesn't exist for this library version.
- `GoogleOAuthProvider` is used in exactly one place in the app (`HomePage.tsx`), so threading the `ready` prop through doesn't affect any other consumer.
- `npx eslint --fix` on both touched files — clean.
- `npm run typecheck` — confirmed identical error count with and without this change (pre-existing unrelated errors only), so this introduces zero new type errors.