### PR TITLE
fix: remove segment_source_beta_requested fake door event

### DIFF
--- a/frontend/web/components/modals/CreateSegmentSourcesModal/CreateSegmentSourcesModal.tsx
+++ b/frontend/web/components/modals/CreateSegmentSourcesModal/CreateSegmentSourcesModal.tsx
@@ -85,7 +85,6 @@ const CreateSegmentSourcesModal: FC<CreateSegmentSourcesModalType> = ({
     if (!selected) {
       return
     }
-    trackSourceEvent('segment_source_beta_requested', selected)
     setRequested((prev) => [...prev, selected.key])
   }
 


### PR DESCRIPTION
Clicking **Request access to the beta** in the create-segment sources fake door was meant to be a no-op, but it tracked a second `segment_source_beta_requested` event alongside `segment_source_clicked`. This removes the extra event; the modal now only tracks `segment_source_clicked` when a source is selected. The thank-you UI state on the button is unchanged.