### PR TITLE
fix(Segments): Flaky test fails because of unspecified Condition ordering

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1425,11 +1425,13 @@ if not 0 <= FEATURE_VALUE_LIMIT <= 2000000:
         "FEATURE_VALUE_LIMIT must be between 0 and 2,000,000 (2MB)."
     )
 
+# TODO: Delete as per https://github.com/Flagsmith/flagsmith/issues/7818
 SEGMENT_RULES_CONDITIONS_LIMIT = env.int("SEGMENT_RULES_CONDITIONS_LIMIT", 100)
 
 # These settings are to handle large datasets / odd behaviour where rules and conditions
 # often aren't returned in the order that they were created in, which the code implicitly
 # expects.
+# TODO: Delete as per https://github.com/Flagsmith/flagsmith/issues/7818
 SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED = env.bool(
     "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED", default=False
 )
@@ -1437,6 +1439,7 @@ SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED = env.bool(
 # In SaaS, we need to be able to split out rules and conditions
 # (since the ordering issue has been evident on rules for longer, and
 # only recently happened to conditions).
+# TODO: Delete as per https://github.com/Flagsmith/flagsmith/issues/7818
 SEGMENT_CONDITIONS_EXPLICIT_ORDERING_ENABLED = env.bool(
     "SEGMENT_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
     default=SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED,

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -1997,8 +1997,10 @@ def test_update_segment__whitelisted_segment_exceeds_max_conditions__returns_200
     mocker: MockerFixture,
     project: Project,
     segment: Segment,
+    settings: SettingsWrapper,
 ) -> None:
     # Given
+    settings.SEGMENT_CONDITIONS_EXPLICIT_ORDERING_ENABLED = True
     WhitelistedSegment.objects.create(segment=segment)
     timestamp = "2099-01-01T00:00:00Z"
     over_limit_rule: SegmentRuleType = {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] ~I have added information to `docs/` if required so people know about the feature.~
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith/issues/7815

- Fix one flaky test caused by `Condition` rows being delivered in unspecified order. See [example](https://github.com/Flagsmith/flagsmith/actions/runs/31699219238/job/94444003369?pr=8281).
- Adds more delete sites for #7818 

## How did you test this code?

Included test change.