### PR TITLE
fix(features): _validate_owner_removal counts request IDs instead of actual existing owners

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -448,8 +448,8 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         serializer.is_valid(raise_exception=True)
         self._validate_owner_removal(
             feature,
-            owners_to_remove=0,
-            group_owners_to_remove=len(serializer.validated_data["group_ids"]),
+            user_ids_to_remove=[],
+            group_ids_to_remove=serializer.validated_data["group_ids"],
         )
         serializer.remove_group_owners(feature)
         response = Response(self.get_serializer(instance=feature).data)
@@ -486,8 +486,8 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         feature = self.get_object()
         self._validate_owner_removal(
             feature,
-            owners_to_remove=len(serializer.validated_data["user_ids"]),
-            group_owners_to_remove=0,
+            user_ids_to_remove=serializer.validated_data["user_ids"],
+            group_ids_to_remove=[],
         )
         serializer.remove_users(feature)
 
@@ -496,11 +496,15 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     def _validate_owner_removal(
         self,
         feature: Feature,
-        owners_to_remove: int,
-        group_owners_to_remove: int,
+        user_ids_to_remove: list[int],
+        group_ids_to_remove: list[int],
     ) -> None:
         if not feature.project.enforce_feature_owners:
             return
+        owners_to_remove = feature.owners.filter(id__in=user_ids_to_remove).count()
+        group_owners_to_remove = feature.group_owners.filter(
+            id__in=group_ids_to_remove
+        ).count()
         remaining = (
             feature.owners.count()
             - owners_to_remove

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -5468,3 +5468,39 @@ def test_remove_group_owners__enforce_owners_user_owners_remain__returns_200(
     feature.refresh_from_db()
     assert group not in feature.group_owners.all()
     assert admin_user in feature.owners.all()
+
+
+def test_remove_group_owners__enforce_owners_nonexistent_group_id_in_request__returns_200(
+    admin_client_new: APIClient,
+    project: Project,
+    feature: Feature,
+    admin_user: FFAdminUser,
+    organisation: Organisation,
+) -> None:
+    # Given
+    project.enforce_feature_owners = True
+    project.save()
+    group = UserPermissionGroup.objects.create(
+        name="Test Group", organisation=organisation
+    )
+    feature.owners.add(admin_user)
+    feature.group_owners.add(group)
+
+    url = reverse(
+        "api-v1:projects:project-features-remove-group-owners",
+        args=[project.id, feature.id],
+    )
+    # A nonexistent group id in the request should not inflate the
+    # removal count and block the removal of the real group owner.
+    data = {"group_ids": [group.id, 999999999]}
+
+    # When
+    response = admin_client_new.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    feature.refresh_from_db()
+    assert group not in feature.group_owners.all()
+    assert admin_user in feature.owners.all()


### PR DESCRIPTION
When `enforce_feature_owners` is enabled, removing feature owners could be incorrectly blocked. `_validate_owner_removal` counted the number of IDs *in the request* rather than the number of IDs that actually exist as owners on the feature. Since the group owner serializer doesn't validate that submitted group IDs exist, a stale or non-existent group ID in a `remove-group-owners` request inflated the removal count and caused the endpoint to reject a legitimate removal with a 400.

## Changes
- [x] `_validate_owner_removal` now checks which of the submitted IDs actually match current owners/group owners on the feature, instead of trusting the request's ID count.

Closes #8038

Review effort: 2/5

## How did you test this code?
Added a regression test reproducing the exact scenario from the issue (removing a real group owner alongside a non-existent group ID) and confirmed it fails on the old code (400) and passes with the fix (200). Ran the full `features` unit test suite (298 passed, 2 unrelated skipped), `mypy`, and the project's pre-commit hooks (lint/format/doc-gen) locally — all green.