### PR TITLE
fix: add request timeouts to analytics integration wrappers

### DIFF
--- a/api/integrations/common/constants.py
+++ b/api/integrations/common/constants.py
@@ -1,0 +1,5 @@
+# Default timeout (in seconds) for outbound HTTP requests made by integration
+# wrappers. Without an explicit timeout, ``requests`` waits indefinitely, so an
+# unresponsive third-party endpoint can hang the worker thread that dispatches
+# the event, leading to resource exhaustion.
+INTEGRATION_REQUEST_TIMEOUT_SECONDS = 10

--- a/api/integrations/datadog/datadog.py
+++ b/api/integrations/datadog/datadog.py
@@ -3,6 +3,10 @@ import logging
 
 import requests
 
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
+
 from audit.models import AuditLog
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 
@@ -46,7 +50,9 @@ class DataDogWrapper(AbstractBaseEventIntegrationWrapper):
             event["source_type_name"] = FLAGSMITH_SOURCE_TYPE_NAME
 
         response = self.session.post(
-            f"{self.events_url}?api_key={self.api_key}", data=json.dumps(event)
+            f"{self.events_url}?api_key={self.api_key}",
+            data=json.dumps(event),
+            timeout=INTEGRATION_REQUEST_TIMEOUT_SECONDS,
         )
         logger.debug(
             "Sent event to DataDog. Response code was %s" % response.status_code

--- a/api/integrations/datadog/datadog.py
+++ b/api/integrations/datadog/datadog.py
@@ -3,11 +3,10 @@ import logging
 
 import requests
 
+from audit.models import AuditLog
 from integrations.common.constants import (
     INTEGRATION_REQUEST_TIMEOUT_SECONDS,
 )
-
-from audit.models import AuditLog
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 
 logger = logging.getLogger(__name__)

--- a/api/integrations/dynatrace/dynatrace.py
+++ b/api/integrations/dynatrace/dynatrace.py
@@ -3,6 +3,10 @@ import logging
 
 import requests
 
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
+
 from audit.models import AuditLog
 from audit.services import get_audited_instance_from_audit_log_record
 from features.models import Feature, FeatureState
@@ -29,7 +33,10 @@ class DynatraceWrapper(AbstractBaseEventIntegrationWrapper):
     def _track_event(self, event: dict) -> None:  # type: ignore[type-arg]
         event["entitySelector"] = self.entity_selector
         response = requests.post(
-            self.url, headers=self._headers(), data=json.dumps(event)
+            self.url,
+            headers=self._headers(),
+            data=json.dumps(event),
+            timeout=INTEGRATION_REQUEST_TIMEOUT_SECONDS,
         )
         logger.debug(
             "Sent event to Dynatrace. Response code was %s" % response.status_code

--- a/api/integrations/dynatrace/dynatrace.py
+++ b/api/integrations/dynatrace/dynatrace.py
@@ -3,14 +3,13 @@ import logging
 
 import requests
 
-from integrations.common.constants import (
-    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
-)
-
 from audit.models import AuditLog
 from audit.services import get_audited_instance_from_audit_log_record
 from features.models import Feature, FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 from segments.models import Segment
 

--- a/api/integrations/grafana/grafana.py
+++ b/api/integrations/grafana/grafana.py
@@ -4,11 +4,10 @@ from typing import Any
 
 import requests
 
+from audit.models import AuditLog
 from integrations.common.constants import (
     INTEGRATION_REQUEST_TIMEOUT_SECONDS,
 )
-
-from audit.models import AuditLog
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 from integrations.grafana.mappers import (
     map_audit_log_record_to_grafana_annotation,

--- a/api/integrations/grafana/grafana.py
+++ b/api/integrations/grafana/grafana.py
@@ -4,6 +4,10 @@ from typing import Any
 
 import requests
 
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
+
 from audit.models import AuditLog
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 from integrations.grafana.mappers import (
@@ -36,6 +40,7 @@ class GrafanaWrapper(AbstractBaseEventIntegrationWrapper):
             url=self.url,
             headers=self._headers(),
             data=json.dumps(event),
+            timeout=INTEGRATION_REQUEST_TIMEOUT_SECONDS,
         )
 
         logger.debug(

--- a/api/integrations/heap/heap.py
+++ b/api/integrations/heap/heap.py
@@ -3,13 +3,12 @@ import typing
 
 import requests
 
-from integrations.common.constants import (
-    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
-)
-
 from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from features.models import FeatureState
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
 from integrations.common.wrapper import AbstractBaseIdentityIntegrationWrapper
 
 from .constants import DEFAULT_HEAP_API_URL

--- a/api/integrations/heap/heap.py
+++ b/api/integrations/heap/heap.py
@@ -3,6 +3,10 @@ import typing
 
 import requests
 
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
+
 from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from features.models import FeatureState
@@ -21,7 +25,11 @@ class HeapWrapper(AbstractBaseIdentityIntegrationWrapper):  # type: ignore[type-
         self.url = f"{base_url}/api/track"
 
     def _identify_user(self, user_data: dict) -> None:  # type: ignore[type-arg]
-        response = requests.post(self.url, json=user_data)
+        response = requests.post(
+            self.url,
+            json=user_data,
+            timeout=INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+        )
         logger.debug("Sent event to Heap. Response code was: %s" % response.status_code)
 
     def generate_user_data(

--- a/api/integrations/mixpanel/mixpanel.py
+++ b/api/integrations/mixpanel/mixpanel.py
@@ -3,6 +3,10 @@ import typing
 
 import requests
 
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
+
 from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from features.models import FeatureState
@@ -30,7 +34,12 @@ class MixpanelWrapper(AbstractBaseIdentityIntegrationWrapper[MixpanelUserData]):
         }
 
     def _identify_user(self, user_data: MixpanelUserData) -> None:
-        response = requests.post(self.url, headers=self.headers, json=user_data)
+        response = requests.post(
+            self.url,
+            headers=self.headers,
+            json=user_data,
+            timeout=INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+        )
         logger.debug(
             "Sent event to Mixpanel. Response code was: %s" % response.status_code
         )

--- a/api/integrations/mixpanel/mixpanel.py
+++ b/api/integrations/mixpanel/mixpanel.py
@@ -3,13 +3,12 @@ import typing
 
 import requests
 
-from integrations.common.constants import (
-    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
-)
-
 from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from features.models import FeatureState
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
 from integrations.common.wrapper import AbstractBaseIdentityIntegrationWrapper
 
 from .constants import DEFAULT_MIXPANEL_API_URL

--- a/api/integrations/new_relic/new_relic.py
+++ b/api/integrations/new_relic/new_relic.py
@@ -3,11 +3,10 @@ import logging
 
 import requests
 
+from audit.models import AuditLog
 from integrations.common.constants import (
     INTEGRATION_REQUEST_TIMEOUT_SECONDS,
 )
-
-from audit.models import AuditLog
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 
 logger = logging.getLogger(__name__)

--- a/api/integrations/new_relic/new_relic.py
+++ b/api/integrations/new_relic/new_relic.py
@@ -3,6 +3,10 @@ import logging
 
 import requests
 
+from integrations.common.constants import (
+    INTEGRATION_REQUEST_TIMEOUT_SECONDS,
+)
+
 from audit.models import AuditLog
 from integrations.common.wrapper import AbstractBaseEventIntegrationWrapper
 
@@ -20,7 +24,10 @@ class NewRelicWrapper(AbstractBaseEventIntegrationWrapper):
 
     def _track_event(self, event: dict) -> None:  # type: ignore[type-arg]
         response = requests.post(
-            self.url, headers=self._headers(), data=json.dumps(event)
+            self.url,
+            headers=self._headers(),
+            data=json.dumps(event),
+            timeout=INTEGRATION_REQUEST_TIMEOUT_SECONDS,
         )
         logger.debug(
             "Sent event to NewRelic. Response code was %s" % response.status_code


### PR DESCRIPTION
## What

Several third-party integration wrappers issue outbound HTTP requests with no `timeout`, so `requests` waits indefinitely for a response:

- `integrations/grafana/grafana.py` - `requests.post`
- `integrations/new_relic/new_relic.py` - `requests.post`
- `integrations/dynatrace/dynatrace.py` - `requests.post`
- `integrations/datadog/datadog.py` - `session.post`
- `integrations/mixpanel/mixpanel.py` - `requests.post`
- `integrations/heap/heap.py` - `requests.post`

Each of these targets a `base_url` that is configured per environment/organisation and stored on the integration model.

## Why it matters

Python `requests` with no `timeout` blocks forever if the remote host accepts the connection but never responds. These wrappers are invoked on every audit-log event and every identify/trait call. Depending on deployment configuration (`ENABLE_POSTPONE_DECORATOR`), the call runs either inline in the request/response cycle or in a spawned daemon thread. In the inline case an unresponsive integration endpoint hangs the worker handling a user request; in the threaded case hung threads accumulate without bound. Either way a slow or black-holed integration host degrades availability (CWE-400, uncontrolled resource consumption).

The rest of the codebase already guards against this: `integrations/github/client.py` uses `GITHUB_API_CALLS_TIMEOUT` and `webhooks/webhooks.py` uses `timeout=10`. These analytics/event wrappers were simply missed.

## Fix

Add a shared `INTEGRATION_REQUEST_TIMEOUT_SECONDS = 10` constant in `integrations/common/constants.py` (matching the existing 10s webhook timeout) and pass it as `timeout=` to each of the outbound calls above. No behavioural change beyond bounding how long a request can hang.

## Test

Existing integration wrapper unit tests continue to pass. To verify the change, mock the transport to never respond and assert the call raises `requests.exceptions.Timeout` after ~10s instead of blocking indefinitely.
