### PR TITLE
feat(identities): evaluate system traits when matching segments for edge identities

### DIFF
--- a/api/environments/dynamodb/wrappers/identity_wrapper.py
+++ b/api/environments/dynamodb/wrappers/identity_wrapper.py
@@ -19,6 +19,9 @@ from environments.dynamodb.wrappers.exceptions import (
     CapacityBudgetExceeded,
     SystemTraitWriteRaceError,
 )
+from environments.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
 from util.engine_models.context.mappers import (
     is_context_in_segment,
     map_environment_identity_to_context,
@@ -103,6 +106,17 @@ class DynamoIdentityWrapper(BaseDynamoWrapper):
         Assumes stored documents never carry `system_traits` as NULL — the
         document mapper omits the attribute when unset.
         """
+        if (
+            isinstance(trait_value, str)
+            and len(trait_value) > TRAIT_STRING_VALUE_MAX_LENGTH
+        ):
+            # The Edge API caps trait values at this length when parsing
+            # identity documents; a longer value there makes every flag
+            # request for the identity fail.
+            raise ValueError(
+                "System trait value must be at most "
+                f"{TRAIT_STRING_VALUE_MAX_LENGTH} characters."
+            )
         composite_key = IdentityModel.generate_composite_key(
             environment_api_key, identifier
         )

--- a/api/environments/dynamodb/wrappers/identity_wrapper.py
+++ b/api/environments/dynamodb/wrappers/identity_wrapper.py
@@ -19,14 +19,14 @@ from environments.dynamodb.wrappers.exceptions import (
     CapacityBudgetExceeded,
     SystemTraitWriteRaceError,
 )
-from environments.identities.traits.constants import (
-    TRAIT_STRING_VALUE_MAX_LENGTH,
-)
 from util.engine_models.context.mappers import (
     is_context_in_segment,
     map_environment_identity_to_context,
 )
 from util.engine_models.identities.models import IdentityModel
+from util.engine_models.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
 from util.mappers import (
     map_engine_identity_to_identity_document,
     map_identity_to_identity_document,

--- a/api/environments/dynamodb/wrappers/identity_wrapper.py
+++ b/api/environments/dynamodb/wrappers/identity_wrapper.py
@@ -19,14 +19,14 @@ from environments.dynamodb.wrappers.exceptions import (
     CapacityBudgetExceeded,
     SystemTraitWriteRaceError,
 )
+from environments.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
 from util.engine_models.context.mappers import (
     is_context_in_segment,
     map_environment_identity_to_context,
 )
 from util.engine_models.identities.models import IdentityModel
-from util.engine_models.identities.traits.constants import (
-    TRAIT_STRING_VALUE_MAX_LENGTH,
-)
 from util.mappers import (
     map_engine_identity_to_identity_document,
     map_identity_to_identity_document,

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -24,6 +24,9 @@ from environments.dynamodb.wrappers.exceptions import (
     SystemTraitWriteRaceError,
 )
 from environments.identities.models import Identity
+from environments.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
 from environments.identities.traits.models import Trait
 from features.models import Feature, FeatureSegment, FeatureState
 from features.multivariate.models import (
@@ -32,9 +35,6 @@ from features.multivariate.models import (
 )
 from segments.models import Condition, Segment, SegmentRule
 from util.engine_models.identities.models import IdentityModel
-from util.engine_models.identities.traits.constants import (
-    TRAIT_STRING_VALUE_MAX_LENGTH,
-)
 from util.mappers import (
     map_environment_to_compressed_environment_document,
     map_identity_to_identity_document,
@@ -438,41 +438,18 @@ def test_get_segment_ids__system_trait_backed_segment__returns_correct_ids(
     assert segment_ids == [member_segment.id]
 
 
-def test_set_system_trait__oversized_string_value__raises(
-    dynamodb_identity_wrapper: DynamoIdentityWrapper,
-) -> None:
+def test_set_system_trait__oversized_string_value__raises() -> None:
     # Given
-    trait_value = "x" * (TRAIT_STRING_VALUE_MAX_LENGTH + 1)
+    wrapper = DynamoIdentityWrapper()
 
     # When / Then
-    with pytest.raises(ValueError, match="at most"):
-        dynamodb_identity_wrapper.set_system_trait(
+    with pytest.raises(ValueError):
+        wrapper.set_system_trait(
             environment_api_key="key",
             identifier="user",
             trait_key="flagsmith_cohort_a",
-            trait_value=trait_value,
+            trait_value="x" * (TRAIT_STRING_VALUE_MAX_LENGTH + 1),
         )
-    assert dynamodb_identity_wrapper.get_item("key_user") is None
-
-
-def test_set_system_trait__string_value_at_max_length__writes(
-    dynamodb_identity_wrapper: DynamoIdentityWrapper,
-) -> None:
-    # Given
-    trait_value = "x" * TRAIT_STRING_VALUE_MAX_LENGTH
-
-    # When
-    dynamodb_identity_wrapper.set_system_trait(
-        environment_api_key="key",
-        identifier="user",
-        trait_key="flagsmith_cohort_a",
-        trait_value=trait_value,
-    )
-
-    # Then
-    document = dynamodb_identity_wrapper.get_item("key_user")
-    assert document is not None
-    assert document["system_traits"] == {"flagsmith_cohort_a": trait_value}
 
 
 def test_get_segment_ids__in_operator_with_integer_traits__returns_matching_segment(

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -24,6 +24,9 @@ from environments.dynamodb.wrappers.exceptions import (
     SystemTraitWriteRaceError,
 )
 from environments.identities.models import Identity
+from environments.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
 from environments.identities.traits.models import Trait
 from features.models import Feature, FeatureSegment, FeatureState
 from features.multivariate.models import (
@@ -433,6 +436,20 @@ def test_get_segment_ids__system_trait_backed_segment__returns_correct_ids(
 
     # Then
     assert segment_ids == [member_segment.id]
+
+
+def test_set_system_trait__oversized_string_value__raises() -> None:
+    # Given
+    wrapper = DynamoIdentityWrapper()
+
+    # When / Then
+    with pytest.raises(ValueError):
+        wrapper.set_system_trait(
+            environment_api_key="key",
+            identifier="user",
+            trait_key="flagsmith_cohort_a",
+            trait_value="x" * (TRAIT_STRING_VALUE_MAX_LENGTH + 1),
+        )
 
 
 def test_get_segment_ids__in_operator_with_integer_traits__returns_matching_segment(

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -6,7 +6,7 @@ from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import Binary
 from botocore.exceptions import ClientError
 from django.core.exceptions import ObjectDoesNotExist
-from flag_engine.segments.constants import IN
+from flag_engine.segments.constants import IN, IS_SET
 from mypy_boto3_dynamodb.service_resource import Table
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
@@ -398,6 +398,41 @@ def test_get_segment_ids__segment_with_feature_overrides__returns_correct_ids(
 
     # Then
     assert segment_ids == [identity_matching_segment.id]
+
+
+def test_get_segment_ids__system_trait_backed_segment__returns_correct_ids(
+    project: "Project",
+    environment: "Environment",
+    identity: "Identity",
+    mocker: "MockerFixture",
+) -> None:
+    # Given - two IS_SET segments: one keyed to a system trait the identity
+    # carries, one keyed to a system trait it does not
+    member_segment = Segment.objects.create(name="Cohort members", project=project)
+    rule = SegmentRule.objects.create(segment=member_segment, type=SegmentRule.ALL_RULE)
+    Condition.objects.create(rule=rule, operator=IS_SET, property="flagsmith_cohort_a")
+    other_segment = Segment.objects.create(name="Other cohort", project=project)
+    other_rule = SegmentRule.objects.create(
+        segment=other_segment, type=SegmentRule.ALL_RULE
+    )
+    Condition.objects.create(
+        rule=other_rule, operator=IS_SET, property="flagsmith_cohort_b"
+    )
+
+    identity_document = map_identity_to_identity_document(identity)
+    identity_document["system_traits"] = {"flagsmith_cohort_a": True}
+    identity_uuid = identity_document["identity_uuid"]
+
+    dynamo_identity_wrapper = DynamoIdentityWrapper()
+    mocker.patch.object(
+        dynamo_identity_wrapper, "get_item_from_uuid", return_value=identity_document
+    )
+
+    # When
+    segment_ids = dynamo_identity_wrapper.get_segment_ids(identity_uuid)  # type: ignore[arg-type]
+
+    # Then
+    assert segment_ids == [member_segment.id]
 
 
 def test_get_segment_ids__in_operator_with_integer_traits__returns_matching_segment(

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -24,9 +24,6 @@ from environments.dynamodb.wrappers.exceptions import (
     SystemTraitWriteRaceError,
 )
 from environments.identities.models import Identity
-from environments.identities.traits.constants import (
-    TRAIT_STRING_VALUE_MAX_LENGTH,
-)
 from environments.identities.traits.models import Trait
 from features.models import Feature, FeatureSegment, FeatureState
 from features.multivariate.models import (
@@ -35,6 +32,9 @@ from features.multivariate.models import (
 )
 from segments.models import Condition, Segment, SegmentRule
 from util.engine_models.identities.models import IdentityModel
+from util.engine_models.identities.traits.constants import (
+    TRAIT_STRING_VALUE_MAX_LENGTH,
+)
 from util.mappers import (
     map_environment_to_compressed_environment_document,
     map_identity_to_identity_document,
@@ -438,18 +438,41 @@ def test_get_segment_ids__system_trait_backed_segment__returns_correct_ids(
     assert segment_ids == [member_segment.id]
 
 
-def test_set_system_trait__oversized_string_value__raises() -> None:
+def test_set_system_trait__oversized_string_value__raises(
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+) -> None:
     # Given
-    wrapper = DynamoIdentityWrapper()
+    trait_value = "x" * (TRAIT_STRING_VALUE_MAX_LENGTH + 1)
 
     # When / Then
-    with pytest.raises(ValueError):
-        wrapper.set_system_trait(
+    with pytest.raises(ValueError, match="at most"):
+        dynamodb_identity_wrapper.set_system_trait(
             environment_api_key="key",
             identifier="user",
             trait_key="flagsmith_cohort_a",
-            trait_value="x" * (TRAIT_STRING_VALUE_MAX_LENGTH + 1),
+            trait_value=trait_value,
         )
+    assert dynamodb_identity_wrapper.get_item("key_user") is None
+
+
+def test_set_system_trait__string_value_at_max_length__writes(
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+) -> None:
+    # Given
+    trait_value = "x" * TRAIT_STRING_VALUE_MAX_LENGTH
+
+    # When
+    dynamodb_identity_wrapper.set_system_trait(
+        environment_api_key="key",
+        identifier="user",
+        trait_key="flagsmith_cohort_a",
+        trait_value=trait_value,
+    )
+
+    # Then
+    document = dynamodb_identity_wrapper.get_item("key_user")
+    assert document is not None
+    assert document["system_traits"] == {"flagsmith_cohort_a": trait_value}
 
 
 def test_get_segment_ids__in_operator_with_integer_traits__returns_matching_segment(

--- a/api/tests/unit/util/engine_models/context/test_unit_context_mappers.py
+++ b/api/tests/unit/util/engine_models/context/test_unit_context_mappers.py
@@ -30,3 +30,31 @@ def test_map_environment_identity_to_context__system_traits__merged_with_system_
         "plan": "free",
         "flagsmith_cohort_a": True,
     }
+
+
+def test_map_environment_identity_to_context__override_traits__system_traits_win(
+    environment: Environment,
+) -> None:
+    # Given
+    identity = IdentityModel(
+        identifier="user-1",
+        environment_api_key=environment.api_key,
+        system_traits={"flagsmith_cohort_a": True},
+    )
+    override_traits = [
+        TraitModel(trait_key="plan", trait_value="trial"),
+        TraitModel(trait_key="flagsmith_cohort_a", trait_value="override-written"),
+    ]
+
+    # When
+    context = map_environment_identity_to_context(
+        environment=environment, identity=identity, override_traits=override_traits
+    )
+
+    # Then
+    identity_context = context["identity"]
+    assert identity_context is not None
+    assert identity_context["traits"] == {
+        "plan": "trial",
+        "flagsmith_cohort_a": True,
+    }

--- a/api/tests/unit/util/engine_models/context/test_unit_context_mappers.py
+++ b/api/tests/unit/util/engine_models/context/test_unit_context_mappers.py
@@ -1,0 +1,32 @@
+from environments.models import Environment
+from util.engine_models.context.mappers import map_environment_identity_to_context
+from util.engine_models.identities.models import IdentityModel
+from util.engine_models.identities.traits.models import TraitModel
+
+
+def test_map_environment_identity_to_context__system_traits__merged_with_system_winning(
+    environment: Environment,
+) -> None:
+    # Given
+    identity = IdentityModel(
+        identifier="user-1",
+        environment_api_key=environment.api_key,
+        identity_traits=[
+            TraitModel(trait_key="plan", trait_value="free"),
+            TraitModel(trait_key="flagsmith_cohort_a", trait_value="user-written"),
+        ],
+        system_traits={"flagsmith_cohort_a": True},
+    )
+
+    # When
+    context = map_environment_identity_to_context(
+        environment=environment, identity=identity, override_traits=None
+    )
+
+    # Then
+    identity_context = context["identity"]
+    assert identity_context is not None
+    assert identity_context["traits"] == {
+        "plan": "free",
+        "flagsmith_cohort_a": True,
+    }

--- a/api/tests/unit/util/engine_models/context/test_unit_context_mappers.py
+++ b/api/tests/unit/util/engine_models/context/test_unit_context_mappers.py
@@ -30,31 +30,3 @@ def test_map_environment_identity_to_context__system_traits__merged_with_system_
         "plan": "free",
         "flagsmith_cohort_a": True,
     }
-
-
-def test_map_environment_identity_to_context__override_traits__system_traits_win(
-    environment: Environment,
-) -> None:
-    # Given
-    identity = IdentityModel(
-        identifier="user-1",
-        environment_api_key=environment.api_key,
-        system_traits={"flagsmith_cohort_a": True},
-    )
-    override_traits = [
-        TraitModel(trait_key="plan", trait_value="trial"),
-        TraitModel(trait_key="flagsmith_cohort_a", trait_value="override-written"),
-    ]
-
-    # When
-    context = map_environment_identity_to_context(
-        environment=environment, identity=identity, override_traits=override_traits
-    )
-
-    # Then
-    identity_context = context["identity"]
-    assert identity_context is not None
-    assert identity_context["traits"] == {
-        "plan": "trial",
-        "flagsmith_cohort_a": True,
-    }

--- a/api/util/engine_models/context/mappers.py
+++ b/api/util/engine_models/context/mappers.py
@@ -42,10 +42,6 @@ def map_environment_identity_to_context(
     :param override_traits: A list of TraitModel objects, to be used in place of
         `identity.identity_traits` if provided.
     :return: An EvaluationContext containing the environment and identity.
-
-    Diverges from upstream: `identity.system_traits` are merged into the
-    context's traits and take precedence over both stored traits and
-    `override_traits`.
     """
     traits = {
         trait.trait_key: trait.trait_value
@@ -54,9 +50,8 @@ def map_environment_identity_to_context(
         )
     }
     if identity.system_traits:
-        # Without this precedence, any SDK client could spoof cohort
-        # membership by writing a trait named like a cohort key. The Edge API
-        # applies the same rule in its own context mapper — keep them in step.
+        # System-owned traits are not user data: on a key clash, the system
+        # value wins.
         traits.update(identity.system_traits)
     return {
         "environment": {

--- a/api/util/engine_models/context/mappers.py
+++ b/api/util/engine_models/context/mappers.py
@@ -42,6 +42,10 @@ def map_environment_identity_to_context(
     :param override_traits: A list of TraitModel objects, to be used in place of
         `identity.identity_traits` if provided.
     :return: An EvaluationContext containing the environment and identity.
+
+    Diverges from upstream: `identity.system_traits` are merged into the
+    context's traits and take precedence over both stored traits and
+    `override_traits`.
     """
     traits = {
         trait.trait_key: trait.trait_value
@@ -50,8 +54,9 @@ def map_environment_identity_to_context(
         )
     }
     if identity.system_traits:
-        # System-owned traits are not user data: on a key clash, the system
-        # value wins.
+        # Without this precedence, any SDK client could spoof cohort
+        # membership by writing a trait named like a cohort key. The Edge API
+        # applies the same rule in its own context mapper — keep them in step.
         traits.update(identity.system_traits)
     return {
         "environment": {

--- a/api/util/engine_models/context/mappers.py
+++ b/api/util/engine_models/context/mappers.py
@@ -43,6 +43,16 @@ def map_environment_identity_to_context(
         `identity.identity_traits` if provided.
     :return: An EvaluationContext containing the environment and identity.
     """
+    traits = {
+        trait.trait_key: trait.trait_value
+        for trait in (
+            override_traits if override_traits is not None else identity.identity_traits
+        )
+    }
+    if identity.system_traits:
+        # System-owned traits are not user data: on a key clash, the system
+        # value wins.
+        traits.update(identity.system_traits)
     return {
         "environment": {
             "key": environment.api_key,
@@ -51,14 +61,7 @@ def map_environment_identity_to_context(
         "identity": {
             "identifier": identity.identifier,
             "key": str(identity.django_id or identity.composite_key),
-            "traits": {
-                trait.trait_key: trait.trait_value
-                for trait in (
-                    override_traits
-                    if override_traits is not None
-                    else identity.identity_traits
-                )
-            },
+            "traits": traits,
         },
     }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to cohort sync (follow-up to #8211, #8212, #8213, #8248).

- `map_environment_identity_to_context` merges the identity document's `system_traits` into the evaluation context's traits; the system value wins on a key clash.
- This makes cohort segments (`IS_SET` on the cohort's system trait key) match for edge identities in the admin API: the identity's segments list and segment-override resolution (`get_segment_ids`).
- No behaviour change for identities without system traits.

## How did you test this code?

Unit test pinning the merge semantics, an end-to-end `get_segment_ids` test with system-trait-backed `IS_SET` segments, and the full edge_api unit and integration suites (including engine document snapshot tests).
