### PR TITLE
fix(github): Trust relationship cannot be created for a repository picked from the list

### DIFF
--- a/api/integrations/github/client.py
+++ b/api/integrations/github/client.py
@@ -242,6 +242,9 @@ def fetch_github_repositories(
             "full_name": i["full_name"],
             "id": i["id"],
             "name": i["name"],
+            # The owner login is needed to derive OIDC audiences for GitHub
+            # Actions trust relationships.
+            "owner": {"login": i["owner"]["login"]},
         }
         for i in json_response["repositories"]
     ]

--- a/api/tests/unit/integrations/github/test_unit_github_views.py
+++ b/api/tests/unit/integrations/github/test_unit_github_views.py
@@ -660,6 +660,7 @@ def test_fetch_repositories__valid_installation__returns_repositories(
                     "full_name": "owner/repo-name",
                     "id": 1,
                     "name": "repo-name",
+                    "owner": {"login": "owner"},
                 },
             ],
             "total_count": 1,
@@ -677,8 +678,14 @@ def test_fetch_repositories__valid_installation__returns_repositories(
     # Then
     assert response.status_code == status.HTTP_200_OK
     response_json = response.json()
-    assert "results" in response_json
-    assert len(response_json["results"]) == 1
+    assert response_json["results"] == [
+        {
+            "full_name": "owner/repo-name",
+            "id": 1,
+            "name": "repo-name",
+            "owner": {"login": "owner"},
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/api/tests/unit/integrations/github/test_unit_github_views.py
+++ b/api/tests/unit/integrations/github/test_unit_github_views.py
@@ -657,10 +657,10 @@ def test_fetch_repositories__valid_installation__returns_repositories(
         json={
             "repositories": [
                 {
-                    "full_name": "owner/repo-name",
+                    "full_name": "acme-inc/my-repo",
                     "id": 1,
-                    "name": "repo-name",
-                    "owner": {"login": "owner"},
+                    "name": "my-repo",
+                    "owner": {"login": "acme-inc"},
                 },
             ],
             "total_count": 1,
@@ -680,10 +680,10 @@ def test_fetch_repositories__valid_installation__returns_repositories(
     response_json = response.json()
     assert response_json["results"] == [
         {
-            "full_name": "owner/repo-name",
+            "full_name": "acme-inc/my-repo",
             "id": 1,
-            "name": "repo-name",
-            "owner": {"login": "owner"},
+            "name": "my-repo",
+            "owner": {"login": "acme-inc"},
         }
     ]
 


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The GitHub trust relationship form derives the OIDC audience from the owner login (`https://github.com/<owner>`). With `owner` missing from the API response to `/api/v1/organisations/{organisation_pk}/github/repositories/`, selecting a repository from the dropdown left the audience blank, which resulted in an invalid trust relationship payload.

In this PR, we add `owner.login` to each `/api/v1/organisations/{organisation_pk}/github/repositories/` result, which is all the frontend needs to build the audience.

## How did you test this code?

Updated a test.
