### PR TITLE
fix(button): give buttons a visible keyboard focus indicator

### DIFF
--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -20,7 +20,7 @@ button.btn {
   &-link {
     color: $primary;
     &:hover,
-    &:focus {
+    &:focus-visible {
       background: transparent;
     }
     &.btn:active {
@@ -32,7 +32,7 @@ button.btn {
   &-danger {
     color: white;
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: white;
       background-color: $btn-danger-hover;
     }
@@ -48,7 +48,7 @@ button.btn {
   &-success {
     color: white;
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: white;
       background-color: $btn-success-hover;
     }
@@ -76,7 +76,7 @@ button.btn {
       color: $primary;
     }
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-outline-hover-bg;
       color: $primary;
     }
@@ -89,7 +89,7 @@ button.btn {
       border-color: $alert-danger-border-color !important;
       color: $danger !important;
       &:hover,
-      &:focus {
+      &:focus-visible {
         background-color: $danger-alfa-8;
       }
       &.btn:active {
@@ -103,7 +103,7 @@ button.btn {
     background-color: $btn-secondary-bg !important;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-secondary-hover-bg !important;
       color: $body-color;
     }
@@ -118,7 +118,7 @@ button.btn {
     background-color: $btn-tertiary-bg;
     box-shadow: 0 10px 20px rgba(247, 213, 110, .2);
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-tertiary-hover-bg;
       color: $body-color;
     }
@@ -131,7 +131,7 @@ button.btn {
   &-success {
     background-color: $btn-success;
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $btn-success-hover;
       color: $text-icon-light;
     }
@@ -160,7 +160,7 @@ button.btn {
     path {
       fill: var(--color-icon-secondary);
     }
-    &:hover,&:focus {
+    &:hover,&:focus-visible {
       background-color: $bg-light300;
       path {
         fill: var(--color-icon-default);
@@ -184,7 +184,7 @@ button.btn {
         }
       }
     }
-    &:focus {
+    &:focus-visible {
       background-color: $basic-alpha-8 !important;
       svg {
         path {
@@ -300,7 +300,7 @@ button.btn-link {
   text-transform: inherit;
   font-weight: 500;
   &:hover,
-  &:focus {
+  &:focus-visible {
     color: var(--color-text-action);
     background: transparent;
     text-decoration: underline;
@@ -356,7 +356,7 @@ $add-btn-size: 34px;
   .btn {
     &.btn-icon {
       color: $body-color-dark;
-      &:hover,&:focus {
+      &:hover,&:focus-visible {
         background-color: $bg-dark300;
       }
     }
@@ -364,7 +364,7 @@ $add-btn-size: 34px;
       color: white;
       background-color: $btn-secondary-bg-dark !important;
       &:hover,
-      &:focus {
+      &:focus-visible {
         background-color: $btn-secondary-hover-bg-dark !important;
       }
       &:active {
@@ -375,7 +375,7 @@ $add-btn-size: 34px;
     &.btn-success {
       background-color: $btn-success;
       &:hover,
-      &:focus {
+      &:focus-visible {
         background-color: $btn-success-hover;
         color: $text-icon-light;
       }
@@ -397,7 +397,7 @@ $add-btn-size: 34px;
         border-color: $primary400;
         background-color: $btn-outline-hover-bg-dark;
       }
-      &:focus {
+      &:focus-visible {
         background-color: $btn-outline-focus-bg-dark;
       }
       &:active {

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -9,8 +9,12 @@ button.btn {
   height: $btn-line-height;
   white-space: nowrap;
   color: white;
+  // Bootstrap's focus ring is a wide box-shadow glow; this replaces it with
+  // the same outline BareButton uses, so icon-only buttons show focus too.
   &:focus-visible {
     box-shadow: none;
+    outline: 2px solid var(--color-border-action);
+    outline-offset: 2px;
   }
 
   &-link {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`.btn:focus-visible` set `box-shadow: none`, removing Bootstrap's focus ring without replacing it, so no button in the app shows keyboard focus. Icon-only buttons show nothing at all, which reads as Tab skipping them.

Two commits:

1. Replaces the suppressed ring with the outline `BareButton` already uses, so the two primitives match. WCAG 2.4.7.
2. Swaps the remaining `:focus` rules to `:focus-visible`, so a mouse click no longer leaves a button looking pressed. This is #7437, which was closed unreviewed; drop the commit if you'd rather keep it separate.

## How did you test this code?

Not yet, hence the draft. It touches every button, so it needs a visual-regression run, particularly icon buttons in table cells and tight flex rows where `outline-offset` may clip.

Found while reviewing #8044.