### PR TITLE
fix: account for RBAC role query in org permission query-count test

### DIFF
--- a/api/tests/unit/permissions/permission_service/test_user_has_organisation_permissions.py
+++ b/api/tests/unit/permissions/permission_service/test_user_has_organisation_permissions.py
@@ -1,5 +1,8 @@
 import typing
 
+import pytest
+from django.conf import settings
+
 from organisations.models import Organisation, UserOrganisation
 from organisations.permissions.models import (
     OrganisationPermissionModel,
@@ -213,6 +216,10 @@ def test_user_has_organisation_permission__group_permission__short_circuits_in_f
     assert result is True
 
 
+@pytest.mark.skipif(
+    settings.IS_RBAC_INSTALLED is True,
+    reason="Skip this test if RBAC is installed",
+)
 def test_user_has_organisation_permission__no_permissions_assigned__checks_each_source_in_four_queries(
     staff_user: FFAdminUser,
     organisation: Organisation,
@@ -226,6 +233,32 @@ def test_user_has_organisation_permission__no_permissions_assigned__checks_each_
     # 3. Check direct user permission (not found)
     # 4. Check group permission (not found; role check skipped without RBAC)
     with django_assert_num_queries(4):
+        result = user_has_organisation_permission(
+            staff_user, organisation, MANAGE_USER_GROUPS
+        )
+
+    # Then
+    assert result is False
+
+
+@pytest.mark.skipif(
+    settings.IS_RBAC_INSTALLED is False,
+    reason="Skip this test if RBAC is not installed",
+)
+def test_user_has_organisation_permission__no_permissions_assigned_with_rbac__checks_each_source_in_five_queries(
+    staff_user: FFAdminUser,
+    organisation: Organisation,
+    django_assert_num_queries: typing.Any,
+) -> None:
+    # Given / When
+    # Should take exactly 5 queries, one per permission source — never a
+    # single combined query joining the user and group permission tables:
+    # 1. Check if user is org admin (is_user_organisation_admin)
+    # 2. Check organisation membership
+    # 3. Check direct user permission (not found)
+    # 4. Check group permission (not found)
+    # 5. Check role permission (not found)
+    with django_assert_num_queries(5):
         result = user_has_organisation_permission(
             staff_user, organisation, MANAGE_USER_GROUPS
         )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8228

The query-count test added in #8230 fails on the private-packages CI run: with RBAC installed, the no-permission path runs a fifth query (the role check), so `django_assert_num_queries(4)` breaks main.

- Skip the 4-query test when RBAC is installed
- Add a 5-query twin (admin, membership, user, group, role) skipped when RBAC is not installed, so both CI environments keep an exact-count guard

## How did you test this code?

Ran the module locally without RBAC: 10 passed, 1 skipped (the RBAC twin). The 5-query expectation matches the failing CI output on main (`Expected to perform 4 queries but 5 were done`).
