### PR TITLE
chore(e2e): pin the environment, drop networkidle, quieten the dev overlay

### DIFF
--- a/frontend/e2e/helpers/e2e-helpers.playwright.ts
+++ b/frontend/e2e/helpers/e2e-helpers.playwright.ts
@@ -248,7 +248,8 @@ export class E2EHelpers {
     const userRow = this.page.locator('[data-test^="user-item-"]').filter({ hasText: identifier }).first();
     await userRow.waitFor({ state: 'visible', timeout: LONG_TIMEOUT });
     await userRow.locator('a').first().click();
-    await this.page.waitForLoadState('networkidle');
+    // No networkidle: it needs a 500ms lull in requests, which a page with
+    // polling never gets, and the wait below is the real signal anyway.
     await this.waitForElementVisible('#add-trait');
   }
 

--- a/frontend/e2e/tests/mv-options-tests.pw.ts
+++ b/frontend/e2e/tests/mv-options-tests.pw.ts
@@ -22,6 +22,7 @@ const variantCards = (page: Page) => page.locator('#create-feature-modal .varian
 test.describe('Multivariate Options', () => {
   test('Repeated saves keep the variant set stable @oss', async ({ page }) => {
     const {
+      click,
       closeModal,
       createRemoteConfig,
       editRemoteConfig,
@@ -29,12 +30,30 @@ test.describe('Multivariate Options', () => {
       gotoFeatures,
       gotoProject,
       login,
+      waitForElementClickable,
       waitForElementNotExist,
+      waitForElementVisible,
     } = createHelpers(page);
 
     log('Login');
     await login(E2E_USER, PASSWORD);
     await gotoProject(E2E_TEST_PROJECT);
+
+    // Another suite creates CR_Test_Env in this shared project and it sorts
+    // ahead of Development, so it becomes the default selection. Saving in a
+    // change-request environment opens a change request instead of saving, so
+    // no toast ever arrives.
+    const isDevelopmentActive = await page
+      .locator(byId('switch-environment-development-active'))
+      .isVisible()
+      .catch(() => false);
+
+    if (!isDevelopmentActive) {
+      log('Switching to development first');
+      await waitForElementClickable(byId('switch-environment-development'));
+      await click(byId('switch-environment-development'));
+      await waitForElementVisible(byId('switch-environment-development-active'));
+    }
 
     log('Create multivariate flag');
     await createRemoteConfig({ name: 'mv_repeat_save', value: 'ctrl_value', mvs: [
@@ -69,13 +88,31 @@ test.describe('Multivariate Options', () => {
       gotoProject,
       login,
       setText,
+      waitForElementClickable,
       waitForElementNotExist,
+      waitForElementVisible,
       waitForToast,
     } = createHelpers(page);
 
     log('Login');
     await login(E2E_USER, PASSWORD);
     await gotoProject(E2E_TEST_PROJECT);
+
+    // Another suite creates CR_Test_Env in this shared project and it sorts
+    // ahead of Development, so it becomes the default selection. Saving in a
+    // change-request environment opens a change request instead of saving, so
+    // no toast ever arrives.
+    const isDevelopmentActive = await page
+      .locator(byId('switch-environment-development-active'))
+      .isVisible()
+      .catch(() => false);
+
+    if (!isDevelopmentActive) {
+      log('Switching to development first');
+      await waitForElementClickable(byId('switch-environment-development'));
+      await click(byId('switch-environment-development'));
+      await waitForElementVisible(byId('switch-environment-development-active'));
+    }
 
     log('Create multivariate flag');
     await createRemoteConfig({ name: 'mv_add_remove', value: 'root_val', mvs: [

--- a/frontend/rspack/rspack.config.local.js
+++ b/frontend/rspack/rspack.config.local.js
@@ -1,6 +1,8 @@
 // rspack.config.local.js (dev)
 const rspack = require('@rspack/core')
-const { ReactRefreshRspackPlugin: ReactRefreshPlugin } = require('@rspack/plugin-react-refresh')
+const {
+  ReactRefreshRspackPlugin: ReactRefreshPlugin,
+} = require('@rspack/plugin-react-refresh')
 const path = require('path')
 const express = require('express')
 
@@ -9,11 +11,22 @@ const base = require('../rspack.config')
 module.exports = {
   ...base,
   devServer: {
+    app: async () => express(),
+    client: {
+      overlay: {
+        errors: true,
+        // An unhandled rejection blanks the app behind a full-screen overlay
+        // that also swallows clicks, which stops E2E runs dead. `_data.js`
+        // rejects with the raw fetch Response on any non-2xx, so a single
+        // uncaught call is enough. The console still reports them.
+        runtimeErrors: false,
+        warnings: false,
+      },
+    },
     historyApiFallback: true,
     hot: true,
     liveReload: false,
     port: process.env.PORT || 8080,
-    app: async () => express(),
     setupMiddlewares: (middlewares, devServer) => {
       // Register the Express routes from api/index on the dev server's app
       require('../api/dev-routes')(devServer.app)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Three unrelated papercuts found while chasing production deploy failures. None are urgent; the deploy blocker itself is #8335.

**mv-options inherited another suite's environment.** It called `gotoProject` and took whatever the app defaulted to. `change-request-test` creates `CR_Test_Env` in the same shared project and it sorts ahead of `Development`, so saving there opened a change request instead of saving, and the toast the test waits for never arrived. It now selects `Development` explicitly, the way `flag-tests` already does.

**`gotoTraits` waited on `networkidle`.** That needs a 500ms lull in requests, which a page with polling never gets, and it's a documented Playwright anti-pattern. The `waitForElementVisible('#add-trait')` on the next line is the real signal, so the call was both redundant and the reason `segment-test` timed out against production. Three other `networkidle` calls remain in the helpers; they aren't implicated yet, so I've left them.

**The dev server turned any unhandled rejection into a full-screen overlay.** It swallows clicks, which stops a local E2E run dead, and `_data.js` rejects with the raw `Response` on every non-2xx so one uncaught call is enough to trigger it. Runtime errors no longer open the overlay; compile errors still do, and the console still reports both. Dev server only, so CI is unaffected.

Worth noting the first item is a workaround, not a cure. Every suite shares one organisation, project and set of environments under `fullyParallel: true`, and that is what produced most of the failures we saw today. Per-test isolation deserves its own issue.

## How did you test this code?

Ran the suite locally and against production (`ENV=prod npm run test`).

- `mv-options` "Variants can be added and removed in a single save" passes, and the environment now resolves to `Development` in the trace rather than `CR_Test_Env`. The other test in that file is still flaky against production for an unrelated reason: `editRemoteConfig` drives the multivariate form with fixed `waitForTimeout` sleeps that don't hold up at production latency. That predates this PR and needs its own fix.
- `segment-test` no longer times out in `gotoTraits`.
- The dev overlay no longer appears on an unhandled rejection; compile errors still surface.
