### PR TITLE
fix(usage): separate the plan meter from the filters

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -15,6 +15,8 @@ import ReactSelect, { components as selectComponents } from 'react-select'
 // Only import components that use the automatic JSX transform (TSX files).
 // Legacy .js files (Flex, Column, Input) use old JSX transform and crash here.
 import Tooltip from '../web/components/Tooltip'
+import Button from '../web/components/base/forms/Button'
+import Loader from '../web/components/Loader'
 import Row from '../web/components/base/grid/Row'
 import FormGroup from '../web/components/base/grid/FormGroup'
 
@@ -53,6 +55,8 @@ global.Select = (props) =>
     }),
   )
 window.Tooltip = Tooltip
+window.Button = Button
+window.Loader = Loader
 window.Row = Row
 window.FormGroup = FormGroup
 // isMobile is set at app boot; stub it so components that read it render in Storybook.

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -515,6 +515,8 @@ export type AuditLogDetail = AuditLogItem & {
     new: FlagsmithValue
   }[]
 }
+export type PaymentMethod = 'CHARGEBEE' | 'XERO' | 'AWS_MARKETPLACE'
+
 export type Subscription = {
   id: number
   uuid: string
@@ -525,7 +527,7 @@ export type Subscription = {
   max_api_calls: number
   cancellation_date: string | null
   customer_id: string
-  payment_method: string
+  payment_method: PaymentMethod | null
   notes: string | null
   has_active_billing_periods: boolean
 }

--- a/frontend/documentation/components/UsageDashboard.stories.tsx
+++ b/frontend/documentation/components/UsageDashboard.stories.tsx
@@ -6,7 +6,6 @@ import UsageBreakdown, {
 } from 'components/pages/usage/components/UsageBreakdown'
 import {
   allowanceWindow,
-  basisExplanation,
   contributionNote,
   isBilledOnAPeriod,
   isBillingPeriodSelected,
@@ -121,7 +120,6 @@ const UsagePage: FC<HarnessProps> = ({
 
   return (
     <UsageDashboard
-      basisExplanation={basisExplanation(basis)}
       breakdown={
         <UsageBreakdown
           {...breakdown}

--- a/frontend/documentation/components/UsageDashboard.stories.tsx
+++ b/frontend/documentation/components/UsageDashboard.stories.tsx
@@ -11,6 +11,7 @@ import {
   isBillingPeriodSelected,
   periodLabel,
   periodsFor,
+  PeriodSelection,
   planSectionCopy,
   resolvePeriod,
   showsPlanCeiling,
@@ -86,9 +87,7 @@ const UsagePage: FC<HarnessProps> = ({
   const planIsBilled = isBilledOnAPeriod(basis)
   const periods = periodsFor(planIsBilled)
 
-  const [chosenPeriod, setChosenPeriod] = useState<BillingPeriod | 'default'>(
-    'default',
-  )
+  const [chosenPeriod, setChosenPeriod] = useState<PeriodSelection>('default')
   const [project, setProject] = useState('All Projects')
 
   const billingPeriod = resolvePeriod(chosenPeriod, planIsBilled)

--- a/frontend/documentation/components/UsageDashboard.stories.tsx
+++ b/frontend/documentation/components/UsageDashboard.stories.tsx
@@ -1,140 +1,237 @@
+import { FC, useState } from 'react'
 import type { Meta, StoryObj } from 'storybook'
 import { UsageDashboard } from 'components/pages/usage'
-import { Res } from 'common/types/responses'
+import UsageBreakdown, {
+  useUsageBreakdown,
+} from 'components/pages/usage/components/UsageBreakdown'
+import {
+  allowanceWindow,
+  basisExplanation,
+  contributionNote,
+  isBilledOnAPeriod,
+  isBillingPeriodSelected,
+  periodLabel,
+  periodsFor,
+  planSectionCopy,
+  resolvePeriod,
+  showsPlanCeiling,
+  usageBasisOf,
+} from 'components/pages/usage/utils'
+import { BillingPeriod, PeriodOption } from 'common/types/requests'
+import { PlanLimit } from 'components/shared/UsageBar/utils'
+import { Subscription } from 'common/types/responses'
+import { toUsageResponse, USAGE_SCENARIOS } from './fixtures/usage'
 
-const meta: Meta<typeof UsageDashboard> = {
-  component: UsageDashboard,
+const PROJECTS = [
+  'All Projects',
+  'Checkout',
+  'Mobile app',
+  'Internal tools',
+  'Marketing site',
+]
+
+// Roughly how much of the organisation each project accounts for.
+const PROJECT_SHARE: Record<string, number> = {
+  'All Projects': 1,
+  'Checkout': 0.38,
+  'Internal tools': 0.07,
+  'Marketing site': 0.13,
+  'Mobile app': 0.42,
+}
+
+const SCENARIO_FOR: Record<string, keyof typeof USAGE_SCENARIOS> = {
+  '90_day_period': 'last90Days',
+  current_billing_period: 'currentBillingPeriod',
+  previous_billing_period: 'previousBillingPeriod',
+  rolling: 'last30Days',
+}
+
+const scenarioFor = (period: BillingPeriod, empty: boolean, free: boolean) => {
+  if (empty) return []
+  if (free) return USAGE_SCENARIOS.freePlan
+  return USAGE_SCENARIOS[SCENARIO_FOR[period ?? 'rolling']]
+}
+
+const subscriptionOf = (values: Partial<Subscription>): Subscription =>
+  ({
+    has_active_billing_periods: false,
+    payment_method: null,
+    plan: 'scale-up',
+    ...values,
+  } as Subscription)
+
+type HarnessProps = {
+  subscription: Subscription
+  limit: PlanLimit
+  /** Overrides the fixture so the meter reads a chosen percentage. */
+  scale?: number
+  empty?: boolean
+  isLoading?: boolean
+  isError?: boolean
+}
+
+/**
+ * Mirrors what UsageDashboardPage derives, using the real utils rather than a
+ * copy of them, so the selects behave here as they do in the app.
+ */
+const UsagePage: FC<HarnessProps> = ({
+  empty,
+  isError,
+  isLoading,
+  limit,
+  scale = 1,
+  subscription,
+}) => {
+  const isFreePlan = subscription.plan === 'free'
+  const basis = usageBasisOf(subscription, isFreePlan)
+  const planIsBilled = isBilledOnAPeriod(basis)
+  const periods = periodsFor(planIsBilled)
+
+  const [chosenPeriod, setChosenPeriod] = useState<BillingPeriod | 'default'>(
+    'default',
+  )
+  const [project, setProject] = useState('All Projects')
+
+  const billingPeriod = resolvePeriod(chosenPeriod, planIsBilled)
+  const share = PROJECT_SHARE[project] ?? 1
+  const filtered = project !== 'All Projects'
+
+  const scoped = toUsageResponse(
+    scenarioFor(billingPeriod, !!empty, isFreePlan),
+    share * scale,
+  )
+  const allowanceTotal = toUsageResponse(
+    scenarioFor(allowanceWindow(basis), !!empty, isFreePlan),
+    scale,
+  ).totals.total
+
+  // The note needs the organisation over the period on screen, not over the
+  // allowance window, or a project can read as more than all of it.
+  const periodTotal = toUsageResponse(
+    scenarioFor(billingPeriod, !!empty, isFreePlan),
+    scale,
+  ).totals.total
+
+  const { setDimension, ...breakdown } = useUsageBreakdown({ data: scoped })
+
+  const scope = `${filtered ? project : 'All projects'} · ${periodLabel(
+    periods,
+    billingPeriod,
+  )}`
+
+  return (
+    <UsageDashboard
+      basisExplanation={basisExplanation(basis)}
+      breakdown={
+        <UsageBreakdown
+          {...breakdown}
+          onChangeDimension={setDimension}
+          scope={scope}
+        />
+      }
+      data={scoped}
+      filters={
+        <Row className='gap-2'>
+          <div style={{ minWidth: 210 }}>
+            <Select
+              aria-label='Period'
+              onChange={(option: PeriodOption) => setChosenPeriod(option.value)}
+              options={periods}
+              value={periods.find((option) => option.value === billingPeriod)}
+            />
+          </div>
+          <div style={{ minWidth: 210 }}>
+            <Select
+              aria-label='Project'
+              onChange={(option: { value: string }) => setProject(option.value)}
+              options={PROJECTS.map((name) => ({ label: name, value: name }))}
+              value={{ label: project, value: project }}
+            />
+          </div>
+        </Row>
+      }
+      hasBillingPeriod={isBillingPeriodSelected(billingPeriod)}
+      isError={isError}
+      isLoading={isLoading}
+      limit={limit}
+      meterNote={
+        filtered
+          ? contributionNote(project, scoped.totals.total, periodTotal)
+          : undefined
+      }
+      onRetry={() => {}}
+      periodLabel={periodLabel(periods, billingPeriod)}
+      planCopy={planSectionCopy(basis, limit)}
+      showPlanCeiling={showsPlanCeiling(
+        billingPeriod,
+        filtered ? 1 : undefined,
+      )}
+      total={allowanceTotal}
+    />
+  )
+}
+
+const meta: Meta<typeof UsagePage> = {
+  component: UsagePage,
   parameters: { layout: 'fullscreen' },
   title: 'Pages/Usage Dashboard/Page',
 }
 export default meta
 
-type Story = StoryObj<typeof UsageDashboard>
+type Story = StoryObj<typeof UsagePage>
 
-const DAY_WEIGHTS = [1.08, 1.12, 1.05, 1.1, 0.98, 0.62, 0.58]
+const billed = subscriptionOf({ has_active_billing_periods: true })
 
-const usage = (days: number, perDay: number): Res['organisationUsage'] => {
-  const events = Array.from({ length: days }).map((_, index) => {
-    const weight = DAY_WEIGHTS[index % DAY_WEIGHTS.length]
-    return {
-      day: `2026-08-${`${index + 1}`.padStart(2, '0')}`,
-      environment_document: Math.round(perDay * weight * 0.04),
-      flags: Math.round(perDay * weight * 0.63),
-      identities: Math.round(perDay * weight * 0.24),
-      labels: { user_agent: null },
-      traits: Math.round(perDay * weight * 0.09),
-    }
-  })
-  const sum = (
-    key: 'flags' | 'identities' | 'traits' | 'environment_document',
-  ) => events.reduce((acc, event) => acc + event[key], 0)
-
-  return {
-    events_list: events,
-    totals: {
-      environmentDocument: sum('environment_document'),
-      flags: sum('flags'),
-      identities: sum('identities'),
-      total:
-        sum('flags') +
-        sum('identities') +
-        sum('traits') +
-        sum('environment_document'),
-      traits: sum('traits'),
-    },
-  }
-}
-
-const paid = usage(18, 70000)
-const free = usage(30, 1800)
-const paidApproaching = usage(26, 75000)
-const paidOver = usage(28, 92000)
-
-// A plan with a billing term: usage climbs towards a reset, so it is drawn
-// cumulatively against the ceiling.
 export const PaidWithABillingPeriod: Story = {
-  args: {
-    data: paid,
-    hasBillingPeriod: true,
-    limit: 2000000,
-    total: paid.totals.total,
-  },
+  args: { limit: 2000000, subscription: billed },
 }
 
 export const PaidApproachingTheLimit: Story = {
-  args: {
-    data: paidApproaching,
-    hasBillingPeriod: true,
-    limit: 2000000,
-    total: paidApproaching.totals.total,
-  },
+  args: { limit: 1400000, subscription: billed },
 }
 
 export const PaidOverTheLimit: Story = {
-  args: {
-    data: paidOver,
-    hasBillingPeriod: true,
-    limit: 2000000,
-    total: paidOver.totals.total,
-  },
+  args: { limit: 900000, subscription: billed },
 }
 
-// No billing term, so no reset to accumulate towards: daily volume instead.
 export const FreeOnARollingWindow: Story = {
-  args: {
-    data: free,
-    hasBillingPeriod: false,
-    limit: 50000,
-    total: free.totals.total,
-  },
+  args: { limit: 50000, subscription: subscriptionOf({ plan: 'free' }) },
 }
 
-// Enterprise agreements are not billed through Chargebee, so they have a real
-// limit and no period. The meter still works; the chart falls back to volume.
+// Enterprise agreements are invoiced outside Chargebee, so they have a real
+// limit and no period. The meter works; the chart falls back to daily volume.
 export const EnterpriseWithoutABillingPeriod: Story = {
   args: {
-    data: paid,
-    hasBillingPeriod: false,
     limit: 50000000,
-    total: paid.totals.total,
+    subscription: subscriptionOf({
+      payment_method: 'XERO',
+      plan: 'enterprise',
+    }),
   },
 }
 
-// Self-hosted has no subscription data at all, so there is nothing to be a
-// percentage of.
-export const WithoutAPlanLimit: Story = {
+// On Chargebee, but no period has arrived. Reads differently from invoiced,
+// because this one may resolve itself.
+export const ChargebeeWithoutAPeriodYet: Story = {
   args: {
-    data: paid,
-    hasBillingPeriod: false,
-    limit: null,
-    total: paid.totals.total,
+    limit: 2000000,
+    subscription: subscriptionOf({ payment_method: 'CHARGEBEE' }),
   },
+}
+
+// Self-hosted has no subscription data at all, so nothing to be a percentage of.
+export const WithoutAPlanLimit: Story = {
+  args: { limit: null, subscription: subscriptionOf({ plan: 'enterprise' }) },
 }
 
 export const NoUsageYet: Story = {
-  args: {
-    data: usage(0, 0),
-    hasBillingPeriod: true,
-    limit: 2000000,
-    total: 0,
-  },
+  args: { empty: true, limit: 2000000, subscription: billed },
 }
 
 export const Loading: Story = {
-  args: {
-    hasBillingPeriod: true,
-    isLoading: true,
-    limit: 2000000,
-    total: 0,
-  },
+  args: { isLoading: true, limit: 2000000, subscription: billed },
 }
 
-/** Distinct from NoUsageYet, which would otherwise look identical. */
 export const FailedToLoad: Story = {
-  args: {
-    hasBillingPeriod: true,
-    isError: true,
-    limit: 2000000,
-    total: 0,
-  },
+  args: { isError: true, limit: 2000000, subscription: billed },
 }

--- a/frontend/documentation/components/UsageDashboard.stories.tsx
+++ b/frontend/documentation/components/UsageDashboard.stories.tsx
@@ -14,6 +14,7 @@ import {
   PeriodSelection,
   planSectionCopy,
   resolvePeriod,
+  showsContribution,
   showsPlanCeiling,
   usageBasisOf,
 } from 'components/pages/usage/utils'
@@ -105,11 +106,6 @@ const UsagePage: FC<HarnessProps> = ({
 
   // The note needs the organisation over the period on screen, not over the
   // allowance window, or a project can read as more than all of it.
-  const periodTotal = toUsageResponse(
-    scenarioFor(billingPeriod, !!empty, isFreePlan),
-    scale,
-  ).totals.total
-
   const { setDimension, ...breakdown } = useUsageBreakdown({ data: scoped })
 
   const scope = `${filtered ? project : 'All projects'} · ${periodLabel(
@@ -152,8 +148,8 @@ const UsagePage: FC<HarnessProps> = ({
       isLoading={isLoading}
       limit={limit}
       meterNote={
-        filtered
-          ? contributionNote(project, scoped.totals.total, periodTotal)
+        showsContribution(basis, billingPeriod, filtered ? 1 : undefined)
+          ? contributionNote(project, scoped.totals.total, allowanceTotal)
           : undefined
       }
       onRetry={() => {}}

--- a/frontend/documentation/components/UsageMeter.stories.tsx
+++ b/frontend/documentation/components/UsageMeter.stories.tsx
@@ -28,7 +28,10 @@ export const OverTheLimit: Story = {
 
 // Nothing to be a percentage of, so the total stands on its own.
 export const WithoutAPlanLimit: Story = {
-  args: { limit: null, total: 340000 },
+  args: {
+    limit: null,
+    total: 340000,
+  },
 }
 
 export const NoUsageYet: Story = {

--- a/frontend/documentation/components/UsageOverTime.stories.tsx
+++ b/frontend/documentation/components/UsageOverTime.stories.tsx
@@ -3,6 +3,7 @@ import UsageOverTime from 'components/pages/usage/components/UsageOverTime'
 import { Res } from 'common/types/responses'
 
 const meta: Meta<typeof UsageOverTime> = {
+  args: { periodLabel: 'Current billing period' },
   component: UsageOverTime,
   parameters: { layout: 'padded' },
   title: 'Pages/Usage Dashboard/Components/UsageOverTime',

--- a/frontend/documentation/components/UsageOverTime.stories.tsx
+++ b/frontend/documentation/components/UsageOverTime.stories.tsx
@@ -69,6 +69,7 @@ export const DailyVolumeOnARollingWindow: Story = {
     data: usage(30, 2000),
     isBillingPeriod: false,
     limit: 50000,
+    periodLabel: 'Last 30 days',
   },
 }
 

--- a/frontend/documentation/components/fixtures/usage.ts
+++ b/frontend/documentation/components/fixtures/usage.ts
@@ -15,14 +15,16 @@ type DailyCounts = {
   environment_document: number
 }
 
-const sum = (
-  events: UsageEventsList[],
-  key: 'flags' | 'identities' | 'traits' | 'environment_document',
-): number => events.reduce((running, event) => running + (event[key] ?? 0), 0)
+type UsageEventKey = 'flags' | 'identities' | 'traits' | 'environment_document'
+
+const sum = (events: UsageEventsList[], key: UsageEventKey): number =>
+  events.reduce((running, event) => running + (event[key] ?? 0), 0)
 
 // The API returns one row per day and client type, so the fixtures split each
 // day the same way, otherwise the SDK breakdown has nothing to group on.
-const SDK_SPLIT: [string | null, number][] = [
+type UserAgent = string | null
+
+const SDK_SPLIT: [UserAgent, number][] = [
   ['flagsmith-python/3.9.1', 0.42],
   ['flagsmith-java/7.2.0', 0.31],
   ['flagsmith-nodejs/5.0.4', 0.19],

--- a/frontend/documentation/components/fixtures/usage.ts
+++ b/frontend/documentation/components/fixtures/usage.ts
@@ -1,0 +1,73 @@
+import { Res, UsageEventsList } from 'common/types/responses'
+import approachingTheLimit from './usage/approaching-the-limit.json'
+import currentBillingPeriod from './usage/current-billing-period.json'
+import freePlan from './usage/free-plan.json'
+import last30Days from './usage/last-30-days.json'
+import last90Days from './usage/last-90-days.json'
+import overTheLimit from './usage/over-the-limit.json'
+import previousBillingPeriod from './usage/previous-billing-period.json'
+
+type DailyCounts = {
+  day: string
+  flags: number
+  identities: number
+  traits: number
+  environment_document: number
+}
+
+const sum = (
+  events: UsageEventsList[],
+  key: 'flags' | 'identities' | 'traits' | 'environment_document',
+): number => events.reduce((running, event) => running + (event[key] ?? 0), 0)
+
+// The API returns one row per day and client type, so the fixtures split each
+// day the same way, otherwise the SDK breakdown has nothing to group on.
+const SDK_SPLIT: [string | null, number][] = [
+  ['flagsmith-python/3.9.1', 0.42],
+  ['flagsmith-java/7.2.0', 0.31],
+  ['flagsmith-nodejs/5.0.4', 0.19],
+  [null, 0.08],
+]
+
+export const toUsageResponse = (
+  days: DailyCounts[],
+  share = 1,
+): Res['organisationUsage'] => {
+  const events: UsageEventsList[] = days.flatMap((day) =>
+    SDK_SPLIT.map(([userAgent, weight]) => ({
+      day: day.day,
+      environment_document: Math.round(
+        day.environment_document * share * weight,
+      ),
+      flags: Math.round(day.flags * share * weight),
+      identities: Math.round(day.identities * share * weight),
+      labels: { user_agent: userAgent },
+      traits: Math.round(day.traits * share * weight),
+    })),
+  )
+
+  return {
+    events_list: events,
+    totals: {
+      environmentDocument: sum(events, 'environment_document'),
+      flags: sum(events, 'flags'),
+      identities: sum(events, 'identities'),
+      total:
+        sum(events, 'flags') +
+        sum(events, 'identities') +
+        sum(events, 'traits') +
+        sum(events, 'environment_document'),
+      traits: sum(events, 'traits'),
+    },
+  }
+}
+
+export const USAGE_SCENARIOS = {
+  approachingTheLimit,
+  currentBillingPeriod,
+  freePlan,
+  last30Days,
+  last90Days,
+  overTheLimit,
+  previousBillingPeriod,
+} as const

--- a/frontend/documentation/components/fixtures/usage/README.md
+++ b/frontend/documentation/components/fixtures/usage/README.md
@@ -1,0 +1,7 @@
+Daily API call counts for the usage dashboard stories.
+
+Each file is one scenario: an array of days, each with the four billable
+request types. Hand editable, so a spike, a plateau or a quiet weekend can be
+drawn deliberately rather than generated.
+
+`toUsageResponse` in `../usage.ts` expands them into the shape the API returns.

--- a/frontend/documentation/components/fixtures/usage/README.md
+++ b/frontend/documentation/components/fixtures/usage/README.md
@@ -1,3 +1,5 @@
+# Usage dashboard fixtures
+
 Daily API call counts for the usage dashboard stories.
 
 Each file is one scenario: an array of days, each with the four billable

--- a/frontend/documentation/components/fixtures/usage/approaching-the-limit.json
+++ b/frontend/documentation/components/fixtures/usage/approaching-the-limit.json
@@ -1,181 +1,181 @@
 [
   {
-    "day": "2026-08-01",
+    "day": "2026-08-06",
     "flags": 51030,
     "identities": 19440,
     "traits": 7290,
     "environment_document": 3240
-  },
-  {
-    "day": "2026-08-02",
-    "flags": 52920,
-    "identities": 20160,
-    "traits": 7560,
-    "environment_document": 3360
-  },
-  {
-    "day": "2026-08-03",
-    "flags": 49612,
-    "identities": 18900,
-    "traits": 7088,
-    "environment_document": 3150
-  },
-  {
-    "day": "2026-08-04",
-    "flags": 51975,
-    "identities": 19800,
-    "traits": 7425,
-    "environment_document": 3300
-  },
-  {
-    "day": "2026-08-05",
-    "flags": 46305,
-    "identities": 17640,
-    "traits": 6615,
-    "environment_document": 2940
-  },
-  {
-    "day": "2026-08-06",
-    "flags": 29295,
-    "identities": 11160,
-    "traits": 4185,
-    "environment_document": 1860
   },
   {
     "day": "2026-08-07",
-    "flags": 27405,
-    "identities": 10440,
-    "traits": 3915,
-    "environment_document": 1740
+    "flags": 52920,
+    "identities": 20160,
+    "traits": 7560,
+    "environment_document": 3360
   },
   {
     "day": "2026-08-08",
-    "flags": 51030,
-    "identities": 19440,
-    "traits": 7290,
-    "environment_document": 3240
+    "flags": 49612,
+    "identities": 18900,
+    "traits": 7088,
+    "environment_document": 3150
   },
   {
     "day": "2026-08-09",
-    "flags": 52920,
-    "identities": 20160,
-    "traits": 7560,
-    "environment_document": 3360
+    "flags": 51975,
+    "identities": 19800,
+    "traits": 7425,
+    "environment_document": 3300
   },
   {
     "day": "2026-08-10",
-    "flags": 49612,
-    "identities": 18900,
-    "traits": 7088,
-    "environment_document": 3150
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
   },
   {
     "day": "2026-08-11",
-    "flags": 51975,
-    "identities": 19800,
-    "traits": 7425,
-    "environment_document": 3300
+    "flags": 29295,
+    "identities": 11160,
+    "traits": 4185,
+    "environment_document": 1860
   },
   {
     "day": "2026-08-12",
-    "flags": 46305,
-    "identities": 17640,
-    "traits": 6615,
-    "environment_document": 2940
+    "flags": 27405,
+    "identities": 10440,
+    "traits": 3915,
+    "environment_document": 1740
   },
   {
     "day": "2026-08-13",
-    "flags": 29295,
-    "identities": 11160,
-    "traits": 4185,
-    "environment_document": 1860
-  },
-  {
-    "day": "2026-08-14",
-    "flags": 27405,
-    "identities": 10440,
-    "traits": 3915,
-    "environment_document": 1740
-  },
-  {
-    "day": "2026-08-15",
     "flags": 51030,
     "identities": 19440,
     "traits": 7290,
     "environment_document": 3240
   },
   {
-    "day": "2026-08-16",
+    "day": "2026-08-14",
     "flags": 52920,
     "identities": 20160,
     "traits": 7560,
     "environment_document": 3360
   },
   {
-    "day": "2026-08-17",
+    "day": "2026-08-15",
     "flags": 49612,
     "identities": 18900,
     "traits": 7088,
     "environment_document": 3150
   },
   {
-    "day": "2026-08-18",
+    "day": "2026-08-16",
     "flags": 51975,
     "identities": 19800,
     "traits": 7425,
     "environment_document": 3300
   },
   {
-    "day": "2026-08-19",
+    "day": "2026-08-17",
     "flags": 46305,
     "identities": 17640,
     "traits": 6615,
     "environment_document": 2940
   },
   {
-    "day": "2026-08-20",
+    "day": "2026-08-18",
     "flags": 29295,
     "identities": 11160,
     "traits": 4185,
     "environment_document": 1860
   },
   {
-    "day": "2026-08-21",
+    "day": "2026-08-19",
     "flags": 27405,
     "identities": 10440,
     "traits": 3915,
     "environment_document": 1740
   },
   {
-    "day": "2026-08-22",
+    "day": "2026-08-20",
     "flags": 51030,
     "identities": 19440,
     "traits": 7290,
     "environment_document": 3240
   },
   {
-    "day": "2026-08-23",
+    "day": "2026-08-21",
     "flags": 52920,
     "identities": 20160,
     "traits": 7560,
     "environment_document": 3360
   },
   {
-    "day": "2026-08-24",
+    "day": "2026-08-22",
     "flags": 49612,
     "identities": 18900,
     "traits": 7088,
     "environment_document": 3150
   },
   {
-    "day": "2026-08-25",
+    "day": "2026-08-23",
     "flags": 51975,
     "identities": 19800,
     "traits": 7425,
     "environment_document": 3300
   },
   {
+    "day": "2026-08-24",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 29295,
+    "identities": 11160,
+    "traits": 4185,
+    "environment_document": 1860
+  },
+  {
     "day": "2026-08-26",
+    "flags": 27405,
+    "identities": 10440,
+    "traits": 3915,
+    "environment_document": 1740
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 51030,
+    "identities": 19440,
+    "traits": 7290,
+    "environment_document": 3240
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 52920,
+    "identities": 20160,
+    "traits": 7560,
+    "environment_document": 3360
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 49612,
+    "identities": 18900,
+    "traits": 7088,
+    "environment_document": 3150
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 51975,
+    "identities": 19800,
+    "traits": 7425,
+    "environment_document": 3300
+  },
+  {
+    "day": "2026-08-31",
     "flags": 46305,
     "identities": 17640,
     "traits": 6615,

--- a/frontend/documentation/components/fixtures/usage/approaching-the-limit.json
+++ b/frontend/documentation/components/fixtures/usage/approaching-the-limit.json
@@ -1,0 +1,184 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 51030,
+    "identities": 19440,
+    "traits": 7290,
+    "environment_document": 3240
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 52920,
+    "identities": 20160,
+    "traits": 7560,
+    "environment_document": 3360
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 49612,
+    "identities": 18900,
+    "traits": 7088,
+    "environment_document": 3150
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 51975,
+    "identities": 19800,
+    "traits": 7425,
+    "environment_document": 3300
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 29295,
+    "identities": 11160,
+    "traits": 4185,
+    "environment_document": 1860
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 27405,
+    "identities": 10440,
+    "traits": 3915,
+    "environment_document": 1740
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 51030,
+    "identities": 19440,
+    "traits": 7290,
+    "environment_document": 3240
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 52920,
+    "identities": 20160,
+    "traits": 7560,
+    "environment_document": 3360
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 49612,
+    "identities": 18900,
+    "traits": 7088,
+    "environment_document": 3150
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 51975,
+    "identities": 19800,
+    "traits": 7425,
+    "environment_document": 3300
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 29295,
+    "identities": 11160,
+    "traits": 4185,
+    "environment_document": 1860
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 27405,
+    "identities": 10440,
+    "traits": 3915,
+    "environment_document": 1740
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 51030,
+    "identities": 19440,
+    "traits": 7290,
+    "environment_document": 3240
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 52920,
+    "identities": 20160,
+    "traits": 7560,
+    "environment_document": 3360
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 49612,
+    "identities": 18900,
+    "traits": 7088,
+    "environment_document": 3150
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 51975,
+    "identities": 19800,
+    "traits": 7425,
+    "environment_document": 3300
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 29295,
+    "identities": 11160,
+    "traits": 4185,
+    "environment_document": 1860
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 27405,
+    "identities": 10440,
+    "traits": 3915,
+    "environment_document": 1740
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 51030,
+    "identities": 19440,
+    "traits": 7290,
+    "environment_document": 3240
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 52920,
+    "identities": 20160,
+    "traits": 7560,
+    "environment_document": 3360
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 49612,
+    "identities": 18900,
+    "traits": 7088,
+    "environment_document": 3150
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 51975,
+    "identities": 19800,
+    "traits": 7425,
+    "environment_document": 3300
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  }
+]

--- a/frontend/documentation/components/fixtures/usage/current-billing-period.json
+++ b/frontend/documentation/components/fixtures/usage/current-billing-period.json
@@ -1,125 +1,125 @@
 [
   {
-    "day": "2026-08-01",
-    "flags": 47628,
-    "identities": 18144,
-    "traits": 6804,
-    "environment_document": 3024
-  },
-  {
-    "day": "2026-08-02",
-    "flags": 49392,
-    "identities": 18816,
-    "traits": 7056,
-    "environment_document": 3136
-  },
-  {
-    "day": "2026-08-03",
-    "flags": 46305,
-    "identities": 17640,
-    "traits": 6615,
-    "environment_document": 2940
-  },
-  {
-    "day": "2026-08-04",
-    "flags": 48510,
-    "identities": 18480,
-    "traits": 6930,
-    "environment_document": 3080
-  },
-  {
-    "day": "2026-08-05",
-    "flags": 43218,
-    "identities": 16464,
-    "traits": 6174,
-    "environment_document": 2744
-  },
-  {
-    "day": "2026-08-06",
-    "flags": 27342,
-    "identities": 10416,
-    "traits": 3906,
-    "environment_document": 1736
-  },
-  {
-    "day": "2026-08-07",
-    "flags": 25578,
-    "identities": 9744,
-    "traits": 3654,
-    "environment_document": 1624
-  },
-  {
-    "day": "2026-08-08",
-    "flags": 47628,
-    "identities": 18144,
-    "traits": 6804,
-    "environment_document": 3024
-  },
-  {
-    "day": "2026-08-09",
-    "flags": 49392,
-    "identities": 18816,
-    "traits": 7056,
-    "environment_document": 3136
-  },
-  {
-    "day": "2026-08-10",
-    "flags": 46305,
-    "identities": 17640,
-    "traits": 6615,
-    "environment_document": 2940
-  },
-  {
-    "day": "2026-08-11",
-    "flags": 48510,
-    "identities": 18480,
-    "traits": 6930,
-    "environment_document": 3080
-  },
-  {
-    "day": "2026-08-12",
-    "flags": 43218,
-    "identities": 16464,
-    "traits": 6174,
-    "environment_document": 2744
-  },
-  {
-    "day": "2026-08-13",
-    "flags": 27342,
-    "identities": 10416,
-    "traits": 3906,
-    "environment_document": 1736
-  },
-  {
     "day": "2026-08-14",
-    "flags": 25578,
-    "identities": 9744,
-    "traits": 3654,
-    "environment_document": 1624
+    "flags": 47628,
+    "identities": 18144,
+    "traits": 6804,
+    "environment_document": 3024
   },
   {
     "day": "2026-08-15",
-    "flags": 47628,
-    "identities": 18144,
-    "traits": 6804,
-    "environment_document": 3024
-  },
-  {
-    "day": "2026-08-16",
     "flags": 49392,
     "identities": 18816,
     "traits": 7056,
     "environment_document": 3136
   },
   {
-    "day": "2026-08-17",
+    "day": "2026-08-16",
     "flags": 46305,
     "identities": 17640,
     "traits": 6615,
     "environment_document": 2940
   },
   {
+    "day": "2026-08-17",
+    "flags": 48510,
+    "identities": 18480,
+    "traits": 6930,
+    "environment_document": 3080
+  },
+  {
     "day": "2026-08-18",
+    "flags": 43218,
+    "identities": 16464,
+    "traits": 6174,
+    "environment_document": 2744
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 27342,
+    "identities": 10416,
+    "traits": 3906,
+    "environment_document": 1736
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 25578,
+    "identities": 9744,
+    "traits": 3654,
+    "environment_document": 1624
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 47628,
+    "identities": 18144,
+    "traits": 6804,
+    "environment_document": 3024
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 49392,
+    "identities": 18816,
+    "traits": 7056,
+    "environment_document": 3136
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 48510,
+    "identities": 18480,
+    "traits": 6930,
+    "environment_document": 3080
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 43218,
+    "identities": 16464,
+    "traits": 6174,
+    "environment_document": 2744
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 27342,
+    "identities": 10416,
+    "traits": 3906,
+    "environment_document": 1736
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 25578,
+    "identities": 9744,
+    "traits": 3654,
+    "environment_document": 1624
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 47628,
+    "identities": 18144,
+    "traits": 6804,
+    "environment_document": 3024
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 49392,
+    "identities": 18816,
+    "traits": 7056,
+    "environment_document": 3136
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-31",
     "flags": 48510,
     "identities": 18480,
     "traits": 6930,

--- a/frontend/documentation/components/fixtures/usage/current-billing-period.json
+++ b/frontend/documentation/components/fixtures/usage/current-billing-period.json
@@ -1,0 +1,128 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 47628,
+    "identities": 18144,
+    "traits": 6804,
+    "environment_document": 3024
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 49392,
+    "identities": 18816,
+    "traits": 7056,
+    "environment_document": 3136
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 48510,
+    "identities": 18480,
+    "traits": 6930,
+    "environment_document": 3080
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 43218,
+    "identities": 16464,
+    "traits": 6174,
+    "environment_document": 2744
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 27342,
+    "identities": 10416,
+    "traits": 3906,
+    "environment_document": 1736
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 25578,
+    "identities": 9744,
+    "traits": 3654,
+    "environment_document": 1624
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 47628,
+    "identities": 18144,
+    "traits": 6804,
+    "environment_document": 3024
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 49392,
+    "identities": 18816,
+    "traits": 7056,
+    "environment_document": 3136
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 48510,
+    "identities": 18480,
+    "traits": 6930,
+    "environment_document": 3080
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 43218,
+    "identities": 16464,
+    "traits": 6174,
+    "environment_document": 2744
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 27342,
+    "identities": 10416,
+    "traits": 3906,
+    "environment_document": 1736
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 25578,
+    "identities": 9744,
+    "traits": 3654,
+    "environment_document": 1624
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 47628,
+    "identities": 18144,
+    "traits": 6804,
+    "environment_document": 3024
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 49392,
+    "identities": 18816,
+    "traits": 7056,
+    "environment_document": 3136
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 46305,
+    "identities": 17640,
+    "traits": 6615,
+    "environment_document": 2940
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 48510,
+    "identities": 18480,
+    "traits": 6930,
+    "environment_document": 3080
+  }
+]

--- a/frontend/documentation/components/fixtures/usage/free-plan.json
+++ b/frontend/documentation/components/fixtures/usage/free-plan.json
@@ -1,209 +1,209 @@
 [
   {
-    "day": "2026-08-01",
+    "day": "2026-08-02",
     "flags": 1225,
     "identities": 467,
     "traits": 175,
     "environment_document": 78
-  },
-  {
-    "day": "2026-08-02",
-    "flags": 1270,
-    "identities": 484,
-    "traits": 181,
-    "environment_document": 81
   },
   {
     "day": "2026-08-03",
-    "flags": 1191,
-    "identities": 454,
-    "traits": 170,
-    "environment_document": 76
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
   },
   {
     "day": "2026-08-04",
-    "flags": 1247,
-    "identities": 475,
-    "traits": 178,
-    "environment_document": 79
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
   },
   {
     "day": "2026-08-05",
-    "flags": 1111,
-    "identities": 423,
-    "traits": 159,
-    "environment_document": 71
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
   },
   {
     "day": "2026-08-06",
-    "flags": 703,
-    "identities": 268,
-    "traits": 100,
-    "environment_document": 45
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
   },
   {
     "day": "2026-08-07",
-    "flags": 658,
-    "identities": 251,
-    "traits": 94,
-    "environment_document": 42
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
   },
   {
     "day": "2026-08-08",
-    "flags": 1225,
-    "identities": 467,
-    "traits": 175,
-    "environment_document": 78
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
   },
   {
     "day": "2026-08-09",
-    "flags": 1270,
-    "identities": 484,
-    "traits": 181,
-    "environment_document": 81
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
   },
   {
     "day": "2026-08-10",
-    "flags": 1191,
-    "identities": 454,
-    "traits": 170,
-    "environment_document": 76
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
   },
   {
     "day": "2026-08-11",
-    "flags": 1247,
-    "identities": 475,
-    "traits": 178,
-    "environment_document": 79
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
   },
   {
     "day": "2026-08-12",
-    "flags": 1111,
-    "identities": 423,
-    "traits": 159,
-    "environment_document": 71
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
   },
   {
     "day": "2026-08-13",
-    "flags": 703,
-    "identities": 268,
-    "traits": 100,
-    "environment_document": 45
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
   },
   {
     "day": "2026-08-14",
-    "flags": 658,
-    "identities": 251,
-    "traits": 94,
-    "environment_document": 42
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
   },
   {
     "day": "2026-08-15",
-    "flags": 1225,
-    "identities": 467,
-    "traits": 175,
-    "environment_document": 78
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
   },
   {
     "day": "2026-08-16",
-    "flags": 1270,
-    "identities": 484,
-    "traits": 181,
-    "environment_document": 81
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
   },
   {
     "day": "2026-08-17",
-    "flags": 1191,
-    "identities": 454,
-    "traits": 170,
-    "environment_document": 76
-  },
-  {
-    "day": "2026-08-18",
-    "flags": 1247,
-    "identities": 475,
-    "traits": 178,
-    "environment_document": 79
-  },
-  {
-    "day": "2026-08-19",
-    "flags": 1111,
-    "identities": 423,
-    "traits": 159,
-    "environment_document": 71
-  },
-  {
-    "day": "2026-08-20",
-    "flags": 703,
-    "identities": 268,
-    "traits": 100,
-    "environment_document": 45
-  },
-  {
-    "day": "2026-08-21",
-    "flags": 658,
-    "identities": 251,
-    "traits": 94,
-    "environment_document": 42
-  },
-  {
-    "day": "2026-08-22",
-    "flags": 1225,
-    "identities": 467,
-    "traits": 175,
-    "environment_document": 78
-  },
-  {
-    "day": "2026-08-23",
     "flags": 1270,
     "identities": 484,
     "traits": 181,
     "environment_document": 81
   },
   {
-    "day": "2026-08-24",
+    "day": "2026-08-18",
     "flags": 1191,
     "identities": 454,
     "traits": 170,
     "environment_document": 76
   },
   {
-    "day": "2026-08-25",
+    "day": "2026-08-19",
     "flags": 1247,
     "identities": 475,
     "traits": 178,
     "environment_document": 79
   },
   {
-    "day": "2026-08-26",
+    "day": "2026-08-20",
     "flags": 1111,
     "identities": 423,
     "traits": 159,
     "environment_document": 71
   },
   {
-    "day": "2026-08-27",
+    "day": "2026-08-21",
     "flags": 703,
     "identities": 268,
     "traits": 100,
     "environment_document": 45
   },
   {
-    "day": "2026-08-28",
+    "day": "2026-08-22",
     "flags": 658,
     "identities": 251,
     "traits": 94,
     "environment_document": 42
   },
   {
-    "day": "2026-08-29",
+    "day": "2026-08-23",
     "flags": 1225,
     "identities": 467,
     "traits": 175,
     "environment_document": 78
   },
   {
+    "day": "2026-08-24",
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
+  },
+  {
     "day": "2026-08-30",
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
+  },
+  {
+    "day": "2026-08-31",
     "flags": 1270,
     "identities": 484,
     "traits": 181,

--- a/frontend/documentation/components/fixtures/usage/free-plan.json
+++ b/frontend/documentation/components/fixtures/usage/free-plan.json
@@ -1,0 +1,212 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 1191,
+    "identities": 454,
+    "traits": 170,
+    "environment_document": 76
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 1247,
+    "identities": 475,
+    "traits": 178,
+    "environment_document": 79
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 1111,
+    "identities": 423,
+    "traits": 159,
+    "environment_document": 71
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 703,
+    "identities": 268,
+    "traits": 100,
+    "environment_document": 45
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 658,
+    "identities": 251,
+    "traits": 94,
+    "environment_document": 42
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 1225,
+    "identities": 467,
+    "traits": 175,
+    "environment_document": 78
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 1270,
+    "identities": 484,
+    "traits": 181,
+    "environment_document": 81
+  }
+]

--- a/frontend/documentation/components/fixtures/usage/last-30-days.json
+++ b/frontend/documentation/components/fixtures/usage/last-30-days.json
@@ -1,0 +1,212 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
+  }
+]

--- a/frontend/documentation/components/fixtures/usage/last-30-days.json
+++ b/frontend/documentation/components/fixtures/usage/last-30-days.json
@@ -1,209 +1,209 @@
 [
   {
-    "day": "2026-08-01",
+    "day": "2026-08-02",
     "flags": 28577,
     "identities": 10886,
     "traits": 4082,
     "environment_document": 1814
-  },
-  {
-    "day": "2026-08-02",
-    "flags": 29635,
-    "identities": 11290,
-    "traits": 4234,
-    "environment_document": 1882
   },
   {
     "day": "2026-08-03",
-    "flags": 27783,
-    "identities": 10584,
-    "traits": 3969,
-    "environment_document": 1764
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
   },
   {
     "day": "2026-08-04",
-    "flags": 29106,
-    "identities": 11088,
-    "traits": 4158,
-    "environment_document": 1848
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
   },
   {
     "day": "2026-08-05",
-    "flags": 25931,
-    "identities": 9878,
-    "traits": 3704,
-    "environment_document": 1646
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
   },
   {
     "day": "2026-08-06",
-    "flags": 16405,
-    "identities": 6250,
-    "traits": 2344,
-    "environment_document": 1042
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
   },
   {
     "day": "2026-08-07",
-    "flags": 15347,
-    "identities": 5846,
-    "traits": 2192,
-    "environment_document": 974
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
   },
   {
     "day": "2026-08-08",
-    "flags": 28577,
-    "identities": 10886,
-    "traits": 4082,
-    "environment_document": 1814
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
   },
   {
     "day": "2026-08-09",
-    "flags": 29635,
-    "identities": 11290,
-    "traits": 4234,
-    "environment_document": 1882
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
   },
   {
     "day": "2026-08-10",
-    "flags": 27783,
-    "identities": 10584,
-    "traits": 3969,
-    "environment_document": 1764
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
   },
   {
     "day": "2026-08-11",
-    "flags": 29106,
-    "identities": 11088,
-    "traits": 4158,
-    "environment_document": 1848
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
   },
   {
     "day": "2026-08-12",
-    "flags": 25931,
-    "identities": 9878,
-    "traits": 3704,
-    "environment_document": 1646
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
   },
   {
     "day": "2026-08-13",
-    "flags": 16405,
-    "identities": 6250,
-    "traits": 2344,
-    "environment_document": 1042
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
   },
   {
     "day": "2026-08-14",
-    "flags": 15347,
-    "identities": 5846,
-    "traits": 2192,
-    "environment_document": 974
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
   },
   {
     "day": "2026-08-15",
-    "flags": 28577,
-    "identities": 10886,
-    "traits": 4082,
-    "environment_document": 1814
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
   },
   {
     "day": "2026-08-16",
-    "flags": 29635,
-    "identities": 11290,
-    "traits": 4234,
-    "environment_document": 1882
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
   },
   {
     "day": "2026-08-17",
-    "flags": 27783,
-    "identities": 10584,
-    "traits": 3969,
-    "environment_document": 1764
-  },
-  {
-    "day": "2026-08-18",
-    "flags": 29106,
-    "identities": 11088,
-    "traits": 4158,
-    "environment_document": 1848
-  },
-  {
-    "day": "2026-08-19",
-    "flags": 25931,
-    "identities": 9878,
-    "traits": 3704,
-    "environment_document": 1646
-  },
-  {
-    "day": "2026-08-20",
-    "flags": 16405,
-    "identities": 6250,
-    "traits": 2344,
-    "environment_document": 1042
-  },
-  {
-    "day": "2026-08-21",
-    "flags": 15347,
-    "identities": 5846,
-    "traits": 2192,
-    "environment_document": 974
-  },
-  {
-    "day": "2026-08-22",
-    "flags": 28577,
-    "identities": 10886,
-    "traits": 4082,
-    "environment_document": 1814
-  },
-  {
-    "day": "2026-08-23",
     "flags": 29635,
     "identities": 11290,
     "traits": 4234,
     "environment_document": 1882
   },
   {
-    "day": "2026-08-24",
+    "day": "2026-08-18",
     "flags": 27783,
     "identities": 10584,
     "traits": 3969,
     "environment_document": 1764
   },
   {
-    "day": "2026-08-25",
+    "day": "2026-08-19",
     "flags": 29106,
     "identities": 11088,
     "traits": 4158,
     "environment_document": 1848
   },
   {
-    "day": "2026-08-26",
+    "day": "2026-08-20",
     "flags": 25931,
     "identities": 9878,
     "traits": 3704,
     "environment_document": 1646
   },
   {
-    "day": "2026-08-27",
+    "day": "2026-08-21",
     "flags": 16405,
     "identities": 6250,
     "traits": 2344,
     "environment_document": 1042
   },
   {
-    "day": "2026-08-28",
+    "day": "2026-08-22",
     "flags": 15347,
     "identities": 5846,
     "traits": 2192,
     "environment_document": 974
   },
   {
-    "day": "2026-08-29",
+    "day": "2026-08-23",
     "flags": 28577,
     "identities": 10886,
     "traits": 4082,
     "environment_document": 1814
   },
   {
+    "day": "2026-08-24",
+    "flags": 29635,
+    "identities": 11290,
+    "traits": 4234,
+    "environment_document": 1882
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 27783,
+    "identities": 10584,
+    "traits": 3969,
+    "environment_document": 1764
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 29106,
+    "identities": 11088,
+    "traits": 4158,
+    "environment_document": 1848
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 25931,
+    "identities": 9878,
+    "traits": 3704,
+    "environment_document": 1646
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 16405,
+    "identities": 6250,
+    "traits": 2344,
+    "environment_document": 1042
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 15347,
+    "identities": 5846,
+    "traits": 2192,
+    "environment_document": 974
+  },
+  {
     "day": "2026-08-30",
+    "flags": 28577,
+    "identities": 10886,
+    "traits": 4082,
+    "environment_document": 1814
+  },
+  {
+    "day": "2026-08-31",
     "flags": 29635,
     "identities": 11290,
     "traits": 4234,

--- a/frontend/documentation/components/fixtures/usage/last-90-days.json
+++ b/frontend/documentation/components/fixtures/usage/last-90-days.json
@@ -1,0 +1,632 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-31",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-32",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-33",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-34",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-35",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-36",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-37",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-38",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-39",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-40",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-41",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-42",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-43",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-44",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-45",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-46",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-47",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-48",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-49",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-50",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-51",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-52",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-53",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-54",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-55",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-56",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-57",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-58",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-59",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-60",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-61",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-62",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-63",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-64",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-65",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-66",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-67",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-68",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-69",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-70",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-71",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-72",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-73",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-74",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-75",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-76",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-77",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-78",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-79",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-80",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-81",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-82",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-83",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-08-84",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-08-85",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-08-86",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-08-87",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-88",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-08-89",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-08-90",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  }
+]

--- a/frontend/documentation/components/fixtures/usage/last-90-days.json
+++ b/frontend/documentation/components/fixtures/usage/last-90-days.json
@@ -1,629 +1,629 @@
 [
   {
-    "day": "2026-08-01",
+    "day": "2026-06-03",
     "flags": 26536,
     "identities": 10109,
     "traits": 3791,
     "environment_document": 1685
+  },
+  {
+    "day": "2026-06-04",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-06-05",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-06-06",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-06-07",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-06-08",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-06-09",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-06-10",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-06-11",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-06-12",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-06-13",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-06-14",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-06-15",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-06-16",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-06-17",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-06-18",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-06-19",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-06-20",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-06-21",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-06-22",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-06-23",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-06-24",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-06-25",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-06-26",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-06-27",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-06-28",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-06-29",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-06-30",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-07-01",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-07-02",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-07-03",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-07-04",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-07-05",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-07-06",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-07-07",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-07-08",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-07-09",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-07-10",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-07-11",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-07-12",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-07-13",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-07-14",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-07-15",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-07-16",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-07-17",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-07-18",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-07-19",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-07-20",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-07-21",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-07-22",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-07-23",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-07-24",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-07-25",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
+  },
+  {
+    "day": "2026-07-26",
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
+  },
+  {
+    "day": "2026-07-27",
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
+  },
+  {
+    "day": "2026-07-28",
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
+  },
+  {
+    "day": "2026-07-29",
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
+  },
+  {
+    "day": "2026-07-30",
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
+  },
+  {
+    "day": "2026-07-31",
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
+  },
+  {
+    "day": "2026-08-01",
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
   },
   {
     "day": "2026-08-02",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
   },
   {
     "day": "2026-08-03",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
   },
   {
     "day": "2026-08-04",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
   },
   {
     "day": "2026-08-05",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
   },
   {
     "day": "2026-08-06",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
   },
   {
     "day": "2026-08-07",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
   },
   {
     "day": "2026-08-08",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
   },
   {
     "day": "2026-08-09",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
   },
   {
     "day": "2026-08-10",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
   },
   {
     "day": "2026-08-11",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
   },
   {
     "day": "2026-08-12",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
   },
   {
     "day": "2026-08-13",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
   },
   {
     "day": "2026-08-14",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
   },
   {
     "day": "2026-08-15",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
   },
   {
     "day": "2026-08-16",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
   },
   {
     "day": "2026-08-17",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
   },
   {
     "day": "2026-08-18",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
   },
   {
     "day": "2026-08-19",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
   },
   {
     "day": "2026-08-20",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
   },
   {
     "day": "2026-08-21",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
   },
   {
     "day": "2026-08-22",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
   },
   {
     "day": "2026-08-23",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
   },
   {
     "day": "2026-08-24",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
+    "flags": 15233,
+    "identities": 5803,
+    "traits": 2176,
+    "environment_document": 967
   },
   {
     "day": "2026-08-25",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
+    "flags": 14251,
+    "identities": 5429,
+    "traits": 2036,
+    "environment_document": 905
   },
   {
     "day": "2026-08-26",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
+    "flags": 26536,
+    "identities": 10109,
+    "traits": 3791,
+    "environment_document": 1685
   },
   {
     "day": "2026-08-27",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
+    "flags": 27518,
+    "identities": 10483,
+    "traits": 3931,
+    "environment_document": 1747
   },
   {
     "day": "2026-08-28",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
+    "flags": 25798,
+    "identities": 9828,
+    "traits": 3686,
+    "environment_document": 1638
   },
   {
     "day": "2026-08-29",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
+    "flags": 27027,
+    "identities": 10296,
+    "traits": 3861,
+    "environment_document": 1716
   },
   {
     "day": "2026-08-30",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
+    "flags": 24079,
+    "identities": 9173,
+    "traits": 3440,
+    "environment_document": 1529
   },
   {
     "day": "2026-08-31",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-32",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-33",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-34",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-35",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-36",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-37",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-38",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-39",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-40",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-41",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-42",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-43",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-44",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-45",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-46",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-47",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-48",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-49",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-50",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-51",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-52",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-53",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-54",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-55",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-56",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-57",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-58",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-59",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-60",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-61",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-62",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-63",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-64",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-65",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-66",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-67",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-68",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-69",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-70",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-71",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-72",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-73",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-74",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-75",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-76",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-77",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-78",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-79",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-80",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-81",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-82",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-83",
-    "flags": 15233,
-    "identities": 5803,
-    "traits": 2176,
-    "environment_document": 967
-  },
-  {
-    "day": "2026-08-84",
-    "flags": 14251,
-    "identities": 5429,
-    "traits": 2036,
-    "environment_document": 905
-  },
-  {
-    "day": "2026-08-85",
-    "flags": 26536,
-    "identities": 10109,
-    "traits": 3791,
-    "environment_document": 1685
-  },
-  {
-    "day": "2026-08-86",
-    "flags": 27518,
-    "identities": 10483,
-    "traits": 3931,
-    "environment_document": 1747
-  },
-  {
-    "day": "2026-08-87",
-    "flags": 25798,
-    "identities": 9828,
-    "traits": 3686,
-    "environment_document": 1638
-  },
-  {
-    "day": "2026-08-88",
-    "flags": 27027,
-    "identities": 10296,
-    "traits": 3861,
-    "environment_document": 1716
-  },
-  {
-    "day": "2026-08-89",
-    "flags": 24079,
-    "identities": 9173,
-    "traits": 3440,
-    "environment_document": 1529
-  },
-  {
-    "day": "2026-08-90",
     "flags": 15233,
     "identities": 5803,
     "traits": 2176,

--- a/frontend/documentation/components/fixtures/usage/over-the-limit.json
+++ b/frontend/documentation/components/fixtures/usage/over-the-limit.json
@@ -1,195 +1,195 @@
 [
   {
-    "day": "2026-08-01",
+    "day": "2026-08-04",
     "flags": 62597,
     "identities": 23846,
     "traits": 8942,
     "environment_document": 3974
-  },
-  {
-    "day": "2026-08-02",
-    "flags": 64915,
-    "identities": 24730,
-    "traits": 9274,
-    "environment_document": 4122
-  },
-  {
-    "day": "2026-08-03",
-    "flags": 60858,
-    "identities": 23184,
-    "traits": 8694,
-    "environment_document": 3864
-  },
-  {
-    "day": "2026-08-04",
-    "flags": 63756,
-    "identities": 24288,
-    "traits": 9108,
-    "environment_document": 4048
   },
   {
     "day": "2026-08-05",
-    "flags": 56801,
-    "identities": 21638,
-    "traits": 8114,
-    "environment_document": 3606
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
   },
   {
     "day": "2026-08-06",
-    "flags": 35935,
-    "identities": 13690,
-    "traits": 5134,
-    "environment_document": 2282
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
   },
   {
     "day": "2026-08-07",
-    "flags": 33617,
-    "identities": 12806,
-    "traits": 4802,
-    "environment_document": 2134
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
   },
   {
     "day": "2026-08-08",
-    "flags": 62597,
-    "identities": 23846,
-    "traits": 8942,
-    "environment_document": 3974
+    "flags": 56801,
+    "identities": 21638,
+    "traits": 8114,
+    "environment_document": 3606
   },
   {
     "day": "2026-08-09",
-    "flags": 64915,
-    "identities": 24730,
-    "traits": 9274,
-    "environment_document": 4122
+    "flags": 35935,
+    "identities": 13690,
+    "traits": 5134,
+    "environment_document": 2282
   },
   {
     "day": "2026-08-10",
-    "flags": 60858,
-    "identities": 23184,
-    "traits": 8694,
-    "environment_document": 3864
+    "flags": 33617,
+    "identities": 12806,
+    "traits": 4802,
+    "environment_document": 2134
   },
   {
     "day": "2026-08-11",
-    "flags": 63756,
-    "identities": 24288,
-    "traits": 9108,
-    "environment_document": 4048
+    "flags": 62597,
+    "identities": 23846,
+    "traits": 8942,
+    "environment_document": 3974
   },
   {
     "day": "2026-08-12",
-    "flags": 56801,
-    "identities": 21638,
-    "traits": 8114,
-    "environment_document": 3606
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
   },
   {
     "day": "2026-08-13",
-    "flags": 35935,
-    "identities": 13690,
-    "traits": 5134,
-    "environment_document": 2282
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
   },
   {
     "day": "2026-08-14",
-    "flags": 33617,
-    "identities": 12806,
-    "traits": 4802,
-    "environment_document": 2134
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
   },
   {
     "day": "2026-08-15",
-    "flags": 62597,
-    "identities": 23846,
-    "traits": 8942,
-    "environment_document": 3974
-  },
-  {
-    "day": "2026-08-16",
-    "flags": 64915,
-    "identities": 24730,
-    "traits": 9274,
-    "environment_document": 4122
-  },
-  {
-    "day": "2026-08-17",
-    "flags": 60858,
-    "identities": 23184,
-    "traits": 8694,
-    "environment_document": 3864
-  },
-  {
-    "day": "2026-08-18",
-    "flags": 63756,
-    "identities": 24288,
-    "traits": 9108,
-    "environment_document": 4048
-  },
-  {
-    "day": "2026-08-19",
     "flags": 56801,
     "identities": 21638,
     "traits": 8114,
     "environment_document": 3606
   },
   {
-    "day": "2026-08-20",
+    "day": "2026-08-16",
     "flags": 35935,
     "identities": 13690,
     "traits": 5134,
     "environment_document": 2282
   },
   {
-    "day": "2026-08-21",
+    "day": "2026-08-17",
     "flags": 33617,
     "identities": 12806,
     "traits": 4802,
     "environment_document": 2134
   },
   {
-    "day": "2026-08-22",
+    "day": "2026-08-18",
     "flags": 62597,
     "identities": 23846,
     "traits": 8942,
     "environment_document": 3974
   },
   {
-    "day": "2026-08-23",
+    "day": "2026-08-19",
     "flags": 64915,
     "identities": 24730,
     "traits": 9274,
     "environment_document": 4122
   },
   {
-    "day": "2026-08-24",
+    "day": "2026-08-20",
     "flags": 60858,
     "identities": 23184,
     "traits": 8694,
     "environment_document": 3864
   },
   {
-    "day": "2026-08-25",
+    "day": "2026-08-21",
     "flags": 63756,
     "identities": 24288,
     "traits": 9108,
     "environment_document": 4048
   },
   {
-    "day": "2026-08-26",
+    "day": "2026-08-22",
     "flags": 56801,
     "identities": 21638,
     "traits": 8114,
     "environment_document": 3606
   },
   {
-    "day": "2026-08-27",
+    "day": "2026-08-23",
     "flags": 35935,
     "identities": 13690,
     "traits": 5134,
     "environment_document": 2282
   },
   {
+    "day": "2026-08-24",
+    "flags": 33617,
+    "identities": 12806,
+    "traits": 4802,
+    "environment_document": 2134
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 62597,
+    "identities": 23846,
+    "traits": 8942,
+    "environment_document": 3974
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
+  },
+  {
     "day": "2026-08-28",
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 56801,
+    "identities": 21638,
+    "traits": 8114,
+    "environment_document": 3606
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 35935,
+    "identities": 13690,
+    "traits": 5134,
+    "environment_document": 2282
+  },
+  {
+    "day": "2026-08-31",
     "flags": 33617,
     "identities": 12806,
     "traits": 4802,

--- a/frontend/documentation/components/fixtures/usage/over-the-limit.json
+++ b/frontend/documentation/components/fixtures/usage/over-the-limit.json
@@ -1,0 +1,198 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 62597,
+    "identities": 23846,
+    "traits": 8942,
+    "environment_document": 3974
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 56801,
+    "identities": 21638,
+    "traits": 8114,
+    "environment_document": 3606
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 35935,
+    "identities": 13690,
+    "traits": 5134,
+    "environment_document": 2282
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 33617,
+    "identities": 12806,
+    "traits": 4802,
+    "environment_document": 2134
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 62597,
+    "identities": 23846,
+    "traits": 8942,
+    "environment_document": 3974
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 56801,
+    "identities": 21638,
+    "traits": 8114,
+    "environment_document": 3606
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 35935,
+    "identities": 13690,
+    "traits": 5134,
+    "environment_document": 2282
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 33617,
+    "identities": 12806,
+    "traits": 4802,
+    "environment_document": 2134
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 62597,
+    "identities": 23846,
+    "traits": 8942,
+    "environment_document": 3974
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 56801,
+    "identities": 21638,
+    "traits": 8114,
+    "environment_document": 3606
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 35935,
+    "identities": 13690,
+    "traits": 5134,
+    "environment_document": 2282
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 33617,
+    "identities": 12806,
+    "traits": 4802,
+    "environment_document": 2134
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 62597,
+    "identities": 23846,
+    "traits": 8942,
+    "environment_document": 3974
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 64915,
+    "identities": 24730,
+    "traits": 9274,
+    "environment_document": 4122
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 60858,
+    "identities": 23184,
+    "traits": 8694,
+    "environment_document": 3864
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 63756,
+    "identities": 24288,
+    "traits": 9108,
+    "environment_document": 4048
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 56801,
+    "identities": 21638,
+    "traits": 8114,
+    "environment_document": 3606
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 35935,
+    "identities": 13690,
+    "traits": 5134,
+    "environment_document": 2282
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 33617,
+    "identities": 12806,
+    "traits": 4802,
+    "environment_document": 2134
+  }
+]

--- a/frontend/documentation/components/fixtures/usage/previous-billing-period.json
+++ b/frontend/documentation/components/fixtures/usage/previous-billing-period.json
@@ -1,216 +1,216 @@
 [
   {
-    "day": "2026-08-01",
+    "day": "2026-07-01",
     "flags": 41504,
     "identities": 15811,
     "traits": 5929,
     "environment_document": 2635
   },
   {
-    "day": "2026-08-02",
+    "day": "2026-07-02",
     "flags": 43042,
     "identities": 16397,
     "traits": 6149,
     "environment_document": 2733
   },
   {
-    "day": "2026-08-03",
+    "day": "2026-07-03",
     "flags": 40352,
     "identities": 15372,
     "traits": 5764,
     "environment_document": 2562
   },
   {
-    "day": "2026-08-04",
+    "day": "2026-07-04",
     "flags": 42273,
     "identities": 16104,
     "traits": 6039,
     "environment_document": 2684
   },
   {
-    "day": "2026-08-05",
+    "day": "2026-07-05",
     "flags": 37661,
     "identities": 14347,
     "traits": 5380,
     "environment_document": 2391
   },
   {
-    "day": "2026-08-06",
+    "day": "2026-07-06",
     "flags": 23827,
     "identities": 9077,
     "traits": 3404,
     "environment_document": 1513
   },
   {
-    "day": "2026-08-07",
+    "day": "2026-07-07",
     "flags": 22289,
     "identities": 8491,
     "traits": 3184,
     "environment_document": 1415
   },
   {
-    "day": "2026-08-08",
+    "day": "2026-07-08",
     "flags": 41504,
     "identities": 15811,
     "traits": 5929,
     "environment_document": 2635
   },
   {
-    "day": "2026-08-09",
+    "day": "2026-07-09",
     "flags": 43042,
     "identities": 16397,
     "traits": 6149,
     "environment_document": 2733
   },
   {
-    "day": "2026-08-10",
+    "day": "2026-07-10",
     "flags": 40352,
     "identities": 15372,
     "traits": 5764,
     "environment_document": 2562
   },
   {
-    "day": "2026-08-11",
+    "day": "2026-07-11",
     "flags": 42273,
     "identities": 16104,
     "traits": 6039,
     "environment_document": 2684
   },
   {
-    "day": "2026-08-12",
+    "day": "2026-07-12",
     "flags": 37661,
     "identities": 14347,
     "traits": 5380,
     "environment_document": 2391
   },
   {
-    "day": "2026-08-13",
+    "day": "2026-07-13",
     "flags": 23827,
     "identities": 9077,
     "traits": 3404,
     "environment_document": 1513
   },
   {
-    "day": "2026-08-14",
+    "day": "2026-07-14",
     "flags": 22289,
     "identities": 8491,
     "traits": 3184,
     "environment_document": 1415
   },
   {
-    "day": "2026-08-15",
+    "day": "2026-07-15",
     "flags": 41504,
     "identities": 15811,
     "traits": 5929,
     "environment_document": 2635
   },
   {
-    "day": "2026-08-16",
+    "day": "2026-07-16",
     "flags": 43042,
     "identities": 16397,
     "traits": 6149,
     "environment_document": 2733
   },
   {
-    "day": "2026-08-17",
+    "day": "2026-07-17",
     "flags": 40352,
     "identities": 15372,
     "traits": 5764,
     "environment_document": 2562
   },
   {
-    "day": "2026-08-18",
+    "day": "2026-07-18",
     "flags": 42273,
     "identities": 16104,
     "traits": 6039,
     "environment_document": 2684
   },
   {
-    "day": "2026-08-19",
+    "day": "2026-07-19",
     "flags": 37661,
     "identities": 14347,
     "traits": 5380,
     "environment_document": 2391
   },
   {
-    "day": "2026-08-20",
+    "day": "2026-07-20",
     "flags": 23827,
     "identities": 9077,
     "traits": 3404,
     "environment_document": 1513
   },
   {
-    "day": "2026-08-21",
+    "day": "2026-07-21",
     "flags": 22289,
     "identities": 8491,
     "traits": 3184,
     "environment_document": 1415
   },
   {
-    "day": "2026-08-22",
+    "day": "2026-07-22",
     "flags": 41504,
     "identities": 15811,
     "traits": 5929,
     "environment_document": 2635
   },
   {
-    "day": "2026-08-23",
+    "day": "2026-07-23",
     "flags": 43042,
     "identities": 16397,
     "traits": 6149,
     "environment_document": 2733
   },
   {
-    "day": "2026-08-24",
+    "day": "2026-07-24",
     "flags": 40352,
     "identities": 15372,
     "traits": 5764,
     "environment_document": 2562
   },
   {
-    "day": "2026-08-25",
+    "day": "2026-07-25",
     "flags": 42273,
     "identities": 16104,
     "traits": 6039,
     "environment_document": 2684
   },
   {
-    "day": "2026-08-26",
+    "day": "2026-07-26",
     "flags": 37661,
     "identities": 14347,
     "traits": 5380,
     "environment_document": 2391
   },
   {
-    "day": "2026-08-27",
+    "day": "2026-07-27",
     "flags": 23827,
     "identities": 9077,
     "traits": 3404,
     "environment_document": 1513
   },
   {
-    "day": "2026-08-28",
+    "day": "2026-07-28",
     "flags": 22289,
     "identities": 8491,
     "traits": 3184,
     "environment_document": 1415
   },
   {
-    "day": "2026-08-29",
+    "day": "2026-07-29",
     "flags": 41504,
     "identities": 15811,
     "traits": 5929,
     "environment_document": 2635
   },
   {
-    "day": "2026-08-30",
+    "day": "2026-07-30",
     "flags": 43042,
     "identities": 16397,
     "traits": 6149,
     "environment_document": 2733
   },
   {
-    "day": "2026-08-31",
+    "day": "2026-07-31",
     "flags": 40352,
     "identities": 15372,
     "traits": 5764,

--- a/frontend/documentation/components/fixtures/usage/previous-billing-period.json
+++ b/frontend/documentation/components/fixtures/usage/previous-billing-period.json
@@ -1,0 +1,219 @@
+[
+  {
+    "day": "2026-08-01",
+    "flags": 41504,
+    "identities": 15811,
+    "traits": 5929,
+    "environment_document": 2635
+  },
+  {
+    "day": "2026-08-02",
+    "flags": 43042,
+    "identities": 16397,
+    "traits": 6149,
+    "environment_document": 2733
+  },
+  {
+    "day": "2026-08-03",
+    "flags": 40352,
+    "identities": 15372,
+    "traits": 5764,
+    "environment_document": 2562
+  },
+  {
+    "day": "2026-08-04",
+    "flags": 42273,
+    "identities": 16104,
+    "traits": 6039,
+    "environment_document": 2684
+  },
+  {
+    "day": "2026-08-05",
+    "flags": 37661,
+    "identities": 14347,
+    "traits": 5380,
+    "environment_document": 2391
+  },
+  {
+    "day": "2026-08-06",
+    "flags": 23827,
+    "identities": 9077,
+    "traits": 3404,
+    "environment_document": 1513
+  },
+  {
+    "day": "2026-08-07",
+    "flags": 22289,
+    "identities": 8491,
+    "traits": 3184,
+    "environment_document": 1415
+  },
+  {
+    "day": "2026-08-08",
+    "flags": 41504,
+    "identities": 15811,
+    "traits": 5929,
+    "environment_document": 2635
+  },
+  {
+    "day": "2026-08-09",
+    "flags": 43042,
+    "identities": 16397,
+    "traits": 6149,
+    "environment_document": 2733
+  },
+  {
+    "day": "2026-08-10",
+    "flags": 40352,
+    "identities": 15372,
+    "traits": 5764,
+    "environment_document": 2562
+  },
+  {
+    "day": "2026-08-11",
+    "flags": 42273,
+    "identities": 16104,
+    "traits": 6039,
+    "environment_document": 2684
+  },
+  {
+    "day": "2026-08-12",
+    "flags": 37661,
+    "identities": 14347,
+    "traits": 5380,
+    "environment_document": 2391
+  },
+  {
+    "day": "2026-08-13",
+    "flags": 23827,
+    "identities": 9077,
+    "traits": 3404,
+    "environment_document": 1513
+  },
+  {
+    "day": "2026-08-14",
+    "flags": 22289,
+    "identities": 8491,
+    "traits": 3184,
+    "environment_document": 1415
+  },
+  {
+    "day": "2026-08-15",
+    "flags": 41504,
+    "identities": 15811,
+    "traits": 5929,
+    "environment_document": 2635
+  },
+  {
+    "day": "2026-08-16",
+    "flags": 43042,
+    "identities": 16397,
+    "traits": 6149,
+    "environment_document": 2733
+  },
+  {
+    "day": "2026-08-17",
+    "flags": 40352,
+    "identities": 15372,
+    "traits": 5764,
+    "environment_document": 2562
+  },
+  {
+    "day": "2026-08-18",
+    "flags": 42273,
+    "identities": 16104,
+    "traits": 6039,
+    "environment_document": 2684
+  },
+  {
+    "day": "2026-08-19",
+    "flags": 37661,
+    "identities": 14347,
+    "traits": 5380,
+    "environment_document": 2391
+  },
+  {
+    "day": "2026-08-20",
+    "flags": 23827,
+    "identities": 9077,
+    "traits": 3404,
+    "environment_document": 1513
+  },
+  {
+    "day": "2026-08-21",
+    "flags": 22289,
+    "identities": 8491,
+    "traits": 3184,
+    "environment_document": 1415
+  },
+  {
+    "day": "2026-08-22",
+    "flags": 41504,
+    "identities": 15811,
+    "traits": 5929,
+    "environment_document": 2635
+  },
+  {
+    "day": "2026-08-23",
+    "flags": 43042,
+    "identities": 16397,
+    "traits": 6149,
+    "environment_document": 2733
+  },
+  {
+    "day": "2026-08-24",
+    "flags": 40352,
+    "identities": 15372,
+    "traits": 5764,
+    "environment_document": 2562
+  },
+  {
+    "day": "2026-08-25",
+    "flags": 42273,
+    "identities": 16104,
+    "traits": 6039,
+    "environment_document": 2684
+  },
+  {
+    "day": "2026-08-26",
+    "flags": 37661,
+    "identities": 14347,
+    "traits": 5380,
+    "environment_document": 2391
+  },
+  {
+    "day": "2026-08-27",
+    "flags": 23827,
+    "identities": 9077,
+    "traits": 3404,
+    "environment_document": 1513
+  },
+  {
+    "day": "2026-08-28",
+    "flags": 22289,
+    "identities": 8491,
+    "traits": 3184,
+    "environment_document": 1415
+  },
+  {
+    "day": "2026-08-29",
+    "flags": 41504,
+    "identities": 15811,
+    "traits": 5929,
+    "environment_document": 2635
+  },
+  {
+    "day": "2026-08-30",
+    "flags": 43042,
+    "identities": 16397,
+    "traits": 6149,
+    "environment_document": 2733
+  },
+  {
+    "day": "2026-08-31",
+    "flags": 40352,
+    "identities": 15372,
+    "traits": 5764,
+    "environment_document": 2562
+  }
+]

--- a/frontend/web/components/ProjectFilter.tsx
+++ b/frontend/web/components/ProjectFilter.tsx
@@ -7,9 +7,11 @@ type ProjectFilterType = {
   onChange: (id: string, name: string) => void
   showAll?: boolean
   inputId?: string
+  'aria-label'?: string
 }
 
 const ProjectFilter: FC<ProjectFilterType> = ({
+  'aria-label': ariaLabel,
   inputId,
   onChange,
   organisationId,
@@ -47,6 +49,7 @@ const ProjectFilter: FC<ProjectFilterType> = ({
         onChange(value.value || '', value.label || '')
       }
       inputId={inputId}
+      aria-label={ariaLabel}
       data-test='project-select'
     />
   )

--- a/frontend/web/components/pages/usage/UsageDashboard.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboard.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode } from 'react'
 import { Res } from 'common/types/responses'
 import { PlanLimit } from 'components/shared/UsageBar/utils'
 import EmptyState from 'components/EmptyState'
+import SectionHeading from './components/SectionHeading'
 import UsageMeter from './components/UsageMeter'
 import UsageOverTime from './components/UsageOverTime'
 
@@ -9,21 +10,35 @@ export type UsageDashboardProps = {
   data: Res['organisationUsage'] | undefined
   total: number
   limit: PlanLimit
+  planCopy: { title: string; hint: string }
+  basisExplanation?: string
+  periodLabel: string
+  meterNote?: ReactNode
+  showPlanCeiling?: boolean
   hasBillingPeriod: boolean
   isError?: boolean
   isLoading?: boolean
+  isExploring?: boolean
+  onRetry?: () => void
   filters?: ReactNode
   breakdown?: ReactNode
 }
 
 const UsageDashboard: FC<UsageDashboardProps> = ({
+  basisExplanation,
   breakdown,
   data,
   filters,
   hasBillingPeriod,
   isError,
+  isExploring,
   isLoading,
   limit,
+  meterNote,
+  onRetry,
+  periodLabel,
+  planCopy,
+  showPlanCeiling,
   total,
 }) => {
   let content
@@ -40,31 +55,54 @@ const UsageDashboard: FC<UsageDashboardProps> = ({
         title='Usage could not be loaded'
         description='Something went wrong fetching usage for this period. Try again in a moment.'
         icon='bar-chart'
+        action={
+          onRetry && (
+            <Button onClick={onRetry} theme='secondary'>
+              Try again
+            </Button>
+          )
+        }
       />
     )
   } else {
     content = (
       <>
-        <UsageMeter total={total} limit={limit} />
-
-        <UsageOverTime
-          data={data}
-          limit={limit}
-          isBillingPeriod={hasBillingPeriod}
+        <SectionHeading
+          title={planCopy.title}
+          hint={[planCopy.hint, basisExplanation].filter(Boolean).join(' ')}
         />
 
-        {breakdown}
+        <UsageMeter total={total} limit={limit} note={meterNote} />
+
+        <SectionHeading
+          title='Explore usage'
+          hint='Narrow the chart and the breakdown by period or project.'
+          action={filters}
+        />
+
+        {isExploring ? (
+          <div className='text-center py-5'>
+            <Loader />
+          </div>
+        ) : (
+          <>
+            <UsageOverTime
+              data={data}
+              limit={showPlanCeiling ? limit : undefined}
+              isBillingPeriod={hasBillingPeriod}
+              periodLabel={periodLabel}
+            />
+
+            {breakdown}
+          </>
+        )}
       </>
     )
   }
 
   return (
     <div className='px-3 px-md-4 py-4'>
-      <Row space className='mb-4 align-items-end'>
-        <h4 className='mb-0'>Usage</h4>
-        {filters}
-      </Row>
-
+      <h4 className='mb-4'>Usage</h4>
       {content}
     </div>
   )

--- a/frontend/web/components/pages/usage/UsageDashboard.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboard.tsx
@@ -11,7 +11,6 @@ export type UsageDashboardProps = {
   total: number
   limit: PlanLimit
   planCopy: { title: string; hint: string }
-  basisExplanation?: string
   periodLabel: string
   meterNote?: ReactNode
   showPlanCeiling?: boolean
@@ -25,7 +24,6 @@ export type UsageDashboardProps = {
 }
 
 const UsageDashboard: FC<UsageDashboardProps> = ({
-  basisExplanation,
   breakdown,
   data,
   filters,
@@ -67,10 +65,7 @@ const UsageDashboard: FC<UsageDashboardProps> = ({
   } else {
     content = (
       <>
-        <SectionHeading
-          title={planCopy.title}
-          hint={[planCopy.hint, basisExplanation].filter(Boolean).join(' ')}
-        />
+        <SectionHeading title={planCopy.title} hint={planCopy.hint} />
 
         <UsageMeter total={total} limit={limit} note={meterNote} />
 

--- a/frontend/web/components/pages/usage/UsageDashboardPage.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboardPage.tsx
@@ -13,6 +13,7 @@ import {
   isBillingPeriodSelected,
   contributionNote,
   planSectionCopy,
+  showsContribution,
   showsPlanCeiling,
   periodLabel,
   periodsFor,
@@ -94,11 +95,12 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
       periodLabel={periodLabel(periods, billingPeriod)}
       showPlanCeiling={showsPlanCeiling(billingPeriod, selectedProjectId)}
       meterNote={
-        selectedProjectId && projectName
+        showsContribution(basis, billingPeriod, selectedProjectId) &&
+        projectName
           ? contributionNote(
               projectName,
               usage.scoped?.totals?.total ?? 0,
-              usage.periodTotal,
+              usage.allowanceTotal,
             )
           : undefined
       }

--- a/frontend/web/components/pages/usage/UsageDashboardPage.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboardPage.tsx
@@ -97,6 +97,7 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
 
   const {
     data: subscriptionMeta,
+    isError: limitFailed,
     isLoading: loadingLimit,
     refetch: refetchLimit,
   } = useGetSubscriptionMetadataQuery(
@@ -144,7 +145,7 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
           scope={scope}
         />
       }
-      isError={organisationFailed || usageFailed}
+      isError={organisationFailed || usageFailed || limitFailed}
       isLoading={loadingOrganisation || loadingPlan || loadingLimit}
       isExploring={loadingUsage}
       onRetry={() => {

--- a/frontend/web/components/pages/usage/UsageDashboardPage.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboardPage.tsx
@@ -13,7 +13,6 @@ import {
   isBillingPeriodSelected,
   contributionNote,
   allowanceWindow,
-  basisExplanation,
   planSectionCopy,
   showsPlanCeiling,
   periodLabel,
@@ -126,7 +125,6 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
       limit={subscriptionMeta?.max_api_calls}
       hasBillingPeriod={isBillingPeriodSelected(billingPeriod)}
       planCopy={planSectionCopy(basis, subscriptionMeta?.max_api_calls)}
-      basisExplanation={basisExplanation(basis)}
       periodLabel={periodLabel(periods, billingPeriod)}
       showPlanCeiling={showsPlanCeiling(billingPeriod, selectedProjectId)}
       meterNote={

--- a/frontend/web/components/pages/usage/UsageDashboardPage.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboardPage.tsx
@@ -109,7 +109,7 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
           scope={scope}
         />
       }
-      isError={organisationFailed || usage.scopedFailed || limitFailed}
+      isError={organisationFailed || usage.failed || limitFailed}
       isLoading={loadingOrganisation || usage.isLoadingPlan || loadingLimit}
       isExploring={usage.isLoadingScoped}
       onRetry={() => {

--- a/frontend/web/components/pages/usage/UsageDashboardPage.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboardPage.tsx
@@ -2,17 +2,16 @@ import { FC, useState } from 'react'
 import { skipToken } from '@reduxjs/toolkit/query'
 import Utils, { planNames } from 'common/utils/utils'
 import { useGetOrganisationQuery } from 'common/services/useOrganisation'
-import { useGetOrganisationUsageQuery } from 'common/services/useOrganisationUsage'
 import { useGetSubscriptionMetadataQuery } from 'common/services/useSubscriptionMetadata'
 import ProjectFilter from 'components/ProjectFilter'
 import { PeriodOption } from 'common/types/requests'
 import UsageBreakdown, { useUsageBreakdown } from './components/UsageBreakdown'
 import UsageDashboard from './UsageDashboard'
+import { useUsageData } from './useUsageData'
 import {
   isBilledOnAPeriod,
   isBillingPeriodSelected,
   contributionNote,
-  allowanceWindow,
   planSectionCopy,
   showsPlanCeiling,
   periodLabel,
@@ -51,48 +50,13 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
   const [chosenPeriod, setChosenPeriod] = useState<PeriodSelection>('default')
   const billingPeriod = resolvePeriod(chosenPeriod, planIsBilled)
 
-  const {
-    data,
-    isError: usageFailed,
-    isFetching: loadingUsage,
-    isUninitialized: usageNotStarted,
-    refetch: refetchUsage,
-  } = useGetOrganisationUsageQuery(
-    organisationId && organisation
-      ? {
-          billing_period: billingPeriod,
-          organisationId,
-          projectId: selectedProjectId,
-        }
-      : skipToken,
-    // usage-data is throttled at five requests a minute per user, so
-    // refetching every time the tab regains focus spends that budget.
-    { refetchOnFocus: false },
-  )
-  const { data: organisationData, isFetching: loadingPlan } =
-    useGetOrganisationUsageQuery(
-      organisationId && organisation
-        ? {
-            // The meter answers for the allowance window, not the one on screen.
-            billing_period: allowanceWindow(basis),
-            organisationId,
-          }
-        : skipToken,
-      // usage-data is throttled at five requests a minute per user, so
-      // refetching every time the tab regains focus spends that budget.
-      { refetchOnFocus: false },
-    )
-
-  // The note compares a project with the organisation over the same period, so
-  // it needs the unfiltered total for the period on screen, not the allowance
-  // one. With no project chosen the arguments match the query above and RTK
-  // serves both from one request.
-  const { data: periodData } = useGetOrganisationUsageQuery(
-    organisationId && organisation && selectedProjectId
-      ? { billing_period: billingPeriod, organisationId }
-      : skipToken,
-    { refetchOnFocus: false },
-  )
+  const usage = useUsageData({
+    basis,
+    organisationId,
+    period: billingPeriod,
+    projectId: selectedProjectId,
+    ready: !!organisation,
+  })
 
   const {
     data: subscriptionMeta,
@@ -105,7 +69,9 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
 
   const periods = periodsFor(planIsBilled)
 
-  const { setDimension, ...breakdown } = useUsageBreakdown({ data })
+  const { setDimension, ...breakdown } = useUsageBreakdown({
+    data: usage.scoped,
+  })
 
   const scope = [
     selectedProjectId ? projectName : 'All projects',
@@ -120,8 +86,8 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
 
   return (
     <UsageDashboard
-      data={data}
-      total={organisationData?.totals?.total ?? 0}
+      data={usage.scoped}
+      total={usage.allowanceTotal}
       limit={subscriptionMeta?.max_api_calls}
       hasBillingPeriod={isBillingPeriodSelected(billingPeriod)}
       planCopy={planSectionCopy(basis, subscriptionMeta?.max_api_calls)}
@@ -131,8 +97,8 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
         selectedProjectId && projectName
           ? contributionNote(
               projectName,
-              data?.totals?.total ?? 0,
-              periodData?.totals?.total ?? 0,
+              usage.scoped?.totals?.total ?? 0,
+              usage.periodTotal,
             )
           : undefined
       }
@@ -143,15 +109,13 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
           scope={scope}
         />
       }
-      isError={organisationFailed || usageFailed || limitFailed}
-      isLoading={loadingOrganisation || loadingPlan || loadingLimit}
-      isExploring={loadingUsage}
+      isError={organisationFailed || usage.scopedFailed || limitFailed}
+      isLoading={loadingOrganisation || usage.isLoadingPlan || loadingLimit}
+      isExploring={usage.isLoadingScoped}
       onRetry={() => {
         refetchOrganisation()
         refetchLimit()
-        if (!usageNotStarted) {
-          refetchUsage()
-        }
+        usage.retry()
       }}
       filters={
         <Row className='gap-2'>

--- a/frontend/web/components/pages/usage/UsageDashboardPage.tsx
+++ b/frontend/web/components/pages/usage/UsageDashboardPage.tsx
@@ -4,17 +4,22 @@ import Utils, { planNames } from 'common/utils/utils'
 import { useGetOrganisationQuery } from 'common/services/useOrganisation'
 import { useGetOrganisationUsageQuery } from 'common/services/useOrganisationUsage'
 import { useGetSubscriptionMetadataQuery } from 'common/services/useSubscriptionMetadata'
-import FieldLabel from 'components/base/forms/FieldLabel'
 import ProjectFilter from 'components/ProjectFilter'
 import { PeriodOption } from 'common/types/requests'
 import UsageBreakdown, { useUsageBreakdown } from './components/UsageBreakdown'
 import UsageDashboard from './UsageDashboard'
 import {
+  isBilledOnAPeriod,
   isBillingPeriodSelected,
+  contributionNote,
+  allowanceWindow,
+  basisExplanation,
+  planSectionCopy,
+  showsPlanCeiling,
   periodLabel,
   periodsFor,
   PeriodSelection,
-  planHasBillingPeriod,
+  usageBasisOf,
   resolvePeriod,
 } from './utils'
 import './UsageDashboardPage.scss'
@@ -34,13 +39,15 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
     data: organisation,
     isError: organisationFailed,
     isLoading: loadingOrganisation,
+    refetch: refetchOrganisation,
   } = useGetOrganisationQuery(
     organisationId ? { id: organisationId } : skipToken,
   )
   const subscription = organisation?.subscription
   const isFreePlan =
     planNames.free === Utils.getPlanName(subscription?.plan ?? '')
-  const planIsBilled = planHasBillingPeriod(subscription, isFreePlan)
+  const basis = usageBasisOf(subscription, isFreePlan)
+  const planIsBilled = isBilledOnAPeriod(basis)
 
   const [chosenPeriod, setChosenPeriod] = useState<PeriodSelection>('default')
   const billingPeriod = resolvePeriod(chosenPeriod, planIsBilled)
@@ -49,6 +56,8 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
     data,
     isError: usageFailed,
     isFetching: loadingUsage,
+    isUninitialized: usageNotStarted,
+    refetch: refetchUsage,
   } = useGetOrganisationUsageQuery(
     organisationId && organisation
       ? {
@@ -57,11 +66,42 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
           projectId: selectedProjectId,
         }
       : skipToken,
+    // usage-data is throttled at five requests a minute per user, so
+    // refetching every time the tab regains focus spends that budget.
+    { refetchOnFocus: false },
   )
-  const { data: subscriptionMeta, isLoading: loadingLimit } =
-    useGetSubscriptionMetadataQuery(
-      organisationId ? { id: organisationId } : skipToken,
+  const { data: organisationData, isFetching: loadingPlan } =
+    useGetOrganisationUsageQuery(
+      organisationId && organisation
+        ? {
+            // The meter answers for the allowance window, not the one on screen.
+            billing_period: allowanceWindow(basis),
+            organisationId,
+          }
+        : skipToken,
+      // usage-data is throttled at five requests a minute per user, so
+      // refetching every time the tab regains focus spends that budget.
+      { refetchOnFocus: false },
     )
+
+  // The note compares a project with the organisation over the same period, so
+  // it needs the unfiltered total for the period on screen, not the allowance
+  // one. With no project chosen the arguments match the query above and RTK
+  // serves both from one request.
+  const { data: periodData } = useGetOrganisationUsageQuery(
+    organisationId && organisation && selectedProjectId
+      ? { billing_period: billingPeriod, organisationId }
+      : skipToken,
+    { refetchOnFocus: false },
+  )
+
+  const {
+    data: subscriptionMeta,
+    isLoading: loadingLimit,
+    refetch: refetchLimit,
+  } = useGetSubscriptionMetadataQuery(
+    organisationId ? { id: organisationId } : skipToken,
+  )
 
   const periods = periodsFor(planIsBilled)
 
@@ -81,9 +121,22 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
   return (
     <UsageDashboard
       data={data}
-      total={data?.totals?.total ?? 0}
+      total={organisationData?.totals?.total ?? 0}
       limit={subscriptionMeta?.max_api_calls}
       hasBillingPeriod={isBillingPeriodSelected(billingPeriod)}
+      planCopy={planSectionCopy(basis, subscriptionMeta?.max_api_calls)}
+      basisExplanation={basisExplanation(basis)}
+      periodLabel={periodLabel(periods, billingPeriod)}
+      showPlanCeiling={showsPlanCeiling(billingPeriod, selectedProjectId)}
+      meterNote={
+        selectedProjectId && projectName
+          ? contributionNote(
+              projectName,
+              data?.totals?.total ?? 0,
+              periodData?.totals?.total ?? 0,
+            )
+          : undefined
+      }
       breakdown={
         <UsageBreakdown
           {...breakdown}
@@ -92,12 +145,20 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
         />
       }
       isError={organisationFailed || usageFailed}
-      isLoading={loadingOrganisation || loadingUsage || loadingLimit}
+      isLoading={loadingOrganisation || loadingPlan || loadingLimit}
+      isExploring={loadingUsage}
+      onRetry={() => {
+        refetchOrganisation()
+        refetchLimit()
+        if (!usageNotStarted) {
+          refetchUsage()
+        }
+      }}
       filters={
-        <Row className='gap-3 align-items-end'>
+        <Row className='gap-2'>
           <div className='usage-dashboard__filter'>
-            <FieldLabel htmlFor='usage-period'>Period</FieldLabel>
             <Select
+              aria-label='Period'
               inputId='usage-period'
               onChange={(option: PeriodOption) => setChosenPeriod(option.value)}
               value={periods.find((period) => period.value === billingPeriod)}
@@ -105,8 +166,8 @@ const UsageDashboardPage: FC<UsageDashboardPageProps> = ({
             />
           </div>
           <div className='usage-dashboard__filter'>
-            <FieldLabel htmlFor='usage-project'>Project</FieldLabel>
             <ProjectFilter
+              aria-label='Project'
               inputId='usage-project'
               showAll
               organisationId={organisationId}

--- a/frontend/web/components/pages/usage/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/__tests__/utils.test.ts
@@ -1,7 +1,13 @@
 import { Subscription } from 'common/types/responses'
 import {
+  contributionNote,
   isBillingPeriodSelected,
-  planHasBillingPeriod,
+  allowanceWindow,
+  planSectionCopy,
+  basisExplanation,
+  allowanceWindowLabel,
+  showsPlanCeiling,
+  usageBasisOf,
   periodsFor,
   resolvePeriod,
 } from 'components/pages/usage/utils'
@@ -10,41 +16,6 @@ const subscription = (values: Partial<Subscription>): Subscription =>
   ({ has_active_billing_periods: false, plan: null, ...values } as Subscription)
 
 describe('UsageDashboard utils', () => {
-  describe('planHasBillingPeriod', () => {
-    it('is true for a paid plan with active billing periods', () => {
-      expect(
-        planHasBillingPeriod(
-          subscription({ has_active_billing_periods: true }),
-          false,
-        ),
-      ).toBe(true)
-    })
-
-    // Enterprise agreements are not billed through Chargebee, so they carry a
-    // limit but no term.
-    it('is false for a paid plan without active billing periods', () => {
-      expect(
-        planHasBillingPeriod(
-          subscription({ has_active_billing_periods: false }),
-          false,
-        ),
-      ).toBe(false)
-    })
-
-    it('is false on the free plan even if the flag is somehow set', () => {
-      expect(
-        planHasBillingPeriod(
-          subscription({ has_active_billing_periods: true }),
-          true,
-        ),
-      ).toBe(false)
-    })
-
-    it('is false before the subscription has loaded', () => {
-      expect(planHasBillingPeriod(undefined, false)).toBe(false)
-    })
-  })
-
   // A billed organisation can still pick a rolling window, and 90 days of
   // usage must not be drawn against a monthly allowance.
   describe('isBillingPeriodSelected', () => {
@@ -78,6 +49,100 @@ describe('UsageDashboard utils', () => {
     // 'Last 30 days' is undefined, so it has to survive rather than fall back.
     it('keeps an explicit rolling-window choice on a billed plan', () => {
       expect(resolvePeriod(undefined, true)).toBeUndefined()
+    })
+  })
+
+  describe('contributionNote', () => {
+    it('says what share of the organisation a project accounts for', () => {
+      expect(contributionNote('Checkout', 400000, 1000000)).toBe(
+        'Checkout accounts for 40% of that usage.',
+      )
+    })
+
+    it('has nothing to say when the organisation used nothing', () => {
+      expect(contributionNote('Checkout', 0, 0)).toBeUndefined()
+    })
+
+    it('never reports a project as more than all of the usage', () => {
+      expect(contributionNote('Checkout', 1000000, 1000000)).toBe(
+        'Checkout accounts for 100% of that usage.',
+      )
+    })
+  })
+
+  describe('planSectionCopy', () => {
+    const rolling = { reason: 'free', window: 'rolling' } as const
+
+    it('measures against the allowance when there is one', () => {
+      const copy = planSectionCopy(rolling, 50000)
+
+      expect(copy.title).toBe('Your plan')
+      expect(copy.hint).toContain('against its allowance')
+    })
+
+    it('claims no allowance where there is none to claim', () => {
+      const copy = planSectionCopy(rolling, null)
+
+      expect(copy.title).toBe('Your usage')
+      expect(copy.hint).toContain('no plan limit')
+      expect(copy.hint).not.toContain('allowance')
+    })
+  })
+
+  describe('usageBasisOf', () => {
+    it('measures a billed organisation over its billing period', () => {
+      const basis = usageBasisOf(
+        subscription({ has_active_billing_periods: true }),
+        false,
+      )
+
+      expect(basis).toEqual({ window: 'billing-period' })
+      expect(allowanceWindow(basis)).toBe('current_billing_period')
+      expect(allowanceWindowLabel(basis)).toBe('this billing period')
+      expect(basisExplanation(basis)).toBeUndefined()
+    })
+
+    it('measures a free plan over the trailing 30 days, by design', () => {
+      const basis = usageBasisOf(subscription({}), true)
+
+      expect(basis).toEqual({ reason: 'free', window: 'rolling' })
+      expect(allowanceWindow(basis)).toBeUndefined()
+      expect(basisExplanation(basis)).toBeUndefined()
+    })
+
+    it('says an invoiced organisation will never have a billing period', () => {
+      const basis = usageBasisOf(
+        subscription({ payment_method: 'XERO' }),
+        false,
+      )
+
+      expect(basis).toEqual({ reason: 'invoiced', window: 'rolling' })
+      expect(basisExplanation(basis)).toContain('invoiced outside it')
+    })
+
+    it('separates a Chargebee organisation whose period has not arrived', () => {
+      const basis = usageBasisOf(
+        subscription({ payment_method: 'CHARGEBEE' }),
+        false,
+      )
+
+      expect(basis).toEqual({ reason: 'unavailable', window: 'rolling' })
+      expect(basisExplanation(basis)).toContain('has reached us')
+    })
+  })
+
+  describe('showsPlanCeiling', () => {
+    it('draws the ceiling for the organisation over a comparable period', () => {
+      expect(showsPlanCeiling(undefined, undefined)).toBe(true)
+      expect(showsPlanCeiling('current_billing_period', undefined)).toBe(true)
+    })
+
+    it('drops it for one project, which will never reach the ceiling', () => {
+      expect(showsPlanCeiling(undefined, 12)).toBe(false)
+    })
+
+    it('drops it for the 90 day window', () => {
+      expect(showsPlanCeiling('90_day_period', undefined)).toBe(false)
     })
   })
 

--- a/frontend/web/components/pages/usage/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/__tests__/utils.test.ts
@@ -117,7 +117,7 @@ describe('UsageDashboard utils', () => {
       )
 
       expect(basis).toEqual({ reason: 'invoiced', window: 'rolling' })
-      expect(basisExplanation(basis)).toContain('invoiced outside it')
+      expect(basisExplanation(basis)).toContain('invoiced directly')
     })
 
     it('separates a Chargebee organisation whose period has not arrived', () => {
@@ -127,7 +127,7 @@ describe('UsageDashboard utils', () => {
       )
 
       expect(basis).toEqual({ reason: 'unavailable', window: 'rolling' })
-      expect(basisExplanation(basis)).toContain('has reached us')
+      expect(basisExplanation(basis)).toContain('do not have a billing period')
     })
   })
 

--- a/frontend/web/components/pages/usage/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   allowanceWindow,
   planSectionCopy,
   allowanceWindowLabel,
+  showsContribution,
   showsPlanCeiling,
   usageBasisOf,
   periodsFor,
@@ -120,6 +121,27 @@ describe('UsageDashboard utils', () => {
       expect(planSectionCopy(basis, 50000).hint).toContain(
         'has no billing period',
       )
+    })
+  })
+
+  describe('showsContribution', () => {
+    const billed = { window: 'billing-period' } as const
+    const rolling = { reason: 'free', window: 'rolling' } as const
+
+    it('compares only over the window the meter is showing', () => {
+      expect(showsContribution(billed, 'current_billing_period', 12)).toBe(true)
+      expect(showsContribution(rolling, undefined, 12)).toBe(true)
+    })
+
+    it('says nothing on a period the meter does not cover', () => {
+      expect(showsContribution(billed, '90_day_period', 12)).toBe(false)
+      expect(showsContribution(rolling, '90_day_period', 12)).toBe(false)
+    })
+
+    it('says nothing without a project', () => {
+      expect(
+        showsContribution(billed, 'current_billing_period', undefined),
+      ).toBe(false)
     })
   })
 

--- a/frontend/web/components/pages/usage/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/__tests__/utils.test.ts
@@ -76,7 +76,7 @@ describe('UsageDashboard utils', () => {
       const copy = planSectionCopy(rolling, 50000)
 
       expect(copy.title).toBe('Your plan')
-      expect(copy.hint).toContain('against its allowance')
+      expect(copy.hint).toContain('against your plan limit')
     })
 
     it('claims no allowance where there is none to claim', () => {

--- a/frontend/web/components/pages/usage/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/__tests__/utils.test.ts
@@ -4,7 +4,6 @@ import {
   isBillingPeriodSelected,
   allowanceWindow,
   planSectionCopy,
-  basisExplanation,
   allowanceWindowLabel,
   showsPlanCeiling,
   usageBasisOf,
@@ -99,7 +98,6 @@ describe('UsageDashboard utils', () => {
       expect(basis).toEqual({ window: 'billing-period' })
       expect(allowanceWindow(basis)).toBe('current_billing_period')
       expect(allowanceWindowLabel(basis)).toBe('this billing period')
-      expect(basisExplanation(basis)).toBeUndefined()
     })
 
     it('measures a free plan over the trailing 30 days, by design', () => {
@@ -107,27 +105,21 @@ describe('UsageDashboard utils', () => {
 
       expect(basis).toEqual({ reason: 'free', window: 'rolling' })
       expect(allowanceWindow(basis)).toBeUndefined()
-      expect(basisExplanation(basis)).toBeUndefined()
+      expect(planSectionCopy(basis, 50000).hint).not.toContain(
+        'no billing period',
+      )
     })
 
-    it('says an invoiced organisation will never have a billing period', () => {
+    it('says so when a paid organisation has no billing period', () => {
       const basis = usageBasisOf(
         subscription({ payment_method: 'XERO' }),
         false,
       )
 
-      expect(basis).toEqual({ reason: 'invoiced', window: 'rolling' })
-      expect(basisExplanation(basis)).toContain('invoiced directly')
-    })
-
-    it('separates a Chargebee organisation whose period has not arrived', () => {
-      const basis = usageBasisOf(
-        subscription({ payment_method: 'CHARGEBEE' }),
-        false,
+      expect(basis).toEqual({ reason: 'no-period', window: 'rolling' })
+      expect(planSectionCopy(basis, 50000).hint).toContain(
+        'has no billing period',
       )
-
-      expect(basis).toEqual({ reason: 'unavailable', window: 'rolling' })
-      expect(basisExplanation(basis)).toContain('do not have a billing period')
     })
   })
 

--- a/frontend/web/components/pages/usage/components/SectionHeading/SectionHeading.tsx
+++ b/frontend/web/components/pages/usage/components/SectionHeading/SectionHeading.tsx
@@ -1,0 +1,19 @@
+import { FC, ReactNode } from 'react'
+
+export type SectionHeadingProps = {
+  title: string
+  hint: string
+  action?: ReactNode
+}
+
+const SectionHeading: FC<SectionHeadingProps> = ({ action, hint, title }) => (
+  <Row space className='align-items-end mb-2 mt-4 gap-3'>
+    <div>
+      <strong>{title}</strong>
+      <div className='fs-captionSmall text-secondary'>{hint}</div>
+    </div>
+    {action}
+  </Row>
+)
+
+export default SectionHeading

--- a/frontend/web/components/pages/usage/components/SectionHeading/index.ts
+++ b/frontend/web/components/pages/usage/components/SectionHeading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SectionHeading'

--- a/frontend/web/components/pages/usage/components/UsageMeter/UsageMeter.scss
+++ b/frontend/web/components/pages/usage/components/UsageMeter/UsageMeter.scss
@@ -6,4 +6,8 @@
   &__fraction {
     font-size: 18px;
   }
+
+  &__note {
+    min-height: 1.5em;
+  }
 }

--- a/frontend/web/components/pages/usage/components/UsageMeter/UsageMeter.tsx
+++ b/frontend/web/components/pages/usage/components/UsageMeter/UsageMeter.tsx
@@ -1,12 +1,7 @@
 import { FC, ReactNode } from 'react'
-import Format from 'common/utils/format'
 import UsageBar from 'components/shared/UsageBar'
-import {
-  PlanLimit,
-  toneFor,
-  usagePercent,
-} from 'components/shared/UsageBar/utils'
-import { meterCopy } from './utils'
+import { PlanLimit } from 'components/shared/UsageBar/utils'
+import { meterCopy, meterTone } from './utils'
 import './UsageMeter.scss'
 
 const WARN_AT = 75
@@ -20,7 +15,7 @@ export type UsageMeterProps = {
 
 const UsageMeter: FC<UsageMeterProps> = ({ limit, note, total }) => {
   const copy = meterCopy(total, limit)
-  const tone = toneFor(usagePercent(total, limit), WARN_AT)
+  const tone = meterTone(total, limit, WARN_AT)
 
   return (
     <div className='p-4 mb-3 border border-default rounded-lg bg-surface-default'>
@@ -28,7 +23,11 @@ const UsageMeter: FC<UsageMeterProps> = ({ limit, note, total }) => {
         <div>
           <p className='fs-caption text-secondary mb-1'>Plan usage</p>
           <div className='d-flex align-items-end gap-2'>
-            <span className={`usage-meter__percent fw-bold lh-1 text-${tone}`}>
+            <span
+              className={`usage-meter__percent fw-bold lh-1 ${
+                tone ? `text-${tone}` : ''
+              }`}
+            >
               {copy.headline}
             </span>
             <span className='fs-captionSmall text-secondary'>
@@ -36,15 +35,17 @@ const UsageMeter: FC<UsageMeterProps> = ({ limit, note, total }) => {
             </span>
           </div>
         </div>
-        <div className='usage-meter__fraction text-end'>
-          <div>
-            <strong>{Format.shortenNumber(total)}</strong>
-            {copy.fractionSuffix}
+        {copy.fraction && (
+          <div className='usage-meter__fraction text-end'>
+            <div>
+              <strong>{copy.fraction.value}</strong>
+              {copy.fraction.suffix}
+            </div>
+            <div className='fs-captionSmall text-secondary'>
+              {copy.fraction.caption}
+            </div>
           </div>
-          <div className='fs-captionSmall text-secondary'>
-            {copy.fractionCaption}
-          </div>
-        </div>
+        )}
       </div>
 
       {!!limit && (
@@ -57,7 +58,9 @@ const UsageMeter: FC<UsageMeterProps> = ({ limit, note, total }) => {
         />
       )}
 
-      {note}
+      <p className='usage-meter__note fs-captionSmall text-secondary mt-3 mb-0'>
+        {note}
+      </p>
     </div>
   )
 }

--- a/frontend/web/components/pages/usage/components/UsageMeter/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/components/UsageMeter/__tests__/utils.test.ts
@@ -1,11 +1,17 @@
-import { meterCopy } from 'components/pages/usage/components/UsageMeter/utils'
+import {
+  meterCopy,
+  meterTone,
+} from 'components/pages/usage/components/UsageMeter/utils'
 
 describe('UsageMeter utils', () => {
   describe('meterCopy', () => {
     it('reads as a percentage of the limit when there is one', () => {
       expect(meterCopy(1500000, 2000000)).toEqual({
-        fractionCaption: 'API calls used / plan limit',
-        fractionSuffix: ' / 2M',
+        fraction: {
+          caption: 'API calls used / plan limit',
+          suffix: ' / 2M',
+          value: '1.5M',
+        },
         headline: '75%',
         headlineCaption: 'of plan consumed',
       })
@@ -20,8 +26,6 @@ describe('UsageMeter utils', () => {
       'falls back to the raw count when the limit is %p',
       (limit) => {
         expect(meterCopy(1500000, limit)).toEqual({
-          fractionCaption: 'API calls used',
-          fractionSuffix: '',
           headline: '1.5M',
           headlineCaption: 'API calls',
         })
@@ -31,6 +35,18 @@ describe('UsageMeter utils', () => {
     it('shows zero rather than NaN for an organisation with no calls', () => {
       expect(meterCopy(0, null).headline).toBe('0')
       expect(meterCopy(0, 2000000).headline).toBe('0%')
+    })
+  })
+
+  describe('meterTone', () => {
+    it('tracks the thresholds when the comparison holds', () => {
+      expect(meterTone(500000, 2000000, 75)).toBe('success')
+      expect(meterTone(1600000, 2000000, 75)).toBe('warning')
+      expect(meterTone(2000000, 2000000, 75)).toBe('danger')
+    })
+
+    it('has no tone to give without a limit', () => {
+      expect(meterTone(9000000, null, 75)).toBeUndefined()
     })
   })
 })

--- a/frontend/web/components/pages/usage/components/UsageMeter/utils.ts
+++ b/frontend/web/components/pages/usage/components/UsageMeter/utils.ts
@@ -1,26 +1,40 @@
 import Format from 'common/utils/format'
-import { PlanLimit, usagePercent } from 'components/shared/UsageBar/utils'
+import {
+  PlanLimit,
+  toneFor,
+  usagePercent,
+  UsageTone,
+} from 'components/shared/UsageBar/utils'
 
-export type MeterCopy = {
+type MeterCopy = {
   headline: string
   headlineCaption: string
-  fractionSuffix: string
-  fractionCaption: string
+  fraction?: {
+    value: string
+    suffix?: string
+    caption: string
+  }
 }
 
-const withLimit = (total: number, limit: number): MeterCopy => ({
-  fractionCaption: 'API calls used / plan limit',
-  fractionSuffix: ` / ${Format.shortenNumber(limit)}`,
-  headline: `${usagePercent(total, limit)}%`,
-  headlineCaption: 'of plan consumed',
-})
-
-const withoutLimit = (total: number): MeterCopy => ({
-  fractionCaption: 'API calls used',
-  fractionSuffix: '',
-  headline: Format.shortenNumber(total),
-  headlineCaption: 'API calls',
-})
-
 export const meterCopy = (total: number, limit: PlanLimit): MeterCopy =>
-  limit ? withLimit(total, limit) : withoutLimit(total)
+  limit
+    ? {
+        fraction: {
+          caption: 'API calls used / plan limit',
+          suffix: ` / ${Format.shortenNumber(limit)}`,
+          value: Format.shortenNumber(total),
+        },
+        headline: `${usagePercent(total, limit)}%`,
+        headlineCaption: 'of plan consumed',
+      }
+    : {
+        headline: Format.shortenNumber(total),
+        headlineCaption: 'API calls',
+      }
+
+export const meterTone = (
+  total: number,
+  limit: PlanLimit,
+  warnAt: number,
+): UsageTone | undefined =>
+  limit ? toneFor(usagePercent(total, limit), warnAt) : undefined

--- a/frontend/web/components/pages/usage/components/UsageOverTime/UsageOverTime.tsx
+++ b/frontend/web/components/pages/usage/components/UsageOverTime/UsageOverTime.tsx
@@ -1,4 +1,5 @@
 import { FC, useMemo } from 'react'
+import Format from 'common/utils/format'
 import { Res } from 'common/types/responses'
 import { colorSurfaceAction } from 'common/theme/tokens'
 import EmptyState from 'components/EmptyState'
@@ -16,6 +17,7 @@ type UsageOverTimeProps = {
   data: Res['organisationUsage'] | undefined
   limit: PlanLimit
   isBillingPeriod: boolean
+  periodLabel: string
 }
 
 const headingFor = (isBillingPeriod: boolean, limit: PlanLimit) => {
@@ -27,6 +29,7 @@ const UsageOverTime: FC<UsageOverTimeProps> = ({
   data,
   isBillingPeriod,
   limit,
+  periodLabel,
 }) => {
   const daily = useMemo(() => dailyTotals(data), [data])
 
@@ -62,9 +65,8 @@ const UsageOverTime: FC<UsageOverTimeProps> = ({
       <div className='d-flex align-items-baseline justify-content-between gap-3 mb-3'>
         <strong>{headingFor(isBillingPeriod, limit)}</strong>
         <span className='fs-captionSmall text-secondary'>
-          {isBillingPeriod
-            ? 'Cumulative · this billing period'
-            : 'Per day · rolling window'}
+          {Format.shortenNumber(data?.totals?.total ?? 0)} API calls ·{' '}
+          {periodLabel}
         </span>
       </div>
       {daily.length ? (

--- a/frontend/web/components/pages/usage/useUsageData.ts
+++ b/frontend/web/components/pages/usage/useUsageData.ts
@@ -21,7 +21,7 @@ export type UsageData = {
   periodTotal: number
   isLoadingPlan: boolean
   isLoadingScoped: boolean
-  scopedFailed: boolean
+  failed: boolean
   retry: () => void
 }
 
@@ -63,14 +63,19 @@ export const useUsageData = ({
 
   return {
     allowanceTotal: allowance.data?.totals?.total ?? 0,
+    // Either query failing leaves a number missing, so both are fatal.
+    failed: scoped.isError || allowance.isError,
+
     isLoadingPlan: allowance.isFetching,
+
     isLoadingScoped: scoped.isFetching,
+
     periodTotal: forPeriod.data?.totals?.total ?? 0,
+
     retry: () => {
       if (!scoped.isUninitialized) scoped.refetch()
       if (!allowance.isUninitialized) allowance.refetch()
     },
     scoped: scoped.data,
-    scopedFailed: scoped.isError,
   }
 }

--- a/frontend/web/components/pages/usage/useUsageData.ts
+++ b/frontend/web/components/pages/usage/useUsageData.ts
@@ -17,8 +17,6 @@ export type UsageData = {
   scoped: Res['organisationUsage'] | undefined
   /** The organisation over the window its allowance covers. Feeds the meter. */
   allowanceTotal: number
-  /** The organisation over the period on screen. The note's denominator. */
-  periodTotal: number
   isLoadingPlan: boolean
   isLoadingScoped: boolean
   failed: boolean
@@ -52,15 +50,6 @@ export const useUsageData = ({
     OPTIONS,
   )
 
-  // Only needed while a project is chosen. Without one its arguments match
-  // `scoped`, so RTK would serve both from a single request anyway.
-  const forPeriod = useGetOrganisationUsageQuery(
-    forOrganisation && projectId
-      ? { ...forOrganisation, billing_period: period }
-      : skipToken,
-    OPTIONS,
-  )
-
   return {
     allowanceTotal: allowance.data?.totals?.total ?? 0,
     // Either query failing leaves a number missing, so both are fatal.
@@ -69,8 +58,6 @@ export const useUsageData = ({
     isLoadingPlan: allowance.isFetching,
 
     isLoadingScoped: scoped.isFetching,
-
-    periodTotal: forPeriod.data?.totals?.total ?? 0,
 
     retry: () => {
       if (!scoped.isUninitialized) scoped.refetch()

--- a/frontend/web/components/pages/usage/useUsageData.ts
+++ b/frontend/web/components/pages/usage/useUsageData.ts
@@ -1,0 +1,76 @@
+import { skipToken } from '@reduxjs/toolkit/query'
+import { BillingPeriod } from 'common/types/requests'
+import { Res } from 'common/types/responses'
+import { useGetOrganisationUsageQuery } from 'common/services/useOrganisationUsage'
+import { allowanceWindow, UsageBasis } from './utils'
+
+type UseUsageData = {
+  organisationId: number | undefined
+  ready: boolean
+  basis: UsageBasis
+  period: BillingPeriod
+  projectId: number | undefined
+}
+
+export type UsageData = {
+  /** The period and project on screen. Feeds the chart and the breakdown. */
+  scoped: Res['organisationUsage'] | undefined
+  /** The organisation over the window its allowance covers. Feeds the meter. */
+  allowanceTotal: number
+  /** The organisation over the period on screen. The note's denominator. */
+  periodTotal: number
+  isLoadingPlan: boolean
+  isLoadingScoped: boolean
+  scopedFailed: boolean
+  retry: () => void
+}
+
+// usage-data is throttled at five requests a minute per user, so refetching
+// every time the tab regains focus spends the budget the page needs.
+const OPTIONS = { refetchOnFocus: false }
+
+export const useUsageData = ({
+  basis,
+  organisationId,
+  period,
+  projectId,
+  ready,
+}: UseUsageData): UsageData => {
+  const forOrganisation = ready && organisationId ? { organisationId } : null
+
+  const scoped = useGetOrganisationUsageQuery(
+    forOrganisation
+      ? { ...forOrganisation, billing_period: period, projectId }
+      : skipToken,
+    OPTIONS,
+  )
+
+  const allowance = useGetOrganisationUsageQuery(
+    forOrganisation
+      ? { ...forOrganisation, billing_period: allowanceWindow(basis) }
+      : skipToken,
+    OPTIONS,
+  )
+
+  // Only needed while a project is chosen. Without one its arguments match
+  // `scoped`, so RTK would serve both from a single request anyway.
+  const forPeriod = useGetOrganisationUsageQuery(
+    forOrganisation && projectId
+      ? { ...forOrganisation, billing_period: period }
+      : skipToken,
+    OPTIONS,
+  )
+
+  return {
+    allowanceTotal: allowance.data?.totals?.total ?? 0,
+    isLoadingPlan: allowance.isFetching,
+    isLoadingScoped: scoped.isFetching,
+    periodTotal: forPeriod.data?.totals?.total ?? 0,
+    retry: () => {
+      if (!scoped.isUninitialized) scoped.refetch()
+      if (!allowance.isUninitialized) allowance.refetch()
+    },
+    scoped: scoped.data,
+    scopedFailed: scoped.isError,
+  }
+}

--- a/frontend/web/components/pages/usage/utils.ts
+++ b/frontend/web/components/pages/usage/utils.ts
@@ -44,15 +44,15 @@ export const planSectionCopy = (
 
   if (basis.window === 'rolling' && basis.reason === 'no-period') {
     return {
-      hint: 'Where your organisation stands against its allowance, measured over the last 30 days as this organisation has no billing period.',
+      hint: `Usage against your plan limit over ${allowanceWindowLabel(
+        basis,
+      )}. This organisation has no billing period.`,
       title: 'Your plan',
     }
   }
 
   return {
-    hint: `Where your organisation stands against its allowance, over ${allowanceWindowLabel(
-      basis,
-    )}.`,
+    hint: `Usage against your plan limit over ${allowanceWindowLabel(basis)}.`,
     title: 'Your plan',
   }
 }

--- a/frontend/web/components/pages/usage/utils.ts
+++ b/frontend/web/components/pages/usage/utils.ts
@@ -84,6 +84,15 @@ export const contributionNote = (
   return `${projectName} accounts for ${percent}% of that usage.`
 }
 
+// The note sits under the meter, so it can only compare over the window the
+// meter shows. On any other period "that usage" would name a figure that is
+// not on screen.
+export const showsContribution = (
+  basis: UsageBasis,
+  period: BillingPeriod,
+  projectId: number | undefined,
+): boolean => !!projectId && period === allowanceWindow(basis)
+
 export const showsPlanCeiling = (
   period: BillingPeriod,
   projectId: number | undefined,

--- a/frontend/web/components/pages/usage/utils.ts
+++ b/frontend/web/components/pages/usage/utils.ts
@@ -22,7 +22,9 @@ const rollingReason = (
   if (isFreePlan) {
     return 'free'
   }
-  // Only Chargebee sends the billing terms, so the others never have one.
+  // Only a self-serve subscription carries billing terms, so anything invoiced
+  // directly never has one. Keep the copy free of the billing provider's name:
+  // customers do not know which one we use, and invoiced ones should not.
   return subscription?.payment_method === 'CHARGEBEE'
     ? 'unavailable'
     : 'invoiced'
@@ -67,9 +69,9 @@ export const basisExplanation = (basis: UsageBasis): string | undefined => {
 
   switch (basis.reason) {
     case 'invoiced':
-      return 'Billing periods come from Chargebee, and this organisation is invoiced outside it.'
+      return 'This organisation is invoiced directly, so it has no billing period.'
     case 'unavailable':
-      return 'No billing period has reached us from Chargebee for this organisation yet.'
+      return 'We do not have a billing period for this organisation yet.'
     default:
       return undefined
   }

--- a/frontend/web/components/pages/usage/utils.ts
+++ b/frontend/web/components/pages/usage/utils.ts
@@ -5,13 +5,75 @@ import {
   rollingPeriodOptions,
 } from 'common/types/requests'
 import { Subscription } from 'common/types/responses'
+import { PlanLimit } from 'components/shared/UsageBar/utils'
 
 export type PeriodSelection = BillingPeriod | 'default'
 
-export const planHasBillingPeriod = (
+export type RollingReason = 'free' | 'invoiced' | 'unavailable'
+
+export type UsageBasis =
+  | { window: 'billing-period' }
+  | { window: 'rolling'; reason: RollingReason }
+
+const rollingReason = (
   subscription: Subscription | undefined,
   isFreePlan: boolean,
-): boolean => !isFreePlan && !!subscription?.has_active_billing_periods
+): RollingReason => {
+  if (isFreePlan) {
+    return 'free'
+  }
+  // Only Chargebee sends the billing terms, so the others never have one.
+  return subscription?.payment_method === 'CHARGEBEE'
+    ? 'unavailable'
+    : 'invoiced'
+}
+
+export const usageBasisOf = (
+  subscription: Subscription | undefined,
+  isFreePlan: boolean,
+): UsageBasis =>
+  !isFreePlan && subscription?.has_active_billing_periods
+    ? { window: 'billing-period' }
+    : { reason: rollingReason(subscription, isFreePlan), window: 'rolling' }
+
+export const isBilledOnAPeriod = (basis: UsageBasis): boolean =>
+  basis.window === 'billing-period'
+
+export const planSectionCopy = (
+  basis: UsageBasis,
+  limit: PlanLimit,
+): { title: string; hint: string } => {
+  if (!limit) {
+    return {
+      hint: `API calls over ${allowanceWindowLabel(
+        basis,
+      )}. This installation has no plan limit.`,
+      title: 'Your usage',
+    }
+  }
+
+  return {
+    hint: `Where your organisation stands against its allowance, over ${allowanceWindowLabel(
+      basis,
+    )}.`,
+    title: 'Your plan',
+  }
+}
+
+export const basisExplanation = (basis: UsageBasis): string | undefined => {
+  if (basis.window === 'billing-period') {
+    return undefined
+  }
+
+  switch (basis.reason) {
+    case 'invoiced':
+      return 'Billing periods come from Chargebee, and this organisation is invoiced outside it.'
+    case 'unavailable':
+      return 'No billing period has reached us from Chargebee for this organisation yet.'
+    default:
+      return undefined
+  }
+}
 
 export const resolvePeriod = (
   chosen: PeriodSelection,
@@ -25,6 +87,31 @@ export const resolvePeriod = (
 
 export const isBillingPeriodSelected = (period: BillingPeriod): boolean =>
   period === 'current_billing_period' || period === 'previous_billing_period'
+
+export const contributionNote = (
+  projectName: string,
+  scopedTotal: number,
+  organisationTotal: number,
+): string | undefined => {
+  if (organisationTotal <= 0) {
+    return undefined
+  }
+
+  const percent = Math.round((scopedTotal / organisationTotal) * 100)
+
+  return `${projectName} accounts for ${percent}% of that usage.`
+}
+
+export const showsPlanCeiling = (
+  period: BillingPeriod,
+  projectId: number | undefined,
+): boolean => period !== '90_day_period' && !projectId
+
+export const allowanceWindow = (basis: UsageBasis): BillingPeriod =>
+  isBilledOnAPeriod(basis) ? 'current_billing_period' : undefined
+
+export const allowanceWindowLabel = (basis: UsageBasis): string =>
+  isBilledOnAPeriod(basis) ? 'this billing period' : 'the last 30 days'
 
 export const periodLabel = (
   periods: PeriodOption[],

--- a/frontend/web/components/pages/usage/utils.ts
+++ b/frontend/web/components/pages/usage/utils.ts
@@ -9,26 +9,11 @@ import { PlanLimit } from 'components/shared/UsageBar/utils'
 
 export type PeriodSelection = BillingPeriod | 'default'
 
-export type RollingReason = 'free' | 'invoiced' | 'unavailable'
+export type RollingReason = 'free' | 'no-period'
 
 export type UsageBasis =
   | { window: 'billing-period' }
   | { window: 'rolling'; reason: RollingReason }
-
-const rollingReason = (
-  subscription: Subscription | undefined,
-  isFreePlan: boolean,
-): RollingReason => {
-  if (isFreePlan) {
-    return 'free'
-  }
-  // Only a self-serve subscription carries billing terms, so anything invoiced
-  // directly never has one. Keep the copy free of the billing provider's name:
-  // customers do not know which one we use, and invoiced ones should not.
-  return subscription?.payment_method === 'CHARGEBEE'
-    ? 'unavailable'
-    : 'invoiced'
-}
 
 export const usageBasisOf = (
   subscription: Subscription | undefined,
@@ -36,7 +21,10 @@ export const usageBasisOf = (
 ): UsageBasis =>
   !isFreePlan && subscription?.has_active_billing_periods
     ? { window: 'billing-period' }
-    : { reason: rollingReason(subscription, isFreePlan), window: 'rolling' }
+    : // A free plan has no billing period by design and needs no explaining. A
+      // paid one is worth saying out loud, whether it is invoiced directly, was
+      // set up by hand, or the dates have gone stale.
+      { reason: isFreePlan ? 'free' : 'no-period', window: 'rolling' }
 
 export const isBilledOnAPeriod = (basis: UsageBasis): boolean =>
   basis.window === 'billing-period'
@@ -54,26 +42,18 @@ export const planSectionCopy = (
     }
   }
 
+  if (basis.window === 'rolling' && basis.reason === 'no-period') {
+    return {
+      hint: 'Where your organisation stands against its allowance, measured over the last 30 days as this organisation has no billing period.',
+      title: 'Your plan',
+    }
+  }
+
   return {
     hint: `Where your organisation stands against its allowance, over ${allowanceWindowLabel(
       basis,
     )}.`,
     title: 'Your plan',
-  }
-}
-
-export const basisExplanation = (basis: UsageBasis): string | undefined => {
-  if (basis.window === 'billing-period') {
-    return undefined
-  }
-
-  switch (basis.reason) {
-    case 'invoiced':
-      return 'This organisation is invoiced directly, so it has no billing period.'
-    case 'unavailable':
-      return 'We do not have a billing period for this organisation yet.'
-    default:
-      return undefined
   }
 }
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

**[Storybook](https://69aedd804464bb3078b3ee78-ucymcboqay.chromatic.com/?path=/story/pages-usage-dashboard-page--paid-with-a-billing-period)** · **[Preview](https://flagsmith-frontend-preview-git-fix-usage-meter-89c724-flagsmith.vercel.app)**

Every state is a working page in Storybook, and the selects work, so the quickest visual review is to open `Pages/Usage Dashboard/Page` and click through the periods and projects. `PaidWithABillingPeriod` is the one nobody can reach with real data, since our own organisation has no billing term.

Fixes #8353, #8354. Raised by Wadii on #8320 and Matt on the preview.

The meter followed the period and project selectors, so it kept dividing one window by another. "Last 90 days" read about three times too high, and picking a project measured it against the whole organisation's allowance.

- **The meter has its own window.** It reports the organisation over the window the allowance covers: the billing period, or the trailing 30 days. The selectors drive the chart and breakdown only.
- **The page is two sections.** "Your plan" holds the meter, no controls. "Explore usage" holds the filters with what they govern. A page-level control that governed part of the page was the confusing part.
- **A project filter adds a line** under the meter, "Checkout accounts for 40% of that usage", instead of re-pointing it. Share of usage, not of allowance, compared over the same period.
- **The chart drops its plan ceiling when filtered**, since one project has no trajectory to the organisation's limit. Its header now shows the total for the selected period.
- **Organisations on a rolling window are told why**, rather than silently looking like a free plan.
- **Failures are recoverable.** A failed subscription metadata request now shows the error state instead of rendering as though there were no plan, and the error state offers a retry.
- **No refetch on tab focus.** Switching tabs reloaded the page behind a loader, and `usage-data` is throttled at 5/min per user.

Two commits are worth reading on their own:

- `fix(storybook)` registers the `Loader` and `Button` globals `preview.js` never had. Unrelated to this feature: every story in the repo that reaches a loading or error state has been throwing.
- `docs(usage)` makes the stories working pages driven by the same utils the page uses, including the paid-with-a-billing-period state nobody here can reach with real data. Most of the +2400 lines are the JSON fixtures.

## How did you test this code?

59 unit tests over the window rules, the plan copy and the contribution note.

On the preview:

- [ ] Change the period: the chart and breakdown follow, the meter does not, and its heading says which window it covers
- [ ] Pick a project: the meter stays on the organisation, the share line appears, the chart loses its limit line
- [ ] Switch tabs and back: no reload
- [ ] Kill the network, reload, restore it, press Try again

In Storybook, `Pages/Usage Dashboard/Page`, where the selects work:

- [ ] `PaidWithABillingPeriod`: cumulative line with a ceiling
- [ ] `EnterpriseWithoutABillingPeriod`: daily bars, heading explains why
- [ ] `WithoutAPlanLimit`: plain count, no bar
