### PR TITLE
feat(mv): render variant keys in mono

### DIFF
--- a/frontend/web/components/experiments/RolloutSplitEditor/RolloutSplitEditor.tsx
+++ b/frontend/web/components/experiments/RolloutSplitEditor/RolloutSplitEditor.tsx
@@ -4,7 +4,7 @@ import Input from 'components/base/forms/Input'
 import ErrorMessage from 'components/ErrorMessage'
 import ColorSwatch from 'components/ColorSwatch'
 import Utils from 'common/utils/utils'
-import { getDefaultVariantKey } from 'common/utils/multivariate'
+import { VariantKey } from 'components/mv/VariantKey'
 import {
   CONTROL_COLOUR,
   VariationSplitEntry,
@@ -76,9 +76,11 @@ const RolloutSplitEditor: FC<RolloutSplitEditorProps> = ({
                 size='md'
                 shape='circle'
               />
-              <span className='rollout-split__name-text'>
-                {option.key || getDefaultVariantKey(index)}
-              </span>
+              <VariantKey
+                className='rollout-split__name-text'
+                value={option.key}
+                index={index}
+              />
             </span>
             <span className='rollout-split__weight'>
               <Input

--- a/frontend/web/components/experiments/VariationTable/VariationTable.tsx
+++ b/frontend/web/components/experiments/VariationTable/VariationTable.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { MultivariateOption } from 'common/types/responses'
 import ColorSwatch from 'components/ColorSwatch'
-import { getDefaultVariantKey } from 'common/utils/multivariate'
+import { VariantKey } from 'components/mv/VariantKey'
 import {
   CONTROL_COLOUR,
   getVariationColour,
@@ -60,9 +60,11 @@ const VariationTable: FC<VariationTableProps> = ({
                 size='md'
                 shape='circle'
               />
-              <span className='variation-table__name-text'>
-                {mv.key || getDefaultVariantKey(index)}
-              </span>
+              <VariantKey
+                className='variation-table__name-text'
+                value={mv.key}
+                index={index}
+              />
             </div>
             <div className='variation-table__cell variation-table__cell--value'>
               {value ? (

--- a/frontend/web/components/mv/VariantKey/VariantKey.tsx
+++ b/frontend/web/components/mv/VariantKey/VariantKey.tsx
@@ -1,0 +1,23 @@
+import React, { ComponentPropsWithoutRef, FC } from 'react'
+import classNames from 'classnames'
+import { getDefaultVariantKey } from 'common/utils/multivariate'
+
+interface VariantKeyProps
+  extends Omit<ComponentPropsWithoutRef<'span'>, 'children'> {
+  // The variant's own key, absent when the user never set one.
+  value?: string | null
+  index: number
+}
+
+// A variant key is an identifier the SDKs match on, so it is set in mono to
+// read as code rather than prose.
+export const VariantKey: FC<VariantKeyProps> = ({
+  className,
+  index,
+  value,
+  ...rest
+}) => (
+  <span className={classNames('font-monospace', className)} {...rest}>
+    {value || getDefaultVariantKey(index)}
+  </span>
+)

--- a/frontend/web/components/mv/VariantKey/VariantKey.tsx
+++ b/frontend/web/components/mv/VariantKey/VariantKey.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, FC } from 'react'
+import { ComponentPropsWithoutRef, FC } from 'react'
 import classNames from 'classnames'
 import { getDefaultVariantKey } from 'common/utils/multivariate'
 

--- a/frontend/web/components/mv/VariantKey/index.ts
+++ b/frontend/web/components/mv/VariantKey/index.ts
@@ -1,0 +1,1 @@
+export { VariantKey } from './VariantKey'

--- a/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
+++ b/frontend/web/components/mv/VariationKeyLabel/VariationKeyLabel.tsx
@@ -4,6 +4,7 @@ import Button from 'components/base/forms/Button'
 import Icon from 'components/icons/Icon'
 import Input from 'components/base/forms/Input'
 import Utils from 'common/utils/utils'
+import { VariantKey } from 'components/mv/VariantKey'
 import { colorIconAction, colorIconSecondary } from 'common/theme/tokens'
 import './VariationKeyLabel.scss'
 
@@ -34,8 +35,6 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
   const [error, setError] = useState<string | null>(null)
 
   const canEdit = !readOnly && !disabled
-  // Fallback label when none is set — persisted on save by the provider.
-  const displayName = value || Utils.getDefaultVariantKey(index)
 
   // Validates the raw input — trimming here would hide a trailing
   // space from the user until their next keystroke.
@@ -146,12 +145,12 @@ export const VariationKeyLabel: FC<VariationKeyLabelProps> = ({
 
   return (
     <Row className='align-items-center'>
-      <span
+      <VariantKey
         className='h6 mb-0 font-weight-semibold'
+        value={value}
+        index={index}
         data-test={`featureVariationKey${index}`}
-      >
-        {displayName}
-      </span>
+      />
       {canEdit && (
         <Button
           theme='text'

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -5,6 +5,7 @@ import { VariationValueInput } from './VariationValueInput'
 import Utils from 'common/utils/utils'
 import { FlagsmithValue, MultivariateOption } from 'common/types/responses'
 import { UnmatchedOverride } from 'common/utils/multivariate'
+import { VariantKey } from './VariantKey'
 
 type VariationOverride = {
   id?: number
@@ -160,7 +161,7 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
           <div key={i} className='panel panel--flat panel-without-heading mb-2'>
             <div className='panel-content'>
               <ValueRowLabel>
-                {theValue.key || Utils.getDefaultVariantKey(i)}
+                <VariantKey value={theValue.key} index={i} />
               </ValueRowLabel>
               <Row>
                 <Flex>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follows @khvn26's suggestion on #8372, that variant keys read as prose when they are actually identifiers.

The premise holds: `MultivariateFeatureOption.key` is declared as *"A stable, human-readable identifier for the variant"*, is validated with `validate_slug`, and `util/mappers/engine.py:189` carries it into the environment document, so local evaluation SDKs match on it. Body type hides the differences that matter when someone transcribes one into code: `0` against `O`, `l` against `1`, a stray trailing character.

- New `VariantKey` component. Resolves `key` or its `Variant_n` fallback and sets it in mono. That fallback was duplicated at every call site.
- Used at the four surfaces that render a key: the identity override selector, the feature editor label, `VariationTable` and `RolloutSplitEditor`.
- `rollout.ts:93` builds a key into a plain label string for a chart legend, so it is untouched.

Uses Bootstrap's `.font-monospace`, which this build already generates: `3rdParty/_bootstrap.scss:12` imports `~bootstrap/scss/root` so `--bs-font-monospace` is defined, line 71 imports the utilities API, and the map-removals below it only touch `color`, `border-color` and `shadow`, so the `font-family` key survives.

### Deliberately not here

**A `--font-family-mono` token.** I built it first and backed it out. There are already two mono stacks in the tree, Bootstrap's `$font-family-monospace` and a hardcoded copy at `styles.scss:74`, and they differ over `SFMono-Regular`. A token copied from either would have been a third. Worth settling separately by pointing `$font-family-monospace` at one agreed stack, which is also the right moment to close the gap where `generate-tokens.mjs` emits utilities for colour, `radius` and `shadow` but not `font-weight`, `duration` or `easing`.

**The rollout summary legend.** `RolloutSummary.tsx:69` renders a variant key too, from `rollout.ts:93`. It is not a JSX swap like the other four: `RolloutSummaryRow` is `{ label, percentage }` with no way to mark a label as a key, the legend mixes keys with a prose `Control` entry, and the label doubles as the React key and as `barSegments[].key`. Covering it means changing that type and threading it through `getTrafficSegments`, which is shared chart plumbing and reviews differently to this.

**Copyable.** It adds a new interaction in four places, with an icon, a tooltip and a copied state, and @khvn26 parked it as not important for the immediate fix. Cheaper to add to this one component later than to four call sites now.

## How did you test this code?

Manually, across all four surfaces: the Edit User Feature modal for a multivariate flag, the feature editor's variant labels, and the two experiments views. Variants with no `key` set still fall back to `Variant_n`.

`npx tsc --noEmit` reports only errors already on `main`. `eslint --fix` reports nothing.
