### PR TITLE
fix(edge): tolerate null system_traits in set_system_trait

### DIFF
--- a/api/environments/dynamodb/wrappers/identity_wrapper.py
+++ b/api/environments/dynamodb/wrappers/identity_wrapper.py
@@ -103,8 +103,8 @@ class DynamoIdentityWrapper(BaseDynamoWrapper):
         document shape just read — a lost race re-reads and retries, and
         `SystemTraitWriteRaceError` is raised once attempts are exhausted.
 
-        Assumes stored documents never carry `system_traits` as NULL — the
-        document mapper omits the attribute when unset.
+        A `system_traits` attribute stored as NULL is treated as absent and
+        replaced.
         """
         if (
             isinstance(trait_value, str)
@@ -157,28 +157,26 @@ class DynamoIdentityWrapper(BaseDynamoWrapper):
                     )
                 else:
                     # If another writer created system_traits after we read
-                    # the document, this write does nothing and their traits
-                    # survive; the returned attributes tell us which happened.
-                    response = self.table.update_item(  # type: ignore[union-attr]
+                    # the document, this write fails the condition and the
+                    # retry adds the trait to their map instead. A NULL
+                    # system_traits counts as absent: nothing can be added
+                    # to it, so it is replaced wholesale.
+                    self.table.update_item(  # type: ignore[union-attr]
                         Key={"composite_key": composite_key},
-                        UpdateExpression=(
-                            "SET system_traits = if_not_exists(system_traits, :init)"
+                        UpdateExpression="SET system_traits = :init",
+                        # Without the composite_key clause, update_item would
+                        # re-create a just-deleted identity as an empty
+                        # document containing nothing but this trait.
+                        ConditionExpression=(
+                            "attribute_exists(composite_key)"
+                            " AND (attribute_not_exists(system_traits)"
+                            " OR attribute_type(system_traits, :null))"
                         ),
-                        # Without this condition, update_item would re-create
-                        # a just-deleted identity as an empty document
-                        # containing nothing but this trait.
-                        ConditionExpression="attribute_exists(composite_key)",
                         ExpressionAttributeValues={
-                            ":init": {trait_key: document_value}
+                            ":init": {trait_key: document_value},
+                            ":null": "NULL",
                         },
-                        ReturnValues="ALL_NEW",
                     )
-                    written_traits = response["Attributes"].get("system_traits")
-                    if isinstance(written_traits, dict) and _system_trait_value_matches(
-                        written_traits.get(trait_key), document_value
-                    ):
-                        return
-                    continue
                 return
             except ClientError as exc:
                 if exc.response["Error"]["Code"] != "ConditionalCheckFailedException":

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -803,6 +803,32 @@ def test_set_system_trait__document_without_system_traits__creates_system_traits
     assert document["system_traits"] == {"cohort_x": True}
 
 
+def test_set_system_trait__null_system_traits__replaces_with_map(
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+) -> None:
+    # Given - a document written with `system_traits: null` by another service
+    dynamodb_identity_wrapper.put_item(
+        {
+            "composite_key": "api-key_user-1",
+            "identifier": "user-1",
+            "environment_api_key": "api-key",
+            "identity_traits": [{"trait_key": "plan", "trait_value": "pro"}],
+            "system_traits": None,
+        }
+    )
+
+    # When
+    dynamodb_identity_wrapper.set_system_trait(
+        environment_api_key="api-key", identifier="user-1", trait_key="cohort_x"
+    )
+
+    # Then
+    document = dynamodb_identity_wrapper.get_item("api-key_user-1")
+    assert document is not None
+    assert document["system_traits"] == {"cohort_x": True}
+    assert document["identity_traits"] == [{"trait_key": "plan", "trait_value": "pro"}]
+
+
 def test_set_system_trait__missing_document__creates_document(
     dynamodb_identity_wrapper: DynamoIdentityWrapper,
 ) -> None:


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`set_system_trait` assumed `system_traits` is never stored as DynamoDB NULL; a null there made every write for the identity exhaust its retries and raise `SystemTraitWriteRaceError`.

- Treat a NULL `system_traits` like a missing attribute and replace it with the new map.
- The write is conditional on the attribute being absent or NULL, so a map created by a concurrent writer is never overwritten — the retry adds the trait to it instead.
- Drops the `ReturnValues` check that previously detected the lost race.

## How did you test this code?

New unit test seeding a document with `system_traits: null`; existing concurrency tests cover the retry path unchanged.