### PR TITLE
fix(segments): Segment Change Requests bypassable via segment deletion

### DIFF
--- a/api/core/exceptions.py
+++ b/api/core/exceptions.py
@@ -1,0 +1,16 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class ChangeRequestsEnabledError(APIException):
+    """Raised where a change can only be made by going through a change request."""
+
+    status_code = status.HTTP_409_CONFLICT
+    default_code = "change_requests_enabled"
+    default_detail = "Cannot make this change where change requests are enabled."
+
+    def __init__(self, detail: str | None = None) -> None:
+        # DRF's default exception handler renders `detail` alone.
+        super().__init__(
+            {"detail": detail or self.default_detail, "code": self.default_code}
+        )

--- a/api/features/future/exceptions.py
+++ b/api/features/future/exceptions.py
@@ -4,20 +4,6 @@ from rest_framework import status
 from rest_framework.exceptions import APIException, NotFound
 
 
-class ChangeRequestsEnabledError(APIException):
-    """Raised where a flag can only be changed by going through a change request."""
-
-    status_code = status.HTTP_409_CONFLICT
-    default_code = "change_requests_enabled"
-    default_detail = (
-        "Cannot update flags in an environment with change requests enabled."
-    )
-
-    def __init__(self) -> None:
-        # DRF's default exception handler renders `detail` alone.
-        super().__init__({"detail": self.default_detail, "code": self.default_code})
-
-
 class DuplicatePriorityError(APIException):
     """Raised where a flag's segment overrides would end up sharing a priority."""
 

--- a/api/features/future/views.py
+++ b/api/features/future/views.py
@@ -9,9 +9,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from core.exceptions import ChangeRequestsEnabledError
 from core.types import AuthenticatedRequest
 from environments.models import Environment
-from features.future.exceptions import ChangeRequestsEnabledError
 from features.future.permissions import (
     check_read_permissions,
     check_segment_overrides_permissions,

--- a/api/features/versioning/managers.py
+++ b/api/features/versioning/managers.py
@@ -14,16 +14,28 @@ with open(Path(__file__).parent.resolve() / "sql/get_latest_versions.sql") as f:
 
 
 class EnvironmentFeatureVersionManager(SoftDeleteManager):  # type: ignore[misc]
-    def get_superseded_versions(
+    def get_superseding_versions(
         self,
         feature_id: typing.Any,
         environment_id: typing.Any,
         live_from: typing.Any,
     ) -> QuerySet["EnvironmentFeatureVersion"]:
         """
-        Get the published versions of a flag that a later version has replaced.
+        Get the versions of a flag that have gone live since the given time.
 
-        Versions are ordered by when they went live, matching what the SDKs serve.
+        A version is superseded once another has gone live after it, so
+        `~Exists(get_superseding_versions(..., live_from=<the version's
+        live_from>))` identifies the version currently being served. Versions
+        scheduled to go live later are excluded, since they are not serving
+        anything yet.
+
+        Ordering by when versions went live rather than when they were created
+        matches what the SDKs serve — see
+        https://github.com/Flagsmith/flagsmith/issues/8127.
+
+        The arguments are loosely typed so that callers can pass `OuterRef`
+        expressions and use this as a correlated subquery, which avoids
+        querying per environment.
         """
         return self.filter(  # type: ignore[no-any-return]
             feature_id=feature_id,

--- a/api/features/versioning/managers.py
+++ b/api/features/versioning/managers.py
@@ -23,7 +23,7 @@ class EnvironmentFeatureVersionManager(SoftDeleteManager):  # type: ignore[misc]
         live_from: datetime | OuterRef,
     ) -> QuerySet["EnvironmentFeatureVersion"]:
         """
-        Get the published versions of a flag that have gone live since a given time.
+        Get the published versions of a flag that went live between the provided `live_from` and now. 
         """
         return self.filter(  # type: ignore[no-any-return]
             feature_id=feature_id,

--- a/api/features/versioning/managers.py
+++ b/api/features/versioning/managers.py
@@ -1,6 +1,8 @@
 import typing
+from datetime import datetime
 from pathlib import Path
 
+from django.db.models import OuterRef
 from django.db.models.query import QuerySet, RawQuerySet
 from django.utils import timezone
 from softdelete.models import SoftDeleteManager  # type: ignore[import-untyped]
@@ -14,28 +16,14 @@ with open(Path(__file__).parent.resolve() / "sql/get_latest_versions.sql") as f:
 
 
 class EnvironmentFeatureVersionManager(SoftDeleteManager):  # type: ignore[misc]
-    def get_superseding_versions(
+    def get_versions_live_since(
         self,
-        feature_id: typing.Any,
-        environment_id: typing.Any,
-        live_from: typing.Any,
+        feature_id: int | OuterRef,
+        environment_id: int | OuterRef,
+        live_from: datetime | OuterRef,
     ) -> QuerySet["EnvironmentFeatureVersion"]:
         """
-        Get the versions of a flag that have gone live since the given time.
-
-        A version is superseded once another has gone live after it, so
-        `~Exists(get_superseding_versions(..., live_from=<the version's
-        live_from>))` identifies the version currently being served. Versions
-        scheduled to go live later are excluded, since they are not serving
-        anything yet.
-
-        Ordering by when versions went live rather than when they were created
-        matches what the SDKs serve — see
-        https://github.com/Flagsmith/flagsmith/issues/8127.
-
-        The arguments are loosely typed so that callers can pass `OuterRef`
-        expressions and use this as a correlated subquery, which avoids
-        querying per environment.
+        Get the published versions of a flag that have gone live since a given time.
         """
         return self.filter(  # type: ignore[no-any-return]
             feature_id=feature_id,

--- a/api/features/versioning/managers.py
+++ b/api/features/versioning/managers.py
@@ -23,7 +23,7 @@ class EnvironmentFeatureVersionManager(SoftDeleteManager):  # type: ignore[misc]
         live_from: datetime | OuterRef,
     ) -> QuerySet["EnvironmentFeatureVersion"]:
         """
-        Get the published versions of a flag that went live between the provided `live_from` and now. 
+        Get the published versions of a flag that went live between the provided `live_from` and now.
         """
         return self.filter(  # type: ignore[no-any-return]
             feature_id=feature_id,

--- a/api/features/versioning/managers.py
+++ b/api/features/versioning/managers.py
@@ -14,6 +14,25 @@ with open(Path(__file__).parent.resolve() / "sql/get_latest_versions.sql") as f:
 
 
 class EnvironmentFeatureVersionManager(SoftDeleteManager):  # type: ignore[misc]
+    def get_superseded_versions(
+        self,
+        feature_id: typing.Any,
+        environment_id: typing.Any,
+        live_from: typing.Any,
+    ) -> QuerySet["EnvironmentFeatureVersion"]:
+        """
+        Get the published versions of a flag that a later version has replaced.
+
+        Versions are ordered by when they went live, matching what the SDKs serve.
+        """
+        return self.filter(  # type: ignore[no-any-return]
+            feature_id=feature_id,
+            environment_id=environment_id,
+            published_at__isnull=False,
+            live_from__lte=timezone.now(),
+            live_from__gt=live_from,
+        )
+
     def get_latest_versions_by_environment_id(self, environment_id: int) -> RawQuerySet:  # type: ignore[type-arg]
         """
         Get the latest EnvironmentFeatureVersion objects for a given environment.

--- a/api/projects/models.py
+++ b/api/projects/models.py
@@ -121,6 +121,11 @@ class Project(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ignore[d
         return "Project %s" % self.name
 
     @property
+    def is_workflow_enabled(self) -> bool:
+        """Whether segment change requests are enabled for this project."""
+        return self.minimum_change_request_approvals is not None
+
+    @property
     def is_too_large(self) -> bool:
         return (
             self.features.count() > self.max_features_allowed

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -16,6 +16,7 @@ from segment_membership.constants import MAX_SEGMENT_MEMBERS_PAGE_SIZE
 from segment_membership.models import SegmentMembershipCount
 from segment_membership.services import enqueue_membership_refresh
 from segments.models import Condition, Segment, SegmentRule, WhitelistedSegment
+from segments.services import get_overrides_in_effect
 from segments.types import (
     LegacySegmentRule,
 )
@@ -129,6 +130,12 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
     metadata = MetadataSerializer(required=False, many=True)
     membership_counts = SegmentMembershipCountSerializer(many=True, read_only=True)
     cohort = serializers.SerializerMethodField()
+    has_overrides = serializers.SerializerMethodField(
+        help_text=(
+            "Whether any feature override points at this segment, counting "
+            "overrides that are live now or scheduled to go live."
+        ),
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
@@ -164,11 +171,13 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
             "membership_counts",
             "managed_by",
             "cohort",
+            "has_overrides",
         ]
         read_only_fields = [
             "managed_by",
             "membership_counts",
             "project",
+            "has_overrides",
         ]
 
     @extend_schema_field(_SegmentCohortSerializer(allow_null=True))
@@ -176,6 +185,13 @@ class SegmentSerializer(MetadataSerializerMixin, WritableNestedModelSerializer):
         # next() over the relation keeps the list view's prefetch cache warm.
         cohort = next(iter(segment.cohorts.all()), None)
         return _SegmentCohortSerializer(cohort).data if cohort else None
+
+    def get_has_overrides(self, segment: Segment) -> bool:
+        # Annotated by `SegmentViewSet.get_queryset`; fall back where a segment
+        # is serialized outside that queryset.
+        if (has_overrides := getattr(segment, "has_overrides", None)) is not None:
+            return bool(has_overrides)
+        return get_overrides_in_effect().filter(segment=segment).exists()
 
     def to_internal_value(self, data: dict[str, Any]) -> Any:
         self._validate_rules_depth(data.get("rules", []))

--- a/api/segments/services.py
+++ b/api/segments/services.py
@@ -34,7 +34,7 @@ def get_overrides_in_effect() -> "QuerySet[FeatureSegment]":
         environment__use_v2_feature_versioning=True,
         environment_feature_version__published_at__isnull=False,
     ) & ~models.Exists(
-        EnvironmentFeatureVersion.objects.get_superseding_versions(
+        EnvironmentFeatureVersion.objects.get_versions_live_since(
             feature_id=models.OuterRef("feature_id"),
             environment_id=models.OuterRef("environment_id"),
             live_from=models.OuterRef("environment_feature_version__live_from"),

--- a/api/segments/services.py
+++ b/api/segments/services.py
@@ -34,7 +34,7 @@ def get_overrides_in_effect() -> "QuerySet[FeatureSegment]":
         environment__use_v2_feature_versioning=True,
         environment_feature_version__published_at__isnull=False,
     ) & ~models.Exists(
-        EnvironmentFeatureVersion.objects.get_superseded_versions(
+        EnvironmentFeatureVersion.objects.get_superseding_versions(
             feature_id=models.OuterRef("feature_id"),
             environment_id=models.OuterRef("environment_id"),
             live_from=models.OuterRef("environment_feature_version__live_from"),

--- a/api/segments/services.py
+++ b/api/segments/services.py
@@ -2,12 +2,48 @@ import typing
 import uuid
 
 from django.db import models, transaction
+from django.db.models import QuerySet
 from django.utils import timezone
 
 from core.dataclasses import AuthorData
+from features.models import FeatureSegment
+from features.versioning.models import EnvironmentFeatureVersion
 
 if typing.TYPE_CHECKING:
     from segments.models import Segment
+
+
+def get_overrides_in_effect() -> "QuerySet[FeatureSegment]":
+    """
+    Get the feature overrides that are live now or scheduled to go live.
+
+    Returns a global queryset; narrow the result down with additional filters.
+    """
+    # Without v2 versioning, a feature segment is the current state, so it
+    # counts unless every feature state on it is held by an open change request.
+    without_v2_versioning = models.Q(
+        models.Q(environment__use_v2_feature_versioning=False),
+        models.Q(feature_states__change_request__isnull=True)
+        | models.Q(feature_states__change_request__committed_at__isnull=False),
+    )
+
+    # With v2 versioning, a published version counts unless another published
+    # version has gone live since, which covers both the version that is live
+    # now and any version scheduled to go live later.
+    with_v2_versioning = models.Q(
+        environment__use_v2_feature_versioning=True,
+        environment_feature_version__published_at__isnull=False,
+    ) & ~models.Exists(
+        EnvironmentFeatureVersion.objects.get_superseded_versions(
+            feature_id=models.OuterRef("feature_id"),
+            environment_id=models.OuterRef("environment_id"),
+            live_from=models.OuterRef("environment_feature_version__live_from"),
+        )
+    )
+
+    return FeatureSegment.objects.filter(  # type: ignore[no-any-return]
+        without_v2_versioning | with_v2_versioning
+    )
 
 
 def delete_segment(

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -1,8 +1,9 @@
-import logging
 from typing import TYPE_CHECKING, Any
 
+import structlog
 from common.environments.permissions import VIEW_IDENTITIES
 from common.projects.permissions import VIEW_PROJECT
+from django.db import models
 from django.db.models import Prefetch
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import extend_schema
@@ -16,6 +17,7 @@ from rest_framework.response import Response
 from app.pagination import CustomPagination
 from cohorts.models import Cohort
 from core.dataclasses import AuthorData
+from core.exceptions import ChangeRequestsEnabledError
 from edge_api.identities.models import EdgeIdentity
 from environments.identities.models import Identity
 from environments.models import Environment
@@ -44,12 +46,12 @@ from .serializers import (
     SegmentMembersResponseSerializer,
     SegmentSerializer,
 )
-from .services import delete_segment
+from .services import delete_segment, get_overrides_in_effect
 
 if TYPE_CHECKING:
     from users.models import FFAdminUser
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger("segments")
 
 
 @method_decorator(
@@ -100,7 +102,13 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             return Segment.objects.none()
 
         project = self.get_project()
-        queryset = Segment.live_objects.filter(project=project, is_system_segment=False)
+        queryset = Segment.live_objects.filter(
+            project=project, is_system_segment=False
+        ).annotate(
+            has_overrides=models.Exists(
+                get_overrides_in_effect().filter(segment_id=models.OuterRef("pk"))
+            )
+        )
 
         if self.action == "list":
             # TODO: at the moment, the UI only shows the name and description of the segment in the list view.
@@ -229,9 +237,62 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
                 "This segment is managed by a cohort and cannot be edited "
                 "or cloned directly."
             )
+        if self.action in ("update", "partial_update"):
+            self._check_change_requests_disabled(obj)
+
+    def _check_change_requests_disabled(self, segment: Segment) -> None:
+        """Refuse to edit a segment that can only be changed by a change request."""
+        if not segment.project.is_workflow_enabled:
+            return
+        if segment.change_request_id is not None:
+            # A draft held by a change request; editing it *is* the workflow.
+            return
+        api_error = ChangeRequestsEnabledError(
+            "Cannot update segments in a project with change requests enabled."
+        )
+        logger.warning(
+            "update_rejected",
+            organisation__id=segment.project.organisation_id,
+            project__id=segment.project_id,
+            segment__id=segment.id,
+            reason=api_error.default_code,
+        )
+        raise api_error
+
+    def _check_segment_is_deletable(self, segment: Segment) -> None:
+        """
+        Refuse to delete an overridden segment where change requests are enabled.
+
+        Deleting a segment deletes the overrides pointing at it, which changes
+        what the SDKs serve without anyone reviewing the change.
+        """
+        if not segment.project.is_workflow_enabled:
+            return
+        if not self._has_overrides(segment):
+            return
+        api_error = ChangeRequestsEnabledError(
+            "Cannot delete a segment with feature overrides in a project with "
+            "change requests enabled. Remove the overrides first."
+        )
+        logger.warning(
+            "delete_rejected",
+            organisation__id=segment.project.organisation_id,
+            project__id=segment.project_id,
+            segment__id=segment.id,
+            reason=api_error.default_code,
+        )
+        raise api_error
+
+    @staticmethod
+    def _has_overrides(segment: Segment) -> bool:
+        # `get_queryset` annotates this; fall back for any other code path.
+        if (has_overrides := getattr(segment, "has_overrides", None)) is not None:
+            return bool(has_overrides)
+        return get_overrides_in_effect().filter(segment=segment).exists()
 
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         segment = self.get_object()
+        self._check_segment_is_deletable(segment)
         author = AuthorData.from_request(request)
         delete_segment(segment, author=author)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -268,7 +268,7 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         """
         if not segment.project.is_workflow_enabled:
             return
-        if not self._has_overrides(segment):
+        if not get_overrides_in_effect().filter(segment=segment).exists():
             return
         api_error = ChangeRequestsEnabledError(
             "Cannot delete a segment with feature overrides in a project with "
@@ -282,13 +282,6 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
             reason=api_error.default_code,
         )
         raise api_error
-
-    @staticmethod
-    def _has_overrides(segment: Segment) -> bool:
-        # `get_queryset` annotates this; fall back for any other code path.
-        if (has_overrides := getattr(segment, "has_overrides", None)) is not None:
-            return bool(has_overrides)
-        return get_overrides_in_effect().filter(segment=segment).exists()
 
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         segment = self.get_object()

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -244,9 +244,6 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         """Refuse to edit a segment that can only be changed by a change request."""
         if not segment.project.is_workflow_enabled:
             return
-        if segment.change_request_id is not None:
-            # A draft held by a change request; editing it *is* the workflow.
-            return
         api_error = ChangeRequestsEnabledError(
             "Cannot update segments in a project with change requests enabled."
         )

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -244,6 +244,9 @@ class SegmentViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         """Refuse to edit a segment that can only be changed by a change request."""
         if not segment.project.is_workflow_enabled:
             return
+        if segment.change_request_id is not None:
+            # A draft held by a change request; editing it *is* the workflow.
+            return
         api_error = ChangeRequestsEnabledError(
             "Cannot update segments in a project with change requests enabled."
         )

--- a/api/tests/integration/features/future/test_flag_endpoint.py
+++ b/api/tests/integration/features/future/test_flag_endpoint.py
@@ -1475,7 +1475,7 @@ def test_update_flag__change_requests_enabled__responds_409(
     # Then
     assert response.status_code == 409
     assert response.json() == {
-        "detail": "Cannot update flags in an environment with change requests enabled.",
+        "detail": "Cannot make this change where change requests are enabled.",
         "code": "change_requests_enabled",
     }
     environment_default = FeatureState.objects.get_live_feature_states(
@@ -2229,7 +2229,7 @@ def test_delete_segment_override__change_requests_enabled__responds_409(
     # Then
     assert response.status_code == 409
     assert response.json() == {
-        "detail": "Cannot update flags in an environment with change requests enabled.",
+        "detail": "Cannot make this change where change requests are enabled.",
         "code": "change_requests_enabled",
     }
     assert (

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -2,6 +2,7 @@ import json
 import random
 from collections.abc import Callable
 from copy import deepcopy
+from datetime import timedelta
 
 import freezegun
 import pytest
@@ -13,6 +14,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from django.utils import timezone
 from flag_engine.segments.constants import EQUAL
 from pytest_django import DjangoAssertNumQueries
 from pytest_django.fixtures import SettingsWrapper
@@ -28,6 +30,7 @@ from cohorts.models import Cohort
 from environments.models import Environment
 from features.models import Feature, FeatureSegment, FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
+from features.workflows.core.models import ChangeRequest
 from metadata.models import (
     Metadata,
     MetadataField,
@@ -47,6 +50,7 @@ from segments.models import (
 # TODO: Delete alias as per https://github.com/Flagsmith/flagsmith/issues/7818
 from segments.types import SegmentRule as SegmentRuleType
 from tests.types import InvalidSegmentRulesCase, WithProjectPermissionsCallable
+from users.models import FFAdminUser
 from util.mappers import map_identity_to_identity_document
 
 User = get_user_model()
@@ -112,6 +116,7 @@ def test_create_segment__valid_rules__creates_segment_with_rules(
         "membership_counts": [],
         "managed_by": "",
         "cohort": None,
+        "has_overrides": False,
         "rules": [
             {
                 "id": mocker.ANY,
@@ -1105,6 +1110,7 @@ def test_update_segment__valid_rules__updates_segment_with_rules(
         "membership_counts": [],
         "managed_by": "",
         "cohort": None,
+        "has_overrides": False,
         "rules": [
             {
                 "id": mocker.ANY,
@@ -2043,6 +2049,7 @@ def test_update_segment__whitelisted_segment_exceeds_max_conditions__returns_200
         "membership_counts": [],
         "managed_by": "",
         "cohort": None,
+        "has_overrides": False,
         "rules": [
             {
                 "id": mocker.ANY,
@@ -2228,6 +2235,7 @@ def test_clone_segment__valid_name__returns_cloned_segment(
             "membership_counts": [],
             "managed_by": "",
             "cohort": None,
+            "has_overrides": False,
             "rules": [],  # TODO: Should contain rules as per https://github.com/Flagsmith/flagsmith/issues/7818
         }
     )
@@ -2433,3 +2441,312 @@ def test_list_segments__cohort_managed__returns_cohort_summary(
         "version": 0,
     }
     assert results[plain_segment.id]["cohort"] is None
+
+
+@pytest.fixture()
+def project_with_change_requests(project: Project) -> Project:
+    project.minimum_change_request_approvals = 1
+    project.save()
+    return project
+
+
+def test_delete_segment__change_requests_disabled__deletes_segment(
+    admin_client: APIClient,
+    project: Project,
+    segment: Segment,
+    segment_featurestate: FeatureState,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail", args=[project.id, segment.id]
+    )
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not Segment.objects.filter(id=segment.id).exists()
+
+
+def test_delete_segment__no_overrides__deletes_segment(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not Segment.objects.filter(id=segment.id).exists()
+
+
+def test_delete_segment__live_override__returns_409(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    segment_featurestate: FeatureState,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["code"] == "change_requests_enabled"
+    assert Segment.objects.filter(id=segment.id).exists()
+
+
+def test_delete_segment__feature_specific_segment_with_live_override__returns_409(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    feature: Feature,
+    environment: Environment,
+    feature_specific_segment: Segment,
+) -> None:
+    # Given
+    FeatureState.objects.create(
+        feature_segment=FeatureSegment.objects.create(
+            feature=feature, segment=feature_specific_segment, environment=environment
+        ),
+        feature=feature,
+        environment=environment,
+    )
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, feature_specific_segment.id],
+    )
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+def test_delete_segment__override_in_uncommitted_change_request__deletes_segment(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    feature: Feature,
+    environment: Environment,
+    change_request: ChangeRequest,
+) -> None:
+    # Given
+    FeatureState.objects.create(
+        feature_segment=FeatureSegment.objects.create(
+            feature=feature, segment=segment, environment=environment
+        ),
+        feature=feature,
+        environment=environment,
+        change_request=change_request,
+        version=None,
+    )
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_delete_segment__override_removed_in_later_version__deletes_segment(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    feature: Feature,
+    environment_v2_versioning: Environment,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    with freezegun.freeze_time("2099-01-01"):
+        version_with_override = EnvironmentFeatureVersion.objects.create(
+            environment=environment_v2_versioning, feature=feature
+        )
+        FeatureState.objects.create(
+            feature_segment=FeatureSegment.objects.create(
+                feature=feature,
+                segment=segment,
+                environment=environment_v2_versioning,
+                environment_feature_version=version_with_override,
+            ),
+            feature=feature,
+            environment=environment_v2_versioning,
+            environment_feature_version=version_with_override,
+        )
+        version_with_override.publish(admin_user)
+
+    with freezegun.freeze_time("2099-01-02"):
+        # A later version drops the override. Creating a version carries the
+        # previous version's overrides forward, so remove it explicitly.
+        version_without_override = EnvironmentFeatureVersion.objects.create(
+            environment=environment_v2_versioning, feature=feature
+        )
+        FeatureSegment.objects.filter(
+            environment_feature_version=version_without_override, segment=segment
+        ).delete()
+        version_without_override.publish(admin_user)
+
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+
+    # When
+    with freezegun.freeze_time("2099-01-03"):
+        response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_delete_segment__override_scheduled_to_go_live__returns_409(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    feature: Feature,
+    environment_v2_versioning: Environment,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    version = EnvironmentFeatureVersion.objects.create(
+        environment=environment_v2_versioning, feature=feature
+    )
+    FeatureState.objects.create(
+        feature_segment=FeatureSegment.objects.create(
+            feature=feature,
+            segment=segment,
+            environment=environment_v2_versioning,
+            environment_feature_version=version,
+        ),
+        feature=feature,
+        environment=environment_v2_versioning,
+        environment_feature_version=version,
+    )
+    version.publish(admin_user, live_from=timezone.now() + timedelta(days=1))
+
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+def test_update_segment__change_requests_enabled__returns_409(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+    data = {
+        "name": "New segment name",
+        "project": project_with_change_requests.id,
+        "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+    }
+
+    # When
+    response = admin_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["code"] == "change_requests_enabled"
+    segment.refresh_from_db()
+    assert segment.name != "New segment name"
+
+
+def test_partial_update_segment__change_requests_enabled__returns_409(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, segment.id],
+    )
+
+    # When
+    response = admin_client.patch(
+        url,
+        data=json.dumps({"description": "Just a description"}),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+def test_update_segment__change_request_draft__updates_segment(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    project_change_request: ChangeRequest,
+) -> None:
+    # Given
+    draft = segment.clone(name="Draft", change_request=project_change_request)
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, draft.id],
+    )
+    data = {
+        "name": "Edited draft",
+        "project": project_with_change_requests.id,
+        "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+    }
+
+    # When
+    response = admin_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code != status.HTTP_409_CONFLICT
+
+
+def test_list_segments__returns_has_overrides(
+    admin_client: APIClient,
+    project: Project,
+    segment: Segment,
+    another_segment: Segment,
+    segment_featurestate: FeatureState,
+) -> None:
+    # Given
+    url = reverse("api-v1:projects:project-segments-list", args=[project.id])
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    has_overrides_by_id = {
+        result["id"]: result["has_overrides"] for result in response.json()["results"]
+    }
+    assert has_overrides_by_id[segment.id] is True
+    assert has_overrides_by_id[another_segment.id] is False

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -2730,7 +2730,7 @@ def test_update_segment__change_request_draft__updates_segment(
     assert response.status_code != status.HTTP_409_CONFLICT
 
 
-def test_list_segments__returns_has_overrides(
+def test_list_segments__mixed_overrides__returns_has_overrides(
     admin_client: APIClient,
     project: Project,
     segment: Segment,

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -2703,6 +2703,79 @@ def test_partial_update_segment__change_requests_enabled__returns_409(
     assert response.status_code == status.HTTP_409_CONFLICT
 
 
+def test_update_segment__change_request_draft__updates_segment(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    project_change_request: ChangeRequest,
+) -> None:
+    """Editing a draft held by a change request is the workflow, not a bypass."""
+    # Given
+    # `clone` leaves `version_of` pointing at the clone itself, which is the
+    # shape the change request API produces when `version_of` is omitted.
+    draft = segment.clone(name="Draft", change_request=project_change_request)
+    assert draft.version_of_id == draft.id
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, draft.id],
+    )
+    data = {
+        "name": "Edited draft",
+        "project": project_with_change_requests.id,
+        "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+    }
+
+    # When
+    response = admin_client.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    draft.refresh_from_db()
+    assert draft.name == "Edited draft"
+
+
+def test_update_segment__draft_of_live_segment__returns_404(
+    admin_client: APIClient,
+    project_with_change_requests: Project,
+    segment: Segment,
+    project_change_request: ChangeRequest,
+) -> None:
+    """A draft of a live segment is not served by this endpoint at all.
+
+    The dashboard sends `version_of`, so the draft is a version rather than a
+    canonical segment, and `Segment.live_objects` excludes it. Such drafts are
+    edited through the change request endpoints.
+    """
+    # Given
+    draft = segment.clone(
+        name="Draft", change_request=project_change_request, version_of=segment
+    )
+    url = reverse(
+        "api-v1:projects:project-segments-detail",
+        args=[project_with_change_requests.id, draft.id],
+    )
+
+    # When
+    response = admin_client.put(
+        url,
+        data=json.dumps(
+            {
+                "name": "Edited draft",
+                "project": project_with_change_requests.id,
+                "rules": [{"type": "ALL", "rules": [], "conditions": []}],
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    draft.refresh_from_db()
+    assert draft.name == "Draft"
+
+
 def test_list_segments__mixed_overrides__returns_has_overrides(
     admin_client: APIClient,
     project: Project,

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -2703,33 +2703,6 @@ def test_partial_update_segment__change_requests_enabled__returns_409(
     assert response.status_code == status.HTTP_409_CONFLICT
 
 
-def test_update_segment__change_request_draft__updates_segment(
-    admin_client: APIClient,
-    project_with_change_requests: Project,
-    segment: Segment,
-    project_change_request: ChangeRequest,
-) -> None:
-    # Given
-    draft = segment.clone(name="Draft", change_request=project_change_request)
-    url = reverse(
-        "api-v1:projects:project-segments-detail",
-        args=[project_with_change_requests.id, draft.id],
-    )
-    data = {
-        "name": "Edited draft",
-        "project": project_with_change_requests.id,
-        "rules": [{"type": "ALL", "rules": [], "conditions": []}],
-    }
-
-    # When
-    response = admin_client.put(
-        url, data=json.dumps(data), content_type="application/json"
-    )
-
-    # Then
-    assert response.status_code != status.HTTP_409_CONFLICT
-
-
 def test_list_segments__mixed_overrides__returns_has_overrides(
     admin_client: APIClient,
     project: Project,

--- a/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
+++ b/docs/docs/administration-and-security/governance-and-compliance/change-requests.md
@@ -92,7 +92,15 @@ to a single environment.
 ### Create a Segment Change Request
 
 Once a project is configured with Segment Change Requests enabled, **editing an existing segment** will require a Change
-Request to be submitted.
+Request to be submitted. This applies to the API as well as the dashboard: requests that write to a segment directly are
+rejected with a `409 Conflict` and a `change_requests_enabled` error code.
+
+**Deleting a segment that has feature overrides** is also refused while Segment Change Requests are enabled.
+That includes live overrides, or scheduled to go live.
+
+To delete such a segment, remove its feature overrides first. Note that removing an override is governed by
+[Feature Change Requests](#feature-change-requests), which are enabled per environment and are separate from Segment
+Change Requests.
 
 While creating a new segment (including rules and conditions) is not gated, a segment only affects identities once
 feature overrides are added to it. Adding segment overrides to a feature can be gated by

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -664,14 +664,36 @@ Attributes:
  - `organisation.id`
  - `reason`
 
+### `segments.delete_rejected`
+
+Logged at `warning` from:
+ - `api/segments/views.py:277`
+
+Attributes:
+ - `organisation.id`
+ - `project.id`
+ - `reason`
+ - `segment.id`
+
 ### `segments.serializers.segment_revision_created`
 
 Logged at `info` from:
- - `api/segments/serializers.py:215`
+ - `api/segments/serializers.py:231`
 
 Attributes:
  - `revision_id`
  - `segment_id`
+
+### `segments.update_rejected`
+
+Logged at `warning` from:
+ - `api/segments/views.py:253`
+
+Attributes:
+ - `organisation.id`
+ - `project.id`
+ - `reason`
+ - `segment.id`
 
 ### `sentry_change_tracking.integration_error`
 

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -667,7 +667,7 @@ Attributes:
 ### `segments.delete_rejected`
 
 Logged at `warning` from:
- - `api/segments/views.py:277`
+ - `api/segments/views.py:274`
 
 Attributes:
  - `organisation.id`
@@ -687,7 +687,7 @@ Attributes:
 ### `segments.update_rejected`
 
 Logged at `warning` from:
- - `api/segments/views.py:253`
+ - `api/segments/views.py:250`
 
 Attributes:
  - `organisation.id`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -667,7 +667,7 @@ Attributes:
 ### `segments.delete_rejected`
 
 Logged at `warning` from:
- - `api/segments/views.py:274`
+ - `api/segments/views.py:277`
 
 Attributes:
  - `organisation.id`
@@ -687,7 +687,7 @@ Attributes:
 ### `segments.update_rejected`
 
 Logged at `warning` from:
- - `api/segments/views.py:250`
+ - `api/segments/views.py:253`
 
 Attributes:
  - `organisation.id`

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -6936,6 +6936,11 @@
               }
             ],
             "readOnly": true
+          },
+          "has_overrides": {
+            "description": "Whether any feature override points at this segment, counting overrides that are live now or scheduled to go live.",
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19265,6 +19265,10 @@ components:
             - $ref: '#/components/schemas/_SegmentCohort'
             - type: 'null'
           readOnly: true
+        has_overrides:
+          description: 'Whether any feature override points at this segment, counting overrides that are live now or scheduled to go live.'
+          type: boolean
+          readOnly: true
         change_request:
           type:
             - integer
@@ -25503,6 +25507,10 @@ components:
             - $ref: '#/components/schemas/_SegmentCohort'
             - type: 'null'
           readOnly: true
+        has_overrides:
+          description: 'Whether any feature override points at this segment, counting overrides that are live now or scheduled to go live.'
+          type: boolean
+          readOnly: true
     PatchedSegmentConfiguration:
       type: object
       properties:
@@ -27239,6 +27247,10 @@ components:
           oneOf:
             - $ref: '#/components/schemas/_SegmentCohort'
             - type: 'null'
+          readOnly: true
+        has_overrides:
+          description: 'Whether any feature override points at this segment, counting overrides that are live now or scheduled to go live.'
+          type: boolean
           readOnly: true
       required:
         - name


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #7532.

In this PR, we prevent the following when Segment Change Requests are enabled:

- Deleting a segment that has live or scheduled feature overrides. Overrides that exist only inside an uncommitted change request do not count.
- Editing a segment directly. `PUT` and `PATCH` on a segment are refused, including metadata-only writes. Drafts held by a change request are exempt, since editing those is the workflow rather than a way around it.

Supporting changes:

- `ChangeRequestsEnabledError` moves from `features/future/exceptions.py` to `core/exceptions.py` so both features and segments raise the same 409 and error code. Its detail message is now generic.
- `Project.is_workflow_enabled`, mirroring `Environment.is_workflow_enabled`.
- `EnvironmentFeatureVersionManager.get_superseded_versions()`, which answers "has a later version already replaced this one" as a correlated subquery. Ordering by go-live rather than creation is deliberate, per #8127.
- Segments now expose `has_overrides`, so the UI is able to gray out submission buttons based on it. 
- `segments/views.py` moves to structlog, emitting `segments.update_rejected` and `segments.delete_rejected`.

Deliberately out of scope:

- Segment creation stays ungated. A segment serves nothing until an override points at it, and adding overrides is governed by Feature Change Requests.
- Custom fields (metadata) are carried into a segment change request but never shown to the approver and dropped on commit (#8350). Because this PR gates metadata-only writes too, custom fields cannot be changed on a change-request-enabled project until #8350 is fixed.
- Override writes themselves are only gated on the newer flag endpoints. `FeatureSegmentViewSet` and `EnvironmentFeatureVersionViewSet.create`/`publish` have no change request check, so the API route around Feature Change Requests remains open. The documentation added here is careful not to claim otherwise.

## How did you test this code?

Added unit tests, and benchmarked `EnvironmentFeatureVersionManager.get_superseded_versions()`.
