### PR TITLE
feat(OIDC): stack the issuer and audience in one column

### DIFF
--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
@@ -1,8 +1,7 @@
-// Column widths and the issuer/audience grid: what the utilities cannot express.
 .trust-relationships {
-  // Both cells stack two lines, so they need more room than `.table-column`
-  // gives a single-line cell. Qualified so it outranks the shorthand there
-  // whichever order the two stylesheets land in.
+  // 12px matches the side padding and gives the two stacked lines room.
+  // Double class so it beats `.table-column`'s padding shorthand whichever
+  // order the stylesheets land in.
   &__name-column.table-column,
   &__config-column.table-column {
     padding-block: 0.75rem;
@@ -13,7 +12,6 @@
     min-width: 0;
   }
 
-  // The two URLs need roughly twice the room the name does.
   &__config-column {
     flex: 2 1 0;
     min-width: 0;
@@ -23,6 +21,7 @@
     flex: 0 0 80px;
   }
 
+  // Lets a long name shrink rather than widen the column and break the ratio.
   &__name-body {
     min-width: 0;
   }
@@ -37,9 +36,5 @@
     margin: 0;
     // Keeps the label on the first line of a value that wraps.
     align-items: baseline;
-  }
-
-  &__config-label {
-    letter-spacing: 0.04em;
   }
 }

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
@@ -27,10 +27,6 @@
     min-width: 0;
   }
 
-  &__name {
-    font-weight: var(--font-weight-medium);
-  }
-
   // A grid rather than two rows, so both values start at the same edge however
   // wide the labels render.
   &__config {
@@ -41,21 +37,9 @@
     margin: 0;
     // Keeps the label on the first line of a value that wraps.
     align-items: baseline;
-
-    // The list's own margins would break the grid rows apart.
-    dt,
-    dd {
-      margin: 0;
-    }
   }
 
   &__config-label {
-    font-weight: var(--font-weight-medium);
     letter-spacing: 0.04em;
-  }
-
-  // Issuers and audiences are long and have no spaces to break on.
-  &__config-value {
-    overflow-wrap: anywhere;
   }
 }

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
@@ -1,0 +1,61 @@
+// Column widths and the issuer/audience grid: what the utilities cannot express.
+.trust-relationships {
+  // Both cells stack two lines, so they need more room than `.table-column`
+  // gives a single-line cell. Qualified so it outranks the shorthand there
+  // whichever order the two stylesheets land in.
+  &__name-column.table-column,
+  &__config-column.table-column {
+    padding-block: 0.75rem;
+  }
+
+  &__name-column {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  // The two URLs need roughly twice the room the name does.
+  &__config-column {
+    flex: 2 1 0;
+    min-width: 0;
+  }
+
+  &__narrow-column {
+    flex: 0 0 80px;
+  }
+
+  &__name-body {
+    min-width: 0;
+  }
+
+  &__name {
+    font-weight: var(--font-weight-medium);
+  }
+
+  // A grid rather than two rows, so both values start at the same edge however
+  // wide the labels render.
+  &__config {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: 1rem;
+    row-gap: 0.25rem;
+    margin: 0;
+    // Keeps the label on the first line of a value that wraps.
+    align-items: baseline;
+
+    // The list's own margins would break the grid rows apart.
+    dt,
+    dd {
+      margin: 0;
+    }
+  }
+
+  &__config-label {
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.04em;
+  }
+
+  // Issuers and audiences are long and have no spaces to break on.
+  &__config-value {
+    overflow-wrap: anywhere;
+  }
+}

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.scss
@@ -33,7 +33,6 @@
     grid-template-columns: auto minmax(0, 1fr);
     column-gap: 1rem;
     row-gap: 0.25rem;
-    margin: 0;
     // Keeps the label on the first line of a value that wraps.
     align-items: baseline;
   }

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
@@ -19,6 +19,13 @@ import {
 } from 'common/services/useTrustRelationship'
 import './TrustRelationships.scss'
 
+// Header and body cells share these, so a column cannot drift out of alignment.
+const COLUMN = {
+  config: 'trust-relationships__config-column table-column',
+  name: 'trust-relationships__name-column table-column px-3',
+  narrow: 'trust-relationships__narrow-column table-column',
+}
+
 const NameCell: FC<{ trustRelationship: TrustRelationship }> = ({
   trustRelationship,
 }) => (
@@ -161,18 +168,10 @@ const TrustRelationships: FC<TrustRelationshipsProps> = ({
           items={data.results}
           header={
             <Row className='table-header'>
-              <div className='trust-relationships__name-column table-column px-3'>
-                Name
-              </div>
-              <div className='trust-relationships__config-column table-column'>
-                OIDC configuration
-              </div>
-              <div className='trust-relationships__narrow-column table-column'>
-                Is admin
-              </div>
-              <div className='trust-relationships__narrow-column table-column'>
-                Remove
-              </div>
+              <div className={COLUMN.name}>Name</div>
+              <div className={COLUMN.config}>OIDC configuration</div>
+              <div className={COLUMN.narrow}>Is admin</div>
+              <div className={COLUMN.narrow}>Remove</div>
             </Row>
           }
           renderRow={(trustRelationship: TrustRelationship) => (
@@ -182,19 +181,19 @@ const TrustRelationships: FC<TrustRelationshipsProps> = ({
               onClick={() => editTrustRelationship(trustRelationship)}
               data-test={`trust-relationship-${trustRelationship.id}`}
             >
-              <div className='trust-relationships__name-column table-column px-3'>
+              <div className={COLUMN.name}>
                 <NameCell trustRelationship={trustRelationship} />
               </div>
-              <div className='trust-relationships__config-column table-column'>
+              <div className={COLUMN.config}>
                 <ConfigurationCell trustRelationship={trustRelationship} />
               </div>
               <div
-                className='trust-relationships__narrow-column table-column'
+                className={COLUMN.narrow}
                 onClick={(e) => e.stopPropagation()}
               >
                 <Switch checked={trustRelationship.is_admin} disabled />
               </div>
-              <div className='trust-relationships__narrow-column table-column'>
+              <div className={COLUMN.narrow}>
                 <Button
                   className='btn btn-with-icon'
                   onClick={(e) => {

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
@@ -43,13 +43,13 @@ const ConfigurationCell: FC<{ trustRelationship: TrustRelationship }> = ({
   trustRelationship,
 }) => (
   <dl className='trust-relationships__config'>
-    <dt className='trust-relationships__config-label font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
+    <dt className='font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
       Issuer
     </dt>
     <dd className='font-monospace text-break m-0'>
       {trustRelationship.issuer}
     </dd>
-    <dt className='trust-relationships__config-label font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
+    <dt className='font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
       Audience
     </dt>
     <dd className='font-monospace text-break m-0'>

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
@@ -30,7 +30,9 @@ const NameCell: FC<{ trustRelationship: TrustRelationship }> = ({
       {providerIconForIssuer(trustRelationship.issuer, 20)}
     </span>
     <div className='trust-relationships__name-body'>
-      <div className='font-weight-medium'>{trustRelationship.name}</div>
+      <div className='font-weight-medium text-break'>
+        {trustRelationship.name}
+      </div>
       <div className='list-item-subtitle'>
         Created {moment(trustRelationship.created_at).format('Do MMM YYYY')}
       </div>
@@ -42,7 +44,7 @@ const NameCell: FC<{ trustRelationship: TrustRelationship }> = ({
 const ConfigurationCell: FC<{ trustRelationship: TrustRelationship }> = ({
   trustRelationship,
 }) => (
-  <dl className='trust-relationships__config'>
+  <dl className='trust-relationships__config m-0'>
     <dt className='font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
       Issuer
     </dt>

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
@@ -30,7 +30,7 @@ const NameCell: FC<{ trustRelationship: TrustRelationship }> = ({
       {providerIconForIssuer(trustRelationship.issuer, 20)}
     </span>
     <div className='trust-relationships__name-body'>
-      <div className='trust-relationships__name'>{trustRelationship.name}</div>
+      <div className='font-weight-medium'>{trustRelationship.name}</div>
       <div className='list-item-subtitle'>
         Created {moment(trustRelationship.created_at).format('Do MMM YYYY')}
       </div>
@@ -43,16 +43,16 @@ const ConfigurationCell: FC<{ trustRelationship: TrustRelationship }> = ({
   trustRelationship,
 }) => (
   <dl className='trust-relationships__config'>
-    <dt className='trust-relationships__config-label fs-captionSmall text-secondary text-uppercase'>
+    <dt className='trust-relationships__config-label font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
       Issuer
     </dt>
-    <dd className='trust-relationships__config-value font-monospace'>
+    <dd className='font-monospace text-break m-0'>
       {trustRelationship.issuer}
     </dd>
-    <dt className='trust-relationships__config-label fs-captionSmall text-secondary text-uppercase'>
+    <dt className='trust-relationships__config-label font-weight-medium fs-captionSmall text-secondary text-uppercase m-0'>
       Audience
     </dt>
-    <dd className='trust-relationships__config-value font-monospace'>
+    <dd className='font-monospace text-break m-0'>
       {trustRelationship.audience}
     </dd>
   </dl>

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/TrustRelationships/TrustRelationships.tsx
@@ -11,27 +11,52 @@ import { trustRelationshipErrorMessage } from 'components/pages/organisation-set
 import NewTrustRelationshipModal from 'components/pages/organisation-settings/tabs/trust-relationships/NewTrustRelationshipModal'
 import TrustRelationshipModal from 'components/pages/organisation-settings/tabs/trust-relationships/TrustRelationshipModal'
 import { isGithubFormEditable } from 'components/pages/organisation-settings/tabs/trust-relationships/github'
-import { providerForIssuer } from 'components/pages/organisation-settings/tabs/trust-relationships/providers'
+import { providerIconForIssuer } from 'components/pages/organisation-settings/tabs/trust-relationships/providers'
 import { TrustRelationship } from 'common/types/responses'
 import {
   useDeleteTrustRelationshipMutation,
   useGetTrustRelationshipsQuery,
 } from 'common/services/useTrustRelationship'
+import './TrustRelationships.scss'
 
-// The issuer always reads in full; a known provider gets a badge alongside it.
-const IssuerCell: FC<{ issuer: string }> = ({ issuer }) => {
-  const provider = providerForIssuer(issuer)
-  return (
-    <Row className='gap-1 align-items-center'>
-      {!!provider && (
-        <span className='d-flex' aria-hidden>
-          {provider.icon(16)}
-        </span>
-      )}
-      <span className='font-monospace'>{issuer}</span>
-    </Row>
-  )
-}
+const NameCell: FC<{ trustRelationship: TrustRelationship }> = ({
+  trustRelationship,
+}) => (
+  <Row className='gap-2 align-items-center' noWrap>
+    <span
+      className='d-flex align-items-center justify-content-center flex-shrink-0 p-2 rounded-lg bg-surface-muted'
+      aria-hidden
+    >
+      {providerIconForIssuer(trustRelationship.issuer, 20)}
+    </span>
+    <div className='trust-relationships__name-body'>
+      <div className='trust-relationships__name'>{trustRelationship.name}</div>
+      <div className='list-item-subtitle'>
+        Created {moment(trustRelationship.created_at).format('Do MMM YYYY')}
+      </div>
+    </div>
+  </Row>
+)
+
+// Both URLs read in full, labelled, so one column carries the whole exchange.
+const ConfigurationCell: FC<{ trustRelationship: TrustRelationship }> = ({
+  trustRelationship,
+}) => (
+  <dl className='trust-relationships__config'>
+    <dt className='trust-relationships__config-label fs-captionSmall text-secondary text-uppercase'>
+      Issuer
+    </dt>
+    <dd className='trust-relationships__config-value font-monospace'>
+      {trustRelationship.issuer}
+    </dd>
+    <dt className='trust-relationships__config-label fs-captionSmall text-secondary text-uppercase'>
+      Audience
+    </dt>
+    <dd className='trust-relationships__config-value font-monospace'>
+      {trustRelationship.audience}
+    </dd>
+  </dl>
+)
 
 type TrustRelationshipsProps = {
   organisationId: number
@@ -134,13 +159,16 @@ const TrustRelationships: FC<TrustRelationshipsProps> = ({
           items={data.results}
           header={
             <Row className='table-header'>
-              <Flex className='table-column px-3'>Name</Flex>
-              <Flex className='table-column'>Issuer</Flex>
-              <Flex className='table-column'>Audience</Flex>
-              <div className='table-column' style={{ width: 80 }}>
+              <div className='trust-relationships__name-column table-column px-3'>
+                Name
+              </div>
+              <div className='trust-relationships__config-column table-column'>
+                OIDC configuration
+              </div>
+              <div className='trust-relationships__narrow-column table-column'>
                 Is admin
               </div>
-              <div className='table-column' style={{ width: 80 }}>
+              <div className='trust-relationships__narrow-column table-column'>
                 Remove
               </div>
             </Row>
@@ -152,29 +180,19 @@ const TrustRelationships: FC<TrustRelationshipsProps> = ({
               onClick={() => editTrustRelationship(trustRelationship)}
               data-test={`trust-relationship-${trustRelationship.id}`}
             >
-              <Flex className='table-column px-3'>
-                <div className='font-weight-medium'>
-                  {trustRelationship.name}
-                </div>
-                <div className='list-item-subtitle'>
-                  Created{' '}
-                  {moment(trustRelationship.created_at).format('Do MMM YYYY')}
-                </div>
-              </Flex>
-              <Flex className='table-column'>
-                <IssuerCell issuer={trustRelationship.issuer} />
-              </Flex>
-              <Flex className='table-column font-monospace'>
-                {trustRelationship.audience}
-              </Flex>
+              <div className='trust-relationships__name-column table-column px-3'>
+                <NameCell trustRelationship={trustRelationship} />
+              </div>
+              <div className='trust-relationships__config-column table-column'>
+                <ConfigurationCell trustRelationship={trustRelationship} />
+              </div>
               <div
-                className='table-column'
-                style={{ width: 80 }}
+                className='trust-relationships__narrow-column table-column'
                 onClick={(e) => e.stopPropagation()}
               >
                 <Switch checked={trustRelationship.is_admin} disabled />
               </div>
-              <div className='table-column' style={{ width: 80 }}>
+              <div className='trust-relationships__narrow-column table-column'>
                 <Button
                   className='btn btn-with-icon'
                   onClick={(e) => {

--- a/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/providers.tsx
+++ b/frontend/web/components/pages/organisation-settings/tabs/trust-relationships/providers.tsx
@@ -19,30 +19,41 @@ export type TrustRelationshipProvider = {
   icon: (size: number) => ReactNode
 }
 
+const GITHUB_PROVIDER: TrustRelationshipProvider = {
+  badge: 'Recommended',
+  description:
+    'Let workflows in a GitHub repository authenticate with their OIDC job token. Recommended if your CI runs on GitHub Actions.',
+  icon: (size) => (
+    <GithubIcon width={size} height={size} fill={colorIconDefault} />
+  ),
+  issuer: GITHUB_ISSUER,
+  key: 'github',
+  label: GITHUB_LABEL,
+}
+
+const OTHER_PROVIDER: TrustRelationshipProvider = {
+  description:
+    'Configure a custom issuer, audience and claim matching rules for any OIDC identity provider, such as GitLab CI or Kubernetes.',
+  icon: (size) => (
+    <Icon name='shield' width={size} height={size} fill={colorIconDefault} />
+  ),
+  key: 'other',
+  label: 'Other OIDC provider',
+}
+
 export const TRUST_RELATIONSHIP_PROVIDERS: TrustRelationshipProvider[] = [
-  {
-    badge: 'Recommended',
-    description:
-      'Let workflows in a GitHub repository authenticate with their OIDC job token. Recommended if your CI runs on GitHub Actions.',
-    icon: (size) => (
-      <GithubIcon width={size} height={size} fill={colorIconDefault} />
-    ),
-    issuer: GITHUB_ISSUER,
-    key: 'github',
-    label: GITHUB_LABEL,
-  },
-  {
-    description:
-      'Configure a custom issuer, audience and claim matching rules for any OIDC identity provider, such as GitLab CI or Kubernetes.',
-    icon: (size) => (
-      <Icon name='shield' width={size} height={size} fill={colorIconDefault} />
-    ),
-    key: 'other',
-    label: 'Other OIDC provider',
-  },
+  GITHUB_PROVIDER,
+  OTHER_PROVIDER,
 ]
 
 export const providerForIssuer = (
   issuer: string,
 ): TrustRelationshipProvider | undefined =>
   TRUST_RELATIONSHIP_PROVIDERS.find((provider) => provider.issuer === issuer)
+
+// Every list row carries an icon, so an issuer we have no preset for falls back
+// to the freeform provider's icon instead of leaving a gap in the column.
+export const providerIconForIssuer = (
+  issuer: string,
+  size: number,
+): ReactNode => (providerForIssuer(issuer) || OTHER_PROVIDER).icon(size)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8040

Follow-up to #8313. Issuer and audience each had their own column, which left both cramped and neither labelled. They now share an "OIDC configuration" column as a label/value stack, and the provider icon moves into the name cell as a tile so every row is identifiable at a glance.

An issuer we have no preset for falls back to the freeform provider's icon, so the column stays even.

| Before | After |
| --- | --- |
|<img width="1028" height="272" alt="image" src="https://github.com/user-attachments/assets/9b65376e-b4c8-43ff-9977-87d9a21d9221" /> | <img width="981" height="270" alt="image" src="https://github.com/user-attachments/assets/3de23567-049d-4d30-ab13-d5d22237a155" /> |

## How did you test this code?

Manually, plus the existing unit tests in the trust relationships suite (29 passing).

Steps:

1. Enable the `trust_relationships` flag for your user, then go to Organisation Settings, API Access.
2. Confirm a GitHub issuer row renders the GitHub tile, and an issuer with no preset falls back to the shield tile.
3. Confirm issuer and audience read as a labelled stack in the single "OIDC configuration" column.
4. Check both light and dark mode.
