### PR TITLE
feat: Add EMAIL_FRONTEND_DOMAIN override to Djoser

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -917,6 +917,12 @@ TRENCH_AUTH = {
     "SECRET_KEY_LENGTH": 32,
 }
 
+# Controls the app domain used in emails (currently invites and change requests).
+# If set, domain stored with `django.contrib.sites` is disregarded.
+DOMAIN_OVERRIDE = env.str("FLAGSMITH_DOMAIN", "")
+# Used when no Django site is specified.
+DEFAULT_DOMAIN = "app.flagsmith.com"
+
 USER_CREATE_PERMISSIONS = env.list(
     "USER_CREATE_PERMISSIONS", default=["custom_auth.permissions.IsSignupAllowed"]
 )
@@ -1294,12 +1300,6 @@ SOFTDELETE_CASCADE_ALLOW_DELETE_ALL = False
 
 # Used for serializing and deserializing GenericForeignKey(used in metadata) using the natural key of the object
 SERIALIZATION_MODULES = {"json": "import_export.json_serializers_with_metadata_support"}
-
-# Controls the app domain used in emails (currently invites and change requests).
-# If set, domain stored with `django.contrib.sites` is disregarded.
-DOMAIN_OVERRIDE = env.str("FLAGSMITH_DOMAIN", "")
-# Used when no Django site is specified.
-DEFAULT_DOMAIN = "app.flagsmith.com"
 
 # Define the cooldown duration, in seconds, for password reset emails
 PASSWORD_RESET_EMAIL_COOLDOWN = env.int("PASSWORD_RESET_EMAIL_COOLDOWN", 60 * 60 * 24)

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -928,6 +928,7 @@ DJOSER = {
     "PASSWORD_RESET_CONFIRM_URL": "password-reset/confirm/{uid}/{token}",
     # if True user required to click activation link in email to activate account
     "SEND_ACTIVATION_EMAIL": env.bool("ENABLE_EMAIL_ACTIVATION", default=False),
+    "EMAIL_FRONTEND_DOMAIN": env.str("FLAGSMITH_DOMAIN", default=""),
     # FE uri to redirect user to from activation email
     "ACTIVATION_URL": "activate/{uid}/{token}",
     # register or activation endpoint will send confirmation email to user

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -928,7 +928,7 @@ DJOSER = {
     "PASSWORD_RESET_CONFIRM_URL": "password-reset/confirm/{uid}/{token}",
     # if True user required to click activation link in email to activate account
     "SEND_ACTIVATION_EMAIL": env.bool("ENABLE_EMAIL_ACTIVATION", default=False),
-    "EMAIL_FRONTEND_DOMAIN": env.str("FLAGSMITH_DOMAIN", default=""),
+    "EMAIL_FRONTEND_DOMAIN": DOMAIN_OVERRIDE,
     # FE uri to redirect user to from activation email
     "ACTIVATION_URL": "activate/{uid}/{token}",
     # register or activation endpoint will send confirmation email to user


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/infrastructure/issues/492

Changes were made in https://github.com/Flagsmith/flagsmith/pull/2120 to allow the domain to be retrieved from an environment variable instead of Django's sites framework, but it didn't account for emails from Djoser (and probably other third-party libs).

`FLAGSMITH_DOMAIN` is already used for `DOMAIN_OVERRIDE`, which has the same purpose.

## How did you test this code?

Manually:

```bash
FLAGSMITH_DOMAIN=asdf.example.com DJANGO_SETTINGS_MODULE=app.settings.local \
  uv run python -c "from django.conf import settings; print(repr(settings.DJOSER['EMAIL_FRONTEND_DOMAIN']))"
```

Send the email: `make serve`, then POST `/api/v1/auth/users/reset_password/` with `{"email": "<your user>"}`. The email is printed in the terminal. The reset link's domain is properly overridden.