### PR TITLE
fix(identities): multivariate override editor hides the identity's override value

### DIFF
--- a/frontend/common/utils/__tests__/multivariate.test.ts
+++ b/frontend/common/utils/__tests__/multivariate.test.ts
@@ -95,6 +95,26 @@ describe('multivariate', () => {
       ).toBe(true)
     })
 
+    // An unloaded feature state must not read as an override: the caller
+    // latches this answer, so a verdict from absent data would stick.
+    it.each`
+      controlValue     | overrideValue    | scenario
+      ${'ENV_DEFAULT'} | ${undefined}     | ${'the override has not loaded'}
+      ${undefined}     | ${'MY_OVERRIDE'} | ${'the control value has not loaded'}
+      ${undefined}     | ${undefined}     | ${'neither has loaded'}
+    `(
+      'withholds a verdict while $scenario',
+      ({ controlValue, overrideValue }) => {
+        expect(
+          hasUnmatchedIdentityOverride({
+            controlValue,
+            overrideValue,
+            variationOverrides: [],
+          }),
+        ).toBe(false)
+      },
+    )
+
     it.each`
       controlValue | overrideValue | expected
       ${null}      | ${undefined}  | ${false}
@@ -169,6 +189,16 @@ describe('multivariate', () => {
           overrideValue: 'MY_OVERRIDE',
         }),
       ).toEqual({ selected: true, value: 'MY_OVERRIDE' })
+    })
+
+    it('does not latch while the override value is unavailable', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: true,
+          latchedValue: undefined,
+          overrideValue: undefined,
+        }),
+      ).toBeUndefined()
     })
 
     // `null` is a real override value, so it has to latch like any other —

--- a/frontend/common/utils/__tests__/multivariate.test.ts
+++ b/frontend/common/utils/__tests__/multivariate.test.ts
@@ -1,5 +1,6 @@
 import {
   getDefaultVariantKey,
+  hasUnmatchedIdentityOverride,
   sortMultivariateOptions,
 } from 'common/utils/multivariate'
 
@@ -50,5 +51,67 @@ describe('multivariate', () => {
 
       expect(options).toEqual([{ id: 2 }, { id: 1 }])
     })
+  })
+
+  describe('hasUnmatchedIdentityOverride', () => {
+    it('detects an override kept from before the flag became multivariate', () => {
+      expect(
+        hasUnmatchedIdentityOverride({
+          controlValue: 'ENV_DEFAULT',
+          overrideValue: 'MY_OVERRIDE',
+          variationOverrides: [],
+        }),
+      ).toBe(true)
+    })
+
+    it('does not flag an identity sitting on the control value', () => {
+      expect(
+        hasUnmatchedIdentityOverride({
+          controlValue: 'ENV_DEFAULT',
+          overrideValue: 'ENV_DEFAULT',
+          variationOverrides: [],
+        }),
+      ).toBe(false)
+    })
+
+    it('does not flag an identity assigned a variation', () => {
+      expect(
+        hasUnmatchedIdentityOverride({
+          controlValue: 'ENV_DEFAULT',
+          overrideValue: 'MY_OVERRIDE',
+          variationOverrides: [{ percentage_allocation: 100 }],
+        }),
+      ).toBe(false)
+    })
+
+    it('flags a partially weighted override, which does not pin a variation', () => {
+      expect(
+        hasUnmatchedIdentityOverride({
+          controlValue: 'ENV_DEFAULT',
+          overrideValue: 'MY_OVERRIDE',
+          variationOverrides: [{ percentage_allocation: 60 }],
+        }),
+      ).toBe(true)
+    })
+
+    it.each`
+      controlValue | overrideValue | expected
+      ${null}      | ${undefined}  | ${false}
+      ${undefined} | ${null}       | ${false}
+      ${null}      | ${''}         | ${true}
+      ${''}        | ${null}       | ${true}
+      ${0}         | ${false}      | ${true}
+    `(
+      'treats control $controlValue against override $overrideValue as $expected',
+      ({ controlValue, expected, overrideValue }) => {
+        expect(
+          hasUnmatchedIdentityOverride({
+            controlValue,
+            overrideValue,
+            variationOverrides: undefined,
+          }),
+        ).toBe(expected)
+      },
+    )
   })
 })

--- a/frontend/common/utils/__tests__/multivariate.test.ts
+++ b/frontend/common/utils/__tests__/multivariate.test.ts
@@ -1,6 +1,7 @@
 import {
   getDefaultVariantKey,
   hasUnmatchedIdentityOverride,
+  resolveUnmatchedOverride,
   sortMultivariateOptions,
 } from 'common/utils/multivariate'
 
@@ -113,5 +114,83 @@ describe('multivariate', () => {
         ).toBe(expected)
       },
     )
+  })
+
+  describe('resolveUnmatchedOverride', () => {
+    it('lists nothing while the identity has no unmatched override', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: false,
+          latchedValue: undefined,
+          overrideValue: 'ENV_DEFAULT',
+        }),
+      ).toBeUndefined()
+    })
+
+    it('latches the override value the first time it is seen', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: true,
+          latchedValue: undefined,
+          overrideValue: 'MY_OVERRIDE',
+        }),
+      ).toEqual({ selected: true, value: 'MY_OVERRIDE' })
+    })
+
+    // The bug this function exists for: presence used to follow selection, so
+    // picking a variation removed the row instead of deselecting it.
+    it('keeps a latched override listed once it stops being selected', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: false,
+          latchedValue: 'MY_OVERRIDE',
+          overrideValue: 'MY_OVERRIDE',
+        }),
+      ).toEqual({ selected: false, value: 'MY_OVERRIDE' })
+    })
+
+    // Picking the control row rewrites the edited value, which must not drag
+    // the listed row along with it — that value is what the user is replacing.
+    it('shows the latched value, not the value the user moved to', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: false,
+          latchedValue: 'MY_OVERRIDE',
+          overrideValue: 'ENV_DEFAULT',
+        }),
+      ).toEqual({ selected: false, value: 'MY_OVERRIDE' })
+    })
+
+    it('reselects the latched override without relatching it', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: true,
+          latchedValue: 'MY_OVERRIDE',
+          overrideValue: 'MY_OVERRIDE',
+        }),
+      ).toEqual({ selected: true, value: 'MY_OVERRIDE' })
+    })
+
+    // `null` is a real override value, so it has to latch like any other —
+    // keying the latch on it would leave the row permanently unlisted.
+    it('latches a null override value', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: true,
+          latchedValue: undefined,
+          overrideValue: null,
+        }),
+      ).toEqual({ selected: true, value: null })
+    })
+
+    it('keeps a latched null override listed once deselected', () => {
+      expect(
+        resolveUnmatchedOverride({
+          isSelected: false,
+          latchedValue: null,
+          overrideValue: 'ENV_DEFAULT',
+        }),
+      ).toEqual({ selected: false, value: null })
+    })
   })
 })

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -13,6 +13,11 @@ export const getDefaultVariantKey = (index: number): string =>
 // the control row reads as selected and the identity looks like it is on the
 // environment default. Detect it so the editor can show the value, and so
 // saving does not quietly replace it with the control value.
+//
+// Reads the current editor state, so it goes false as soon as the user picks
+// the control or a variation. That drives which row is selected and what save
+// writes; whether the row is listed at all is latched separately, as the value
+// is only gone once saved.
 export const hasUnmatchedIdentityOverride = ({
   controlValue,
   overrideValue,

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -18,6 +18,24 @@ export const getDefaultVariantKey = (index: number): string =>
 // the control or a variation. That drives which row is selected and what save
 // writes; whether the row is listed at all is latched separately, as the value
 // is only gone once saved.
+// Only the allocation matters here: a variation pinned at 100% is what makes
+// an override expressible as a variation rather than a free-form value.
+export type VariationOverrides =
+  | { percentage_allocation: number }[]
+  | null
+  | undefined
+
+// An override the variation radios cannot express, and whether it is still the
+// value in play.
+export type UnmatchedOverride = {
+  selected: boolean
+  value: FlagsmithValue
+}
+
+// What a previous resolve latched: undefined until an unmatched override has
+// been seen at all.
+export type LatchedOverrideValue = FlagsmithValue | undefined
+
 export const hasUnmatchedIdentityOverride = ({
   controlValue,
   overrideValue,
@@ -25,7 +43,7 @@ export const hasUnmatchedIdentityOverride = ({
 }: {
   controlValue: FlagsmithValue
   overrideValue: FlagsmithValue
-  variationOverrides: { percentage_allocation: number }[] | null | undefined
+  variationOverrides: VariationOverrides
 }): boolean =>
   !variationOverrides?.some(
     (variation) => variation.percentage_allocation === 100,
@@ -43,9 +61,9 @@ export const resolveUnmatchedOverride = ({
   overrideValue,
 }: {
   isSelected: boolean
-  latchedValue: FlagsmithValue | undefined
+  latchedValue: LatchedOverrideValue
   overrideValue: FlagsmithValue
-}): { selected: boolean; value: FlagsmithValue } | undefined => {
+}): UnmatchedOverride | undefined => {
   // `null` is a valid override value, so the latch is keyed on `undefined`.
   const value =
     latchedValue === undefined && isSelected ? overrideValue : latchedValue

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -41,13 +41,20 @@ export const hasUnmatchedIdentityOverride = ({
   overrideValue,
   variationOverrides,
 }: {
-  controlValue: FlagsmithValue
-  overrideValue: FlagsmithValue
+  controlValue: FlagsmithValue | undefined
+  overrideValue: FlagsmithValue | undefined
   variationOverrides: VariationOverrides
 }): boolean =>
+  // `undefined` means the feature state has not loaded, which is not the same
+  // as an override of `null`. Answering from absent data would say "unmatched"
+  // for any non-null control value, and the caller latches that answer for the
+  // lifetime of the editor — so withhold a verdict until both sides are known.
+  controlValue !== undefined &&
+  overrideValue !== undefined &&
   !variationOverrides?.some(
     (variation) => variation.percentage_allocation === 100,
-  ) && (overrideValue ?? null) !== (controlValue ?? null)
+  ) &&
+  overrideValue !== controlValue
 
 // The editor lists an unmatched override until the modal is saved, but selects
 // it only while it is still the value in play. Presence therefore latches:
@@ -62,9 +69,10 @@ export const resolveUnmatchedOverride = ({
 }: {
   isSelected: boolean
   latchedValue: LatchedOverrideValue
-  overrideValue: FlagsmithValue
+  overrideValue: FlagsmithValue | undefined
 }): UnmatchedOverride | undefined => {
-  // `null` is a valid override value, so the latch is keyed on `undefined`.
+  // `null` is a valid override value, so the latch is keyed on `undefined` —
+  // which doubles as the not-yet-loaded state, and so never latches.
   const value =
     latchedValue === undefined && isSelected ? overrideValue : latchedValue
   return value === undefined ? undefined : { selected: isSelected, value }

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -31,6 +31,27 @@ export const hasUnmatchedIdentityOverride = ({
     (variation) => variation.percentage_allocation === 100,
   ) && (overrideValue ?? null) !== (controlValue ?? null)
 
+// The editor lists an unmatched override until the modal is saved, but selects
+// it only while it is still the value in play. Presence therefore latches:
+// deriving it from the live predicate instead removed the row the moment a
+// variation was picked, taking away both the value being replaced and the only
+// way back to it. `latchedValue` carries what a previous call resolved, so
+// callers hold one value rather than reimplementing the rule.
+export const resolveUnmatchedOverride = ({
+  isSelected,
+  latchedValue,
+  overrideValue,
+}: {
+  isSelected: boolean
+  latchedValue: FlagsmithValue | undefined
+  overrideValue: FlagsmithValue
+}): { selected: boolean; value: FlagsmithValue } | undefined => {
+  // `null` is a valid override value, so the latch is keyed on `undefined`.
+  const value =
+    latchedValue === undefined && isSelected ? overrideValue : latchedValue
+  return value === undefined ? undefined : { selected: isSelected, value }
+}
+
 // Options not yet saved have no id and sort last, in input order.
 export const sortMultivariateOptions = <T extends { id?: number | null }>(
   options: T[],

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -1,9 +1,30 @@
+import { FlagsmithValue } from 'common/types/responses'
+
 // The label a variant displays (and is saved with) when the user never
 // sets one — keep display, validation and save payloads consistent.
 // Kept outside Utils so Storybook-rendered components can use it without
 // pulling in Utils' store dependencies (Storybook stubs out Utils).
 export const getDefaultVariantKey = (index: number): string =>
   `Variant_${index + 1}`
+
+// An identity override made before its flag became multivariate keeps a
+// free-form value. The multivariate editor only offers the environment's
+// control value and each variation, so such a value has nowhere to appear:
+// the control row reads as selected and the identity looks like it is on the
+// environment default. Detect it so the editor can show the value, and so
+// saving does not quietly replace it with the control value.
+export const hasUnmatchedIdentityOverride = ({
+  controlValue,
+  overrideValue,
+  variationOverrides,
+}: {
+  controlValue: FlagsmithValue
+  overrideValue: FlagsmithValue
+  variationOverrides: { percentage_allocation: number }[] | null | undefined
+}): boolean =>
+  !variationOverrides?.some(
+    (variation) => variation.percentage_allocation === 100,
+  ) && (overrideValue ?? null) !== (controlValue ?? null)
 
 // Options not yet saved have no id and sort last, in input order.
 export const sortMultivariateOptions = <T extends { id?: number | null }>(

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -27,6 +27,7 @@ import ExternalResourcesTable from 'components/ExternalResourcesTable'
 import GitHubLinkSection from 'components/GitHubLinkSection'
 import GitLabLinkSection from 'components/GitLabLinkSection'
 import type { ExternalResource } from 'common/types/responses'
+import { hasUnmatchedIdentityOverride } from 'common/utils/multivariate'
 import { saveFeatureWithValidation } from 'components/saveFeatureWithValidation'
 import FeatureHistory from 'components/FeatureHistory'
 import { getChangeRequests } from 'common/services/useChangeRequest'
@@ -330,6 +331,17 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
     const hasMultivariate =
       props.environmentFlag?.multivariate_feature_state_values?.length
 
+    // A multivariate override is stored as the control value plus a variation
+    // at 100%, so its value is normally re-synced to the control on save. An
+    // override predating the flag becoming multivariate holds a value that
+    // this model cannot express, and re-syncing would destroy it.
+    const keepsOwnValue = hasUnmatchedIdentityOverride({
+      controlValue:
+        projectFlag.environment_feature_state?.feature_state_value ?? null,
+      overrideValue: environmentFlag.feature_state_value ?? null,
+      variationOverrides: environmentFlag.multivariate_feature_state_values,
+    })
+
     if (identity) {
       !isSaving &&
         projectFlag.name &&
@@ -339,9 +351,10 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
           identity,
           identityFlag: Object.assign({}, props.identityFlag || {}, {
             enabled: environmentFlag.enabled,
-            feature_state_value: hasMultivariate
-              ? props.environmentFlag?.feature_state_value
-              : cleanInputValue(environmentFlag.feature_state_value),
+            feature_state_value:
+              hasMultivariate && !keepsOwnValue
+                ? props.environmentFlag?.feature_state_value
+                : cleanInputValue(environmentFlag.feature_state_value),
             multivariate_options:
               environmentFlag.multivariate_feature_state_values,
           }),

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -21,7 +21,10 @@ import {
   MultivariateOption,
   ProjectFlag,
 } from 'common/types/responses'
-import { hasUnmatchedIdentityOverride } from 'common/utils/multivariate'
+import {
+  hasUnmatchedIdentityOverride,
+  resolveUnmatchedOverride,
+} from 'common/utils/multivariate'
 import { FeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
 import ExperimentFreezeNotice from 'components/modals/create-feature/components/ExperimentFreezeNotice'
 import { useHasPermission } from 'common/providers/Permission'
@@ -298,25 +301,16 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
       variationOverrides: identityVariations,
     })
 
-  // Picking a variation deselects the override but must not remove it: the
-  // value is only gone once saved, and until then it is what the user is
-  // choosing to replace — and the only way back if they change their mind.
-  // Latched rather than read once on mount, as the feature state loads async.
-  // `null` is a valid override value, so the latch is keyed on `undefined`.
-  const unmatchedOverrideValue = useRef<FlagsmithValue | undefined>(undefined)
-  if (
-    unmatchedOverrideSelected &&
-    unmatchedOverrideValue.current === undefined
-  ) {
-    unmatchedOverrideValue.current = featureState.feature_state_value ?? null
-  }
-  const unmatchedOverride =
-    unmatchedOverrideValue.current === undefined
-      ? undefined
-      : {
-          selected: unmatchedOverrideSelected,
-          value: unmatchedOverrideValue.current,
-        }
+  // Held in a ref rather than read once on mount, as the feature state loads
+  // async — there is no single render at which the override is known to be
+  // there. See resolveUnmatchedOverride for why presence outlives selection.
+  const latchedOverrideValue = useRef<FlagsmithValue | undefined>(undefined)
+  const unmatchedOverride = resolveUnmatchedOverride({
+    isSelected: unmatchedOverrideSelected,
+    latchedValue: latchedOverrideValue.current,
+    overrideValue: featureState.feature_state_value ?? null,
+  })
+  latchedOverrideValue.current = unmatchedOverride?.value
 
   if (compareOpen && canCompareValue && environmentId) {
     return (

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -20,6 +20,7 @@ import {
   MultivariateOption,
   ProjectFlag,
 } from 'common/types/responses'
+import { hasUnmatchedIdentityOverride } from 'common/utils/multivariate'
 import { FeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
 import ExperimentFreezeNotice from 'components/modals/create-feature/components/ExperimentFreezeNotice'
 import { useHasPermission } from 'common/providers/Permission'
@@ -281,6 +282,23 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
     !!multivariate_options.length
   )
 
+  const controlValue =
+    projectFlag.environment_feature_state?.feature_state_value ?? null
+
+  // An override that predates the flag becoming multivariate holds a value the
+  // control/variation radios cannot express, so surface it rather than letting
+  // the control row imply the identity is on the environment default.
+  const unmatchedOverride =
+    !!identity &&
+    hasVariations &&
+    hasUnmatchedIdentityOverride({
+      controlValue,
+      overrideValue: featureState.feature_state_value ?? null,
+      variationOverrides: identityVariations,
+    })
+      ? { value: featureState.feature_state_value ?? null }
+      : undefined
+
   if (compareOpen && canCompareValue && environmentId) {
     return (
       <div className={`${identity ? 'mx-3' : ''}`}>
@@ -412,14 +430,15 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
         <div>
           <FormGroup className='mb-4'>
             {variationsInfo}
+            {!!unmatchedOverride && (
+              <WarningMessage warningMessage="This identity override contains a value that is not one of this flag's variations. We recommend changing it." />
+            )}
             <VariationOptions
               canCreateFeature={false}
               disabled
               select
-              controlValue={
-                projectFlag.environment_feature_state?.feature_state_value ??
-                null
-              }
+              unmatchedOverride={unmatchedOverride}
+              controlValue={controlValue}
               controlPercentage={controlPercentage}
               variationOverrides={identityVariations as any}
               setValue={(value) =>

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -17,12 +17,12 @@ import { FlagValueFooter } from 'components/modals/FlagValueFooter'
 import Utils from 'common/utils/utils'
 import {
   FeatureState,
-  FlagsmithValue,
   MultivariateOption,
   ProjectFlag,
 } from 'common/types/responses'
 import {
   hasUnmatchedIdentityOverride,
+  LatchedOverrideValue,
   resolveUnmatchedOverride,
 } from 'common/utils/multivariate'
 import { FeatureExperimentFreeze } from 'common/hooks/useFeatureExperimentFreeze'
@@ -304,7 +304,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   // Held in a ref rather than read once on mount, as the feature state loads
   // async — there is no single render at which the override is known to be
   // there. See resolveUnmatchedOverride for why presence outlives selection.
-  const latchedOverrideValue = useRef<FlagsmithValue | undefined>(undefined)
+  const latchedOverrideValue = useRef<LatchedOverrideValue>(undefined)
   const unmatchedOverride = resolveUnmatchedOverride({
     isSelected: unmatchedOverrideSelected,
     latchedValue: latchedOverrideValue.current,

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
 import InputGroup from 'components/base/forms/InputGroup'
 import ValueEditor from 'components/ValueEditor'
 import Constants from 'common/constants'
@@ -17,6 +17,7 @@ import { FlagValueFooter } from 'components/modals/FlagValueFooter'
 import Utils from 'common/utils/utils'
 import {
   FeatureState,
+  FlagsmithValue,
   MultivariateOption,
   ProjectFlag,
 } from 'common/types/responses'
@@ -288,7 +289,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   // An override that predates the flag becoming multivariate holds a value the
   // control/variation radios cannot express, so surface it rather than letting
   // the control row imply the identity is on the environment default.
-  const unmatchedOverride =
+  const unmatchedOverrideSelected =
     !!identity &&
     hasVariations &&
     hasUnmatchedIdentityOverride({
@@ -296,8 +297,26 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
       overrideValue: featureState.feature_state_value ?? null,
       variationOverrides: identityVariations,
     })
-      ? { value: featureState.feature_state_value ?? null }
-      : undefined
+
+  // Picking a variation deselects the override but must not remove it: the
+  // value is only gone once saved, and until then it is what the user is
+  // choosing to replace — and the only way back if they change their mind.
+  // Latched rather than read once on mount, as the feature state loads async.
+  // `null` is a valid override value, so the latch is keyed on `undefined`.
+  const unmatchedOverrideValue = useRef<FlagsmithValue | undefined>(undefined)
+  if (
+    unmatchedOverrideSelected &&
+    unmatchedOverrideValue.current === undefined
+  ) {
+    unmatchedOverrideValue.current = featureState.feature_state_value ?? null
+  }
+  const unmatchedOverride =
+    unmatchedOverrideValue.current === undefined
+      ? undefined
+      : {
+          selected: unmatchedOverrideSelected,
+          value: unmatchedOverrideValue.current,
+        }
 
   if (compareOpen && canCompareValue && environmentId) {
     return (
@@ -430,7 +449,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
         <div>
           <FormGroup className='mb-4'>
             {variationsInfo}
-            {!!unmatchedOverride && (
+            {unmatchedOverrideSelected && (
               <WarningMessage warningMessage="This identity override contains a value that is not one of this flag's variations. We recommend changing it." />
             )}
             <VariationOptions

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -286,8 +286,10 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
     !!multivariate_options.length
   )
 
+  // Left undefined while unloaded rather than coerced to null, which is itself
+  // a valid value — see hasUnmatchedIdentityOverride.
   const controlValue =
-    projectFlag.environment_feature_state?.feature_state_value ?? null
+    projectFlag.environment_feature_state?.feature_state_value
 
   // An override that predates the flag becoming multivariate holds a value the
   // control/variation radios cannot express, so surface it rather than letting
@@ -297,7 +299,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
     hasVariations &&
     hasUnmatchedIdentityOverride({
       controlValue,
-      overrideValue: featureState.feature_state_value ?? null,
+      overrideValue: featureState.feature_state_value,
       variationOverrides: identityVariations,
     })
 
@@ -308,7 +310,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   const unmatchedOverride = resolveUnmatchedOverride({
     isSelected: unmatchedOverrideSelected,
     latchedValue: latchedOverrideValue.current,
-    overrideValue: featureState.feature_state_value ?? null,
+    overrideValue: featureState.feature_state_value,
   })
   latchedOverrideValue.current = unmatchedOverride?.value
 
@@ -451,7 +453,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
               disabled
               select
               unmatchedOverride={unmatchedOverride}
-              controlValue={controlValue}
+              controlValue={controlValue ?? null}
               controlPercentage={controlPercentage}
               variationOverrides={identityVariations as any}
               setValue={(value) =>

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -23,9 +23,9 @@ interface VariationOptionsProps {
   removeVariation: (i: number) => void
   select?: boolean
   // An override value that is neither the control value nor one of the
-  // variations. Shown read-only and selected, so the identity does not read as
-  // being on the control value.
-  unmatchedOverride?: { value: FlagsmithValue }
+  // variations. Shown read-only, so the identity does not read as being on the
+  // control value. Stays listed once deselected — it is only gone on save.
+  unmatchedOverride?: { selected: boolean; value: FlagsmithValue }
   setValue: (value: FlagsmithValue) => void
   setVariations: (variations: VariationOverride[]) => void
   unsavedVariations?: boolean[]
@@ -61,7 +61,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
     return null
   }
   const controlSelected =
-    !unmatchedOverride &&
+    !unmatchedOverride?.selected &&
     (!variationOverrides ||
       !variationOverrides.find((v) => v.percentage_allocation === 100))
   return (
@@ -82,7 +82,17 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
                   value={Utils.getTypedValue(unmatchedOverride.value)}
                 />
               </Flex>
-              <div className='btn-radio btn-radio-on ml-2' />
+              <div
+                data-test='select-unmatched-override'
+                onMouseDown={(e) => {
+                  e.stopPropagation()
+                  setVariations([])
+                  setValue?.(unmatchedOverride.value)
+                }}
+                className={`btn-radio ml-2 ${
+                  unmatchedOverride.selected ? 'btn-radio-on' : ''
+                }`}
+              />
             </Row>
           </div>
         </div>

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -4,6 +4,7 @@ import ErrorMessage from 'components/ErrorMessage'
 import { VariationValueInput } from './VariationValueInput'
 import Utils from 'common/utils/utils'
 import { FlagsmithValue, MultivariateOption } from 'common/types/responses'
+import { UnmatchedOverride } from 'common/utils/multivariate'
 
 type VariationOverride = {
   id?: number
@@ -25,7 +26,7 @@ interface VariationOptionsProps {
   // An override value that is neither the control value nor one of the
   // variations. Shown read-only, so the identity does not read as being on the
   // control value. Stays listed once deselected — it is only gone on save.
-  unmatchedOverride?: { selected: boolean; value: FlagsmithValue }
+  unmatchedOverride?: UnmatchedOverride
   setValue: (value: FlagsmithValue) => void
   setVariations: (variations: VariationOverride[]) => void
   unsavedVariations?: boolean[]

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -22,6 +22,10 @@ interface VariationOptionsProps {
   readOnly?: boolean
   removeVariation: (i: number) => void
   select?: boolean
+  // An override value that is neither the control value nor one of the
+  // variations. Shown read-only and selected, so the identity does not read as
+  // being on the control value.
+  unmatchedOverride?: { value: FlagsmithValue }
   setValue: (value: FlagsmithValue) => void
   setVariations: (variations: VariationOverride[]) => void
   unsavedVariations?: boolean[]
@@ -46,6 +50,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
   select,
   setValue,
   setVariations,
+  unmatchedOverride,
   unsavedVariations,
   updateVariation,
   variationOverrides,
@@ -56,8 +61,9 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
     return null
   }
   const controlSelected =
-    !variationOverrides ||
-    !variationOverrides.find((v) => v.percentage_allocation === 100)
+    !unmatchedOverride &&
+    (!variationOverrides ||
+      !variationOverrides.find((v) => v.percentage_allocation === 100))
   return (
     <>
       {invalid && (
@@ -65,6 +71,21 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
           className='mt-2'
           error='Your variation percentage splits total to over 100%'
         />
+      )}
+      {select && !!unmatchedOverride && (
+        <div className='panel panel--flat panel-without-heading mb-2'>
+          <div className='panel-content'>
+            <Row>
+              <Flex>
+                <ValueEditor
+                  disabled
+                  value={Utils.getTypedValue(unmatchedOverride.value)}
+                />
+              </Flex>
+              <div className='btn-radio btn-radio-on ml-2' />
+            </Row>
+          </div>
+        </div>
       )}
       {select && (
         <div className='panel panel--flat panel-without-heading mb-2'>


### PR DESCRIPTION
When a flag with an existing identity override is later made multivariate, the _Edit User Feature_ modal stops showing what that identity is actually being served. The editor offers only the environment's control value and each variation as radios, so an override holding anything else has nowhere to appear — the control row reads as selected and the identity looks like it is on the environment default. The override is intact and the SDK keeps serving it, but saving the modal replaced it with the control value, so the value could be lost by simply opening and saving.

Rather than hiding it, the editor now shows the override's own value as a read-only, already-selected row alongside the variations, and warns that the value is not one of them so the user can move the identity onto a variation deliberately. Saving keeps the value unless the user picks the control or a variation instead.

## Changes

- [x] The _Edit User Feature_ modal shows an identity's override value even when it is not one of the flag's variations.
- [x] A warning explains that the value is not a variation, and recommends changing it.
- [x] Saving the modal no longer replaces such an override with the environment's control value.
- [x] Tests covering when an override counts as unrepresentable by the variation radios.

Closes https://github.com/Flagsmith/flagsmith/issues/8271

Review effort: 2/5

## How did you test this code?

Manually, end to end, against a local API and dashboard, following the reproduction steps in the issue: a flag with control value `ENV_DEFAULT`, an identity override of `MY_OVERRIDE`, then a variation `VARIANT_A` added to make the flag multivariate.

- Opening _Edit User Feature_ for that identity shows the warning, `MY_OVERRIDE` selected and read-only, `ENV_DEFAULT` and `VARIANT_A` unselected. On `main` the same modal shows `ENV_DEFAULT` selected and `MY_OVERRIDE` nowhere.
- Pressing _Update Feature_ without changing the selection leaves the stored value as `MY_OVERRIDE` (confirmed directly in the database). On `main` this is where the override was replaced with the control value.

Automated: the rule deciding whether an override is representable by the variation radios is unit tested in `common/utils/__tests__/multivariate.test.ts`, including the plan-unchanged case, an identity assigned a variation, a partially weighted override, and null/undefined/empty edge cases. `npm run test:unit` passes in full (402 tests), `npm run lint` reports nothing on the changed files, and `npm run typecheck` produces an identical error set to `main` for them.

## A note on behaviour

The same guard applies when a multivariate identity override's stored value has drifted from the environment's control value for any other reason — for example the environment control being edited after the override was made. Previously a save silently re-synced the identity onto the new control value, changing what that identity is served; now the value is shown, flagged, and left alone until the user chooses. That seemed the safer default given the issue is about a value disappearing, but say the word if you would rather keep re-syncing in that case.