### PR TITLE
fix(sentry): match uploaded sourcemap release to the app's release

### DIFF
--- a/frontend/rspack/rspack.config.prod.js
+++ b/frontend/rspack/rspack.config.prod.js
@@ -7,13 +7,17 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin')
 const base = require('../rspack.config')
 
+// One release id for both the app and the sourcemap upload, so Sentry can
+// match events to maps and de-minify traces.
+const SENTRY_RELEASE = Date.now().toString()
+
 const extraPlugins = [
   new rspack.CssExtractRspackPlugin({
     chunkFilename: '[id].[fullhash].css',
     filename: '[name].[fullhash].css',
   }),
   new rspack.DefinePlugin({
-    SENTRY_RELEASE_VERSION: JSON.stringify(Date.now().toString()),
+    SENTRY_RELEASE_VERSION: JSON.stringify(SENTRY_RELEASE),
     __DEV__: false,
   }),
 ]
@@ -74,6 +78,7 @@ module.exports = {
               authToken: process.env.SENTRY_AUTH_TOKEN,
               org: 'flagsmith',
               project: 'flagsmith-frontend',
+              release: { name: SENTRY_RELEASE },
             }),
           ]
         : [],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The Sentry webpack plugin in `rspack.config.prod.js` had no `release` set, so it uploaded sourcemaps under an auto-detected name (git SHA / its own default). The app, meanwhile, reports `Date.now()` as its release via `SENTRY_RELEASE_VERSION`. Because the two didn't match, Sentry couldn't associate events with the uploaded sourcemaps, so production stack traces stayed minified and grouped poorly (one bug fragmented into several issues).

This computes the release id once and passes it to both the `DefinePlugin` (what the app reports) and `sentryWebpackPlugin` (what the sourcemaps are uploaded under), so they match.

Note: upload still only runs when `SENTRY_AUTH_TOKEN` is present in the build env, so that also needs to be set in the prod pipeline for maps to reach Sentry.

## How did you test this code?

This is build-config only, so it's verified by inspection and by a follow-up check after deploy:

1. A prod build now passes the same value to `SENTRY_RELEASE_VERSION` and to the plugin's `release.name`.
2. After a release with `SENTRY_AUTH_TOKEN` set, confirm a newly reported frontend error shows de-minified frames in Sentry (function names + source lines) instead of minified `?(…):224:63`.
