### PR TITLE
fix(forms): colour a control that is already known to be invalid

### DIFF
--- a/frontend/documentation/components/InputGroup.stories.tsx
+++ b/frontend/documentation/components/InputGroup.stories.tsx
@@ -77,6 +77,21 @@ export const MultipleErrors: Story = {
   ),
 }
 
+// Untouched on purpose: isInvalid colours the control straight away, which is
+// what a form submitted with Enter needs. isValid alone waits for a blur.
+export const InvalidBeforeBlur: Story = {
+  render: () => (
+    <Field
+      title='Email'
+      isInvalid
+      inputProps={{
+        error: 'A user with this email address already exists.',
+        name: 'email',
+      }}
+    />
+  ),
+}
+
 export const Disabled: Story = {
   render: () => <Field title='Email' initialValue='you@example.com' disabled />,
 }

--- a/frontend/web/components/base/forms/Input.tsx
+++ b/frontend/web/components/base/forms/Input.tsx
@@ -21,6 +21,8 @@ export interface InputMethods {
 
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  // Show the invalid state without waiting for the field to be touched, for a
+  // validity known up front, e.g. the API rejected the value.
   autoValidate?: boolean
   centered?: boolean
   inputClassName?: string
@@ -69,9 +71,7 @@ const Input: React.FC<InputProps> = ({
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [isFocused, setIsFocused] = useState(false)
-  const [shouldValidate, setShouldValidate] = useState(
-    !!value || !!autoValidate,
-  )
+  const [hasBeenTouched, setHasBeenTouched] = useState(!!value)
   const [type, setType] = useState(typeProp)
 
   // No-op under E2E to avoid programmatic focus stealing during tests; native
@@ -90,7 +90,7 @@ const Input: React.FC<InputProps> = ({
 
   const onBlur = (e: FocusEvent<HTMLInputElement>) => {
     setIsFocused(false)
-    setShouldValidate(true)
+    setHasBeenTouched(true)
     onBlurProp?.(e)
   }
 
@@ -101,7 +101,7 @@ const Input: React.FC<InputProps> = ({
     onKeyDownProp?.(e)
   }
 
-  const invalid = shouldValidate && !isValid
+  const invalid = (hasBeenTouched || !!autoValidate) && !isValid
   const success = isValid && showSuccess
   const sizeClassName = size ? sizeClassNames[size] : ''
   const containerClassName = cn(

--- a/frontend/web/components/base/forms/InputGroup.tsx
+++ b/frontend/web/components/base/forms/InputGroup.tsx
@@ -94,6 +94,14 @@ const InputGroup: FC<InputGroupProps> = ({
   // the message for this field (htmlFor/id/aria-describedby all share `id`).
   const errorId = `${id}-error`
   const hasError = Array.isArray(error) ? error.length > 0 : !!error
+  // isInvalid is the caller stating the value is wrong, so it beats the computed
+  // validity and skips the wait for a blur.
+  let inputIsValid: boolean | undefined
+  if (isInvalid) {
+    inputIsValid = false
+  } else if (isValid !== null && isValid !== undefined) {
+    inputIsValid = !!isValid
+  }
   let errorContent: ReactNode = null
   if (typeof error === 'string') {
     errorContent = error
@@ -152,11 +160,8 @@ const InputGroup: FC<InputGroupProps> = ({
                   inputRef.current = c
                 }}
                 {...restInputProps}
-                isValid={
-                  isValid === null || isValid === undefined
-                    ? undefined
-                    : !!isValid
-                }
+                autoValidate={!!isInvalid}
+                isValid={inputIsValid}
                 disabled={disabled}
                 defaultValue={defaultValue}
                 value={value}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Split out of #8177, where it was scope creep.

A text field only turns red once it has been blurred. Submit a form with
Enter and you get the error message underneath a grey border, so nothing
points at the field that is wrong.

`autoValidate` already meant "do not wait for the field to be touched", but it
was copied into state at mount, so it could not react to an error arriving
later. Reading it live is the fix:

```diff
-const [shouldValidate, setShouldValidate] = useState(!!value || !!autoValidate)
+const [hasBeenTouched, setHasBeenTouched] = useState(!!value)
-const invalid = shouldValidate && !isValid
+const invalid = (hasBeenTouched || !!autoValidate) && !isValid
```

`InputGroup` already had an `isInvalid` prop, but it only put a class on the
wrapper and never reached the control. It now forwards to `Input`.

No new prop, and no call site has to change.

## How did you test this code?

The behaviour is opt-in, so the 100-odd existing `InputGroup` call sites are
unaffected: `isInvalid` currently has no consumers on main, and `autoValidate`
has exactly one (`RegexTester`), which passes a static `true` and so behaves
identically either way.

- [ ] Storybook, `Components/Forms/InputGroup`: the new **InvalidBeforeBlur** story should show a red border on an untouched field. On main the same story is grey.
- [ ] The other InputGroup stories (WithError, MultipleErrors, Disabled, Sizes) should be unchanged.
- [ ] `Components/Forms/Input` stories unchanged.
- [ ] A form where a field validates on blur should still stay neutral until you leave it, i.e. no form goes red before you have typed.
