### PR TITLE
ci(frontend-deploy): report every deploy outcome in one Slack message

### DIFF
--- a/.github/actions/notify-slack-deploy/action.yml
+++ b/.github/actions/notify-slack-deploy/action.yml
@@ -1,5 +1,5 @@
 name: Notify Slack of a deploy
-description: Post a deploy notification to a Slack incoming webhook, prompting a smoke test.
+description: Post the outcome of a deploy to a Slack incoming webhook.
 
 inputs:
   webhook_url:
@@ -15,6 +15,26 @@ inputs:
     description: The environment that was deployed to.
     required: false
     default: production
+  conclusion:
+    description: >
+      The deploy run's conclusion, straight from workflow_run. Only success and
+      cancelled get their own copy; anything else reads as a failure.
+    required: true
+  commit_sha:
+    description: The commit that was deployed.
+    required: true
+  actor:
+    description: The GitHub login that triggered the deploy.
+    required: true
+  run_url:
+    description: Link to the deploy run, not to the run posting this.
+    required: true
+  started_at:
+    description: When the deploy run started, ISO 8601. Omitted from the message if absent.
+    required: false
+  ended_at:
+    description: When the deploy run finished, ISO 8601. Paired with started_at for the duration.
+    required: false
 
 runs:
   using: composite
@@ -27,62 +47,46 @@ runs:
         SERVICE: ${{ inputs.service }}
         APP_URL: ${{ inputs.app_url }}
         ENVIRONMENT: ${{ inputs.environment }}
-        COMMIT_SHA: ${{ github.sha }}
-        ACTOR: ${{ github.actor }}
-        WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      # jq builds the payload so every value is escaped for us, rather than
-      # interpolated into a JSON heredoc.
+        CONCLUSION: ${{ inputs.conclusion }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
+        ACTOR: ${{ inputs.actor }}
+        RUN_URL: ${{ inputs.run_url }}
+        STARTED_AT: ${{ inputs.started_at }}
+        ENDED_AT: ${{ inputs.ended_at }}
       run: |
+        set -euo pipefail
+
+        # Best effort: a timestamp that will not parse costs the message two
+        # fields rather than failing the run.
+        epoch() { date -u -d "$1" +%s 2>/dev/null || true; }
+
+        started_epoch="$([ -n "$STARTED_AT" ] && epoch "$STARTED_AT" || true)"
+        ended_epoch="$([ -n "$ENDED_AT" ] && epoch "$ENDED_AT" || true)"
+        started_label=''
+        duration=''
+
+        if [ -n "$started_epoch" ]; then
+          started_label="$(date -u -d "@$started_epoch" '+%H:%M UTC' 2>/dev/null || true)"
+          if [ -n "$ended_epoch" ] && [ "$ended_epoch" -ge "$started_epoch" ]; then
+            elapsed=$(( ended_epoch - started_epoch ))
+            duration="$(( elapsed / 60 ))m $(( elapsed % 60 ))s"
+          fi
+        fi
+
+        # jq escapes every value for us, unlike a JSON heredoc.
         jq -n \
           --arg service "$SERVICE" \
           --arg environment "$ENVIRONMENT" \
+          --arg conclusion "$CONCLUSION" \
           --arg short_sha "${COMMIT_SHA:0:7}" \
           --arg actor "$ACTOR" \
           --arg app_url "$APP_URL" \
-          --arg workflow_url "$WORKFLOW_URL" \
-          '($environment | (.[0:1] | ascii_upcase) + .[1:]) as $env_name |
-          {
-            # Slack honours username on this webhook but ignores icon_emoji.
-            # The avatar comes from the icon set on the Slack app itself.
-            username: "\($service) Deploy",
-            text: "🚀 \($service) deployed to \($environment): smoke test required",
-            blocks: [
-              {
-                type: "header",
-                text: { type: "plain_text", text: "🚀 \($service) deployed to \($environment)" }
-              },
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text: "🧪 *\($env_name) smoke test required*\n\nPlease verify the application directly in \($environment)."
-                }
-              },
-              {
-                type: "section",
-                fields: [
-                  { type: "mrkdwn", text: "*Commit:*\n\($short_sha)" },
-                  { type: "mrkdwn", text: "*Deployed by:*\n@\($actor)" }
-                ]
-              },
-              {
-                type: "actions",
-                elements: [
-                  {
-                    type: "button",
-                    text: { type: "plain_text", text: "Open \($env_name)" },
-                    url: $app_url
-                  },
-                  {
-                    type: "button",
-                    text: { type: "plain_text", text: "View GitHub Actions" },
-                    url: $workflow_url
-                  }
-                ]
-              }
-            ]
-          }' \
-          | curl --fail-with-body --connect-timeout 10 --max-time 30 -X POST \
-              -H 'Content-Type: application/json' \
-              --data @- \
-              "$SLACK_WEBHOOK_URL"
+          --arg run_url "$RUN_URL" \
+          --arg started_epoch "$started_epoch" \
+          --arg started_label "$started_label" \
+          --arg duration "$duration" \
+          -f "$GITHUB_ACTION_PATH/payload.jq" \
+        | curl --fail-with-body --connect-timeout 10 --max-time 30 -X POST \
+            -H 'Content-Type: application/json' \
+            --data @- \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/actions/notify-slack-deploy/payload.jq
+++ b/.github/actions/notify-slack-deploy/payload.jq
@@ -1,0 +1,83 @@
+# Slack Block Kit payload for a deploy notification.
+# Run with jq -n and the --arg values listed in action.yml.
+
+($environment | (.[0:1] | ascii_upcase) + .[1:]) as $env_name |
+
+# Only success and cancelled need their own words. Everything else GitHub
+# reports, timed_out and skipped included, means the deploy did not happen.
+(if $conclusion == "success" then
+  {
+    headline: "🚀 \($service) deployed to \($environment)",
+    body: "🧪 *\($env_name) smoke test required*\n\nPlease verify the application directly in \($environment).",
+    actor_label: "Deployed by",
+    link_app: true
+  }
+elif $conclusion == "cancelled" then
+  {
+    headline: "⏭️ \($service) deploy to \($environment) stopped",
+    # run-tests cancels itself in progress when the next commit lands on main,
+    # which is upstream of the deploy. A hand cancellation can land anywhere,
+    # including mid-deploy, so do not assert what the environment is serving.
+    body: "Cancelled before finishing. If a newer commit superseded this run, \($environment) is unchanged and the newer run deploys instead. If it was cancelled by hand, check the run to see whether the deploy had started.",
+    actor_label: "Pushed by",
+    link_app: false
+  }
+else
+  {
+    headline: "🛑 \($service) deploy to \($environment) failed",
+    body: "\($env_name) is unchanged and still serving the previous release.",
+    actor_label: "Pushed by",
+    link_app: false
+  }
+end) as $copy |
+
+{
+  # Slack honours username on this webhook but ignores icon_emoji. The avatar
+  # comes from the icon set on the Slack app itself.
+  username: "\($service) Deploy",
+  text: $copy.headline,
+  blocks: [
+    {
+      type: "header",
+      text: { type: "plain_text", text: $copy.headline }
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: $copy.body }
+    },
+    {
+      type: "section",
+      fields: (
+        [
+          { type: "mrkdwn", text: "*Commit:*\n\($short_sha)" },
+          { type: "mrkdwn", text: "*\($copy.actor_label):*\n@\($actor)" }
+        ]
+        # Slack renders this date token in the reader's own timezone; the text
+        # after the pipe is the fallback everywhere else.
+        + (if $started_epoch != "" then
+            [{ type: "mrkdwn", text: "*Started:*\n<!date^\($started_epoch)^{time}|\($started_label)>" }]
+           else [] end)
+        + (if $duration != "" then
+            [{ type: "mrkdwn", text: "*Duration:*\n\($duration)" }]
+           else [] end)
+      )
+    },
+    {
+      type: "actions",
+      elements: (
+        (if $copy.link_app then
+          [{
+            type: "button",
+            text: { type: "plain_text", text: "Open \($env_name)" },
+            url: $app_url
+          }]
+         else [] end)
+        + [{
+            type: "button",
+            text: { type: "plain_text", text: "View GitHub Actions" },
+            url: $run_url
+          }]
+      )
+    }
+  ]
+}

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -79,14 +79,17 @@ jobs:
       npm_build_environment: prod
     secrets: inherit
 
-  notify-production-smoke-test:
-    name: Notify Production Smoke Test
-    needs: deploy-production
-    if: ${{ needs.deploy-production.result == 'success' }}
+  notify-production-deploy:
+    name: Notify Production Deploy
+    needs: [run-unit-tests, run-tests, deploy-production]
+    # Reports whatever happened, so a failed or superseded run is announced too.
+    if: ${{ always() }}
     runs-on: ubuntu-latest
-    # Only needs to read the repo to resolve the local action below.
     permissions:
+      # Enough to resolve the local action below.
       contents: read
+      # Reading this run's start time for the timings in the message.
+      actions: read
 
     steps:
       - name: Cloning repo
@@ -95,15 +98,50 @@ jobs:
           # Nothing runs git after this, so the token need not persist.
           persist-credentials: false
 
+      - name: Resolve what to report
+        id: outcome
+        env:
+          UNIT_TESTS: ${{ needs.run-unit-tests.result }}
+          E2E_TESTS: ${{ needs.run-tests.result }}
+          DEPLOY: ${{ needs.deploy-production.result }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_API_PATH: repos/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -eu
+
+          # Only the production job decides this. deploy-demo and deploy-demo2
+          # run alongside it, so the run's own conclusion cannot be used: one
+          # failed demo would report production as failed.
+          # A supersede reads as cancelled rather than failed, since run-tests
+          # cancels itself in progress when the next commit lands on main.
+          if [ "$DEPLOY" = success ]; then
+            conclusion=success
+          elif [ "$UNIT_TESTS" = cancelled ] || [ "$E2E_TESTS" = cancelled ] || [ "$DEPLOY" = cancelled ]; then
+            conclusion=cancelled
+          else
+            conclusion=failure
+          fi
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+
+          # Best effort: without it the message loses two fields and stays true.
+          started_at="$(gh api "$RUN_API_PATH" --jq '.run_started_at' 2>/dev/null || true)"
+          echo "started_at=$started_at" >> "$GITHUB_OUTPUT"
+          echo "ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Notify Slack
-        # The deploy has already succeeded by this point, so a Slack outage or a
-        # rotated webhook should not fail the run.
+        # The run is over by this point, so a Slack outage must not fail it.
         continue-on-error: true
         uses: ./.github/actions/notify-slack-deploy
         with:
           webhook_url: ${{ secrets.SLACK_FRONTEND_DEPLOY_WEBHOOK }}
           service: Frontend
           app_url: https://app.flagsmith.com
+          conclusion: ${{ steps.outcome.outputs.conclusion }}
+          commit_sha: ${{ github.sha }}
+          actor: ${{ github.actor }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          started_at: ${{ steps.outcome.outputs.started_at }}
+          ended_at: ${{ steps.outcome.outputs.ended_at }}
 
   deploy-demo:
     name: Deploy to Vercel Demo


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`#frontend-deploy` gets three messages per deploy: a start card and a terminal card from the GitHub Slack app, plus our own notification. The app's `✅ succeeded` card duplicates ours with less detail, no commit, no actor, no link to production. On 25 Aug that was ~18 messages for 6 runs.

Our notification only fired on success, so unsubscribing the app would have lost the failed and cancelled cases. This moves them here.

- The job now runs on `always()` and takes its outcome from `needs.deploy-production.result`, not the run's own conclusion. `deploy-demo` and `deploy-demo2` run alongside production, so one failed demo would otherwise report production as failed while it was serving the new release.
- Three outcomes: **deployed**, **failed**, **stopped**. Only a deploy gets the Open Production button and the smoke test ask.
- The card carries the run start time and duration, replacing the app's start ping.
- Cancelled gets its own wording. Job level concurrency on `run-tests` stops a run whenever the next commit lands on main, so most cancellations mean superseded, and the app rendered those with a red cross. The copy does not assert what production is serving, since a hand cancellation can land mid-deploy.
- The Block Kit payload moves to `payload.jq`, so it can be read and run on its own.

18 messages down to 6, one per run.

### Deployed

<img width="729" height="360" alt="image" src="https://github.com/user-attachments/assets/3c42754e-e4f5-4afb-b019-5bb5140797b0" />

### Failed

<img width="731" height="325" alt="image" src="https://github.com/user-attachments/assets/15c9bfe7-1a52-4167-a8c5-e4d065bcd3f8" />

### Stopped (superseded)

<img width="731" height="347" alt="image" src="https://github.com/user-attachments/assets/9b65c8b1-66c4-4055-817c-04a02dce3939" />

### Follow-up, not in this PR

Once a **superseded** run has been reported by the new card, the app subscription needs removing from the channel by hand, otherwise the duplicates continue. Waiting for that specific case is deliberate: it is the one path that depends on `always()` scheduling a job after a cancellation, which cannot be verified before merge.

```
/github unsubscribe Flagsmith/flagsmith workflows:{name:"Frontend Deploy to Production" event:"push" branch:"main"}
```

## How did you test this code?

Rendered all three cards through Slack's Block Kit Builder using the action's real `payload.jq` (screenshots above). Ran `payload.jq` directly for every conclusion: `success` and `cancelled` get their own copy, `failure`, `timed_out` and `skipped` all read as failed, and with no timings supplied the Started and Duration fields drop out. Checked the timing logic in an `ubuntu:24.04` container since it needs GNU `date -d`, covering both timestamps, start only, neither, end before start, and unparseable input.

Checked the outcome mapping across the seven `needs.*.result` combinations that can occur, including production succeeding while a demo fails, which reports `success`.

Not exercised end to end, and it cannot be: this workflow only runs on push to `main`. The Slack step is `continue-on-error: true` and the job is downstream of the deploy, so nothing here can affect a deploy. The one behaviour that needs a live run is whether `always()` schedules the job after a concurrency cancellation, which is why the unsubscribe waits on seeing a supersede reported.
