### PR TITLE
fix(billing): max seats stays out of sync after plan upgrades

### DIFF
--- a/api/organisations/chargebee/webhook_handlers.py
+++ b/api/organisations/chargebee/webhook_handlers.py
@@ -151,6 +151,19 @@ def process_subscription(request: Request) -> Response:  # noqa: C901
         chargebee_subscription=subscription,
         customer_email=customer["email"],
     )
+
+    # `update_plan` only reads the plan's own metadata, so seats and API calls
+    # bought as addons never reach the subscription, and a subscription whose
+    # plan is unchanged is never updated at all. The extracted metadata accounts
+    # for both the plan and its addons, so use it as the source of truth.
+    if (
+        existing_subscription.max_seats != subscription_metadata.seats
+        or existing_subscription.max_api_calls != subscription_metadata.api_calls
+    ):
+        existing_subscription.max_seats = subscription_metadata.seats
+        existing_subscription.max_api_calls = subscription_metadata.api_calls
+        existing_subscription.save()
+
     osic_defaults = {
         "chargebee_updated_at": timezone.now(),
         "allowed_30d_api_calls": subscription_metadata.api_calls,

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -1402,6 +1402,117 @@ def test_chargebee_webhook__plan_changed__updates_seats_and_api_calls(  # type: 
         assert subscription_information_cache.chargebee_updated_at > updated_at
 
 
+@mock.patch("organisations.models.get_plan_meta_data")
+@mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
+def test_chargebee_webhook__seats_added_to_same_plan__updates_seats(
+    mock_extract_subscription_metadata: MagicMock,
+    mock_get_plan_meta_data: MagicMock,
+    subscription: Subscription,
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    chargebee_email = "chargebee@test.com"
+    url = reverse("api-v1:chargebee-webhook")
+
+    subscription.subscription_id = "sub-id"
+    subscription.plan = "scale-up-v2"
+    subscription.max_seats = 5
+    subscription.max_api_calls = 1_000_000
+    subscription.save()
+
+    # An additional seat addon raises the allowance without changing the plan.
+    mock_extract_subscription_metadata.return_value = ChargebeeObjMetadata(
+        seats=6,
+        api_calls=1_000_000,
+        projects=10,
+        chargebee_email=chargebee_email,
+    )
+
+    data = {
+        "content": {
+            "subscription": {
+                "status": "active",
+                "id": subscription.subscription_id,
+                "plan_id": subscription.plan,
+            },
+            "customer": {"email": chargebee_email},
+        }
+    }
+
+    # When
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    mock_get_plan_meta_data.assert_not_called()
+
+    subscription.refresh_from_db()
+    assert subscription.max_seats == 6
+
+    subscription_information_cache = (
+        OrganisationSubscriptionInformationCache.objects.get(organisation=organisation)
+    )
+    assert subscription_information_cache.allowed_seats == 6
+
+
+@mock.patch("organisations.models.get_plan_meta_data")
+@mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
+def test_chargebee_webhook__plan_changed_with_addons__updates_seats(
+    mock_extract_subscription_metadata: MagicMock,
+    mock_get_plan_meta_data: MagicMock,
+    subscription: Subscription,
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    chargebee_email = "chargebee@test.com"
+    url = reverse("api-v1:chargebee-webhook")
+
+    subscription.subscription_id = "sub-id"
+    subscription.save()
+
+    # The plan on its own allows 5 seats, but the subscription also carries
+    # addons worth 3 more.
+    mock_get_plan_meta_data.return_value = {"seats": 5, "api_calls": 1_000_000}
+    mock_extract_subscription_metadata.return_value = ChargebeeObjMetadata(
+        seats=8,
+        api_calls=1_000_000,
+        projects=10,
+        chargebee_email=chargebee_email,
+    )
+
+    data = {
+        "content": {
+            "subscription": {
+                "status": "active",
+                "id": subscription.subscription_id,
+                "plan_id": "scale-up-v2",
+            },
+            "customer": {"email": chargebee_email},
+        }
+    }
+
+    # When
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    subscription.refresh_from_db()
+    assert subscription.plan == "scale-up-v2"
+    assert subscription.max_seats == 8
+
+    subscription_information_cache = (
+        OrganisationSubscriptionInformationCache.objects.get(organisation=organisation)
+    )
+    assert subscription_information_cache.allowed_seats == 8
+
+
 def test_delete_organisation__other_org_exists__preserves_other_subscriptions(  # type: ignore[no-untyped-def]
     admin_client, admin_user, organisation, subscription
 ) -> None:


### PR DESCRIPTION
Seat allowances bought as Chargebee addons never reached the organisation's subscription record, so the seat count shown on _Users and Permissions_ stayed at the old value after a seat upgrade while _Organisation Billing_ showed the correct one. Anyone who buys extra seats sees a stale — and lower — limit on the page they use to manage their team.

The subscription record was only refreshed when the Chargebee plan ID itself changed, and even then it took its allowances from the plan's own metadata, which knows nothing about addons. Since seat upgrades are sold as addons, the record was never updated. The subscription information cache behind the billing page was already deriving its figures from the plan _and_ its addons, which is why the two pages disagreed. The webhook now takes the seat and API call allowances from that same addon-aware source.

## Changes

- [x] Seats added to an existing plan are now reflected on the _Users and Permissions_ page.
- [x] The same applies to plan upgrades that come with addons, and to API call allowances.
- [x] Tests covering both cases, which fail without the fix.

Closes https://github.com/Flagsmith/flagsmith-private/issues/267

Review effort: 2/5

## How did you test this code?

Automated. Two tests were added to `test_unit_organisations_views.py`, both of which fail on `main` and pass with this change:

- `test_chargebee_webhook__seats_added_to_same_plan__updates_seats` — an addon raises the seat count while the plan is unchanged. Fails without the fix with `assert 5 == 6`.
- `test_chargebee_webhook__plan_changed_with_addons__updates_seats` — a plan change where addons add seats on top of the plan's own allowance. Fails without the fix with `assert 5 == 8`, the plan's figure winning over the real one.

`tests/unit/organisations` and `tests/unit/sales_dashboard` pass in full (370 passed, 1 skipped), as do `make typecheck` on the changed files and the pre-commit suite.

## One thing to flag

This keeps the record in sync from here on: an organisation's seat count corrects itself the next time Chargebee sends a subscription webhook for it. Organisations whose record is already stale today are not backfilled, so they will keep showing the old number until their subscription next changes.

`_update_caches_with_chargebee_data`, the periodic reconciliation task, already holds both the subscription and the addon-aware metadata and could heal every stale record in a few lines. I have left it out because backfilling live billing data seemed like your call rather than mine — happy to add it if you would like it in this PR.