### PR TITLE
feat(onboarding): run the tour against the project named in the URL

### DIFF
--- a/frontend/common/hooks/__tests__/useLastEnv.test.ts
+++ b/frontend/common/hooks/__tests__/useLastEnv.test.ts
@@ -1,0 +1,16 @@
+import { parseLastEnv } from 'common/hooks/useLastEnv'
+
+describe('parseLastEnv', () => {
+  it('reads what usePageTracking wrote', () => {
+    const raw = JSON.stringify({ environmentId: 'abc', orgId: 1, projectId: 2 })
+    expect(parseLastEnv(raw)).toEqual({
+      environmentId: 'abc',
+      orgId: 1,
+      projectId: 2,
+    })
+  })
+
+  it.each([null, '', 'not json', '{'])('survives %p', (raw) => {
+    expect(parseLastEnv(raw)).toBeNull()
+  })
+})

--- a/frontend/common/hooks/useLastEnv.ts
+++ b/frontend/common/hooks/useLastEnv.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+// `lastEnv` is written by usePageTracking as you browse, and read by App and Nav
+// to restore where you were. environmentId is the api_key, since routes use it.
+export type LastEnv = {
+  orgId?: number | string
+  projectId?: number | string
+  environmentId?: string
+}
+
+export const parseLastEnv = (raw: string | null): LastEnv | null => {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+export const useLastEnv = (): LastEnv | null => {
+  const [lastEnv, setLastEnv] = useState<LastEnv | null>(null)
+
+  useEffect(() => {
+    if (typeof AsyncStorage === 'undefined') return
+    Promise.resolve(AsyncStorage.getItem('lastEnv')).then((raw) =>
+      setLastEnv(parseLastEnv(raw)),
+    )
+  }, [])
+
+  return lastEnv
+}

--- a/frontend/web/components/navigation/navbars/TopNavbar.tsx
+++ b/frontend/web/components/navigation/navbars/TopNavbar.tsx
@@ -8,6 +8,7 @@ import Headway from 'components/Headway'
 import { Project } from 'common/types/responses'
 import AccountDropdown from 'components/navigation/AccountDropdown'
 import ThemeToggle from 'components/ThemeToggle'
+import { useLastEnv } from 'common/hooks/useLastEnv'
 
 type TopNavType = {
   activeProject: Project | undefined
@@ -15,6 +16,14 @@ type TopNavType = {
 }
 
 const TopNavbar: FC<TopNavType> = ({ activeProject, projectId }) => {
+  // Name the project the tour should run against: the one you're in, else the
+  // one you were last in. Without it the page falls back to the org's first.
+  const lastEnv = useLastEnv()
+  const onboardingProjectId = projectId ?? lastEnv?.projectId
+  const gettingStartedTo = onboardingProjectId
+    ? `/getting-started?project=${onboardingProjectId}`
+    : '/getting-started'
+
   return (
     <React.Fragment>
       <nav className='mt-2 mb-1 space flex-row hidden-xs-down'>
@@ -33,7 +42,7 @@ const TopNavbar: FC<TopNavType> = ({ activeProject, projectId }) => {
           )}
           <NavLink
             activeClassName='active'
-            to={'/getting-started'}
+            to={gettingStartedTo}
             className='d-flex gap-1 d-none d-md-flex text-end lh-1 align-items-center'
           >
             <span>

--- a/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
+++ b/frontend/web/components/pages/onboarding/OnboardingFlow/OnboardingFlow.tsx
@@ -17,6 +17,7 @@ import { useOnboardingConnection } from 'components/pages/onboarding/hooks/useOn
 import { useUpdateOrganisationMutation } from 'common/services/useOrganisation'
 import { useUpdateProjectMutation } from 'common/services/useProject'
 import API from 'project/api'
+import OnboardingAlreadySetUp from 'components/pages/onboarding/onboarding-already-set-up'
 import Constants from 'common/constants'
 import './OnboardingFlow.scss'
 
@@ -30,6 +31,7 @@ const OnboardingFlow: FC = () => {
     environment,
     environmentKey,
     featureName: bootstrappedFeatureName,
+    hasDemoFlag,
     organisationId,
     organisationName,
     projectId,
@@ -194,6 +196,17 @@ const OnboardingFlow: FC = () => {
         </p>
         <Button onClick={() => window.location.reload()}>Try again</Button>
       </div>
+    )
+  }
+
+  // The project already had flags, so nothing was seeded to tour with.
+  if (!hasDemoFlag) {
+    return (
+      <OnboardingAlreadySetUp
+        projectName={projectDisplayName}
+        featuresHref={`/project/${projectId}/environment/${environmentKey}/features`}
+        onSkip={skipToApp}
+      />
     )
   }
 

--- a/frontend/web/components/pages/onboarding/hooks/__tests__/demoFlag.test.ts
+++ b/frontend/web/components/pages/onboarding/hooks/__tests__/demoFlag.test.ts
@@ -1,0 +1,45 @@
+import { ProjectFlag, Tag } from 'common/types/responses'
+import {
+  DEMO_FLAG_NAME,
+  findDemoFlag,
+  shouldSeedDemoFlag,
+} from 'components/pages/onboarding/hooks/demoFlag'
+
+const flag = (name: string, tags: number[] = []): ProjectFlag =>
+  ({ id: name.length, name, tags } as ProjectFlag)
+
+const onboardingTag = { id: 7, label: 'Onboarding' } as Tag
+
+describe('shouldSeedDemoFlag', () => {
+  it('seeds into an empty project', () => {
+    expect(shouldSeedDemoFlag([])).toBe(true)
+  })
+
+  it('seeds nothing once the project has flags of its own', () => {
+    // The customer's list. A flag they did not ask for would appear in every
+    // environment, production included.
+    expect(shouldSeedDemoFlag([flag('checkout_v2')])).toBe(false)
+  })
+})
+
+describe('findDemoFlag', () => {
+  it('finds a previous run by its tag, whatever it was renamed to', () => {
+    const renamed = flag('my_own_name', [onboardingTag.id])
+    expect(findDemoFlag([flag('checkout_v2'), renamed], onboardingTag)).toBe(
+      renamed,
+    )
+  })
+
+  it('falls back to the name when the tag is missing', () => {
+    const demo = flag(DEMO_FLAG_NAME)
+    expect(findDemoFlag([flag('checkout_v2'), demo], undefined)).toBe(demo)
+  })
+
+  it('finds nothing in a project that never ran the tour', () => {
+    expect(findDemoFlag([flag('checkout_v2')], onboardingTag)).toBeUndefined()
+  })
+
+  it('finds nothing in an empty project', () => {
+    expect(findDemoFlag([], onboardingTag)).toBeUndefined()
+  })
+})

--- a/frontend/web/components/pages/onboarding/hooks/__tests__/onboardingProject.test.ts
+++ b/frontend/web/components/pages/onboarding/hooks/__tests__/onboardingProject.test.ts
@@ -1,0 +1,30 @@
+import { ProjectSummary } from 'common/types/responses'
+import { selectOnboardingProject } from 'components/pages/onboarding/hooks/onboardingProject'
+
+const project = (id: number): ProjectSummary =>
+  ({ id, name: `project ${id}` } as ProjectSummary)
+
+const projects = [project(10), project(20), project(30)]
+
+describe('selectOnboardingProject', () => {
+  it('runs against the project named in the URL', () => {
+    expect(selectOnboardingProject(projects, 20)).toBe(projects[1])
+  })
+
+  it('matches the id as a string, which is how it arrives', () => {
+    expect(selectOnboardingProject(projects, '30')).toBe(projects[2])
+  })
+
+  it('ignores a project outside this organisation', () => {
+    // A link carried over from another org, or an edited URL.
+    expect(selectOnboardingProject(projects, 999)).toBe(projects[0])
+  })
+
+  it.each([null, undefined, ''])('falls back to the first with %p', (id) => {
+    expect(selectOnboardingProject(projects, id)).toBe(projects[0])
+  })
+
+  it('returns nothing for an empty org, so the caller creates one', () => {
+    expect(selectOnboardingProject([], 20)).toBeUndefined()
+  })
+})

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -16,6 +16,12 @@ import {
   ProjectSummary,
   Tag,
 } from 'common/types/responses'
+import {
+  DEMO_FLAG_NAME,
+  ONBOARDING_TAG,
+  findDemoFlag,
+  shouldSeedDemoFlag,
+} from './demoFlag'
 import { SmartDefaults } from './useSmartDefaults'
 import { createOrganisationViaAccountStore } from './createOrganisationViaAccountStore'
 import API from 'project/api'
@@ -23,17 +29,10 @@ import Constants from 'common/constants'
 
 type Store = ReturnType<typeof getStore>
 
-const FLAG_NAME = 'show_demo_button'
 const DEFAULT_ORG_NAME = 'My organisation'
 const DEFAULT_PROJECT_NAME = 'My first project'
 const DEV_ENVIRONMENT_NAME = 'Development'
 const PROD_ENVIRONMENT_NAME = 'Production'
-const ONBOARDING_TAG = {
-  color: '#3cb371',
-  description: 'Created during onboarding',
-  label: 'Onboarding',
-}
-
 type ExistingOrg = { id: number; name: string }
 
 export type BootstrapInput = {
@@ -47,6 +46,9 @@ export type OnboardingBootstrap = {
   project: ProjectSummary
   environment: Environment
   featureName: string
+  // False when the project already had flags, so we seeded nothing and the tour
+  // has no flag of its own to teach with.
+  hasDemoFlag: boolean
 }
 
 async function ensureOrganisation(
@@ -154,20 +156,20 @@ async function ensureFlag(
       }),
     )
     .unwrap()
+  const results = flags?.results ?? []
   const onboardingTag = await findOnboardingTag(store, project.id)
-  const existing =
-    (onboardingTag &&
-      flags?.results?.find((f) => f.tags?.includes(onboardingTag.id))) ||
-    flags?.results?.find((f) => f.name === FLAG_NAME)
+  const existing = findDemoFlag(results, onboardingTag)
   if (existing) {
     return existing
   }
-  const isFirstFeature = !flags?.results?.length
+  if (!shouldSeedDemoFlag(results)) {
+    return undefined
+  }
   const created = await store
     .dispatch(
       projectFlagService.endpoints.createProjectFlag.initiate({
         body: {
-          name: FLAG_NAME,
+          name: DEMO_FLAG_NAME,
           project: project.id,
           type: 'STANDARD',
         } as Req['createProjectFlag']['body'],
@@ -175,9 +177,7 @@ async function ensureFlag(
       }),
     )
     .unwrap()
-  if (isFirstFeature) {
-    API.trackEvent(Constants.events.CREATE_FIRST_FEATURE)
-  }
+  API.trackEvent(Constants.events.CREATE_FIRST_FEATURE)
   return created
 }
 
@@ -227,7 +227,8 @@ export async function bootstrapOnboarding(
   AppActions.refreshOrganisation()
   return {
     environment,
-    featureName: flag?.name ?? FLAG_NAME,
+    featureName: flag?.name ?? DEMO_FLAG_NAME,
+    hasDemoFlag: !!flag,
     organisationId: organisation.id,
     organisationName: organisation.name,
     project,

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -16,6 +16,7 @@ import {
   ProjectSummary,
   Tag,
 } from 'common/types/responses'
+import { selectOnboardingProject } from './onboardingProject'
 import {
   DEMO_FLAG_NAME,
   ONBOARDING_TAG,
@@ -36,6 +37,8 @@ const PROD_ENVIRONMENT_NAME = 'Production'
 type ExistingOrg = { id: number; name: string }
 
 export type BootstrapInput = {
+  // From `?project=` on the entry URL. Ignored when it isn't in this org.
+  requestedProjectId?: string | null
   defaults: SmartDefaults
   existingOrg?: ExistingOrg
 }
@@ -75,11 +78,12 @@ async function ensureProject(
   store: Store,
   organisationId: number,
   defaults: SmartDefaults,
+  requestedProjectId?: string | null,
 ): Promise<ProjectSummary> {
   const projects = await store
     .dispatch(projectService.endpoints.getProjects.initiate({ organisationId }))
     .unwrap()
-  const existing = projects?.[0]
+  const existing = selectOnboardingProject(projects ?? [], requestedProjectId)
   if (existing) {
     return existing
   }
@@ -218,7 +222,12 @@ export async function bootstrapOnboarding(
   input: BootstrapInput,
 ): Promise<OnboardingBootstrap> {
   const organisation = await ensureOrganisation(store, input)
-  const project = await ensureProject(store, organisation.id, input.defaults)
+  const project = await ensureProject(
+    store,
+    organisation.id,
+    input.defaults,
+    input.requestedProjectId,
+  )
   const environment = await ensureEnvironments(store, project)
   const flag = await ensureFlag(store, project)
   if (flag) {

--- a/frontend/web/components/pages/onboarding/hooks/demoFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/demoFlag.ts
@@ -1,0 +1,25 @@
+import { ProjectFlag, Tag } from 'common/types/responses'
+
+export const DEMO_FLAG_NAME = 'show_demo_button'
+
+export const ONBOARDING_TAG = {
+  color: '#3cb371',
+  description: 'Created during onboarding',
+  label: 'Onboarding',
+}
+
+// The demo flag from a previous run: tagged first, since the user is free to
+// rename it, and a rename is a delete and recreate so the name alone is not
+// reliable.
+export const findDemoFlag = (
+  flags: ProjectFlag[],
+  onboardingTag?: Tag,
+): ProjectFlag | undefined =>
+  (onboardingTag && flags.find((f) => f.tags?.includes(onboardingTag.id))) ||
+  flags.find((f) => f.name === DEMO_FLAG_NAME)
+
+// Only seed into an empty project. An established project's flag list belongs to
+// the customer, and a flag they did not ask for turns up in every environment,
+// production included, because features are project-level.
+export const shouldSeedDemoFlag = (flags: ProjectFlag[]): boolean =>
+  !flags.length

--- a/frontend/web/components/pages/onboarding/hooks/onboardingProject.ts
+++ b/frontend/web/components/pages/onboarding/hooks/onboardingProject.ts
@@ -1,0 +1,14 @@
+import { ProjectSummary } from 'common/types/responses'
+
+// /getting-started is an entry point rather than a project-scoped page, so the
+// project it should run against arrives as `?project=`. The URL is authoritative:
+// an id that isn't in this organisation's list is ignored rather than trusted.
+export const selectOnboardingProject = (
+  projects: ProjectSummary[],
+  requestedProjectId?: string | number | null,
+): ProjectSummary | undefined => {
+  const requested =
+    !!requestedProjectId &&
+    projects.find((p) => `${p.id}` === `${requestedProjectId}`)
+  return requested || projects[0]
+}

--- a/frontend/web/components/pages/onboarding/hooks/useEnsureOnboardingResources.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useEnsureOnboardingResources.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import { getStore } from 'common/store'
 import { useGetOrganisationsQuery } from 'common/services/useOrganisation'
 import useSelectedOrganisation from 'common/hooks/useSelectedOrganisation'
@@ -38,6 +39,10 @@ export const useEnsureOnboardingResources = (): OnboardingResources => {
     profile?.first_name ?? '',
   )
   const selectedOrganisation = useSelectedOrganisation()
+  // Which project to run against. The nav link carries it; a bare
+  // /getting-started (a fresh signup) has none.
+  const { search } = useLocation()
+  const requestedProjectId = new URLSearchParams(search).get('project')
 
   const [status, setStatus] = useState<OnboardingResourcesStatus>('creating')
   const [environment, setEnvironment] = useState<Environment | null>(null)
@@ -69,7 +74,11 @@ export const useEnsureOnboardingResources = (): OnboardingResources => {
       ? { id: existing.id, name: existing.name }
       : undefined
 
-    bootstrapOnboarding(getStore(), { defaults, existingOrg })
+    bootstrapOnboarding(getStore(), {
+      defaults,
+      existingOrg,
+      requestedProjectId,
+    })
       .then((res) => {
         setOrganisationId(res.organisationId)
         setOrganisationName(res.organisationName)
@@ -86,7 +95,16 @@ export const useEnsureOnboardingResources = (): OnboardingResources => {
         setError(e)
         setStatus('error')
       })
-  }, [profile, orgsLoading, organisations, selectedOrganisation, defaults])
+    // ranRef makes this run once, so requestedProjectId is read at that moment
+    // and a later URL change doesn't re-provision.
+  }, [
+    profile,
+    orgsLoading,
+    organisations,
+    selectedOrganisation,
+    defaults,
+    requestedProjectId,
+  ])
 
   return {
     caseSensitive,

--- a/frontend/web/components/pages/onboarding/hooks/useEnsureOnboardingResources.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useEnsureOnboardingResources.ts
@@ -15,6 +15,7 @@ export type OnboardingResources = {
   organisationName: string
   projectName: string
   featureName: string
+  hasDemoFlag: boolean
   caseSensitive: boolean
   environment: Environment | null
   environmentKey: string
@@ -46,6 +47,7 @@ export const useEnsureOnboardingResources = (): OnboardingResources => {
   const [organisationName, setOrganisationName] = useState('')
   const [projectName, setProjectName] = useState('')
   const [featureName, setFeatureName] = useState('')
+  const [hasDemoFlag, setHasDemoFlag] = useState(true)
   // Whether the project enforces lower-case feature names; drives the same name
   // normalisation the create-feature modal applies (see the header).
   const [caseSensitive, setCaseSensitive] = useState(false)
@@ -77,6 +79,7 @@ export const useEnsureOnboardingResources = (): OnboardingResources => {
         setEnvironment(res.environment)
         setEnvironmentKey(res.environment.api_key)
         setFeatureName(res.featureName)
+        setHasDemoFlag(res.hasDemoFlag)
         setStatus('ready')
       })
       .catch((e) => {
@@ -91,6 +94,7 @@ export const useEnsureOnboardingResources = (): OnboardingResources => {
     environmentKey,
     error,
     featureName,
+    hasDemoFlag,
     organisationId,
     organisationName,
     projectId,

--- a/frontend/web/components/pages/onboarding/onboarding-already-set-up/OnboardingAlreadySetUp.tsx
+++ b/frontend/web/components/pages/onboarding/onboarding-already-set-up/OnboardingAlreadySetUp.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react'
+import Link from 'components/base/link'
+import Button from 'components/base/forms/Button'
+
+export type OnboardingAlreadySetUpProps = {
+  projectName: string
+  // Where to send them to carry on with their own flags.
+  featuresHref: string
+  onSkip: () => void
+}
+
+// Shown when the tour has nothing to teach with: the project already has flags,
+// so we seed no demo flag (see ensureFlag) and there is no point walking someone
+// through connecting a project that is already connected.
+const OnboardingAlreadySetUp: FC<OnboardingAlreadySetUpProps> = ({
+  featuresHref,
+  onSkip,
+  projectName,
+}) => (
+  <div className='onboarding-flow mx-auto text-center'>
+    <h2 className='mb-2'>You&apos;re already set up</h2>
+    <p className='text-muted mb-3'>
+      {projectName} already has flags, so we haven&apos;t added a demo one.
+    </p>
+    <div className='d-flex justify-content-center align-items-center gap-3'>
+      <Button onClick={onSkip}>Go to your projects</Button>
+      <Link to={featuresHref}>View flags in {projectName}</Link>
+    </div>
+  </div>
+)
+
+export default OnboardingAlreadySetUp

--- a/frontend/web/components/pages/onboarding/onboarding-already-set-up/index.ts
+++ b/frontend/web/components/pages/onboarding/onboarding-already-set-up/index.ts
@@ -1,0 +1,2 @@
+export { default } from './OnboardingAlreadySetUp'
+export type { OnboardingAlreadySetUpProps } from './OnboardingAlreadySetUp'


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Stacked on #8217. Suggested by @Zaimwa9.

`/getting-started` carries no project, so the tour ran against the org's first one. You could be inside project B, click Getting Started, and see project A.

- The nav link now names the project: the one you're in (`TopNavbar` already has `projectId`), else the one you were last in.
- The page runs against that project, but only if it's in this organisation's list. Otherwise it falls back, so a link carried across orgs or an edited URL can't point the tour somewhere it shouldn't.
- A bare `/getting-started`, which is what a fresh signup gets, behaves as before.

A query param rather than a nested route: `/getting-started` has to work before any project exists. `/project/:id/environment/:key/getting-started` is the better shape and would delete this selection code, but it needs an entry that provisions and redirects, plus a decision on whether the tour keeps its chromeless layout. Worth doing with the drawer.

Environment choice is unchanged, still `Development` or the first one. `lastEnv` holds an environment too, but using it would mean telling someone to wire up production during a tour.

## How did you test this code?

- [x] 12 unit tests: URL project wins, id matched as a string, id outside the org ignored, no param, empty org, plus `parseLastEnv` against absent and malformed storage
- [x] `test:unit` (406), `typecheck` and `lint` clean

- [ ] Inside project B: link carries `?project=<B>` and the tour shows B
- [ ] Outside a project: falls back to the one you were last in
- [ ] After switching org: no stale project from the previous one
- [ ] URL edited to another org's project: falls back
- [ ] New signup: unchanged
