### PR TITLE
fix: identify user before sending warehouse test event

### DIFF
--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/sendWarehouseTestEvent.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/sendWarehouseTestEvent.test.ts
@@ -1,11 +1,12 @@
 import sendWarehouseTestEvent from 'components/pages/environment-settings/tabs/warehouse-tab/sendWarehouseTestEvent'
 
 const init = jest.fn().mockResolvedValue(undefined)
+const identify = jest.fn().mockResolvedValue(undefined)
 const trackEvent = jest.fn()
 const flushEvents = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('@flagsmith/flagsmith/isomorphic', () => ({
-  createFlagsmithInstance: () => ({ flushEvents, init, trackEvent }),
+  createFlagsmithInstance: () => ({ flushEvents, identify, init, trackEvent }),
 }))
 
 jest.mock('common/project', () => ({
@@ -16,6 +17,7 @@ jest.mock('common/project', () => ({
 describe('sendWarehouseTestEvent', () => {
   beforeEach(() => {
     init.mockClear()
+    identify.mockClear()
     trackEvent.mockClear()
     flushEvents.mockClear()
   })
@@ -33,11 +35,13 @@ describe('sendWarehouseTestEvent', () => {
     )
   })
 
-  it('tracks the test_custom_event after init', async () => {
+  it('identifies a test user and tracks the test_custom_event after init', async () => {
     await sendWarehouseTestEvent('env-key-123')
 
+    expect(identify).toHaveBeenCalledWith('test_warehouse_user')
     expect(trackEvent).toHaveBeenCalledWith('test_custom_event')
     expect(init).toHaveBeenCalledTimes(1)
+    expect(identify).toHaveBeenCalledTimes(1)
     expect(trackEvent).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/sendWarehouseTestEvent.test.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/__tests__/sendWarehouseTestEvent.test.ts
@@ -1,12 +1,11 @@
 import sendWarehouseTestEvent from 'components/pages/environment-settings/tabs/warehouse-tab/sendWarehouseTestEvent'
 
 const init = jest.fn().mockResolvedValue(undefined)
-const identify = jest.fn().mockResolvedValue(undefined)
 const trackEvent = jest.fn()
 const flushEvents = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('@flagsmith/flagsmith/isomorphic', () => ({
-  createFlagsmithInstance: () => ({ flushEvents, identify, init, trackEvent }),
+  createFlagsmithInstance: () => ({ flushEvents, init, trackEvent }),
 }))
 
 jest.mock('common/project', () => ({
@@ -17,7 +16,6 @@ jest.mock('common/project', () => ({
 describe('sendWarehouseTestEvent', () => {
   beforeEach(() => {
     init.mockClear()
-    identify.mockClear()
     trackEvent.mockClear()
     flushEvents.mockClear()
   })
@@ -30,18 +28,17 @@ describe('sendWarehouseTestEvent', () => {
         defaultFlags: {},
         enableEvents: true,
         environmentID: 'env-key-123',
+        identity: 'test_warehouse_user',
         preventFetch: true,
       }),
     )
   })
 
-  it('identifies a test user and tracks the test_custom_event after init', async () => {
+  it('tracks the test_custom_event after init', async () => {
     await sendWarehouseTestEvent('env-key-123')
 
-    expect(identify).toHaveBeenCalledWith('test_warehouse_user')
     expect(trackEvent).toHaveBeenCalledWith('test_custom_event')
     expect(init).toHaveBeenCalledTimes(1)
-    expect(identify).toHaveBeenCalledTimes(1)
     expect(trackEvent).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/sendWarehouseTestEvent.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/sendWarehouseTestEvent.ts
@@ -20,6 +20,7 @@ const sendWarehouseTestEvent = async (environmentId: string): Promise<void> => {
     enableEvents: true,
     environmentID: environmentId,
     fetch: globalThis.fetch.bind(globalThis),
+    identity: 'test_warehouse_user',
     preventFetch: true,
     ...(Project.flagsmithClientEventsAPI && {
       eventProcessorConfig: {
@@ -27,7 +28,6 @@ const sendWarehouseTestEvent = async (environmentId: string): Promise<void> => {
       },
     }),
   })
-  await instance.identify('test_warehouse_user')
   instance.trackEvent('test_custom_event')
   await instance.flushEvents()
 }

--- a/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/sendWarehouseTestEvent.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/warehouse-tab/sendWarehouseTestEvent.ts
@@ -27,6 +27,7 @@ const sendWarehouseTestEvent = async (environmentId: string): Promise<void> => {
       },
     }),
   })
+  await instance.identify('test_warehouse_user')
   instance.trackEvent('test_custom_event')
   await instance.flushEvents()
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The warehouse test event ("Send your first event" button) was sending events with `identifier: null` because the SDK instance never identified a user. The ingestion pipeline now requires an identifier, so the event was silently dropped.

Added `instance.identify('test_warehouse_user')` after init and before `trackEvent`, so the event payload includes a non-null identifier.

## How did you test this code?

Unit tests updated and passing (`npm run test:unit -- --testPathPatterns='sendWarehouseTestEvent'`). Verified the identify call is made with `'test_warehouse_user'` before the event is tracked.