### PR TITLE
fix(identities): label the rows in the identity override selector

### DIFF
--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -45,8 +45,8 @@ interface ValueRowLabelProps {
 
 // Each row shows a bare value, so it needs saying which value it is.
 const ValueRowLabel: FC<ValueRowLabelProps> = ({ children }) => (
-  <div className='mb-1'>
-    <span className='text-small text-secondary'>{children}</span>
+  <div className='mb-2'>
+    <span className='h6 mb-0 font-weight-semibold'>{children}</span>
   </div>
 )
 

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -39,8 +39,12 @@ interface VariationOptionsProps {
   weightTitle: string
 }
 
+interface SelectRowLabelProps {
+  text: string
+}
+
 // Select rows show a bare value, so each needs saying what it is.
-const SelectRowLabel: React.FC<{ text: string }> = ({ text }) => (
+const SelectRowLabel: React.FC<SelectRowLabelProps> = ({ text }) => (
   <div className='mb-2'>
     <span className='h6 mb-0 font-weight-semibold'>{text}</span>
   </div>

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FC, ReactNode } from 'react'
 import ValueEditor from 'components/ValueEditor'
 import ErrorMessage from 'components/ErrorMessage'
 import { VariationValueInput } from './VariationValueInput'
@@ -40,17 +40,17 @@ interface VariationOptionsProps {
 }
 
 interface ValueRowLabelProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 // Each row shows a bare value, so it needs saying which value it is.
-const ValueRowLabel: React.FC<ValueRowLabelProps> = ({ children }) => (
+const ValueRowLabel: FC<ValueRowLabelProps> = ({ children }) => (
   <div className='mb-2'>
     <span className='h6 mb-0 font-weight-semibold'>{children}</span>
   </div>
 )
 
-export const VariationOptions: React.FC<VariationOptionsProps> = ({
+export const VariationOptions: FC<VariationOptionsProps> = ({
   apiErrors,
   canCreateFeature,
   controlPercentage,

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -39,13 +39,10 @@ interface VariationOptionsProps {
   weightTitle: string
 }
 
-// Rows in the select list show a bare value, so each one needs saying what it
-// is: the identity's own override, the environment default, or a named variant.
-const SelectRowLabel: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => (
+// Select rows show a bare value, so each needs saying what it is.
+const SelectRowLabel: React.FC<{ text: string }> = ({ text }) => (
   <div className='mb-2'>
-    <span className='h6 mb-0 font-weight-semibold'>{children}</span>
+    <span className='h6 mb-0 font-weight-semibold'>{text}</span>
   </div>
 )
 
@@ -86,7 +83,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
       {select && !!unmatchedOverride && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
-            <SelectRowLabel>Current override</SelectRowLabel>
+            <SelectRowLabel text='Current override' />
             <Row>
               <Flex>
                 <ValueEditor
@@ -112,7 +109,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
       {select && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
-            <SelectRowLabel>Environment default</SelectRowLabel>
+            <SelectRowLabel text='Environment default' />
             <Row>
               <Flex>
                 <ValueEditor
@@ -158,9 +155,9 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
         return select ? (
           <div key={i} className='panel panel--flat panel-without-heading mb-2'>
             <div className='panel-content'>
-              <SelectRowLabel>
-                {theValue.key || Utils.getDefaultVariantKey(i)}
-              </SelectRowLabel>
+              <SelectRowLabel
+                text={theValue.key || Utils.getDefaultVariantKey(i)}
+              />
               <Row>
                 <Flex>
                   <ValueEditor

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -45,8 +45,8 @@ interface ValueRowLabelProps {
 
 // Each row shows a bare value, so it needs saying which value it is.
 const ValueRowLabel: FC<ValueRowLabelProps> = ({ children }) => (
-  <div className='mb-2'>
-    <span className='h6 mb-0 font-weight-semibold'>{children}</span>
+  <div className='mb-1'>
+    <span className='text-small text-secondary'>{children}</span>
   </div>
 )
 
@@ -113,7 +113,7 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
       {select && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
-            <ValueRowLabel>Environment default</ValueRowLabel>
+            <ValueRowLabel>Control value</ValueRowLabel>
             <Row>
               <Flex>
                 <ValueEditor

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -39,14 +39,14 @@ interface VariationOptionsProps {
   weightTitle: string
 }
 
-interface SelectRowLabelProps {
-  text: string
+interface ValueRowLabelProps {
+  children: React.ReactNode
 }
 
-// Select rows show a bare value, so each needs saying what it is.
-const SelectRowLabel: React.FC<SelectRowLabelProps> = ({ text }) => (
+// Each row shows a bare value, so it needs saying which value it is.
+const ValueRowLabel: React.FC<ValueRowLabelProps> = ({ children }) => (
   <div className='mb-2'>
-    <span className='h6 mb-0 font-weight-semibold'>{text}</span>
+    <span className='h6 mb-0 font-weight-semibold'>{children}</span>
   </div>
 )
 
@@ -87,7 +87,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
       {select && !!unmatchedOverride && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
-            <SelectRowLabel text='Current override' />
+            <ValueRowLabel>Current override</ValueRowLabel>
             <Row>
               <Flex>
                 <ValueEditor
@@ -113,7 +113,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
       {select && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
-            <SelectRowLabel text='Environment default' />
+            <ValueRowLabel>Environment default</ValueRowLabel>
             <Row>
               <Flex>
                 <ValueEditor
@@ -159,9 +159,9 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
         return select ? (
           <div key={i} className='panel panel--flat panel-without-heading mb-2'>
             <div className='panel-content'>
-              <SelectRowLabel
-                text={theValue.key || Utils.getDefaultVariantKey(i)}
-              />
+              <ValueRowLabel>
+                {theValue.key || Utils.getDefaultVariantKey(i)}
+              </ValueRowLabel>
               <Row>
                 <Flex>
                   <ValueEditor

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -39,6 +39,16 @@ interface VariationOptionsProps {
   weightTitle: string
 }
 
+// Rows in the select list show a bare value, so each one needs saying what it
+// is: the identity's own override, the environment default, or a named variant.
+const SelectRowLabel: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <div className='mb-2'>
+    <span className='h6 mb-0 font-weight-semibold'>{children}</span>
+  </div>
+)
+
 export const VariationOptions: React.FC<VariationOptionsProps> = ({
   apiErrors,
   canCreateFeature,
@@ -76,6 +86,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
       {select && !!unmatchedOverride && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
+            <SelectRowLabel>Current override</SelectRowLabel>
             <Row>
               <Flex>
                 <ValueEditor
@@ -101,6 +112,7 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
       {select && (
         <div className='panel panel--flat panel-without-heading mb-2'>
           <div className='panel-content'>
+            <SelectRowLabel>Environment default</SelectRowLabel>
             <Row>
               <Flex>
                 <ValueEditor
@@ -144,8 +156,11 @@ export const VariationOptions: React.FC<VariationOptionsProps> = ({
           )
         }
         return select ? (
-          <div className='panel panel--flat panel-without-heading mb-2'>
+          <div key={i} className='panel panel--flat panel-without-heading mb-2'>
             <div className='panel-content'>
+              <SelectRowLabel>
+                {theValue.key || Utils.getDefaultVariantKey(i)}
+              </SelectRowLabel>
               <Row>
                 <Flex>
                   <ValueEditor


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follows #8279. That PR started showing an identity's override value when it is not one of the flag's variations, but the selector it appears in renders every row as a bare value plus a radio. Nothing says which row is the override, which is the environment default, or which variant is which, so the list reads as a column of unlabelled JSON. A user hitting the new warning has no way to tell what they are choosing between.

- The unmatched override row is labelled `Current override`.
- The control row is labelled `Environment default`.
- Each variation is labelled with its key, falling back to `Variant_n` exactly as the feature editor does.
- The mapped rows get a list key, which they were missing.

The variant keys were already there, from #7736. They were just never rendered in this view.

## How did you test this code?

Manually, in the Edit User Feature modal for a multivariate flag with an identity override that is not one of the variations. All three row types now carry a label, and a variation with no key set falls back to its `Variant_n` name.

`npx tsc --noEmit` reports the same three pre-existing errors in this file before and after the change, at shifted line numbers. `eslint --fix` reports nothing.
