### PR TITLE
fix(Multivariate): creating an option without default_percentage_allocation returns 500

### DIFF
--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -61,6 +61,14 @@ class FeatureMVOptionsValuesResponseSerializer(serializers.Serializer):  # type:
 
 
 class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSerializer):
+    # The model field has `default=100`, which only makes DRF mark this field
+    # `required=False` — it does not carry the default into `validated_data`.
+    # Declare it explicitly so omitting it from the request does not raise a
+    # `KeyError` in `validate()` below.
+    default_percentage_allocation = serializers.FloatField(
+        default=100, min_value=0, max_value=100
+    )
+
     class Meta(NestedMultivariateFeatureOptionSerializer.Meta):
         fields = NestedMultivariateFeatureOptionSerializer.Meta.fields + ("feature",)  # type: ignore[assignment]
         read_only_fields = ("uuid",)  # type: ignore[assignment]

--- a/api/tests/integration/features/multivariate/test_integration_multivariate.py
+++ b/api/tests/integration/features/multivariate/test_integration_multivariate.py
@@ -44,6 +44,32 @@ def test_create_mv_option__valid_data__returns_created(  # type: ignore[no-untyp
     assert set(data.items()).issubset(set(response.json().items()))
 
 
+def test_create_mv_option__no_default_percentage_allocation__defaults_to_100(
+    admin_client_new: APIClient,
+    project: int,
+    feature: int,
+) -> None:
+    # Given - the request omits `default_percentage_allocation` entirely
+    url = reverse(
+        "api-v1:projects:feature-mv-options-list",
+        args=[project, feature],
+    )
+    data = {
+        "type": "unicode",
+        "feature": feature,
+        "string_value": "bigger",
+    }
+    # When
+    response = admin_client_new.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    # Then - it defaults to the model's default instead of a 500 KeyError
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["default_percentage_allocation"] == 100
+
+
 def test_create_mv_option__with_key__returns_created_with_key(
     admin_client_new: APIClient,
     project: int,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6615

`MultivariateFeatureOptionSerializer.validate()` reads `attrs["default_percentage_allocation"]` directly. The model field has `default=100`, which makes DRF mark the serializer field `required=False`, but DRF does not carry a model field's default into `validated_data` — it only omits the key entirely from `attrs` if the request doesn't supply it. So POSTing to create a multivariate option without `default_percentage_allocation` in the payload raised an unhandled `KeyError` (500) instead of falling back to the model's own default of 100.

Fixed by declaring the field explicitly on the serializer with `default=100` (carrying forward the existing `min_value`/`max_value` validators), so DRF always populates `validated_data` with it.

## How did you test this code?

Added `test_create_mv_option__no_default_percentage_allocation__defaults_to_100`, following the existing integration test conventions in `test_integration_multivariate.py`. Confirmed it reproduces the exact reported `KeyError` when temporarily reverting the fix, and passes with the fix applied. Ran the full multivariate test suite (65 tests, unit + integration) — all green. Ran `make lint` and `make typecheck` — both clean.