### PR TITLE
fix: treat stale experiment refresh requests as settled

### DIFF
--- a/frontend/web/components/experiments/results/__tests__/exposuresViewState.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/exposuresViewState.test.ts
@@ -24,6 +24,13 @@ const loaded = exposures({
 })
 
 describe('deriveExposuresViewState', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-12T11:05:00Z'))
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('is empty when there is no payload and nothing in flight', () => {
     expect(deriveExposuresViewState(exposures()).kind).toBe('empty')
   })
@@ -55,6 +62,14 @@ describe('deriveExposuresViewState', () => {
       refresh_requested_at: '2026-06-12T13:00:00Z',
     })
     expect(state.kind).toBe('refreshing')
+  })
+
+  it('ignores a refresh request older than the cutoff', () => {
+    const state = deriveExposuresViewState({
+      ...loaded,
+      refresh_requested_at: '2026-06-12T10:54:00Z',
+    })
+    expect(state.kind).toBe('loaded')
   })
 })
 

--- a/frontend/web/components/experiments/results/__tests__/resultsViewState.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/resultsViewState.test.ts
@@ -25,6 +25,13 @@ const loaded = results({
 })
 
 describe('deriveResultsViewState', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-12T11:05:00Z'))
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('is empty when there is no payload and nothing in flight', () => {
     expect(deriveResultsViewState(results()).kind).toBe('empty')
   })
@@ -54,6 +61,28 @@ describe('deriveResultsViewState', () => {
       ...loaded,
       last_error_at: '2026-06-12T12:00:00Z',
       refresh_requested_at: '2026-06-12T13:00:00Z',
+    })
+    expect(state.kind).toBe('refreshing')
+  })
+
+  const staleCases: [string, Partial<ExperimentBayesianResults>, string][] = [
+    ['loaded', loaded, 'loaded'],
+    ['empty', results(), 'empty'],
+  ]
+  staleCases.forEach(([name, base, expected]) => {
+    it(`ignores a refresh request older than the cutoff (${name})`, () => {
+      const state = deriveResultsViewState({
+        ...results(base),
+        refresh_requested_at: '2026-06-12T10:54:00Z',
+      })
+      expect(state.kind).toBe(expected)
+    })
+  })
+
+  it('still refreshes just inside the cutoff', () => {
+    const state = deriveResultsViewState({
+      ...loaded,
+      refresh_requested_at: '2026-06-12T10:56:00Z',
     })
     expect(state.kind).toBe('refreshing')
   })

--- a/frontend/web/components/experiments/results/exposuresViewState.ts
+++ b/frontend/web/components/experiments/results/exposuresViewState.ts
@@ -18,12 +18,17 @@ export type RefreshLabel = { message: string; tone: 'muted' | 'danger' }
 export const REFRESH_POLL_INTERVAL_MS = 10000
 export const POLL_TIMEOUT_MS = 120000
 export const DEFAULT_RETRY_AFTER_S = 300
+export const REFRESH_STALE_CUTOFF_MS = 10 * 60 * 1000
 
 const ms = (iso: string | null): number => (iso ? new Date(iso).getTime() : 0)
 
 const isRefreshing = (e: ExperimentExposures): boolean => {
   const requested = ms(e.refresh_requested_at)
-  return requested > 0 && requested > Math.max(ms(e.as_of), ms(e.last_error_at))
+  return (
+    requested > 0 &&
+    requested > Math.max(ms(e.as_of), ms(e.last_error_at)) &&
+    Date.now() - requested < REFRESH_STALE_CUTOFF_MS
+  )
 }
 
 const hasError = (e: ExperimentExposures): boolean =>

--- a/frontend/web/components/experiments/results/resultsViewState.ts
+++ b/frontend/web/components/experiments/results/resultsViewState.ts
@@ -21,12 +21,17 @@ export type RefreshLabel = { message: string; tone: 'muted' | 'danger' }
 export const REFRESH_POLL_INTERVAL_MS = 10000
 export const POLL_TIMEOUT_MS = 120000
 export const DEFAULT_RETRY_AFTER_S = 300
+export const REFRESH_STALE_CUTOFF_MS = 10 * 60 * 1000
 
 const ms = (iso: string | null): number => (iso ? new Date(iso).getTime() : 0)
 
 const isRefreshing = (r: ExperimentBayesianResults): boolean => {
   const requested = ms(r.refresh_requested_at)
-  return requested > 0 && requested > Math.max(ms(r.as_of), ms(r.last_error_at))
+  return (
+    requested > 0 &&
+    requested > Math.max(ms(r.as_of), ms(r.last_error_at)) &&
+    Date.now() - requested < REFRESH_STALE_CUTOFF_MS
+  )
 }
 
 const hasError = (r: ExperimentBayesianResults): boolean =>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

If an experiment compute task dies without recording a result or an error, `refresh_requested_at` stays newer than `as_of`/`last_error_at` and the Refresh button spins (and polls) forever.

Adds a 10-minute staleness cutoff to the frontend `isRefreshing` derivation: past it, the UI renders as normal and the button re-enables so the user can re-request computation.

## How did you test this code?

Unit tests for the stale/non-stale cases. Manually verified a stuck experiment now renders normally with Refresh available.
