### PR TITLE
feat: load HubSpot script on staging

### DIFF
--- a/frontend/env/project_staging.js
+++ b/frontend/env/project_staging.js
@@ -16,6 +16,8 @@ const Project = {
   flagsmithClientEdgeAPI: 'https://edge.bullet-train-staging.win/api/v1/',
 
   flagsmithClientEventsAPI: 'https://events.bullet-train-staging.win/',
+
+  hubspot: '//js-eu1.hs-scripts.com/143451822.js',
   // This is used for Sentry tracking
   maintenance: false,
   plans: {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [ ] I have filled in the "How did you test this code" section below.

## Changes

Adds the `hubspot` key to `frontend/env/project_staging.js`, pointing at the same portal as prod (`143451822`).

This is to enable the HubSpot chat button in staging for testing purposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)