### PR TITLE
fix: keep experiment refresh state until requests settle

### DIFF
--- a/frontend/web/components/experiments/results/ExperimentResultsRefreshControl.tsx
+++ b/frontend/web/components/experiments/results/ExperimentResultsRefreshControl.tsx
@@ -15,6 +15,7 @@ import {
   canRefreshResults,
   deriveResultsViewState,
   getResultsRefreshLabel,
+  hasRefreshSettled,
 } from './resultsViewState'
 import { deriveExposuresViewState } from './exposuresViewState'
 
@@ -58,14 +59,16 @@ const ExperimentResultsRefreshControl: FC<
   const [pollStartedAt, setPollStartedAt] = useState<number | null>(null)
   const [retryAfter, startRetryCountdown] = useCountdown()
 
-  const { data: results } = useGetExperimentBayesianResultsQuery(
-    { environmentId, experimentId },
-    { pollingInterval: pollInterval },
-  )
-  const { data: exposures } = useGetExperimentExposuresQuery(
-    { environmentId, experimentId },
-    { pollingInterval: pollInterval },
-  )
+  const { data: results, isFetching: isFetchingResults } =
+    useGetExperimentBayesianResultsQuery(
+      { environmentId, experimentId },
+      { pollingInterval: pollInterval },
+    )
+  const { data: exposures, isFetching: isFetchingExposures } =
+    useGetExperimentExposuresQuery(
+      { environmentId, experimentId },
+      { pollingInterval: pollInterval },
+    )
   const [refreshResults, { isLoading: isSubmittingResults }] =
     useRefreshExperimentBayesianResultsMutation()
   const [refreshExposures, { isLoading: isSubmittingExposures }] =
@@ -78,9 +81,16 @@ const ExperimentResultsRefreshControl: FC<
   const eitherRefreshing =
     resultsViewState.kind === 'refreshing' ||
     exposuresViewState.kind === 'refreshing'
-  const bothSettled =
-    resultsViewState.kind !== 'refreshing' &&
-    exposuresViewState.kind !== 'refreshing'
+  const requestsInFlight =
+    isSubmittingResults ||
+    isSubmittingExposures ||
+    isFetchingResults ||
+    isFetchingExposures
+  const bothSettled = hasRefreshSettled(
+    resultsViewState,
+    exposuresViewState,
+    requestsInFlight,
+  )
 
   const pollTimedOut =
     pollStartedAt !== null && Date.now() - pollStartedAt > POLL_TIMEOUT_MS

--- a/frontend/web/components/experiments/results/__tests__/resultsViewState.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/resultsViewState.test.ts
@@ -2,6 +2,7 @@ import {
   canRefreshResults,
   deriveResultsViewState,
   getResultsRefreshLabel,
+  hasRefreshSettled,
 } from 'components/experiments/results/resultsViewState'
 import {
   ExperimentBayesianResults,
@@ -79,6 +80,45 @@ describe('canRefreshResults', () => {
         reason: 'final',
       },
     )
+  })
+})
+
+describe('hasRefreshSettled', () => {
+  const settledCases: [
+    string,
+    Parameters<typeof hasRefreshSettled>,
+    boolean,
+  ][] = [
+    [
+      'settled view states with nothing in flight',
+      [{ kind: 'loaded' }, { kind: 'loaded' }, false],
+      true,
+    ],
+    [
+      'stale settled view states while requests are still in flight',
+      [{ kind: 'loaded' }, { kind: 'loaded' }, true],
+      false,
+    ],
+    [
+      'results still refreshing',
+      [{ kind: 'refreshing' }, { kind: 'loaded' }, false],
+      false,
+    ],
+    [
+      'exposures still refreshing',
+      [{ kind: 'loaded' }, { kind: 'refreshing' }, false],
+      false,
+    ],
+    [
+      'error view state with nothing in flight',
+      [{ kind: 'error', staleAvailable: true }, { kind: 'empty' }, false],
+      true,
+    ],
+  ]
+  settledCases.forEach(([name, args, expected]) => {
+    it(`${name} → ${expected}`, () => {
+      expect(hasRefreshSettled(...args)).toBe(expected)
+    })
   })
 })
 

--- a/frontend/web/components/experiments/results/resultsViewState.ts
+++ b/frontend/web/components/experiments/results/resultsViewState.ts
@@ -3,6 +3,7 @@ import {
   ExperimentStatus,
 } from 'common/types/responses'
 import { formatCountdown } from 'common/hooks/useCountdown'
+import { ExposuresViewState } from './exposuresViewState'
 
 export type ResultsViewState =
   | { kind: 'empty' }
@@ -46,7 +47,7 @@ export const deriveResultsViewState = (
 
 export const hasRefreshSettled = (
   resultsViewState: ResultsViewState,
-  exposuresViewState: { kind: string },
+  exposuresViewState: ExposuresViewState,
   requestsInFlight: boolean,
 ): boolean =>
   !requestsInFlight &&

--- a/frontend/web/components/experiments/results/resultsViewState.ts
+++ b/frontend/web/components/experiments/results/resultsViewState.ts
@@ -44,6 +44,15 @@ export const deriveResultsViewState = (
   return { kind: 'empty' }
 }
 
+export const hasRefreshSettled = (
+  resultsViewState: ResultsViewState,
+  exposuresViewState: { kind: string },
+  requestsInFlight: boolean,
+): boolean =>
+  !requestsInFlight &&
+  resultsViewState.kind !== 'refreshing' &&
+  exposuresViewState.kind !== 'refreshing'
+
 export const canRefreshResults = (
   status: ExperimentStatus,
   results: ExperimentBayesianResults | null | undefined,


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Clicking Refresh on the experiment results page flashed the button: the settle effect cleared `refreshRequested` against stale cached data, dropping the spinner until the invalidation refetch landed (and breaking the poll timeout guard). "Settled" now also requires no in-flight requests, extracted as `hasRefreshSettled()`.

## How did you test this code?

Unit tests for `hasRefreshSettled`, plus manually: Refresh now spins continuously until results update, no flash.
