### PR TITLE
fix(ci): Update API Flagsmith Defaults fails with jq compile errors

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -208,6 +208,32 @@ generate-docs-private:
 add-known-sdk-version:
 	uv run python scripts/add-known-sdk-version.py $(opts)
 
+# Exported so the recipe can pass it to jq as a single argument. Do not inline this
+# into the recipe: line continuations inside single quotes are passed to jq verbatim.
+define MASK_ENVIRONMENT_DOCUMENT_JQ
+{
+  id: 0,
+  api_key: "masked",
+  name,
+  use_identity_composite_key_for_hashing,
+  feature_states: [.feature_states[] | select(.feature.id | IN($$ids[]))],
+  project: {
+    id: 0,
+    name: .project.name,
+    hide_disabled_flags: .project.hide_disabled_flags,
+    segments: [],
+    organisation: {
+      id: 0,
+      name: .project.organisation.name,
+      feature_analytics: .project.organisation.feature_analytics,
+      stop_serving_flags: .project.organisation.stop_serving_flags,
+      persist_trait_data: .project.organisation.persist_trait_data
+    }
+  }
+}
+endef
+export MASK_ENVIRONMENT_DOCUMENT_JQ
+
 .PHONY: update-flagsmith-environment
 update-flagsmith-environment:
 	project=$$(jq -er .project ../flagsmith.json) && \
@@ -215,23 +241,6 @@ update-flagsmith-environment:
 	  | jq -er '(if type == "array" then . else .results end) | map(select(.label == "api")) | .[0].id') && \
 	ids=$$(flagsmith api "/api/v1/projects/$$project/features/?tags=$$tag&page_size=1000" --no-input \
 	  | jq -ec '[.results[].id]') && \
-	flagsmith environment document --no-input | jq --argjson ids "$$ids" '{ \
-	  id: 0, \
-	  api_key: "masked", \
-	  name, \
-	  use_identity_composite_key_for_hashing, \
-	  feature_states: [.feature_states[] | select(.feature.id | IN($$ids[]))], \
-	  project: { \
-	    id: 0, \
-	    name: .project.name, \
-	    hide_disabled_flags: .project.hide_disabled_flags, \
-	    segments: [], \
-	    organisation: { \
-	      id: 0, \
-	      name: .project.organisation.name, \
-	      feature_analytics: .project.organisation.feature_analytics, \
-	      stop_serving_flags: .project.organisation.stop_serving_flags, \
-	      persist_trait_data: .project.organisation.persist_trait_data \
-	    } \
-	  } \
-	}' > $(FLAGSMITH_DOCUMENT_PATH)
+	flagsmith environment document --no-input \
+	  | jq --argjson ids "$$ids" "$$MASK_ENVIRONMENT_DOCUMENT_JQ" \
+	  > $(FLAGSMITH_DOCUMENT_PATH)


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The `update-flagsmith-environment` Make target embedded a multi-line jq program inside single quotes, using trailing `\` line continuations to keep the recipe readable. Backslash-newline is literal inside single quotes, so jq received `{ \`, `  id: 0, \` and so on, and failed with 27 compile errors:

```
jq: error: syntax error, unexpected INVALID_CHARACTER (Unix shell quoting issues?) at <top-level>, line 1:
{ \
```

The filter now lives in an exported `define` block instead.

## How did you test this code?

Ran the exported filter over the committed environment document, using its own feature IDs as `$ids`, and confirmed it round-trips unchanged:

```sh
cd api
ids=$(jq -ec '[.feature_states[].feature.id]' integrations/flagsmith/data/environment.json)
jq --argjson ids "$ids" "$MASK_ENVIRONMENT_DOCUMENT_JQ" \
  integrations/flagsmith/data/environment.json > /tmp/out.json
diff <(jq -S . integrations/flagsmith/data/environment.json) <(jq -S . /tmp/out.json)  # no output
```

Also checked `make -n update-flagsmith-environment` to confirm the recipe expands to valid shell.
