### PR TITLE
feat(experimentation): set 365-day retention on Firehose CloudWatch log groups

### DIFF
--- a/api/experimentation/ingestion_infra_service.py
+++ b/api/experimentation/ingestion_infra_service.py
@@ -50,6 +50,8 @@ ORGANISATION_TAG_KEY = "organisation_id"
 # Firehose writes delivery failures to this CloudWatch log group and stream.
 LOG_GROUP_NAME_PREFIX = "/aws/kinesisfirehose/"
 LOG_STREAM_NAME = "DestinationDelivery"
+# Must be one of the values accepted by CloudWatch Logs PutRetentionPolicy.
+LOG_RETENTION_DAYS = 365
 
 
 def _add_account_regional_namespace_header(
@@ -199,6 +201,10 @@ def _create_delivery_stream(
     log_group_name = get_log_group_name(organisation_id)
     logs = _get_logs_client()
     logs.create_log_group(logGroupName=log_group_name)
+    logs.put_retention_policy(
+        logGroupName=log_group_name,
+        retentionInDays=LOG_RETENTION_DAYS,
+    )
     logs.create_log_stream(
         logGroupName=log_group_name,
         logStreamName=LOG_STREAM_NAME,

--- a/api/tests/unit/experimentation/test_ingestion_infra_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_infra_service.py
@@ -157,6 +157,10 @@ def test_provision_ingestion_infrastructure__fresh_account__creates_bucket_and_s
     assert stream_tags["Tags"] == [{"Key": "organisation_id", "Value": "42"}]
 
     logs = boto3.client("logs", region_name="eu-west-2")
+    log_groups = logs.describe_log_groups(
+        logGroupNamePrefix="/aws/kinesisfirehose/events-ingestion-org-42",
+    )["logGroups"]
+    assert [group["retentionInDays"] for group in log_groups] == [365]
     log_streams = logs.describe_log_streams(
         logGroupName="/aws/kinesisfirehose/events-ingestion-org-42",
     )["logStreams"]

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -103,7 +103,7 @@ Attributes:
 ### `experimentation.ingestion_infra.bucket_created`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:108`
+ - `api/experimentation/ingestion_infra_service.py:110`
 
 Attributes:
  - `bucket.name`
@@ -112,7 +112,7 @@ Attributes:
 ### `experimentation.ingestion_infra.deprovisioned`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:261`
+ - `api/experimentation/ingestion_infra_service.py:267`
 
 Attributes:
  - `bucket.name`
@@ -141,7 +141,7 @@ Attributes:
 ### `experimentation.ingestion_infra.stream_created`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:215`
+ - `api/experimentation/ingestion_infra_service.py:221`
 
 Attributes:
  - `bucket.name`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The per-organisation Firehose delivery-failure log groups were created without a retention policy, so CloudWatch kept them forever.

- Set a 365-day retention policy on the log group at provisioning time.
- Existing log groups are unaffected; they need a one-off backfill.

## How did you test this code?

Unit tests in `test_ingestion_infra_service.py` assert the retention policy on the created log group via moto; all 7 tests pass locally.