### PR TITLE
chore: notify Slack after frontend production deploy

### DIFF
--- a/.github/actions/notify-slack-deploy/action.yml
+++ b/.github/actions/notify-slack-deploy/action.yml
@@ -1,0 +1,88 @@
+name: Notify Slack of a deploy
+description: Post a deploy notification to a Slack incoming webhook, prompting a smoke test.
+
+inputs:
+  webhook_url:
+    description: The Slack incoming webhook to post the notification to.
+    required: true
+  service:
+    description: The name of the deployed service, e.g. Frontend.
+    required: true
+  app_url:
+    description: The URL of the deployed application, linked from the notification.
+    required: true
+  environment:
+    description: The environment that was deployed to.
+    required: false
+    default: production
+
+runs:
+  using: composite
+
+  steps:
+    - name: Post to Slack
+      shell: bash
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
+        SERVICE: ${{ inputs.service }}
+        APP_URL: ${{ inputs.app_url }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        COMMIT_SHA: ${{ github.sha }}
+        ACTOR: ${{ github.actor }}
+        WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # jq builds the payload so every value is escaped for us, rather than
+      # interpolated into a JSON heredoc.
+      run: |
+        jq -n \
+          --arg service "$SERVICE" \
+          --arg environment "$ENVIRONMENT" \
+          --arg short_sha "${COMMIT_SHA:0:7}" \
+          --arg actor "$ACTOR" \
+          --arg app_url "$APP_URL" \
+          --arg workflow_url "$WORKFLOW_URL" \
+          '($environment | (.[0:1] | ascii_upcase) + .[1:]) as $env_name |
+          {
+            # Slack honours username on this webhook but ignores icon_emoji.
+            # The avatar comes from the icon set on the Slack app itself.
+            username: "\($service) Deploy",
+            text: "🚀 \($service) deployed to \($environment): smoke test required",
+            blocks: [
+              {
+                type: "header",
+                text: { type: "plain_text", text: "🚀 \($service) deployed to \($environment)" }
+              },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "🧪 *\($env_name) smoke test required*\n\nPlease verify the application directly in \($environment)."
+                }
+              },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: "*Commit:*\n\($short_sha)" },
+                  { type: "mrkdwn", text: "*Deployed by:*\n@\($actor)" }
+                ]
+              },
+              {
+                type: "actions",
+                elements: [
+                  {
+                    type: "button",
+                    text: { type: "plain_text", text: "Open \($env_name)" },
+                    url: $app_url
+                  },
+                  {
+                    type: "button",
+                    text: { type: "plain_text", text: "View GitHub Actions" },
+                    url: $workflow_url
+                  }
+                ]
+              }
+            ]
+          }' \
+          | curl --fail-with-body --connect-timeout 10 --max-time 30 -X POST \
+              -H 'Content-Type: application/json' \
+              --data @- \
+              "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -79,6 +79,32 @@ jobs:
       npm_build_environment: prod
     secrets: inherit
 
+  notify-production-smoke-test:
+    name: Notify Production Smoke Test
+    needs: deploy-production
+    if: ${{ needs.deploy-production.result == 'success' }}
+    runs-on: ubuntu-latest
+    # Only needs to read the repo to resolve the local action below.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # Nothing runs git after this, so the token need not persist.
+          persist-credentials: false
+
+      - name: Notify Slack
+        # The deploy has already succeeded by this point, so a Slack outage or a
+        # rotated webhook should not fail the run.
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_FRONTEND_DEPLOY_WEBHOOK }}
+          service: Frontend
+          app_url: https://app.flagsmith.com
+
   deploy-demo:
     name: Deploy to Vercel Demo
     needs: run-tests


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

### Changes

Adds a `notify-production-smoke-test` job to the frontend production deploy workflow. After a successful deploy it posts to `#frontend-deploy` with the commit, who deployed, and links to production and the Actions run, as a prompt to smoke test.

The message is built by a composite action (`.github/actions/notify-slack-deploy`) so the API and MCP deploys can reuse it, and jq assembles the payload so values are escaped rather than interpolated into JSON.

Two deliberate choices:

- An incoming webhook (`SLACK_FRONTEND_DEPLOY_WEBHOOK`) rather than the `SLACK_TOKEN` the e2e-tests action uses, so the message is pinned to one channel and the workflow needs no Slack API scope.
- `continue-on-error` on the step, because the deploy has already succeeded by the time this runs, so a Slack outage should not turn the run red. The job takes `contents: read` and nothing else.

Deployer is plain text for this first version, not a Slack mention. GitHub handles are not Slack member IDs, and nothing derivable in CI maps reliably to one.

### How did you test this code?

Ran the composite action from a throwaway workflow on this branch, [run 32483691892](https://github.com/Flagsmith/flagsmith/actions/runs/32483691892). Slack returned `ok` and the message rendered in `#frontend-deploy` with both buttons working. That workflow is not part of this PR.

Also checked the rendered payload is valid Block Kit JSON, and that the job is skipped rather than run when `deploy-production` does not succeed.