### PR TITLE
fix(Audit): Retrieving records via /api/v1/audit/ with a master API key results in error

### DIFF
--- a/api/api_keys/user.py
+++ b/api/api_keys/user.py
@@ -42,6 +42,11 @@ class APIKeyUser(UserABC):
     def organisations(self) -> QuerySet[Organisation]:
         return Organisation.objects.filter(id=self.key.organisation_id)  # type: ignore[no-any-return]
 
+    def get_admin_organisations(self) -> QuerySet[Organisation]:
+        if not self.key.is_admin:
+            return Organisation.objects.none()  # type: ignore[no-any-return]
+        return Organisation.objects.filter(id=self.key.organisation_id)  # type: ignore[no-any-return]
+
     def belongs_to(self, organisation_id: int) -> bool:
         return self.key.organisation_id == organisation_id
 

--- a/api/audit/views.py
+++ b/api/audit/views.py
@@ -19,7 +19,7 @@ from audit.serializers import (
     AuditLogRetrieveSerializer,
     AuditLogsQueryParamSerializer,
 )
-from organisations.models import Organisation, OrganisationRole
+from organisations.models import Organisation
 
 
 @method_decorator(
@@ -93,8 +93,7 @@ class _BaseAuditLogViewSet(
 class AllAuditLogViewSet(_BaseAuditLogViewSet):
     def _get_base_filters(self) -> Q:
         return Q(
-            project__organisation__userorganisation__user=self.request.user,
-            project__organisation__userorganisation__role=OrganisationRole.ADMIN,
+            project__organisation__in=self.request.user.get_admin_organisations()  # type: ignore[union-attr]
         )
 
     def _get_organisation(self) -> Organisation | None:
@@ -109,9 +108,7 @@ class AllAuditLogViewSet(_BaseAuditLogViewSet):
         Since we're applying the base filters to the query set
         """
         return (  # type: ignore[no-any-return]
-            self.request.user.organisations.filter(  # type: ignore[union-attr]
-                userorganisation__role=OrganisationRole.ADMIN
-            )
+            self.request.user.get_admin_organisations()  # type: ignore[union-attr]
             .select_related("subscription", "subscription_information_cache")
             .first()
         )

--- a/api/tests/unit/audit/test_unit_audit_views.py
+++ b/api/tests/unit/audit/test_unit_audit_views.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api_keys.models import MasterAPIKey
 from audit.constants import ENVIRONMENT_FEATURE_VERSION_PUBLISHED_MESSAGE
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
@@ -168,6 +169,69 @@ def test_list_audit_log__admin_of_another_organisation__returns_empty(
     response = api_client.get(url)
 
     # Then
+    assert response.json()["count"] == 0
+
+
+def test_list_audit_log__admin_master_api_key__returns_organisation_logs(
+    admin_master_api_key_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+) -> None:
+    # Given
+    audit_log = AuditLog.objects.create(project=project)
+    url = reverse("api-v1:audit-list")
+
+    # When
+    response = admin_master_api_key_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    response_json = response.json()
+    assert response_json["count"] == 1
+    assert response_json["results"][0]["id"] == audit_log.id
+
+
+def test_list_audit_log__non_admin_master_api_key__returns_empty(
+    master_api_key: typing.Tuple[MasterAPIKey, str],
+    api_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+) -> None:
+    # Given
+    AuditLog.objects.create(project=project)
+    url = reverse("api-v1:audit-list")
+
+    api_client.credentials(HTTP_AUTHORIZATION="Api-Key " + master_api_key[1])
+
+    # When
+    response = api_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["count"] == 0
+
+
+def test_list_audit_log__master_api_key_of_another_organisation__returns_empty(
+    api_client: APIClient,
+    organisation: Organisation,
+    project: Project,
+) -> None:
+    # Given
+    another_organisation = Organisation.objects.create(name="another organisation")
+    _, key = MasterAPIKey.objects.create_key(
+        name="another_key", organisation=another_organisation, is_admin=True
+    )
+
+    AuditLog.objects.create(project=project)
+    url = reverse("api-v1:audit-list")
+
+    api_client.credentials(HTTP_AUTHORIZATION="Api-Key " + key)
+
+    # When
+    response = api_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["count"] == 0
 
 

--- a/api/tests/unit/platform_hub/test_views.py
+++ b/api/tests/unit/platform_hub/test_views.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api_keys.models import MasterAPIKey
 from environments.models import Environment
 from features.models import Feature
 from organisations.models import Organisation, OrganisationRole
@@ -144,6 +145,39 @@ def test_organisations_view__user_admin_of_one_org__returns_only_that_org(
     assert len(data) == 1
     assert data[0]["id"] == platform_hub_organisation.id
     assert data[0]["name"] == "Platform Hub Org"
+
+
+def test_organisations_view__admin_master_api_key__returns_only_that_org(
+    platform_hub_organisation: Organisation,
+    platform_hub_project: Project,
+    platform_hub_environment: Environment,
+    platform_hub_feature: Feature,
+    other_organisation: Organisation,
+    other_org_project: Project,
+    other_org_environment: Environment,
+    other_org_feature: Feature,
+    settings: pytest.FixtureRequest,
+) -> None:
+    # Given
+    settings.USE_POSTGRES_FOR_ANALYTICS = False  # type: ignore[attr-defined]
+    settings.INFLUXDB_TOKEN = ""  # type: ignore[attr-defined]
+
+    _, key = MasterAPIKey.objects.create_key(
+        name="platform_hub_key", organisation=platform_hub_organisation, is_admin=True
+    )
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Api-Key " + key)
+
+    url = reverse("api-v1:platform-hub:organisations")
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == platform_hub_organisation.id
 
 
 def test_organisations_view__non_admin_org_exists__excludes_non_admin_orgs(

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -73,7 +73,7 @@ def test_get_admin_organisations__user_with_mixed_roles__returns_only_admin_orgs
     admin_user.add_organisation(non_admin_organisation, OrganisationRole.USER)
 
     # When
-    admin_orgs = admin_user.get_admin_organisations()  # type: ignore[no-untyped-call]
+    admin_orgs = admin_user.get_admin_organisations()
 
     # Then
     assert organisation in admin_orgs

--- a/api/users/abc.py
+++ b/api/users/abc.py
@@ -18,6 +18,10 @@ class UserABC(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def get_admin_organisations(self) -> QuerySet[Organisation]:
+        raise NotImplementedError()
+
+    @abstractmethod
     def is_project_admin(self, project: "Project") -> bool:
         raise NotImplementedError()
 

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -254,8 +254,8 @@ class FFAdminUser(LifecycleModel, AbstractUser):  # type: ignore[django-manager-
     def is_organisation_admin(self, organisation: typing.Union["Organisation", int]):  # type: ignore[no-untyped-def]
         return is_user_organisation_admin(self, organisation)
 
-    def get_admin_organisations(self):  # type: ignore[no-untyped-def]
-        return Organisation.objects.filter(
+    def get_admin_organisations(self) -> QuerySet[Organisation]:
+        return Organisation.objects.filter(  # type: ignore[no-any-return]
             userorganisation__user=self,
             userorganisation__role=OrganisationRole.ADMIN.name,
         )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Listing audit log records with a Master API Key returns a 500 instead of the records. Anyone driving Flagsmith through the Terraform provider, a CI script, or a SIEM/compliance pipeline cannot read the audit log at all with the credential they already use for everything else — the endpoint fails before it gets as far as checking what the key is allowed to see.

The endpoint assumed the caller was always a signed-in user, and looked up their organisations by following a database relation that only exists for real user accounts. A Master API Key is not a user account, so that lookup fell over.

- [x] `/api/v1/audit/` now returns audit logs for Master API Key callers instead of erroring.
- [x] Who can see what is unchanged: an admin key sees its own organisation's records, and a non-admin key sees nothing — the same rule already applied to admin and non-admin users.
- [x] The six Platform Hub endpoints had the same underlying assumption and were also erroring for Master API Keys. They are fixed by the same change, and covered by a test.
- [x] Removed two now-redundant `type: ignore` comments in the surrounding code.

Closes #6583

Review effort: 2/5

## How did you test this code?

Added tests that fail on `main` and pass with this change:

- `/api/v1/audit/` with an admin Master API Key returns the organisation's records. Without the fix this reproduces the reported `TypeError: Field 'id' expected a number but got <APIKeyUser>` exactly.
- `/api/v1/audit/` with a non-admin Master API Key returns an empty list, matching the existing behaviour for non-admin users.
- `/api/v1/audit/` with an admin Master API Key belonging to a different organisation returns an empty list, so the fix does not leak records across organisations.
- Platform Hub organisations endpoint with an admin Master API Key returns that organisation. Without the fix this raises `AttributeError: 'APIKeyUser' object has no attribute 'get_admin_organisations'`.

The existing tests covering user-authenticated access to this endpoint (regular user, and admin of another organisation) still pass unchanged, which is what confirms the visibility rules did not shift.

Also ran the full backend suite (4518 passed, 48 skipped — the only errors were InfluxDB connection failures from that service not running locally, in tests unrelated to this change), `mypy` in strict mode across the codebase, and `pre-commit` over the changed files.
