### PR TITLE
chore(__future__): Drop the AnonymousUser asserts and the strict log assertions

### DIFF
--- a/api/core/types.py
+++ b/api/core/types.py
@@ -1,0 +1,14 @@
+from rest_framework.request import Request
+
+from api_keys.user import APIKeyUser
+from users.models import FFAdminUser
+
+
+class AuthenticatedRequest(Request):
+    """A request a permission class has already vetted as authenticated.
+
+    Annotate a view method with this in place of `Request` to narrow `request.user`,
+    which DRF types as possibly anonymous, wherever `IsAuthenticated` guarantees a user.
+    """
+
+    user: FFAdminUser | APIKeyUser

--- a/api/features/future/views.py
+++ b/api/features/future/views.py
@@ -3,14 +3,13 @@
 from collections.abc import Mapping
 
 import structlog
-from django.contrib.auth.models import AnonymousUser
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from core.types import AuthenticatedRequest
 from environments.models import Environment
 from features.future.exceptions import ChangeRequestsEnabledError
 from features.future.permissions import (
@@ -68,9 +67,9 @@ class FlagAPIView(APIView):
         tags=["experimental"],
         description="Read what the flag serves in the environment.",
     )
-    def get(self, request: Request, environment_key: str, feature_id: int) -> Response:
-        assert not isinstance(request.user, AnonymousUser)
-
+    def get(
+        self, request: AuthenticatedRequest, environment_key: str, feature_id: int
+    ) -> Response:
         environment = _get_environment(environment_key)
         check_read_permissions(request.user, environment)
         feature = _get_feature(environment, feature_id)
@@ -84,7 +83,7 @@ class FlagAPIView(APIView):
         description="Update the properties given, leaving the rest as they are.",
     )
     def patch(
-        self, request: Request, environment_key: str, feature_id: int
+        self, request: AuthenticatedRequest, environment_key: str, feature_id: int
     ) -> Response:
         return self._update_flag(request, environment_key, feature_id, replace=False)
 
@@ -94,19 +93,19 @@ class FlagAPIView(APIView):
         tags=["experimental"],
         description="Replace the properties given, resetting what they omit.",
     )
-    def put(self, request: Request, environment_key: str, feature_id: int) -> Response:
+    def put(
+        self, request: AuthenticatedRequest, environment_key: str, feature_id: int
+    ) -> Response:
         return self._update_flag(request, environment_key, feature_id, replace=True)
 
     def _update_flag(
         self,
-        request: Request,
+        request: AuthenticatedRequest,
         environment_key: str,
         feature_id: int,
         *,
         replace: bool,
     ) -> Response:
-        assert not isinstance(request.user, AnonymousUser)
-
         if not isinstance(request.data, Mapping):
             raise ValidationError("Expected an object.")
 
@@ -147,10 +146,12 @@ class SegmentOverrideAPIView(APIView):
         ),
     )
     def delete(
-        self, request: Request, environment_key: str, feature_id: int, segment_id: int
+        self,
+        request: AuthenticatedRequest,
+        environment_key: str,
+        feature_id: int,
+        segment_id: int,
     ) -> Response:
-        assert not isinstance(request.user, AnonymousUser)
-
         environment = _get_environment(environment_key)
         check_segment_overrides_permissions(request.user, environment)
         feature = _get_feature(environment, feature_id)

--- a/api/tests/integration/features/future/test_flag_endpoint.py
+++ b/api/tests/integration/features/future/test_flag_endpoint.py
@@ -95,7 +95,6 @@ def two_segment_overrides(
     admin_client_new: APIClient,
     environment_api_key: str,
     feature: int,
-    log: StructuredLogCapture,
     segment: int,
     segment_2: int,
     versioned_environment: Environment,
@@ -123,7 +122,6 @@ def two_segment_overrides(
         format="json",
     )
     assert response.status_code == 200
-    log.events.clear()
 
 
 @pytest.mark.parametrize(
@@ -309,19 +307,17 @@ def test_update_flag__patch_environment_default_enabled__toggles_flag(
         feature_segment=None,
     ).get()
     assert environment_default.enabled is True
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_environment_default_value__updates_value(
@@ -356,19 +352,17 @@ def test_update_flag__patch_environment_default_value__updates_value(
         feature_segment=None,
     ).get()
     assert environment_default.get_feature_state_value() == 1000
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_environment_default_variants__reweights_variants(
@@ -422,19 +416,17 @@ def test_update_flag__patch_environment_default_variants__reweights_variants(
             "multivariate_feature_option_id", "percentage_allocation"
         )
     ) == {variant_a: 25, variant_b: 25.5}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": mv_feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=mv_feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_segment_override_enabled__creates_override(
@@ -481,19 +473,17 @@ def test_update_flag__patch_segment_override_enabled__creates_override(
     assert override.feature_segment.priority == 0
     assert override.enabled is True
     assert override.get_feature_state_value() == default_feature_value
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_segment_override_value__overrides_value(
@@ -553,19 +543,17 @@ def test_update_flag__patch_segment_override_value__overrides_value(
         live_feature_states.get(feature_segment=None).get_feature_state_value()
         == default_feature_value
     )
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__new_segment_override_without_state__inherits_environment_default_state(
@@ -590,7 +578,6 @@ def test_update_flag__new_segment_override_without_state__inherits_environment_d
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.patch(
@@ -623,19 +610,17 @@ def test_update_flag__new_segment_override_without_state__inherits_environment_d
     ).get(feature_segment__segment_id=segment)
     assert override.enabled is True
     assert override.get_feature_state_value() == "control"
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_segment_overrides_without_priority__sets_priority_from_position(
@@ -666,7 +651,6 @@ def test_update_flag__patch_segment_overrides_without_priority__sets_priority_fr
         (override["segment"]["id"], override["priority"])
         for override in setup_response.json()["segment_overrides"]
     ] == [(segment, 0), (segment_2, 1)]  # Priority is inferred when creating overrides
-    log.events.clear()
 
     # When
     response = admin_client_new.patch(
@@ -714,19 +698,17 @@ def test_update_flag__patch_segment_overrides_without_priority__sets_priority_fr
         .exclude(feature_segment=None)
         .values_list("feature_segment__segment_id", "feature_segment__priority")
     ) == {segment: 0, segment_2: 1}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [segment_2],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[segment_2],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_segment_override_priority__writes_priority_as_given(
@@ -757,7 +739,6 @@ def test_update_flag__patch_segment_override_priority__writes_priority_as_given(
         (override["segment"]["id"], override["priority"])
         for override in setup_response.json()["segment_overrides"]
     ] == [(segment_2, 1), (segment, 10)]
-    log.events.clear()
 
     # When
     response = admin_client_new.patch(
@@ -801,19 +782,17 @@ def test_update_flag__patch_segment_override_priority__writes_priority_as_given(
         .exclude(feature_segment=None)
         .values_list("feature_segment__segment_id", "feature_segment__priority")
     ) == {segment: 5, segment_2: 1}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [segment],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[segment],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_segment_override_priority_in_use__responds_400(
@@ -930,7 +909,6 @@ def test_update_flag__patch_segment_overrides_swapping_priorities__reorders_over
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.patch(
@@ -960,19 +938,17 @@ def test_update_flag__patch_segment_overrides_swapping_priorities__reorders_over
         .exclude(feature_segment=None)
         .values_list("feature_segment__segment_id", "feature_segment__priority")
     ) == {segment: 1, segment_2: 0}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [segment_2, segment],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[segment_2, segment],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__patch_segment_override_variants__reweights_for_segment_only(
@@ -1049,19 +1025,17 @@ def test_update_flag__patch_segment_override_variants__reweights_for_segment_onl
             "multivariate_feature_option_id", "percentage_allocation"
         )
     ) == {variant_a: 10, variant_b: 20}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": mv_feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=mv_feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__new_segment_override_without_variants__inherits_environment_default_variants(
@@ -1091,7 +1065,6 @@ def test_update_flag__new_segment_override_without_variants__inherits_environmen
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.patch(
@@ -1135,19 +1108,17 @@ def test_update_flag__new_segment_override_without_variants__inherits_environmen
             "multivariate_feature_option_id", "percentage_allocation"
         )
     ) == {variant_a: 25, variant_b: 25.5}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": mv_feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=mv_feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__put_segment_override_without_variants__inherits_environment_default_variants(
@@ -1187,7 +1158,6 @@ def test_update_flag__put_segment_override_without_variants__inherits_environmen
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.put(
@@ -1231,19 +1201,17 @@ def test_update_flag__put_segment_override_without_variants__inherits_environmen
             "multivariate_feature_option_id", "percentage_allocation"
         )
     ) == {variant_a: 25, variant_b: 25.5}
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": mv_feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [segment],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=mv_feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[segment],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__put_environment_default__replaces_environment_default(
@@ -1267,7 +1235,6 @@ def test_update_flag__put_environment_default__replaces_environment_default(
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.put(
@@ -1293,19 +1260,17 @@ def test_update_flag__put_environment_default__replaces_environment_default(
     ).get()
     assert environment_default.enabled is True
     assert environment_default.get_feature_state_value() is None
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__put_segment_overrides__replaces_segment_overrides(
@@ -1335,7 +1300,6 @@ def test_update_flag__put_segment_overrides__replaces_segment_overrides(
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.put(
@@ -1385,19 +1349,17 @@ def test_update_flag__put_segment_overrides__replaces_segment_overrides(
         live_feature_states.get(feature_segment=None).get_feature_state_value()
         == "control"
     )
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [segment],
-            "segment_overrides__deleted__segment__ids": [segment_2],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[segment],
+        segment_overrides__deleted__segment__ids=[segment_2],
+    )
 
 
 def test_update_flag__put_environment_default_and_segment_overrides__replaces_both(
@@ -1426,7 +1388,6 @@ def test_update_flag__put_environment_default_and_segment_overrides__replaces_bo
         format="json",
     )
     assert setup_response.status_code == 200
-    log.events.clear()
 
     # When
     response = admin_client_new.put(
@@ -1480,19 +1441,17 @@ def test_update_flag__put_environment_default_and_segment_overrides__replaces_bo
         ).get_feature_state_value()
         == 42
     )
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [segment_2],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[segment_2],
+    )
 
 
 def test_update_flag__change_requests_enabled__responds_409(
@@ -1525,17 +1484,15 @@ def test_update_flag__change_requests_enabled__responds_409(
         feature_segment=None,
     ).get()
     assert environment_default.enabled is False
-    assert log.events == [
-        {
-            "level": "warning",
-            "event": "flag.update_rejected",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "reason": "change_requests_enabled",
-        },
-    ]
+    assert log.has(
+        "flag.update_rejected",
+        level="warning",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        reason="change_requests_enabled",
+    )
 
 
 def test_update_flag__value_not_matching_type__responds_400(
@@ -1815,19 +1772,17 @@ def test_update_flag__update_feature_state_permission__gates_environment_default
     )
     assert live_feature_states.get(feature_segment=None).enabled is True
     assert not live_feature_states.exclude(feature_segment=None).exists()
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__manage_segment_overrides_permission__gates_segment_overrides_only(
@@ -1874,19 +1829,17 @@ def test_update_flag__manage_segment_overrides_permission__gates_segment_overrid
     override = live_feature_states.get(feature_segment__segment_id=segment)
     assert override.enabled is True
     assert live_feature_states.get(feature_segment=None).enabled is False
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [segment],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[segment],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[],
+    )
 
 
 def test_update_flag__unknown_variant__responds_400(
@@ -2143,19 +2096,17 @@ def test_delete_segment_override__existing_override__removes_override(
         )
     ) == {segment_2: 1}
     assert live_feature_states.get(feature_segment=None).enabled is False
-    assert log.events == [
-        {
-            "level": "info",
-            "event": "flag.updated",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "segment_overrides__created__segment__ids": [],
-            "segment_overrides__updated__segment__ids": [],
-            "segment_overrides__deleted__segment__ids": [segment],
-        },
-    ]
+    assert log.has(
+        "flag.updated",
+        level="info",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        segment_overrides__created__segment__ids=[],
+        segment_overrides__updated__segment__ids=[],
+        segment_overrides__deleted__segment__ids=[segment],
+    )
 
 
 def test_delete_segment_override__environment_versioned__publishes_new_version(
@@ -2289,17 +2240,15 @@ def test_delete_segment_override__change_requests_enabled__responds_409(
         .filter(feature_segment__segment_id=segment)
         .exists()
     )
-    assert log.events == [
-        {
-            "level": "warning",
-            "event": "flag.update_rejected",
-            "organisation__id": versioned_environment.project.organisation_id,
-            "project__id": versioned_environment.project_id,
-            "environment__id": versioned_environment.id,
-            "feature__id": feature,
-            "reason": "change_requests_enabled",
-        },
-    ]
+    assert log.has(
+        "flag.update_rejected",
+        level="warning",
+        organisation__id=versioned_environment.project.organisation_id,
+        project__id=versioned_environment.project_id,
+        environment__id=versioned_environment.id,
+        feature__id=feature,
+        reason="change_requests_enabled",
+    )
 
 
 def test_delete_segment_override__user_without_environment_permissions__responds_404(
@@ -2328,7 +2277,9 @@ def test_delete_segment_override__user_without_environment_permissions__responds
         .filter(feature_segment__segment_id=segment)
         .exists()
     )
-    assert log.events == []
+    assert not log.has(
+        "flag.updated", segment_overrides__deleted__segment__ids=[segment]
+    )
 
 
 @pytest.mark.parametrize(

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -267,7 +267,7 @@ Attributes:
 ### `features.flag.update_rejected`
 
 Logged at `warning` from:
- - `api/features/future/views.py:50`
+ - `api/features/future/views.py:49`
 
 Attributes:
  - `environment.id`


### PR DESCRIPTION

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Cleanup only — no behaviour changes.

In this PR, we remove the `not isinstance(request.user, AnonymousUser)` littered across the codebase in favour of a centralised `AuthenticatedRequest` type, and migrate most of the logging assertions to `log.has` to avoid having to call `log.events.clear()` in the functional tests' fixtures.

Stacked on https://github.com/Flagsmith/flagsmith/pull/8307.

## How did you test this code?

Green CI is sufficient.