### PR TITLE
fix(onboarding): let segment overrides match the entry decision

### DIFF
--- a/frontend/common/utils/onboardingEntry.ts
+++ b/frontend/common/utils/onboardingEntry.ts
@@ -23,8 +23,8 @@ export type OnboardingEntryDecision = {
 export async function decideOnboardingEntry(
   email?: string,
 ): Promise<OnboardingEntryDecision> {
-  // No trait means no segment override can match, and email is the only trait
-  // we have before the organisation exists.
+  // Only used to match segment overrides, not for bucketing. An override on
+  // another trait needs that trait passed here too.
   // @ts-expect-error transient is missing from the SDK's identify type
   await flagsmith.identify('', email ? { email } : {}, true)
   const flag = flagsmith.getExperimentFlag('onboarding_quickstart_flow')

--- a/frontend/common/utils/onboardingEntry.ts
+++ b/frontend/common/utils/onboardingEntry.ts
@@ -20,9 +20,13 @@ export type OnboardingEntryDecision = {
  * the logged-in user, and the routing it should have driven has happened.
  * Call `persistOnboardingEntry` with an accepted decision.
  */
-export async function decideOnboardingEntry(): Promise<OnboardingEntryDecision> {
+export async function decideOnboardingEntry(
+  email?: string,
+): Promise<OnboardingEntryDecision> {
+  // No trait means no segment override can match, and email is the only trait
+  // we have before the organisation exists.
   // @ts-expect-error transient is missing from the SDK's identify type
-  await flagsmith.identify('', {}, true)
+  await flagsmith.identify('', email ? { email } : {}, true)
   const flag = flagsmith.getExperimentFlag('onboarding_quickstart_flow')
   const identifier = flagsmith.getContext().identity?.identifier
   const variant: OnboardingVariant =

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -151,7 +151,9 @@ const App = class extends Component {
       // instead of blocking the redirect.
       Promise.race([
         AccountStore.getUser()?.isGettingStarted
-          ? decideOnboardingEntry().catch(() => null)
+          ? decideOnboardingEntry(AccountStore.getUser()?.email).catch(
+              () => null,
+            )
           : Promise.resolve(null),
         new Promise((resolve) => setTimeout(() => resolve(null), 2000)),
       ]).then((decision) => {


### PR DESCRIPTION
## Changes

Contributes to #7540

Signing up with a `@flagsmith.com` email gave me the legacy flow, even though the `flagsmith_team` segment on `onboarding_quickstart_flow` should have put me into the new one.

The segment was fine. The entry decision identifies with no traits (`flagsmith.identify('', {}, true)`), and segment overrides match on traits, so none could ever apply. This passes the user's email through as a transient trait.

Bucketing is unchanged: the split is keyed on the identifier the API assigns, not on traits.

## How did you test this code?

Reproduced the symptom by signing up with a `@flagsmith.com` email. Unit tests and eslint pass.

Not confirmed end to end: sign up with an email in the `flagsmith_team` segment and check you land on the new onboarding.