### PR TITLE
fix: experiment form UX fixes

### DIFF
--- a/frontend/web/components/PageTitle.tsx
+++ b/frontend/web/components/PageTitle.tsx
@@ -20,7 +20,7 @@ const PageTitle: FC<PageTitleType> = ({ children, className, cta, title }) => {
             </Row>
           )}
         </div>
-        {!!cta && <div className='float-end ms-lg-2'>{cta}</div>}
+        {!!cta && <div className='float-end'>{cta}</div>}
       </div>
       <hr className='mb-0 mt-3' />
     </div>

--- a/frontend/web/components/experiments/EventNameSelect/EventNameSelect.tsx
+++ b/frontend/web/components/experiments/EventNameSelect/EventNameSelect.tsx
@@ -40,7 +40,10 @@ const EventNameSelect: FC<EventNameSelectProps> = ({ onChange, value }) => {
   // clicking outside commits the value instead of clearing it.
   const handleInputChange = (val: string, meta: InputActionMeta) => {
     if (meta.action === 'input-change') setInputValue(val)
-    if (meta.action === 'set-value') setInputValue('')
+  }
+  const handleChange = (option: EventOption | null) => {
+    setInputValue('')
+    onChange(option?.value ?? '')
   }
   const handleBlur = () => {
     if (!inputValue) return
@@ -63,7 +66,7 @@ const EventNameSelect: FC<EventNameSelectProps> = ({ onChange, value }) => {
         menuPlacement='auto'
         options={options}
         value={value ? { label: value, value } : null}
-        onChange={(option: EventOption | null) => onChange(option?.value ?? '')}
+        onChange={handleChange}
         placeholder='e.g. checkout_completed'
         formatCreateLabel={(input: string) => `Use "${input}"`}
         noOptionsMessage={() => 'Type to add a new event'}

--- a/frontend/web/components/experiments/EventNameSelect/EventNameSelect.tsx
+++ b/frontend/web/components/experiments/EventNameSelect/EventNameSelect.tsx
@@ -1,5 +1,6 @@
-import { FC, useMemo } from 'react'
+import { FC, useMemo, useState } from 'react'
 import CreatableSelect from 'react-select/creatable'
+import { InputActionMeta } from 'react-select'
 import {
   useGetWarehouseConnectionEventsQuery,
   useGetWarehouseConnectionsQuery,
@@ -33,6 +34,19 @@ const EventNameSelect: FC<EventNameSelectProps> = ({ onChange, value }) => {
   )
   const options = useMemo(() => buildEventOptions(data?.events), [data?.events])
   const showWarning = isSuccess && isUnknownEvent(value, data?.events)
+  const [inputValue, setInputValue] = useState('')
+
+  // Keep the typed text on blur (react-select discards it by default) so
+  // clicking outside commits the value instead of clearing it.
+  const handleInputChange = (val: string, meta: InputActionMeta) => {
+    if (meta.action === 'input-change') setInputValue(val)
+    if (meta.action === 'set-value') setInputValue('')
+  }
+  const handleBlur = () => {
+    if (!inputValue) return
+    onChange(inputValue)
+    setInputValue('')
+  }
 
   return (
     <div className='event-name-select'>
@@ -42,6 +56,9 @@ const EventNameSelect: FC<EventNameSelectProps> = ({ onChange, value }) => {
         classNamePrefix='react-select'
         isClearable
         isLoading={isLoading}
+        inputValue={inputValue}
+        onInputChange={handleInputChange}
+        onBlur={handleBlur}
         maxMenuHeight={200}
         menuPlacement='auto'
         options={options}

--- a/frontend/web/components/experiments/results/ExperimentSummaryScorecard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentSummaryScorecard.tsx
@@ -51,16 +51,12 @@ const ExperimentSummaryScorecard: FC<ExperimentSummaryScorecardProps> = ({
             loading={!hasResults}
             value={
               summary?.winnerName ? (
-                <span
-                  className={summary.controlWins ? undefined : 'text-success'}
-                >
-                  <VariantName
-                    fit
-                    colour={summary.winnerColour}
-                    fontSize={24}
-                    name={summary.winnerName}
-                  />
-                </span>
+                <VariantName
+                  fit
+                  colour={summary.winnerColour}
+                  fontSize={24}
+                  name={summary.winnerName}
+                />
               ) : undefined
             }
           />

--- a/frontend/web/components/experiments/steps/SetupStep.tsx
+++ b/frontend/web/components/experiments/steps/SetupStep.tsx
@@ -45,7 +45,7 @@ const SetupStep: FC<SetupStepProps> = ({
         search: search || undefined,
         type: 'MULTIVARIATE',
       },
-      { skip: !numericEnvId },
+      { refetchOnMountOrArgChange: true, skip: !numericEnvId },
     )
 
   const multivariateFeatures = featureList?.results ?? []


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Small experiment UX fixes:

- Refetch multivariate flags when landing on the experiment setup step, so flags made multivariate in another tab appear without a full refresh.
- Keep the typed event name when the metric event combobox loses focus. The reactstrap modal wrapper steals focus on any click inside it, which made react-select discard the draft; the value is now committed on blur.
- Winning variation stat now renders in the default text colour, matching the other result cards.
- Removed a redundant `ms-lg-2` on the `PageTitle` CTA that indented the button when it wraps below the description (e.g. Segments page).

## How did you test this code?

Manually.

<img width="788" height="134" alt="image" src="https://github.com/user-attachments/assets/67e9edcb-d93e-4839-b0d5-f36deb608987" />

<img width="1156" height="148" alt="image" src="https://github.com/user-attachments/assets/8119d09e-e4da-4568-9bca-fb35b6e57ebb" />

