### PR TITLE
fix(value-editor): restore the border on JSON values

### DIFF
--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -282,9 +282,6 @@
   }
 }
 
-.json {
-  border: none;
-}
 .value-editor pre {
   overflow: hidden;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Removes a stale, bare `.json { border: none }` rule in `_hljs.scss` that overrides the `.hljs` border on the value editor's `<code class="json">`, so JSON values render without the box shown for `.txt` / `.xml` / `.toml` / `.yaml`.

The selector is unscoped (it also matches the `.json` language tab) and same-specificity as `.hljs`, so being declared later it wins and strips the border. Removing it lets JSON use the same `.hljs` border as the other languages. `.json` is the only affected language; there are no other bare language-class selectors.

## How did you test this code?

Manually:

1. Open a feature value editor (or an identity override) and enter a value.
2. Switch the language between `.txt`, `.xml`, `.toml`, `.yaml`, `.json`.
3. Before: `.json` shows no bordered box; the others do.
4. After: `.json` renders the same bordered box as the other languages.
