### PR TITLE
ci: Migrate update-flagsmith-environment to Flagsmith/setup-cli action

### DIFF
--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -7,13 +7,12 @@ on:
 
 permissions:
   contents: read
+  id-token: write # For the Flagsmith trust relationship
 
 jobs:
   update_server_defaults:
     runs-on: depot-ubuntu-latest
     name: Update API Flagsmith Defaults
-    env:
-      FLAGSMITH_API_KEY: ${{ secrets.FLAGSMITH_API_KEY }}
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -30,7 +29,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Install Flagsmith CLI
-        run: curl -fsSL https://raw.githubusercontent.com/Flagsmith/flagsmith-cli/main/install.sh | sh
+        uses: Flagsmith/setup-cli@c7154aaa37dff8aca0b66afc1e6722e7ad00c115 # v1.0.0
 
       - name: Update defaults
         run: make -C api update-flagsmith-environment


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

In this PR, we migrate `update-flagsmith-environment.yml` workflow to the `Flagsmith/setup-cli` action.

Supporting configuration, done out-of-band on the Flagsmith organisation:

- A trust relationship scoped to this repository and, via the `workflow_ref` claim, to `.github/workflows/update-flagsmith-environment.yml`. It carries the `CI - update-flagsmith-environment` role.
- That role has `VIEW_ENVIRONMENT` on Production, which covers `flagsmith environment document`, and `VIEW_PROJECT` because `make -C api update-flagsmith-environment` lists the project's tags and features first.

Once this is merged and a run has gone green, the `FLAGSMITH_API_KEY` repository secret can be removed.

## How did you test this code?

Will test in CI.
