### PR TITLE
feat: create segment from CSV drawer

### DIFF
--- a/frontend/common/theme/tokens.json
+++ b/frontend/common/theme/tokens.json
@@ -94,6 +94,7 @@
       "action-active": { "cssVar": "--color-surface-action-active", "light": "#3919b7", "dark": "#4e25db" },
       "action-subtle": { "cssVar": "--color-surface-action-subtle", "light": "rgba(104, 55, 252, 0.08)", "dark": "rgba(255, 255, 255, 0.08)" },
       "action-muted": { "cssVar": "--color-surface-action-muted", "light": "rgba(104, 55, 252, 0.16)", "dark": "rgba(255, 255, 255, 0.16)" },
+      "action-tint": { "cssVar": "--color-surface-action-tint", "light": "rgba(104, 55, 252, 0.12)", "dark": "rgba(144, 106, 246, 0.16)", "description": "Selected/highlighted surface that keeps its purple cast in dark mode, unlike the neutral dark alphas of action-subtle/action-muted." },
       "danger": { "cssVar": "--color-surface-danger", "light": "rgba(239, 77, 86, 0.08)", "dark": "oklch(from var(--red-500) 0.18 0.02 h)" },
       "success": { "cssVar": "--color-surface-success", "light": "rgba(39, 171, 149, 0.08)", "dark": "oklch(from var(--green-500) 0.18 0.02 h)" },
       "warning": { "cssVar": "--color-surface-warning", "light": "rgba(255, 159, 67, 0.08)", "dark": "oklch(from var(--orange-500) 0.18 0.02 h)" },

--- a/frontend/common/theme/tokens.ts
+++ b/frontend/common/theme/tokens.ts
@@ -179,6 +179,8 @@ export const colorSurfaceActionMuted =
   'var(--color-surface-action-muted, rgba(104, 55, 252, 0.16))'
 export const colorSurfaceActionSubtle =
   'var(--color-surface-action-subtle, rgba(104, 55, 252, 0.08))'
+export const colorSurfaceActionTint =
+  'var(--color-surface-action-tint, rgba(104, 55, 252, 0.12))'
 export const colorSurfaceActive =
   'var(--color-surface-active, rgba(0, 0, 0, 0.16))'
 export const colorSurfaceDanger =

--- a/frontend/common/utils/__tests__/csv.test.ts
+++ b/frontend/common/utils/__tests__/csv.test.ts
@@ -1,0 +1,81 @@
+import { extractIdentifiers, parseCsvText, toParsedCsv } from 'common/utils/csv'
+
+describe('parseCsvText', () => {
+  const cases: [string, string, string[][]][] = [
+    ['single column', 'a\nb\nc', [['a'], ['b'], ['c']]],
+    [
+      'multiple columns',
+      'id,email\n1,a@b.com',
+      [
+        ['id', 'email'],
+        ['1', 'a@b.com'],
+      ],
+    ],
+    ['crlf line endings', 'a\r\nb\r\n', [['a'], ['b']]],
+    [
+      'quoted fields with commas and escaped quotes',
+      '"a,b","say ""hi"""\nc,d',
+      [
+        ['a,b', 'say "hi"'],
+        ['c', 'd'],
+      ],
+    ],
+    ['blank lines dropped', 'a\n\n \nb', [['a'], ['b']]],
+    ['empty input', '', []],
+  ]
+
+  test.each(cases)('%s', (_, input, expected) => {
+    expect(parseCsvText(input)).toEqual(expected)
+  })
+})
+
+describe('toParsedCsv', () => {
+  const rawRows = [
+    ['id', 'email'],
+    ['1', 'a@b.com'],
+  ]
+
+  test('with headers, first row becomes column names', () => {
+    expect(toParsedCsv(rawRows, true)).toEqual({
+      columns: ['id', 'email'],
+      rows: [['1', 'a@b.com']],
+    })
+  })
+
+  test('without headers, generates Column N names', () => {
+    expect(toParsedCsv(rawRows, false)).toEqual({
+      columns: ['Column 1', 'Column 2'],
+      rows: rawRows,
+    })
+  })
+
+  test('blank header cells fall back to Column N', () => {
+    expect(toParsedCsv([['id', ''], ['1']], true).columns).toEqual([
+      'id',
+      'Column 2',
+    ])
+  })
+
+  test('empty input yields no columns or rows', () => {
+    expect(toParsedCsv([], true)).toEqual({ columns: [], rows: [] })
+  })
+})
+
+describe('extractIdentifiers', () => {
+  test('trims values and counts empty and duplicate rows', () => {
+    const rows = [['a'], [' b '], [''], ['a'], ['  '], ['b']]
+    expect(extractIdentifiers(rows, 0)).toEqual({
+      duplicateCount: 2,
+      emptyCount: 2,
+      identifiers: ['a', 'b'],
+    })
+  })
+
+  test('missing cells in short rows count as empty', () => {
+    expect(extractIdentifiers([['x', 'y'], ['z']], 1)).toEqual({
+      duplicateCount: 0,
+      emptyCount: 1,
+      identifiers: ['y'],
+    })
+  })
+})

--- a/frontend/common/utils/csv.ts
+++ b/frontend/common/utils/csv.ts
@@ -1,0 +1,98 @@
+export type ParsedCsv = {
+  columns: string[]
+  rows: string[][]
+}
+
+export type ExtractedIdentifiers = {
+  duplicateCount: number
+  emptyCount: number
+  identifiers: string[]
+}
+
+export function parseCsvText(text: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += char
+      }
+    } else if (char === '"') {
+      inQuotes = true
+    } else if (char === ',') {
+      row.push(field)
+      field = ''
+    } else if (char === '\n' || char === '\r') {
+      if (char === '\r' && text[i + 1] === '\n') {
+        i++
+      }
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+    } else {
+      field += char
+    }
+  }
+  if (field !== '' || row.length) {
+    row.push(field)
+    rows.push(row)
+  }
+  return rows.filter((cells) => cells.some((cell) => cell.trim() !== ''))
+}
+
+export function toParsedCsv(
+  rawRows: string[][],
+  hasHeaders: boolean,
+): ParsedCsv {
+  if (!rawRows.length) {
+    return { columns: [], rows: [] }
+  }
+  const columnCount = Math.max(...rawRows.map((cells) => cells.length))
+  if (hasHeaders) {
+    const [header, ...rows] = rawRows
+    return {
+      columns: Array.from(
+        { length: columnCount },
+        (_, i) => header[i]?.trim() || `Column ${i + 1}`,
+      ),
+      rows,
+    }
+  }
+  return {
+    columns: Array.from({ length: columnCount }, (_, i) => `Column ${i + 1}`),
+    rows: rawRows,
+  }
+}
+
+export function extractIdentifiers(
+  rows: string[][],
+  columnIndex: number,
+): ExtractedIdentifiers {
+  const seen = new Set<string>()
+  const identifiers: string[] = []
+  let emptyCount = 0
+  let duplicateCount = 0
+  for (const cells of rows) {
+    const value = (cells[columnIndex] ?? '').trim()
+    if (!value) {
+      emptyCount++
+    } else if (seen.has(value)) {
+      duplicateCount++
+    } else {
+      seen.add(value)
+      identifiers.push(value)
+    }
+  }
+  return { duplicateCount, emptyCount, identifiers }
+}

--- a/frontend/documentation/TokenReference.generated.stories.tsx
+++ b/frontend/documentation/TokenReference.generated.stories.tsx
@@ -119,6 +119,14 @@ export const AllTokens: StoryObj = {
           </tr>
           <tr>
             <td>
+              <code>--color-surface-action-tint</code>
+            </td>
+            <td>
+              <code>oklch(from var(--purple-600) l c h / 0.12)</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
               <code>--color-surface-danger</code>
             </td>
             <td>

--- a/frontend/e2e/helpers/e2e-helpers.playwright.ts
+++ b/frontend/e2e/helpers/e2e-helpers.playwright.ts
@@ -538,7 +538,18 @@ export class E2EHelpers {
   ) {
     await this.click(byId('show-create-segment-btn'));
     const flagsmith = await getFlagsmith();
-    if (flagsmith.hasFeature('create_segment_with_external_sources')) {
+    const segmentSources = flagsmith.getValue(
+      'create_segment_with_external_sources',
+      {
+        fallback: null,
+        json: true,
+      },
+    );
+    if (
+      flagsmith.hasFeature('create_segment_with_external_sources') &&
+      Array.isArray(segmentSources) &&
+      segmentSources.some((source) => source?.visible !== false)
+    ) {
       await this.click(byId('create-segment-manually'));
     }
     await this.setText(byId('segmentID'), name);

--- a/frontend/web/components/CsvUpload/CsvUpload.scss
+++ b/frontend/web/components/CsvUpload/CsvUpload.scss
@@ -1,0 +1,15 @@
+.csv-upload {
+  &__droparea {
+    padding: 32px;
+    border: 1px dashed var(--color-border-action);
+  }
+
+  &__file-card {
+    border: 1px solid var(--color-border-default);
+  }
+
+  &__file-icon {
+    width: 36px;
+    height: 36px;
+  }
+}

--- a/frontend/web/components/CsvUpload/CsvUpload.tsx
+++ b/frontend/web/components/CsvUpload/CsvUpload.tsx
@@ -1,0 +1,99 @@
+import { FC, useCallback, useState } from 'react'
+import { useDropzone } from 'react-dropzone'
+import { colorIconAction } from 'common/theme/tokens'
+import DropIcon from 'components/icons/DropIcon'
+import Icon from 'components/icons/Icon'
+import Button from 'components/base/forms/Button'
+import ErrorMessage from 'components/ErrorMessage'
+import './CsvUpload.scss'
+
+export type CsvUploadType = {
+  value: File | null
+  rowCount?: number
+  onChange: (file: File, text: string) => void
+}
+
+const formatFileSize = (bytes: number) => {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+const CsvUpload: FC<CsvUploadType> = ({ onChange, rowCount, value }) => {
+  const [error, setError] = useState('')
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      setError('')
+      const file = acceptedFiles[0]
+      if (!file) {
+        return
+      }
+      const reader = new FileReader()
+      reader.addEventListener('load', () => {
+        onChange(file, `${reader.result}`)
+      })
+      reader.addEventListener('error', () => {
+        setError('Error reading file')
+      })
+      reader.readAsText(file)
+    },
+    [onChange],
+  )
+
+  const { getInputProps, getRootProps, open } = useDropzone({
+    accept: {
+      'text/csv': ['.csv'],
+    },
+    multiple: false,
+    noClick: true,
+    noKeyboard: true,
+    onDrop,
+    onDropRejected: () => {
+      setError('Please select a CSV file')
+    },
+  })
+
+  return (
+    <div className='csv-upload'>
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        {value ? (
+          <div className='csv-upload__file-card d-flex align-items-center gap-3 p-3 rounded-lg bg-surface-default'>
+            <span className='csv-upload__file-icon d-inline-flex align-items-center justify-content-center flex-shrink-0 rounded-md bg-surface-action-tint'>
+              <Icon name='file-text' width={20} fill={colorIconAction} />
+            </span>
+            <div className='flex-fill overflow-hidden'>
+              <div className='fw-semibold text-truncate'>{value.name}</div>
+              <div className='fs-small text-secondary'>
+                {formatFileSize(value.size)}
+                {typeof rowCount === 'number' &&
+                  ` · ${rowCount.toLocaleString()} ${
+                    rowCount === 1 ? 'row' : 'rows'
+                  }`}
+              </div>
+            </div>
+            <Button theme='outline' onClick={open}>
+              Replace file
+            </Button>
+          </div>
+        ) : (
+          <div className='csv-upload__droparea text-center rounded-lg'>
+            <DropIcon />
+            <div className='mt-2 mb-2'>
+              <strong>Drag and drop your CSV here</strong>
+            </div>
+            <div className='text-secondary fs-small mb-3'>
+              or browse it from your computer
+            </div>
+            <Button onClick={open}>Select file</Button>
+          </div>
+        )}
+      </div>
+      {!!error && <ErrorMessage error={error} />}
+    </div>
+  )
+}
+
+export default CsvUpload

--- a/frontend/web/components/CsvUpload/index.ts
+++ b/frontend/web/components/CsvUpload/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CsvUpload'

--- a/frontend/web/components/EnvironmentSelect.tsx
+++ b/frontend/web/components/EnvironmentSelect.tsx
@@ -18,6 +18,7 @@ type EnvironmentSelectType = Partial<Omit<Props, 'value'>> & {
   readOnly?: boolean
   idField?: 'id' | 'api_key'
   ignore?: string[]
+  size?: 'default' | 'select-sm' | 'select-xsm'
   dataTest?: (value: { label: string }) => string
 }
 
@@ -30,6 +31,7 @@ const EnvironmentSelect: FC<EnvironmentSelectType> = ({
   projectId,
   readOnly,
   showAll,
+  size = 'select-xsm',
   value,
   ...rest
 }) => {
@@ -64,7 +66,7 @@ const EnvironmentSelect: FC<EnvironmentSelectType> = ({
     <div data-test={dataTestProp}>
       <Select
         {...rest}
-        className='react-select select-xsm'
+        className={size === 'default' ? 'react-select' : `react-select ${size}`}
         value={
           foundValue
             ? foundValue

--- a/frontend/web/components/EnvironmentSelect.tsx
+++ b/frontend/web/components/EnvironmentSelect.tsx
@@ -66,7 +66,7 @@ const EnvironmentSelect: FC<EnvironmentSelectType> = ({
     <div data-test={dataTestProp}>
       <Select
         {...rest}
-        className={size === 'default' ? 'react-select' : `react-select ${size}`}
+        size={size === 'default' ? undefined : size}
         value={
           foundValue
             ? foundValue

--- a/frontend/web/components/base/forms/Checkbox.tsx
+++ b/frontend/web/components/base/forms/Checkbox.tsx
@@ -25,7 +25,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
       <input id={idRef.current} type='checkbox' checked={checked} />
       <label
         onClick={handleChange}
-        className='mb-0 user-select-none d-inline'
+        className='mb-0 user-select-none d-inline cursor-pointer'
         htmlFor={idRef.current}
       >
         <span className='checkbox mr-2'>

--- a/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.scss
+++ b/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.scss
@@ -1,0 +1,38 @@
+.create-segment-from-csv {
+  &__select {
+    width: 220px;
+  }
+
+  &__section-label {
+    font-size: 12px;
+    letter-spacing: 0.05em;
+  }
+
+  &__preview {
+    border: 1px solid var(--color-border-default);
+
+    table {
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 12px 16px;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    thead th {
+      background: var(--color-surface-muted);
+    }
+
+    tbody tr {
+      border-top: 1px solid var(--color-border-default);
+      color: var(--color-text-secondary);
+    }
+
+    .create-segment-from-csv__cell--selected {
+      background: var(--color-surface-action-tint);
+    }
+  }
+}

--- a/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.tsx
+++ b/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.tsx
@@ -1,0 +1,292 @@
+import React, { FC, FormEvent, useMemo, useState } from 'react'
+import classNames from 'classnames'
+import Constants from 'common/constants'
+import Format from 'common/utils/format'
+import Utils from 'common/utils/utils'
+import { extractIdentifiers, parseCsvText, toParsedCsv } from 'common/utils/csv'
+import { useGetSupportedContentTypeQuery } from 'common/services/useSupportedContentType'
+import AccountStore from 'common/stores/account-store'
+import { colorIconSuccess } from 'common/theme/tokens'
+import Button from 'components/base/forms/Button'
+import Checkbox from 'components/base/forms/Checkbox'
+import Input from 'components/base/forms/Input'
+import InputGroup from 'components/base/forms/InputGroup'
+import CsvUpload from 'components/CsvUpload'
+import EnvironmentSelect from 'components/EnvironmentSelect'
+import ErrorMessage from 'components/ErrorMessage'
+import Icon from 'components/icons/Icon'
+import AddMetadataToEntity from 'components/metadata/AddMetadataToEntity'
+import TabItem from 'components/navigation/TabMenu/TabItem'
+import Tabs from 'components/navigation/TabMenu/Tabs'
+import './CreateSegmentFromCsv.scss'
+
+const PREVIEW_ROW_COUNT = 5
+
+type CreateSegmentFromCsvType = {
+  projectId: number | string
+}
+
+const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [environmentId, setEnvironmentId] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [rawRows, setRawRows] = useState<string[][]>([])
+  const [hasHeaders, setHasHeaders] = useState(true)
+  const [selectedColumn, setSelectedColumn] = useState<number | null>(null)
+  const [tab, setTab] = useState(0)
+
+  const metadataEnable = Utils.getPlansPermission('METADATA')
+  const { data: supportedContentTypes } = useGetSupportedContentTypeQuery({
+    organisation_id: AccountStore.getOrganisation().id,
+  })
+  const segmentContentType = useMemo(
+    () =>
+      supportedContentTypes &&
+      Utils.getContentType(supportedContentTypes, 'model', 'segment'),
+    [supportedContentTypes],
+  )
+
+  const parsed = useMemo(
+    () => toParsedCsv(rawRows, hasHeaders),
+    [rawRows, hasHeaders],
+  )
+  const columnIndex = parsed.columns.length === 1 ? 0 : selectedColumn
+  const extraction = useMemo(
+    () =>
+      columnIndex === null
+        ? null
+        : extractIdentifiers(parsed.rows, columnIndex),
+    [parsed.rows, columnIndex],
+  )
+
+  const isBlocked = !!extraction && !extraction.identifiers.length
+  const canSubmit =
+    !!name && !!environmentId && !!file && !!extraction && !isBlocked
+
+  const onFile = (newFile: File, text: string) => {
+    setFile(newFile)
+    setRawRows(parseCsvText(text))
+    setSelectedColumn(null)
+  }
+
+  const save = (e: FormEvent) => {
+    e.preventDefault()
+    // TODO: submit to the cohorts API once the creation endpoint exists
+  }
+
+  const columnName = columnIndex === null ? '' : parsed.columns[columnIndex]
+  let fileError = null
+  if (file && !parsed.columns.length) {
+    fileError = 'The file appears to be empty.'
+  } else if (file && !parsed.rows.length) {
+    fileError =
+      'No data rows found. If the first row is data rather than a header, untick "First row contains headers".'
+  }
+
+  const form = (
+    <form
+      className='px-2 pt-4'
+      id='create-segment-from-csv-modal'
+      onSubmit={save}
+    >
+      <div className='mb-4'>
+        <label htmlFor='segmentID'>Name*</label>
+        <Flex>
+          <Input
+            data-test='segmentID'
+            name='id'
+            id='segmentID'
+            maxLength={Constants.forms.maxLength.SEGMENT_ID}
+            value={name}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setName(
+                Format.enumeration
+                  .set(Utils.safeParseEventValue(e))
+                  .toLowerCase(),
+              )
+            }}
+            isValid={!!name?.length}
+            type='text'
+            placeholder='E.g. power_users'
+          />
+        </Flex>
+      </div>
+      <InputGroup
+        className='mb-4'
+        value={description}
+        inputProps={{ className: 'full-width', name: 'featureDesc' }}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setDescription(Utils.safeParseEventValue(e))
+        }}
+        type='text'
+        title='Description'
+        placeholder="e.g. 'People who have spent over $100' "
+      />
+      <div className='mb-4'>
+        <label>Environment</label>
+        <div className='create-segment-from-csv__select'>
+          <EnvironmentSelect
+            projectId={Number(projectId)}
+            idField='id'
+            size='default'
+            value={environmentId}
+            onChange={(value) => setEnvironmentId(`${value}`)}
+          />
+        </div>
+        <div className='fs-small text-muted mt-1'>
+          The uploaded identities will be targeted in this environment only.
+        </div>
+      </div>
+      <div className='mb-4'>
+        <CsvUpload
+          value={file}
+          rowCount={file ? parsed.rows.length : undefined}
+          onChange={onFile}
+        />
+      </div>
+      {!!file && !!parsed.columns.length && (
+        <div className='mb-4 d-flex align-items-end justify-content-between gap-3 flex-wrap'>
+          {fileError ? (
+            <div />
+          ) : (
+            <div>
+              <label>Identifier column</label>
+              <div className='create-segment-from-csv__select'>
+                <Select
+                  data-test='identifier-column-select'
+                  isDisabled={parsed.columns.length === 1}
+                  placeholder='Select column'
+                  value={
+                    columnIndex === null
+                      ? null
+                      : { label: columnName, value: columnIndex }
+                  }
+                  options={parsed.columns.map((label, value) => ({
+                    label,
+                    value,
+                  }))}
+                  onChange={(option: { value: number }) =>
+                    setSelectedColumn(option.value)
+                  }
+                />
+              </div>
+            </div>
+          )}
+          <div className='mb-2'>
+            <Checkbox
+              label='First row contains headers'
+              checked={hasHeaders}
+              onChange={setHasHeaders}
+            />
+          </div>
+        </div>
+      )}
+      {!!fileError && <ErrorMessage error={fileError} />}
+      {!!file && !fileError && (
+        <>
+          {!!parsed.rows.length && (
+            <div className='mb-4'>
+              <div className='create-segment-from-csv__section-label fw-semibold text-secondary text-uppercase mb-2'>
+                Preview (first {PREVIEW_ROW_COUNT} rows)
+              </div>
+              <div className='create-segment-from-csv__preview rounded-lg overflow-auto'>
+                <table className='mb-0 w-100 fs-small'>
+                  <thead>
+                    <tr>
+                      {parsed.columns.map((column, i) => (
+                        <th
+                          key={i}
+                          className={classNames('fw-semibold', {
+                            'create-segment-from-csv__cell--selected':
+                              i === columnIndex,
+                          })}
+                        >
+                          {column}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {parsed.rows.slice(0, PREVIEW_ROW_COUNT).map((row, i) => (
+                      <tr key={i}>
+                        {parsed.columns.map((_, j) => (
+                          <td
+                            key={j}
+                            className={classNames({
+                              'create-segment-from-csv__cell--selected':
+                                j === columnIndex,
+                            })}
+                          >
+                            {row[j]}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {!!extraction && !isBlocked && (
+                <div className='d-flex align-items-center gap-2 mt-2 fs-small text-secondary'>
+                  <Icon
+                    name='checkmark-circle'
+                    width={16}
+                    fill={colorIconSuccess}
+                  />
+                  <span>
+                    {extraction.identifiers.length.toLocaleString()}{' '}
+                    {extraction.identifiers.length === 1
+                      ? 'identifier'
+                      : 'identifiers'}{' '}
+                    detected. Duplicates and empty rows will be ignored.
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+          {isBlocked && (
+            <ErrorMessage
+              error={`No valid identifiers found in "${columnName}". Choose a different column or check your file.`}
+            />
+          )}
+        </>
+      )}
+      <div className='text-right py-3'>
+        <Button data-test='create-segment' disabled={!canSubmit} type='submit'>
+          Create Segment
+        </Button>
+      </div>
+    </form>
+  )
+
+  if (!metadataEnable || !segmentContentType?.id) {
+    return form
+  }
+
+  return (
+    <Tabs value={tab} onChange={(newTab: number) => setTab(newTab)}>
+      <TabItem
+        tabLabelString='Basic configuration'
+        tabLabel='Basic configuration'
+      >
+        {form}
+      </TabItem>
+      <TabItem tabLabelString='Custom Fields' tabLabel='Custom Fields'>
+        <FormGroup className='px-2 pt-4 setting'>
+          <InputGroup
+            component={
+              <AddMetadataToEntity
+                organisationId={AccountStore.getOrganisation().id}
+                projectId={Number(projectId)}
+                entityContentType={segmentContentType.id}
+                entity={segmentContentType.model}
+              />
+            }
+          />
+        </FormGroup>
+      </TabItem>
+    </Tabs>
+  )
+}
+
+export default CreateSegmentFromCsv

--- a/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.tsx
+++ b/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.tsx
@@ -9,7 +9,7 @@ import AccountStore from 'common/stores/account-store'
 import { colorIconSuccess } from 'common/theme/tokens'
 import Button from 'components/base/forms/Button'
 import Checkbox from 'components/base/forms/Checkbox'
-import Input from 'components/base/forms/Input'
+import FieldLabel from 'components/base/forms/FieldLabel'
 import InputGroup from 'components/base/forms/InputGroup'
 import CsvUpload from 'components/CsvUpload'
 import EnvironmentSelect from 'components/EnvironmentSelect'
@@ -90,28 +90,25 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
       id='create-segment-from-csv-modal'
       onSubmit={save}
     >
-      <div className='mb-4'>
-        <label htmlFor='segmentID'>Name*</label>
-        <Flex>
-          <Input
-            data-test='segmentID'
-            name='id'
-            id='segmentID'
-            maxLength={Constants.forms.maxLength.SEGMENT_ID}
-            value={name}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setName(
-                Format.enumeration
-                  .set(Utils.safeParseEventValue(e))
-                  .toLowerCase(),
-              )
-            }}
-            isValid={!!name?.length}
-            type='text'
-            placeholder='E.g. power_users'
-          />
-        </Flex>
-      </div>
+      <InputGroup
+        className='mb-4'
+        id='segmentID'
+        data-test='segmentID'
+        title='Name*'
+        value={name}
+        inputProps={{
+          maxLength: Constants.forms.maxLength.SEGMENT_ID,
+          name: 'id',
+        }}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setName(
+            Format.enumeration.set(Utils.safeParseEventValue(e)).toLowerCase(),
+          )
+        }}
+        isValid={!!name?.length}
+        type='text'
+        placeholder='E.g. power_users'
+      />
       <InputGroup
         className='mb-4'
         value={description}
@@ -124,9 +121,10 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
         placeholder="e.g. 'People who have spent over $100' "
       />
       <div className='mb-4'>
-        <label>Environment</label>
+        <FieldLabel htmlFor='environment-select'>Environment</FieldLabel>
         <div className='create-segment-from-csv__select'>
           <EnvironmentSelect
+            inputId='environment-select'
             projectId={Number(projectId)}
             idField='id'
             size='default'
@@ -151,9 +149,12 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
             <div />
           ) : (
             <div>
-              <label>Identifier column</label>
+              <FieldLabel htmlFor='identifier-column-select'>
+                Identifier column
+              </FieldLabel>
               <div className='create-segment-from-csv__select'>
                 <Select
+                  inputId='identifier-column-select'
                   data-test='identifier-column-select'
                   isDisabled={parsed.columns.length === 1}
                   placeholder='Select column'

--- a/frontend/web/components/modals/CreateSegmentFromCsv/index.ts
+++ b/frontend/web/components/modals/CreateSegmentFromCsv/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CreateSegmentFromCsv'

--- a/frontend/web/components/modals/CreateSegmentSourcesModal/CreateSegmentSourcesModal.tsx
+++ b/frontend/web/components/modals/CreateSegmentSourcesModal/CreateSegmentSourcesModal.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from 'react'
 import flagsmith from '@flagsmith/flagsmith'
 import classNames from 'classnames'
 import AccountStore from 'common/stores/account-store'
+import Utils from 'common/utils/utils'
 import { colorIconAction } from 'common/theme/tokens'
 import Button from 'components/base/forms/Button'
 import BareButton from 'components/base/forms/BareButton'
@@ -9,7 +10,8 @@ import Chip from 'components/base/Chip'
 import Icon from 'components/icons/Icon'
 import './CreateSegmentSourcesModal.scss'
 
-type SegmentSource = {
+export type SegmentSource = {
+  active: boolean
   description: string
   image?: string
   key: string
@@ -18,45 +20,77 @@ type SegmentSource = {
 
 type SelectedSegmentSource = SegmentSource | null
 
-const SOURCES: SegmentSource[] = [
-  {
-    description:
-      'Upload identifiers to create a managed segment. Update members with a new upload.',
-    key: 'csv',
-    name: 'From a CSV list',
-  },
-  {
-    description:
-      'Sync a behavioural cohort as a managed segment, updated on schedule or real-time.',
-    image: '/static/images/integrations/amplitude.svg',
-    key: 'amplitude',
-    name: 'Amplitude',
-  },
-  {
-    description:
-      'A managed segment that updates as users enter and exit your Mixpanel cohort.',
-    image: '/static/images/integrations/mp.svg',
-    key: 'mixpanel',
-    name: 'Mixpanel',
-  },
-  {
+const SOURCE_DETAILS: Record<string, Omit<SegmentSource, 'active'>> = {
+  adobe_journey_manager: {
     description:
       'Activate an Adobe audience as a managed segment, refreshed automatically by Adobe.',
     image: '/static/images/integrations/adobe-analytics.png',
     key: 'adobe_journey_manager',
     name: 'Adobe Journey Manager',
   },
-]
+  amplitude: {
+    description:
+      'Sync a behavioural cohort as a managed segment, updated on schedule or real-time.',
+    image: '/static/images/integrations/amplitude.svg',
+    key: 'amplitude',
+    name: 'Amplitude',
+  },
+  csv: {
+    description:
+      'Upload identifiers to create a managed segment. Update members with a new upload.',
+    key: 'csv',
+    name: 'From a CSV list',
+  },
+  mixpanel: {
+    description:
+      'A managed segment that updates as users enter and exit your Mixpanel cohort.',
+    image: '/static/images/integrations/mp.svg',
+    key: 'mixpanel',
+    name: 'Mixpanel',
+  },
+}
+
+type SegmentSourceFlagEntry = {
+  active?: boolean
+  name?: string
+  visible?: boolean
+}
+
+export function getSegmentSources(): SegmentSource[] {
+  const config = Utils.getFlagsmithJSONValue(
+    'create_segment_with_external_sources',
+    [],
+  )
+  if (!Array.isArray(config)) {
+    return []
+  }
+  return (config as SegmentSourceFlagEntry[])
+    .filter(
+      (entry) => entry?.visible !== false && SOURCE_DETAILS[entry?.name ?? ''],
+    )
+    .map((entry) => ({
+      ...SOURCE_DETAILS[entry.name ?? ''],
+      active: !!entry.active,
+    }))
+}
 
 type CreateSegmentSourcesModalType = {
   onManual: () => void
+  onCsv?: () => void
+  sources: SegmentSource[]
 }
 
 const CreateSegmentSourcesModal: FC<CreateSegmentSourcesModalType> = ({
+  onCsv,
   onManual,
+  sources,
 }) => {
   const [selected, setSelected] = useState<SelectedSegmentSource>(null)
   const [requested, setRequested] = useState<string[]>([])
+
+  const sourceHandlers: Partial<Record<string, () => void>> = {
+    csv: onCsv,
+  }
 
   const trackSourceEvent = (event: string, source: SegmentSource) => {
     flagsmith.trackEvent(event, {
@@ -74,6 +108,12 @@ const CreateSegmentSourcesModal: FC<CreateSegmentSourcesModalType> = ({
   }
 
   const selectSource = (source: SegmentSource) => {
+    const handler = source.active ? sourceHandlers[source.key] : undefined
+    if (handler) {
+      closeModal()
+      handler()
+      return
+    }
     if (selected?.key === source.key) {
       return
     }
@@ -111,8 +151,9 @@ const CreateSegmentSourcesModal: FC<CreateSegmentSourcesModalType> = ({
         </div>
       </BareButton>
       <div className='row g-0'>
-        {SOURCES.map((source) => {
+        {sources.map((source) => {
           const isSelected = selected?.key === source.key
+          const isFakeDoor = !source.active || !sourceHandlers[source.key]
           return (
             <div key={source.key} className='col-md-6 p-1'>
               <BareButton
@@ -147,10 +188,12 @@ const CreateSegmentSourcesModal: FC<CreateSegmentSourcesModalType> = ({
                     {source.description}
                   </div>
                 </div>
-                <Chip size='xs' variant='accent' className='fw-semibold'>
-                  <Icon name='rocket' width={12} />
-                  Beta
-                </Chip>
+                {isFakeDoor && (
+                  <Chip size='xs' variant='accent' className='fw-semibold'>
+                    <Icon name='rocket' width={12} />
+                    Beta
+                  </Chip>
+                )}
               </BareButton>
             </div>
           )

--- a/frontend/web/components/modals/CreateSegmentSourcesModal/index.ts
+++ b/frontend/web/components/modals/CreateSegmentSourcesModal/index.ts
@@ -1,1 +1,2 @@
-export { default } from './CreateSegmentSourcesModal'
+export { default, getSegmentSources } from './CreateSegmentSourcesModal'
+export type { SegmentSource } from './CreateSegmentSourcesModal'

--- a/frontend/web/components/modals/base/Modal.tsx
+++ b/frontend/web/components/modals/base/Modal.tsx
@@ -37,7 +37,9 @@ const withModal = (
     shouldInterceptClose?: boolean
   } = {},
 ) => {
-  return (props: ModalProps) => {
+  // HTMLAttributes types the native title attribute as a string; the modal
+  // header renders any node.
+  return (props: Omit<ModalProps, 'title'> & { title?: ReactNode }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [isOpen, setIsOpen] = useState(true)
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -126,7 +128,7 @@ export const openConfirm = (global.openConfirm = ({
 })
 
 export const openModal = (global.openModal = (
-  title: string,
+  title: ReactNode,
   body: ReactNode,
   className?: string,
   onClose?: () => void,

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -12,8 +12,12 @@ import {
 import { useHasPermission } from 'common/providers/Permission'
 import API from 'project/api'
 import Button from 'components/base/forms/Button'
+import Chip from 'components/base/Chip'
 import CreateSegmentModal from 'components/modals/CreateSegment'
-import CreateSegmentSourcesModal from 'components/modals/CreateSegmentSourcesModal'
+import CreateSegmentFromCsv from 'components/modals/CreateSegmentFromCsv'
+import CreateSegmentSourcesModal, {
+  getSegmentSources,
+} from 'components/modals/CreateSegmentSourcesModal'
 import PanelSearch from 'components/PanelSearch'
 import JSONReference from 'components/JSONReference'
 
@@ -100,11 +104,32 @@ const SegmentsPage: FC = () => {
     )
   }
 
+  const openCreateSegmentFromCsvDrawer = () => {
+    openModal(
+      <div className='d-flex align-items-center gap-2'>
+        New Segment
+        <Chip size='xs' variant='accent'>
+          CSV
+        </Chip>
+      </div>,
+      <CreateSegmentFromCsv projectId={projectId} />,
+      'side-modal create-new-segment-modal',
+    )
+  }
+
   const newSegment = () => {
-    if (Utils.getFlagsmithHasFeature('create_segment_with_external_sources')) {
+    const sources = getSegmentSources()
+    if (
+      Utils.getFlagsmithHasFeature('create_segment_with_external_sources') &&
+      sources.length
+    ) {
       openModal(
         'Create Segment',
-        <CreateSegmentSourcesModal onManual={openCreateSegmentDrawer} />,
+        <CreateSegmentSourcesModal
+          sources={sources}
+          onManual={openCreateSegmentDrawer}
+          onCsv={openCreateSegmentFromCsvDrawer}
+        />,
         'p-0 modal--wide',
       )
     } else {

--- a/frontend/web/styles/3rdParty/_react-select.scss
+++ b/frontend/web/styles/3rdParty/_react-select.scss
@@ -202,6 +202,9 @@
   &.select-xsm {
     font-size: $font-size-sm;
   }
+  &__control:not(&__control--is-disabled) {
+    cursor: pointer;
+  }
   &__option {
     color: $body-color !important;
     background: white !important;

--- a/frontend/web/styles/_token-utilities.scss
+++ b/frontend/web/styles/_token-utilities.scss
@@ -11,6 +11,7 @@
 .bg-surface-action-hover { background-color: var(--color-surface-action-hover); }
 .bg-surface-action-muted { background-color: var(--color-surface-action-muted); }
 .bg-surface-action-subtle { background-color: var(--color-surface-action-subtle); }
+.bg-surface-action-tint { background-color: var(--color-surface-action-tint); }
 .bg-surface-active { background-color: var(--color-surface-active); }
 .bg-surface-danger { background-color: var(--color-surface-danger); }
 .bg-surface-default { background-color: var(--color-surface-default); }

--- a/frontend/web/styles/_tokens.scss
+++ b/frontend/web/styles/_tokens.scss
@@ -92,6 +92,7 @@
   --color-surface-action-hover: var(--purple-700);
   --color-surface-action-muted: oklch(from var(--purple-600) l c h / 0.16);
   --color-surface-action-subtle: oklch(from var(--purple-600) l c h / 0.08);
+  --color-surface-action-tint: oklch(from var(--purple-600) l c h / 0.12);
   --color-surface-active: oklch(from var(--slate-1000) l c h / 0.16);
   --color-surface-danger: oklch(from var(--red-500) l c h / 0.08);
   --color-surface-default: var(--slate-0);
@@ -197,6 +198,7 @@
   --color-surface-action-hover: var(--purple-600);
   --color-surface-action-muted: oklch(from var(--slate-0) l c h / 0.16);
   --color-surface-action-subtle: oklch(from var(--slate-0) l c h / 0.08);
+  --color-surface-action-tint: oklch(from var(--purple-400) l c h / 0.16);
   --color-surface-active: oklch(from var(--slate-0) l c h / 0.16);
   --color-surface-danger: oklch(from var(--red-500) 0.18 0.02 h);
   --color-surface-default: var(--slate-950);


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Adds the "New Segment — from a CSV list" drawer behind the segment sources modal, and makes the sources modal config-driven instead of hardcoded.

**Flag-driven sources.** The modal now reads its cards from the JSON value of the `create_segment_with_external_sources` flag:

```json
[
  { "active": true, "name": "csv", "visible": true },
  { "active": false, "name": "amplitude", "visible": true },
  { "active": false, "name": "mixpanel", "visible": true },
  { "active": false, "name": "adobe_journey_manager", "visible": true }
]
```

`visible: false` hides a card, `active: false` renders it as a Beta fake door, `active: true` makes it real (currently only CSV has an implementation — an active source without one safely stays a fake door). Array order controls display order. Copy and icons stay in the frontend. Flag enabled with an empty or invalid value falls back to the manual drawer.

**CSV drawer.**

- Client-side CSV parsing (quoted fields, CRLF, BOM)
- Optional header row
- Identifier column selection with a highlighted 5-row preview
- Ignored-row warnings (empty/duplicate) and a blocking error when a column yields no identifiers
- Submission is wired in the follow-up PR

## How did you test this code?

Unit tests for the CSV parser/extractor (`common/utils/__tests__/csv.test.ts`). Manually:

1. Set the JSON value above on the `create_segment_with_external_sources` flag and enable it.
2. Segments → Create Segment: modal shows the cards; non-active sources show the Beta chip and the request-access flow.
3. Click "From a CSV list" (active): the drawer opens; upload a CSV with/without headers, switch the identifier column, and check the preview, warnings, and the empty-column blocking error.
4. Disable the flag or set the value to `[]`: the button opens the manual drawer directly.


## Screens
**Upload screen**
<img width="687" height="773" alt="image" src="https://github.com/user-attachments/assets/3082a052-c15c-4d50-b240-059ac0ac999d" />

**Uploaded but unselected**
<img width="701" height="927" alt="image" src="https://github.com/user-attachments/assets/c6e55cd4-19d8-4457-8938-48e69e4db406" />

**Uploaded selected**
<img width="694" height="945" alt="image" src="https://github.com/user-attachments/assets/42d43cb1-7976-4273-aac3-caa56f56a2f1" />
<img width="702" height="961" alt="image" src="https://github.com/user-attachments/assets/33a9a8ec-3159-40ca-9d38-8c43ba9ef7da" />

**Error states**
<img width="689" height="861" alt="image" src="https://github.com/user-attachments/assets/1b7a4950-b76b-40e6-bdf6-f77e4e3f3305" />
<img width="692" height="682" alt="image" src="https://github.com/user-attachments/assets/a018d039-ef62-4fa4-94f6-19f1248be0ae" />
<img width="705" height="701" alt="image" src="https://github.com/user-attachments/assets/52918cea-1c27-411b-823e-4e803cfc9ab1" />
