### PR TITLE
fix(e2e): decide the signup flow from the redirect

### DIFF
--- a/frontend/e2e/tests/initialise-tests.pw.ts
+++ b/frontend/e2e/tests/initialise-tests.pw.ts
@@ -30,13 +30,9 @@ test.describe('Signup', () => {
     await setText(byId('email'), E2E_SIGN_UP_USER);
     await setText(byId('password'), PASSWORD);
     await click(byId('signup-btn'));
-    // The app decides between the legacy /create page and the single-page flow
-    // at /getting-started (onboarding_quickstart_flow). It reads that flag
-    // under a per-signup identity, so a percentage rollout lands differently
-    // run to run and cannot be predicted here: `hasFeature` in this process
-    // has no identity and only ever sees the environment default. Wait for
-    // whichever redirect happened, then bow out if it isn't ours; the
-    // single-page flow is covered by onboarding-tests.
+    // Which flow we get cannot be decided before signing up: the app reads
+    // onboarding_quickstart_flow under a per-signup identity, while
+    // `hasFeature` here has none and only sees the environment default.
     await page.waitForURL(/\/(create|getting-started)/, { timeout: 20000 });
     test.skip(
       new URL(page.url()).pathname.startsWith('/getting-started'),

--- a/frontend/e2e/tests/initialise-tests.pw.ts
+++ b/frontend/e2e/tests/initialise-tests.pw.ts
@@ -30,8 +30,9 @@ test.describe('Signup', () => {
     await setText(byId('email'), E2E_SIGN_UP_USER);
     await setText(byId('password'), PASSWORD);
     await click(byId('signup-btn'));
-    // onboarding_quickstart_flow buckets on an identity the API assigns, while
-    // `hasFeature` here identifies nobody and only sees the environment default.
+    // onboarding_quickstart_flow buckets per organisation, on an identifier
+    // created at signup. `hasFeature` here identifies nobody, so it only ever
+    // sees the environment default.
     await page.waitForURL(
       (url) => url.pathname === '/create' || url.pathname === '/getting-started',
       { timeout: 20000 },

--- a/frontend/e2e/tests/initialise-tests.pw.ts
+++ b/frontend/e2e/tests/initialise-tests.pw.ts
@@ -13,15 +13,6 @@ test.describe('Signup', () => {
     const { addErrorLogging, click, logout, setText, waitForElementVisible } = createHelpers(page);
     const flagsmith = await getFlagsmith();
 
-    // The new single-page onboarding flow (onboarding_quickstart_flow) replaces
-    // the legacy getting-started page that this test drives, so the legacy
-    // signup-to-integration-to-project path doesn't exist when the flag is on.
-    // Skip it in that case; the new flow gets its own coverage.
-    test.skip(
-      flagsmith.hasFeature('onboarding_quickstart_flow'),
-      'Legacy signup flow superseded by onboarding_quickstart_flow',
-    );
-
     // Add error logging
     await addErrorLogging();
 
@@ -39,8 +30,18 @@ test.describe('Signup', () => {
     await setText(byId('email'), E2E_SIGN_UP_USER);
     await setText(byId('password'), PASSWORD);
     await click(byId('signup-btn'));
-    // Wait for navigation and form to load after signup
-    await page.waitForURL(/\/create/, { timeout: 20000 });
+    // The app decides between the legacy /create page and the single-page flow
+    // at /getting-started (onboarding_quickstart_flow). It reads that flag
+    // under a per-signup identity, so a percentage rollout lands differently
+    // run to run and cannot be predicted here: `hasFeature` in this process
+    // has no identity and only ever sees the environment default. Wait for
+    // whichever redirect happened, then bow out if it isn't ours; the
+    // single-page flow is covered by onboarding-tests.
+    await page.waitForURL(/\/(create|getting-started)/, { timeout: 20000 });
+    test.skip(
+      new URL(page.url()).pathname.startsWith('/getting-started'),
+      'Signup entered the single-page onboarding flow',
+    );
     await waitForElementVisible('[name="orgName"]');
     await visualSnapshot(page, 'create-organisation', testInfo)
 

--- a/frontend/e2e/tests/initialise-tests.pw.ts
+++ b/frontend/e2e/tests/initialise-tests.pw.ts
@@ -30,9 +30,8 @@ test.describe('Signup', () => {
     await setText(byId('email'), E2E_SIGN_UP_USER);
     await setText(byId('password'), PASSWORD);
     await click(byId('signup-btn'));
-    // Which flow we get cannot be decided before signing up: the app reads
-    // onboarding_quickstart_flow under a server-assigned anonymous identity,
-    // while `hasFeature` here has none and only sees the environment default.
+    // onboarding_quickstart_flow buckets on an identity the API assigns, while
+    // `hasFeature` here identifies nobody and only sees the environment default.
     await page.waitForURL(
       (url) => url.pathname === '/create' || url.pathname === '/getting-started',
       { timeout: 20000 },

--- a/frontend/e2e/tests/initialise-tests.pw.ts
+++ b/frontend/e2e/tests/initialise-tests.pw.ts
@@ -33,9 +33,12 @@ test.describe('Signup', () => {
     // Which flow we get cannot be decided before signing up: the app reads
     // onboarding_quickstart_flow under a per-signup identity, while
     // `hasFeature` here has none and only sees the environment default.
-    await page.waitForURL(/\/(create|getting-started)/, { timeout: 20000 });
+    await page.waitForURL(
+      (url) => url.pathname === '/create' || url.pathname === '/getting-started',
+      { timeout: 20000 },
+    );
     test.skip(
-      new URL(page.url()).pathname.startsWith('/getting-started'),
+      new URL(page.url()).pathname === '/getting-started',
       'Signup entered the single-page onboarding flow',
     );
     await waitForElementVisible('[name="orgName"]');

--- a/frontend/e2e/tests/initialise-tests.pw.ts
+++ b/frontend/e2e/tests/initialise-tests.pw.ts
@@ -31,8 +31,8 @@ test.describe('Signup', () => {
     await setText(byId('password'), PASSWORD);
     await click(byId('signup-btn'));
     // Which flow we get cannot be decided before signing up: the app reads
-    // onboarding_quickstart_flow under a per-signup identity, while
-    // `hasFeature` here has none and only sees the environment default.
+    // onboarding_quickstart_flow under a server-assigned anonymous identity,
+    // while `hasFeature` here has none and only sees the environment default.
     await page.waitForURL(
       (url) => url.pathname === '/create' || url.pathname === '/getting-started',
       { timeout: 20000 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The signup test decided which onboarding flow it would get before signing up, with `test.skip(flagsmith.hasFeature('onboarding_quickstart_flow'))`. That check runs in the test process, which initialises the SDK without an identity, so it only sees the environment default. The app evaluates the flag under a per-signup identity and production rolls it out by percentage, so the test drove the legacy flow while the app redirected to `/getting-started`, then timed out waiting for `/create`.

It now waits for whichever redirect happened and skips if it isn't the legacy one. That also stops the retries poisoning themselves: a failure left the signup user behind, so every retry then failed at `/login` for an unrelated reason.

This has blocked the production deploy gate since 19 Aug 11:57Z.

## How did you test this code?

Ran the suite against production (`ENV=prod npm run test`), where the flag is rolled out.

- Before: failed all three attempts, the first on `/getting-started`, the retries on `/login`.
- After: skips when it lands in the single-page flow, passes when it lands on control. The gate is unblocked either way.
