### PR TITLE
fix(tokens): text on surfaces fails WCAG AA contrast

### DIFF
--- a/frontend/common/theme/tokens.json
+++ b/frontend/common/theme/tokens.json
@@ -105,9 +105,9 @@
       "tertiary": { "cssVar": "--color-text-tertiary", "light": "#9da4ae", "dark": "rgba(255, 255, 255, 0.48)" },
       "disabled": { "cssVar": "--color-text-disabled", "light": "#9da4ae", "dark": "rgba(255, 255, 255, 0.32)" },
       "action": { "cssVar": "--color-text-action", "light": "#6837fc", "dark": "#906af6" },
-      "danger": { "cssVar": "--color-text-danger", "light": "#bb1720", "dark": "#ef4d56", "description": "Darker than border/icon danger to clear 4.5:1 on the tint." },
-      "success": { "cssVar": "--color-text-success", "light": "#13787b", "dark": "#27ab95", "description": "Darker than border/icon success to clear 4.5:1 on the tint." },
-      "warning": { "cssVar": "--color-text-warning", "light": "#9f5208", "dark": "#ff9f43", "description": "Darker than border/icon warning to clear 4.5:1 on the tint." },
+      "danger": { "cssVar": "--color-text-danger", "light": "#bb1720", "dark": "#ef4d56", "description": "In light mode, darker than border/icon danger to clear 4.5:1 on the tint." },
+      "success": { "cssVar": "--color-text-success", "light": "#13787b", "dark": "#27ab95", "description": "In light mode, darker than border/icon success to clear 4.5:1 on the tint." },
+      "warning": { "cssVar": "--color-text-warning", "light": "#9f5208", "dark": "#ff9f43", "description": "In light mode, darker than border/icon warning to clear 4.5:1 on the tint." },
       "info": { "cssVar": "--color-text-info", "light": "#0aaddf", "dark": "#0aaddf" }
     },
     "code": {

--- a/frontend/common/theme/tokens.json
+++ b/frontend/common/theme/tokens.json
@@ -105,9 +105,9 @@
       "tertiary": { "cssVar": "--color-text-tertiary", "light": "#9da4ae", "dark": "rgba(255, 255, 255, 0.48)" },
       "disabled": { "cssVar": "--color-text-disabled", "light": "#9da4ae", "dark": "rgba(255, 255, 255, 0.32)" },
       "action": { "cssVar": "--color-text-action", "light": "#6837fc", "dark": "#906af6" },
-      "danger": { "cssVar": "--color-text-danger", "light": "#ef4d56", "dark": "#ef4d56" },
-      "success": { "cssVar": "--color-text-success", "light": "#27ab95", "dark": "#27ab95" },
-      "warning": { "cssVar": "--color-text-warning", "light": "#ff9f43", "dark": "#ff9f43" },
+      "danger": { "cssVar": "--color-text-danger", "light": "#bb1720", "dark": "#ef4d56", "description": "Darker than border/icon danger to clear 4.5:1 on the tint." },
+      "success": { "cssVar": "--color-text-success", "light": "#13787b", "dark": "#27ab95", "description": "Darker than border/icon success to clear 4.5:1 on the tint." },
+      "warning": { "cssVar": "--color-text-warning", "light": "#9f5208", "dark": "#ff9f43", "description": "Darker than border/icon warning to clear 4.5:1 on the tint." },
       "info": { "cssVar": "--color-text-info", "light": "#0aaddf", "dark": "#0aaddf" }
     },
     "code": {

--- a/frontend/common/theme/tokens.ts
+++ b/frontend/common/theme/tokens.ts
@@ -198,14 +198,14 @@ export const colorSurfaceWarning =
 
 // Text
 export const colorTextAction = 'var(--color-text-action, #6837fc)'
-export const colorTextDanger = 'var(--color-text-danger, #ef4d56)'
+export const colorTextDanger = 'var(--color-text-danger, #bb1720)'
 export const colorTextDefault = 'var(--color-text-default, #1a2634)'
 export const colorTextDisabled = 'var(--color-text-disabled, #9da4ae)'
 export const colorTextInfo = 'var(--color-text-info, #0aaddf)'
 export const colorTextSecondary = 'var(--color-text-secondary, #656d7b)'
-export const colorTextSuccess = 'var(--color-text-success, #27ab95)'
+export const colorTextSuccess = 'var(--color-text-success, #13787b)'
 export const colorTextTertiary = 'var(--color-text-tertiary, #9da4ae)'
-export const colorTextWarning = 'var(--color-text-warning, #ff9f43)'
+export const colorTextWarning = 'var(--color-text-warning, #9f5208)'
 
 // Chart
 export const colorChart1 = 'var(--color-chart-1, #0aaddf)'

--- a/frontend/documentation/TokenReference.generated.stories.tsx
+++ b/frontend/documentation/TokenReference.generated.stories.tsx
@@ -205,7 +205,7 @@ export const AllTokens: StoryObj = {
               <code>--color-text-danger</code>
             </td>
             <td>
-              <code>var(--red-500)</code>
+              <code>var(--red-700)</code>
             </td>
           </tr>
           <tr>
@@ -213,7 +213,7 @@ export const AllTokens: StoryObj = {
               <code>--color-text-success</code>
             </td>
             <td>
-              <code>var(--green-500)</code>
+              <code>var(--green-600)</code>
             </td>
           </tr>
           <tr>
@@ -221,7 +221,7 @@ export const AllTokens: StoryObj = {
               <code>--color-text-warning</code>
             </td>
             <td>
-              <code>var(--orange-500)</code>
+              <code>var(--orange-800)</code>
             </td>
           </tr>
           <tr>

--- a/frontend/web/styles/_tokens.scss
+++ b/frontend/web/styles/_tokens.scss
@@ -105,14 +105,14 @@
 
   // Text
   --color-text-action: var(--purple-600);
-  --color-text-danger: var(--red-500);
+  --color-text-danger: var(--red-700);
   --color-text-default: var(--slate-600);
   --color-text-disabled: var(--slate-300);
   --color-text-info: var(--blue-500);
   --color-text-secondary: var(--slate-500);
-  --color-text-success: var(--green-500);
+  --color-text-success: var(--green-600);
   --color-text-tertiary: var(--slate-300);
-  --color-text-warning: var(--orange-500);
+  --color-text-warning: var(--orange-800);
 
   // Code
   --color-code-builtin: var(--gold-700);
@@ -208,10 +208,13 @@
   --color-surface-success: oklch(from var(--green-500) 0.18 0.02 h);
   --color-surface-warning: oklch(from var(--orange-500) 0.18 0.02 h);
   --color-text-action: var(--purple-400);
+  --color-text-danger: var(--red-500);
   --color-text-default: var(--slate-0);
   --color-text-disabled: oklch(from var(--slate-0) l c h / 0.32);
   --color-text-secondary: var(--slate-300);
+  --color-text-success: var(--green-500);
   --color-text-tertiary: oklch(from var(--slate-0) l c h / 0.48);
+  --color-text-warning: var(--orange-500);
   --color-code-builtin: var(--gold-400);
   --color-code-comment: var(--slate-500);
   --color-code-keyword: var(--purple-400);


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8235

Status text failed WCAG AA against the surfaces it sits on. Measured in light mode:

| Pair | Before | After |
|---|---|---|
| `text-warning` on `surface-warning` | 1.93:1 | 5.38:1 |
| `text-success` on `surface-success` | 2.64:1 | 4.85:1 |
| `text-danger` on `surface-danger` | 3.25:1 | 5.86:1 |

AA wants 4.5:1 for body text.

It was not only the pairing: `text-warning` was 2.04:1 on plain white, so it failed as body text on any light background.

Light mode now uses steps that already exist in the palette, `red-700`, `green-600` and `orange-800`, rather than new values. Dark mode keeps the brand 500s, since those surfaces are dark tints and darkening the text there would make it worse. The tokens previously had no dark override at all, so they inherited the light value.

Border and icon tokens are unchanged. Non-text contrast only needs 3:1, so the brand colours stay wherever they are decorative.

Affects the components already using these pairs: `experiments/StatusBadge`, `MetricsComparisonTable`, `WizardStepper`, `WarehouseSetup`, `SetupStep`.

## How did you test this code?

Ratios computed from the resolved token values with the WCAG relative luminance formula, before and after.

**Not yet checked in a browser**, which is why this is a draft. Two things need eyes:

1. Dark mode. The dark surfaces are `oklch(from var(--x-500) 0.18 0.02 h)`, which I could not compute reliably outside the browser. The 500s should be comfortable against them but the ratios are unmeasured.
2. Large display text. Anywhere these tokens are used at 24px or above only needs 3:1 and will now render noticeably darker, so it is worth a look at the experiments tables and the wizard stepper.
