### PR TITLE
fix(organisations): don't fetch an organisation with a non-numeric id

### DIFF
--- a/frontend/common/stores/organisation-store.js
+++ b/frontend/common/stores/organisation-store.js
@@ -7,8 +7,8 @@ import { getSubscriptionMetadata } from 'common/services/useSubscriptionMetadata
 import Dispatcher from 'common/dispatcher/dispatcher'
 import BaseStore from './base/_store'
 import data from 'common/data/base/_data'
+import { isNumericId } from 'common/utils/isNumericId'
 import filter from 'lodash/filter'
-import find from 'lodash/find'
 import findIndex from 'lodash/findIndex'
 import keyBy from 'lodash/keyBy'
 
@@ -75,10 +75,7 @@ const controller = {
     const idInt = parseInt(id)
     store.saving()
     if (store.model) {
-      store.model.projects = filter(
-        store.model.projects,
-        (p) => p.id !== idInt,
-      )
+      store.model.projects = filter(store.model.projects, (p) => p.id !== idInt)
       store.model.keyedProjects = keyBy(store.model.projects, 'id')
     }
     API.trackEvent(Constants.events.REMOVE_PROJECT)
@@ -118,6 +115,11 @@ const controller = {
       })
   },
   getOrganisation: (id, force) => {
+    // store.id seeds to the string 'account' and the dispatcher falls back to
+    // it, so a non-numeric id reaches here. The API can only reject it.
+    if (!isNumericId(id)) {
+      return
+    }
     if (`${id}` !== `${store.id}` || force) {
       store.id = id
       store.loading()
@@ -211,7 +213,9 @@ const controller = {
             projects.sort((a, b) => {
               const textA = a.name.toLowerCase()
               const textB = b.name.toLowerCase()
-              return textA < textB ? -1 : textA > textB ? 1 : 0
+              // Not localeCompare: it orders accents differently.
+              if (textA < textB) return -1
+              return textA > textB ? 1 : 0
             })
             store.model.projects = projects
             store.model.keyedProjects = keyBy(store.model.projects, 'id')

--- a/frontend/common/utils/__tests__/isNumericId.test.ts
+++ b/frontend/common/utils/__tests__/isNumericId.test.ts
@@ -1,7 +1,9 @@
 import { isNumericId } from 'common/utils/isNumericId'
 
 describe('isNumericId', () => {
-  it.each([1, 42, '7'])('accepts %p', (id) => {
+  // '007' is deliberate: DRF coerces a leading-zero string to the key 7, so the
+  // request works and rejecting it would be stricter than the API.
+  it.each([1, 42, '7', '007'])('accepts %p', (id) => {
     expect(isNumericId(id)).toBe(true)
   })
 

--- a/frontend/common/utils/__tests__/isNumericId.test.ts
+++ b/frontend/common/utils/__tests__/isNumericId.test.ts
@@ -1,0 +1,34 @@
+import { isNumericId } from 'common/utils/isNumericId'
+
+describe('isNumericId', () => {
+  it.each([1, 42, '7'])('accepts %p', (id) => {
+    expect(isNumericId(id)).toBe(true)
+  })
+
+  // 'account' prompted this: it reached projects/?organisation=account, which
+  // the API rejects as not an integer.
+  it.each(['account', 'undefined', 'NaN', '1.5', 'getting-started'])(
+    'refuses %p',
+    (id) => {
+      expect(isNumericId(id)).toBe(false)
+    },
+  )
+
+  it.each([undefined, null, '', 0, NaN])('refuses %p', (id) => {
+    expect(isNumericId(id)).toBe(false)
+  })
+
+  // Number() turns each of these into an integer, so truthiness alone lets
+  // them through.
+  it.each([true, [], ['5'], {}])('refuses the coercible %p', (id) => {
+    expect(isNumericId(id)).toBe(false)
+  })
+
+  // 0 and '0' disagreed under the truthiness check. Neither is a primary key.
+  it.each(['0', 0, '-1', -1])(
+    'refuses %p, which is not a primary key',
+    (id) => {
+      expect(isNumericId(id)).toBe(false)
+    },
+  )
+})

--- a/frontend/common/utils/isNumericId.ts
+++ b/frontend/common/utils/isNumericId.ts
@@ -1,0 +1,7 @@
+// Ids reach API calls unvalidated, since route params and store values arrive
+// as strings. Number() also coerces non-ids ([] and true become numbers), so the
+// input is narrowed first, and an id must be positive: these are serial keys.
+export const isNumericId = (id: unknown): boolean =>
+  (typeof id === 'number' || typeof id === 'string') &&
+  Number.isInteger(Number(id)) &&
+  Number(id) > 0


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

**Reviewing this:** one guard, at `organisation-store.js:120`, refusing an id the API cannot accept. The judgement call is what is *not* here: onboarding's refresh, which triggered this, is left alone because nothing reads it. Safe to skim the tests and three lint-driven reformats in the same file (a dead import, a `filter` reflow, the unnested ternary).

## Changes

`/getting-started` sent `organisation=account`, giving a 400 on `projects/` and a 500 on `organisations/{id}/users/`, plus a red `[object Response]` overlay locally.

We send that id ourselves. None of the code below changes in this PR, it is just where the id comes from:

```
bootstrapOnboarding.ts    AppActions.refreshOrganisation()      // no id
app-actions.js            dispatches GET_ORGANISATION, id absent
organisation-store.js     getOrganisation(action.id || store.id)
organisation-store.js     id: 'account'                          // seed value
```

`getOrganisation` now returns early on a non-numeric id, via a new `isNumericId`. `Number()` on its own is not enough, since it also accepts `[]`, `['5']` and `true`, so the input is narrowed to a string or a number first and has to be a positive integer.

Onboarding is left alone, because that refresh has never worked and nothing reads it. The project switcher is RTK (`BreadcrumbSeparator.tsx:198`) and `createProject` already invalidates the `Project` tag. The one Flux consumer of the organisation's project list is the organisation projects page, which fetches on mount (`ProjectManageWidget.tsx:63`).

The nested ternary in the same file is unnested because the commit hook lints whole staged files. It keeps the original comparison rather than `localeCompare`, which orders accents differently.

Production hits the same two failures and just renders an empty organisation view.

## Screenshots

**Before**, the local dev overlay:

<img width="1510" height="577" alt="image" src="https://github.com/user-attachments/assets/7db4081e-dc04-4135-8057-79a3dda16c4a" />

## How did you test this code?

- [x] `isNumericId` unit tests (21)
- [x] `test:unit` (422) clean, and no new typecheck errors in the touched files
- [x] `/getting-started`: no red overlay, and no `organisation=account` request in the network tab
- [x] Project switcher: the project onboarding creates shows up without a reload
- [x] Organisation projects page: still lists projects, each with its environments
