### PR TITLE
fix: match Scale-Up plan ids case-insensitively

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -312,7 +312,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         return self.subscription_plan_family == SubscriptionPlanFamily.ENTERPRISE
 
     def get_scaleup_plan_version(self) -> int:
-        if match := re.match(r"scale-up-v(\d+)", self.plan or ""):
+        if match := re.match(r"scale-up-v(\d+)", self.plan or "", re.IGNORECASE):
             return int(match.group(1))
         return 1
 

--- a/api/organisations/subscriptions/serializers/mixins.py
+++ b/api/organisations/subscriptions/serializers/mixins.py
@@ -29,8 +29,13 @@ class ReadOnlyIfNotValidPlanMixin:
 
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
+        # Chargebee plan ids cannot be renamed and are mixed-case as of
+        # Scale-Up v4 (e.g. "Scale-Up-v4-USD-Yearly"), so match them
+        # case-insensitively.
         self.invalid_plans_regex_matcher = (
-            re.compile(self.invalid_plans_regex) if self.invalid_plans_regex else None
+            re.compile(self.invalid_plans_regex, re.IGNORECASE)
+            if self.invalid_plans_regex
+            else None
         )
 
     def get_fields(self, *args, **kwargs):  # type: ignore[no-untyped-def]

--- a/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
+++ b/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
@@ -14,6 +14,7 @@ from organisations.subscriptions.serializers.mixins import (
     (
         ("invalid-plan-id", ("invalid-plan-id",), ""),
         ("invalid-plan-id", tuple(), "invalid-.*"),
+        ("Scale-Up-v4-USD-Yearly", tuple(), r"^(free|startup.*|scale-up.*)$"),
     ),
 )
 def test_read_only_if_not_valid_plan_mixin__invalid_plan__sets_fields_read_only(

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -304,6 +304,8 @@ def test_is_auto_seat_upgrade_available__given_plan_and_seat_count__returns_expe
         ("scale-up", 1),
         ("startup-v2", 1),
         (None, 1),
+        ("Scale-Up-v4-USD-Yearly", 4),
+        ("Scale-Up-v4-USD-Monthly", 4),
     ],
 )
 def test_get_scaleup_plan_version__given_plan__returns_expected(

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -103,7 +103,7 @@ Attributes:
 ### `core.encrypted_field.decrypt_failed`
 
 Logged at `warning` from:
- - `api/core/fields.py:37`
+ - `api/core/fields.py:62`
 
 Attributes:
  - `exc_info`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22243,6 +22243,7 @@ components:
           readOnly: true
         url:
           type: string
+          format: uri
           maxLength: 200
         enabled:
           type: boolean
@@ -24193,6 +24194,7 @@ components:
           readOnly: true
         url:
           type: string
+          format: uri
           maxLength: 200
         enabled:
           type: boolean
@@ -25045,6 +25047,7 @@ components:
         url:
           type: string
           format: uri
+          maxLength: 200
         enabled:
           type: boolean
         created_at:
@@ -25066,6 +25069,7 @@ components:
           readOnly: true
         url:
           type: string
+          format: uri
           maxLength: 200
         secret:
           type: string
@@ -28035,6 +28039,7 @@ components:
         url:
           type: string
           format: uri
+          maxLength: 200
         enabled:
           type: boolean
         created_at:
@@ -28058,6 +28063,7 @@ components:
           readOnly: true
         url:
           type: string
+          format: uri
           maxLength: 200
         secret:
           type: string


### PR DESCRIPTION
## Summary

Scale-Up returned as v4 with mixed-case Chargebee plan ids (`Scale-Up-v4-USD-Yearly` / `Scale-Up-v4-USD-Monthly`), but two plan-id checks still match case-sensitively:

- `Subscription.get_scaleup_plan_version()` fails to match the v4 ids and falls back to version 1, so v4 Scale-Up organisations are treated as pre-v4 and keep **unlimited audit log visibility** (`audit_log_visibility_days = None`).
- `ReadOnlyIfNotValidPlanMixin` compiles `invalid_plans_regex` case-sensitively, so `ProjectCreateSerializer`'s `scale-up.*` gate misses v4 plans and the plan-gated project fields (`stale_flags_limit_days`, `enable_realtime_updates`) become **writable for Scale-Up v4 organisations**.

Both now match case-insensitively. Chargebee plan ids cannot be renamed, and `SubscriptionPlanFamily.get_by_plan_id` already normalises its input for exactly this reason — this brings the remaining two checks in line.

Part of #8074 (the two backend acceptance criteria in this repo; the stale-flags tagging item lives in flagsmith-private and the billing-page plan descriptions are a separate frontend change).

## Test plan

- Extended `test_get_scaleup_plan_version__given_plan__returns_expected` with the production v4 plan ids — fails without the fix.
- Extended the `ReadOnlyIfNotValidPlanMixin` read-only parametrisation with a mixed-case plan id against the production regex from `ProjectCreateSerializer`.
- Ran locally: 9/9 plan-version tests and 5/5 mixin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)