### PR TITLE
fix(onboarding): run the tour in the project you just created

### DIFF
--- a/frontend/web/components/pages/onboarding/bootstrap/__tests__/onboardingProject.test.ts
+++ b/frontend/web/components/pages/onboarding/bootstrap/__tests__/onboardingProject.test.ts
@@ -1,0 +1,20 @@
+import { ProjectSummary } from 'common/types/responses'
+import { newestProject } from 'components/pages/onboarding/bootstrap/onboardingProject'
+
+const project = (id: number): ProjectSummary => ({ id } as ProjectSummary)
+
+describe('newestProject', () => {
+  it('takes the project the user just created, not the first returned', () => {
+    const created = project(9)
+    expect(newestProject([project(2), created, project(5)])).toBe(created)
+  })
+
+  it('takes the only project there is', () => {
+    const only = project(3)
+    expect(newestProject([only])).toBe(only)
+  })
+
+  it('finds nothing in an organisation with no projects', () => {
+    expect(newestProject([])).toBeUndefined()
+  })
+})

--- a/frontend/web/components/pages/onboarding/bootstrap/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/bootstrap/bootstrapOnboarding.ts
@@ -24,6 +24,7 @@ import {
   findOnboardingTag,
   shouldSeedDemoFlag,
 } from './demoFlag'
+import { newestProject } from './onboardingProject'
 import { SmartDefaults } from 'components/pages/onboarding/hooks/useSmartDefaults'
 import { createOrganisationViaAccountStore } from './createOrganisationViaAccountStore'
 import API from 'project/api'
@@ -81,7 +82,7 @@ async function ensureProject(
   const projects = await store
     .dispatch(projectService.endpoints.getProjects.initiate({ organisationId }))
     .unwrap()
-  const existing = projects?.[0]
+  const existing = newestProject(projects ?? [])
   if (existing) {
     return existing
   }

--- a/frontend/web/components/pages/onboarding/bootstrap/onboardingProject.ts
+++ b/frontend/web/components/pages/onboarding/bootstrap/onboardingProject.ts
@@ -1,0 +1,12 @@
+import { ProjectSummary } from 'common/types/responses'
+
+// The project the user just made: creating one and clicking Getting Started is
+// how you run onboarding again. The list comes back in no useful order, so go
+// by id rather than position.
+export const newestProject = (
+  projects: ProjectSummary[],
+): ProjectSummary | undefined =>
+  projects.reduce<ProjectSummary | undefined>(
+    (newest, project) => (!newest || project.id > newest.id ? project : newest),
+    undefined,
+  )


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Stacked on #8217, which decides whether a project may be toured. This decides which project we look at.

- `ensureProject` took whichever project the API returned first, so onboarding couldn't be re-run by creating a project, and an empty first project got seeded instead. Now it takes the newest.

Still open: if that newest project is a colleague's and still empty, it's still seeded. Telling that apart needs a persisted "has onboarded" flag on the user.

## How did you test this code?

- [x] 3 unit tests on the rule, checked by mutation
- [x] `test:unit` (407) and `lint` clean, no typecheck errors in the touched files
- [ ] Existing account, new empty project: tour runs there rather than in the first project
- [ ] New account: unchanged, project created and tour runs
- [ ] Mid-tour refresh: still resumes
