### PR TITLE
feat: cohort segment detail view with CSV re-synchronisation

### DIFF
--- a/api/cohorts/migrations/0004_cohort_last_synced_at.py
+++ b/api/cohorts/migrations/0004_cohort_last_synced_at.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cohorts", "0003_cohort_sync_key"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="cohort",
+            name="last_synced_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/api/cohorts/migrations/0005_cohort_last_synced_at.py
+++ b/api/cohorts/migrations/0005_cohort_last_synced_at.py
@@ -3,7 +3,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("cohorts", "0003_cohort_sync_key"),
+        ("cohorts", "0004_mixpanel_source"),
     ]
 
     operations = [

--- a/api/cohorts/models.py
+++ b/api/cohorts/models.py
@@ -36,6 +36,7 @@ class Cohort(SoftDeleteExportableModel):
     external_id = models.CharField(max_length=255, null=True, blank=True)
     version = models.PositiveIntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
+    last_synced_at = models.DateTimeField(null=True, blank=True)
     # Deletion drains memberships from the identity store first; the cohort is
     # only soft-deleted once drained. This marks it as awaiting that final step.
     deletion_requested_at = models.DateTimeField(null=True, blank=True)

--- a/api/cohorts/serializers.py
+++ b/api/cohorts/serializers.py
@@ -60,7 +60,14 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
 
     @extend_schema_field(CohortMembershipCountsSerializer)
     def get_membership_counts(self, cohort: Cohort) -> dict[str, int]:
-        # Clients derive sync status and progress from these.
+        # Clients derive sync status and progress from these. The viewset
+        # annotates the counts; a freshly created cohort isn't annotated.
+        if (applied := getattr(cohort, "applied_count", None)) is not None:
+            return {
+                "applied": applied,
+                "pending_add": getattr(cohort, "pending_add_count", 0),
+                "pending_remove": getattr(cohort, "pending_remove_count", 0),
+            }
         return cohort.memberships.aggregate(
             applied=Count("id", filter=Q(state=CohortMembershipState.APPLIED)),
             pending_add=Count("id", filter=Q(state=CohortMembershipState.PENDING_ADD)),
@@ -71,6 +78,14 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
 
     def validate(self, attrs: dict[str, typing.Any]) -> dict[str, typing.Any]:
         attrs = super().validate(attrs)
+        if self.instance is not None:
+            # Metadata is create-only; accepting it silently would misreport
+            # the PATCH as applied.
+            if "metadata" in attrs:
+                raise serializers.ValidationError(
+                    {"metadata": "Metadata cannot be updated."}
+                )
+            return attrs
         environment = Environment.objects.get(
             api_key=self.context["view"].kwargs["environment_api_key"]
         )
@@ -94,7 +109,6 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
 
     def update(self, instance: Cohort, validated_data: dict[str, typing.Any]) -> Cohort:
         # Only the managed segment's fields are updatable.
-        validated_data.pop("metadata", None)
         segment_data = validated_data.pop("segment", {})
         if segment_data:
             segment = instance.segment

--- a/api/cohorts/serializers.py
+++ b/api/cohorts/serializers.py
@@ -63,9 +63,7 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
         # Clients derive sync status and progress from these.
         return cohort.memberships.aggregate(
             applied=Count("id", filter=Q(state=CohortMembershipState.APPLIED)),
-            pending_add=Count(
-                "id", filter=Q(state=CohortMembershipState.PENDING_ADD)
-            ),
+            pending_add=Count("id", filter=Q(state=CohortMembershipState.PENDING_ADD)),
             pending_remove=Count(
                 "id", filter=Q(state=CohortMembershipState.PENDING_REMOVE)
             ),
@@ -94,9 +92,7 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
             _SegmentMetadataHandler()._update_metadata(cohort.segment, metadata_data)
         return cohort
 
-    def update(
-        self, instance: Cohort, validated_data: dict[str, typing.Any]
-    ) -> Cohort:
+    def update(self, instance: Cohort, validated_data: dict[str, typing.Any]) -> Cohort:
         # Only the managed segment's fields are updatable.
         validated_data.pop("metadata", None)
         segment_data = validated_data.pop("segment", {})

--- a/api/cohorts/serializers.py
+++ b/api/cohorts/serializers.py
@@ -78,13 +78,9 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
 
     def validate(self, attrs: dict[str, typing.Any]) -> dict[str, typing.Any]:
         attrs = super().validate(attrs)
-        if self.instance is not None:
-            # Metadata is create-only; accepting it silently would misreport
-            # the PATCH as applied.
-            if "metadata" in attrs:
-                raise serializers.ValidationError(
-                    {"metadata": "Metadata cannot be updated."}
-                )
+        if self.instance is not None and "metadata" not in attrs:
+            # A partial update without metadata must not fail the
+            # required-metadata check.
             return attrs
         environment = Environment.objects.get(
             api_key=self.context["view"].kwargs["environment_api_key"]
@@ -109,12 +105,15 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
 
     def update(self, instance: Cohort, validated_data: dict[str, typing.Any]) -> Cohort:
         # Only the managed segment's fields are updatable.
+        metadata_data = validated_data.pop("metadata", None)
         segment_data = validated_data.pop("segment", {})
         if segment_data:
             segment = instance.segment
             for field, value in segment_data.items():
                 setattr(segment, field, value)
             segment.save(update_fields=list(segment_data))
+        if metadata_data is not None:
+            _SegmentMetadataHandler()._update_metadata(instance.segment, metadata_data)
         return instance
 
 

--- a/api/cohorts/serializers.py
+++ b/api/cohorts/serializers.py
@@ -1,11 +1,13 @@
 import typing
 
 from django.core.files.uploadedfile import UploadedFile
+from django.db.models import Count, Q
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from cohorts.constants import COHORT_CSV_MAX_FILE_SIZE_BYTES
 from cohorts.exceptions import CsvFileTooLargeError
-from cohorts.models import Cohort, CohortSyncKey
+from cohorts.models import Cohort, CohortMembershipState, CohortSyncKey
 from cohorts.services import create_cohort
 from environments.models import Environment
 from metadata.serializers import MetadataSerializer, MetadataSerializerMixin
@@ -19,12 +21,19 @@ class _SegmentMetadataHandler(MetadataSerializerMixin):
         model = Segment
 
 
+class CohortMembershipCountsSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    applied = serializers.IntegerField(min_value=0)
+    pending_add = serializers.IntegerField(min_value=0)
+    pending_remove = serializers.IntegerField(min_value=0)
+
+
 class CohortSerializer(serializers.ModelSerializer[Cohort]):
     name = serializers.CharField(max_length=2000, source="segment.name")
     description = serializers.CharField(
         source="segment.description", required=False, allow_null=True
     )
     metadata = MetadataSerializer(required=False, many=True, write_only=True)
+    membership_counts = serializers.SerializerMethodField()
 
     class Meta:
         model = Cohort
@@ -38,8 +47,29 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
             "source_type",
             "version",
             "created_at",
+            "last_synced_at",
+            "membership_counts",
         )
-        read_only_fields = ("segment", "source_type", "version", "created_at")
+        read_only_fields = (
+            "segment",
+            "source_type",
+            "version",
+            "created_at",
+            "last_synced_at",
+        )
+
+    @extend_schema_field(CohortMembershipCountsSerializer)
+    def get_membership_counts(self, cohort: Cohort) -> dict[str, int]:
+        # Clients derive sync status and progress from these.
+        return cohort.memberships.aggregate(
+            applied=Count("id", filter=Q(state=CohortMembershipState.APPLIED)),
+            pending_add=Count(
+                "id", filter=Q(state=CohortMembershipState.PENDING_ADD)
+            ),
+            pending_remove=Count(
+                "id", filter=Q(state=CohortMembershipState.PENDING_REMOVE)
+            ),
+        )
 
     def validate(self, attrs: dict[str, typing.Any]) -> dict[str, typing.Any]:
         attrs = super().validate(attrs)
@@ -63,6 +93,19 @@ class CohortSerializer(serializers.ModelSerializer[Cohort]):
         if metadata_data:
             _SegmentMetadataHandler()._update_metadata(cohort.segment, metadata_data)
         return cohort
+
+    def update(
+        self, instance: Cohort, validated_data: dict[str, typing.Any]
+    ) -> Cohort:
+        # Only the managed segment's fields are updatable.
+        validated_data.pop("metadata", None)
+        segment_data = validated_data.pop("segment", {})
+        if segment_data:
+            segment = instance.segment
+            for field, value in segment_data.items():
+                setattr(segment, field, value)
+            segment.save(update_fields=list(segment_data))
+        return instance
 
 
 class CohortSyncKeySerializer(serializers.ModelSerializer[CohortSyncKey]):

--- a/api/cohorts/services.py
+++ b/api/cohorts/services.py
@@ -404,8 +404,10 @@ def sync_cohort_memberships_from_csv(
             state=CohortMembershipState.PENDING_REMOVE, updated_at=timezone.now()
         )
 
-    Cohort.objects.filter(id=cohort.id).update(version=F("version") + 1)
-    cohort.refresh_from_db(fields=["version"])
+    Cohort.objects.filter(id=cohort.id).update(
+        version=F("version") + 1, last_synced_at=timezone.now()
+    )
+    cohort.refresh_from_db(fields=["version", "last_synced_at"])
     apply_cohort_membership_deltas.delay(kwargs={"cohort_id": cohort.id})
 
     flagsmith_cohorts_csv_syncs_total.inc()

--- a/api/cohorts/views.py
+++ b/api/cohorts/views.py
@@ -30,7 +30,9 @@ from users.models import FFAdminUser
     ),
     retrieve=extend_schema(description="Retrieve a cohort."),
     partial_update=extend_schema(
-        description="Update the cohort's managed segment name and description."
+        description=(
+            "Update the cohort's managed segment name, description and metadata."
+        )
     ),
     destroy=extend_schema(
         description=(

--- a/api/cohorts/views.py
+++ b/api/cohorts/views.py
@@ -1,4 +1,4 @@
-from django.db.models import QuerySet
+from django.db.models import Count, Q, QuerySet
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
@@ -10,7 +10,7 @@ from rest_framework.serializers import BaseSerializer
 
 from api.serializers import ErrorSerializer
 from cohorts import services
-from cohorts.models import Cohort, CohortSyncKey
+from cohorts.models import Cohort, CohortMembershipState, CohortSyncKey
 from cohorts.permissions import CohortPermission, CohortPlanPermission
 from cohorts.serializers import (
     CohortCsvSyncResultSerializer,
@@ -65,6 +65,20 @@ class CohortViewSet(
             .get_queryset()
             .filter(deletion_requested_at__isnull=True)
             .select_related("segment")
+            .annotate(
+                applied_count=Count(
+                    "memberships",
+                    filter=Q(memberships__state=CohortMembershipState.APPLIED),
+                ),
+                pending_add_count=Count(
+                    "memberships",
+                    filter=Q(memberships__state=CohortMembershipState.PENDING_ADD),
+                ),
+                pending_remove_count=Count(
+                    "memberships",
+                    filter=Q(memberships__state=CohortMembershipState.PENDING_REMOVE),
+                ),
+            )
             .order_by("id")
         )
 

--- a/api/cohorts/views.py
+++ b/api/cohorts/views.py
@@ -29,6 +29,9 @@ from users.models import FFAdminUser
         description="Create a cohort and the managed segment that targets it."
     ),
     retrieve=extend_schema(description="Retrieve a cohort."),
+    partial_update=extend_schema(
+        description="Update the cohort's managed segment name and description."
+    ),
     destroy=extend_schema(
         description=(
             "Request cohort deletion. Memberships are drained from identity "
@@ -42,6 +45,7 @@ class CohortViewSet(
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
     mixins.DestroyModelMixin,
 ):
     serializer_class = CohortSerializer
@@ -50,6 +54,8 @@ class CohortViewSet(
     model_class = Cohort
     lookup_field = "id"
     lookup_url_kwarg = "cohort_id"
+    # PATCH only: a cohort has no meaningful full replacement.
+    http_method_names = ["get", "post", "patch", "delete", "head", "options"]
 
     def get_queryset(self) -> QuerySet[Cohort]:
         # A cohort awaiting drain-then-delete is already gone from the

--- a/api/tests/unit/cohorts/test_views.py
+++ b/api/tests/unit/cohorts/test_views.py
@@ -166,6 +166,105 @@ def test_list_cohorts__deletion_requested_cohort__excluded(
     assert response.json()[0]["name"] == edge_cohort.segment.name
 
 
+def test_retrieve_cohort__mixed_membership_states__returns_membership_counts(
+    staff_client: APIClient,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    with_environment_permissions(  # type: ignore[call-arg]
+        [VIEW_ENVIRONMENT], environment_id=edge_cohort.environment_id
+    )
+    memberships = {
+        "applied-1": CohortMembershipState.APPLIED,
+        "applied-2": CohortMembershipState.APPLIED,
+        "pending-add-1": CohortMembershipState.PENDING_ADD,
+        "pending-remove-1": CohortMembershipState.PENDING_REMOVE,
+    }
+    CohortMembership.objects.bulk_create(
+        CohortMembership(cohort=edge_cohort, identifier=identifier, state=state)
+        for identifier, state in memberships.items()
+    )
+    url = reverse(
+        "api-v1:environments:cohorts:cohorts-detail",
+        args=[edge_cohort.environment.api_key, edge_cohort.id],
+    )
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["membership_counts"] == {
+        "applied": 2,
+        "pending_add": 1,
+        "pending_remove": 1,
+    }
+    assert response.json()["last_synced_at"] is None
+
+
+def test_update_cohort__staff_with_manage_segments__updates_segment_fields(
+    staff_client: APIClient,
+    dynamo_enabled_project: Project,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_project_permissions: WithProjectPermissionsCallable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions(  # type: ignore[call-arg]
+        [MANAGE_SEGMENTS], project_id=dynamo_enabled_project.id
+    )
+    with_environment_permissions(  # type: ignore[call-arg]
+        [VIEW_ENVIRONMENT, MANAGE_SEGMENT_OVERRIDES],
+        environment_id=edge_cohort.environment_id,
+    )
+    url = reverse(
+        "api-v1:environments:cohorts:cohorts-detail",
+        args=[edge_cohort.environment.api_key, edge_cohort.id],
+    )
+
+    # When
+    response = staff_client.patch(
+        url,
+        data={"name": "renamed", "description": "Updated description"},
+        format="json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    edge_cohort.segment.refresh_from_db()
+    assert edge_cohort.segment.name == "renamed"
+    assert edge_cohort.segment.description == "Updated description"
+    assert response.json()["name"] == "renamed"
+    assert response.json()["description"] == "Updated description"
+
+
+def test_update_cohort__staff_without_permission__returns_403(
+    staff_client: APIClient,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    with_environment_permissions(  # type: ignore[call-arg]
+        [VIEW_ENVIRONMENT], environment_id=edge_cohort.environment_id
+    )
+    url = reverse(
+        "api-v1:environments:cohorts:cohorts-detail",
+        args=[edge_cohort.environment.api_key, edge_cohort.id],
+    )
+
+    # When
+    response = staff_client.patch(url, data={"name": "renamed"}, format="json")
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    edge_cohort.segment.refresh_from_db()
+    assert edge_cohort.segment.name != "renamed"
+
+
 def test_delete_cohort__staff_with_manage_segments__returns_202(
     staff_client: APIClient,
     dynamo_enabled_project: Project,
@@ -501,6 +600,7 @@ def test_sync_csv__staff_with_manage_segments__returns_202_with_counts(
     assert all(m.state == CohortMembershipState.APPLIED for m in memberships)
     edge_cohort.refresh_from_db()
     assert edge_cohort.version == 1
+    assert edge_cohort.last_synced_at is not None
 
 
 def test_sync_csv__without_permission__returns_403(

--- a/api/tests/unit/cohorts/test_views.py
+++ b/api/tests/unit/cohorts/test_views.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 from common.environments.permissions import (
     MANAGE_SEGMENT_OVERRIDES,
@@ -27,6 +29,9 @@ from tests.types import (
     WithEnvironmentPermissionsCallable,
     WithProjectPermissionsCallable,
 )
+
+if typing.TYPE_CHECKING:
+    from pytest_django.fixtures import DjangoAssertNumQueries
 
 
 def test_create_cohort__staff_with_manage_segments__returns_201(
@@ -166,6 +171,48 @@ def test_list_cohorts__deletion_requested_cohort__excluded(
     assert response.json()[0]["name"] == edge_cohort.segment.name
 
 
+def test_list_cohorts__multiple_cohorts__membership_counts_in_constant_queries(
+    staff_client: APIClient,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+    django_assert_num_queries: "DjangoAssertNumQueries",
+) -> None:
+    # Given
+    environment = edge_cohort.environment
+    with_environment_permissions(  # type: ignore[call-arg]
+        [VIEW_ENVIRONMENT], environment_id=environment.id
+    )
+    CohortMembership.objects.create(
+        cohort=edge_cohort, identifier="applied-1", state=CohortMembershipState.APPLIED
+    )
+    other_cohort = Cohort.objects.create(
+        environment=environment,
+        segment=Segment.objects.create(name="other", project=environment.project),
+    )
+    CohortMembership.objects.bulk_create(
+        CohortMembership(cohort=other_cohort, identifier=identifier, state=state)
+        for identifier, state in {
+            "pending-add-1": CohortMembershipState.PENDING_ADD,
+            "pending-remove-1": CohortMembershipState.PENDING_REMOVE,
+        }.items()
+    )
+    url = reverse(
+        "api-v1:environments:cohorts:cohorts-list", args=[environment.api_key]
+    )
+
+    # When
+    with django_assert_num_queries(10):
+        response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert [row["membership_counts"] for row in response.json()] == [
+        {"applied": 1, "pending_add": 0, "pending_remove": 0},
+        {"applied": 0, "pending_add": 1, "pending_remove": 1},
+    ]
+
+
 def test_retrieve_cohort__mixed_membership_states__returns_membership_counts(
     staff_client: APIClient,
     edge_cohort: Cohort,
@@ -239,6 +286,39 @@ def test_update_cohort__staff_with_manage_segments__updates_segment_fields(
     assert edge_cohort.segment.description == "Updated description"
     assert response.json()["name"] == "renamed"
     assert response.json()["description"] == "Updated description"
+
+
+def test_update_cohort__metadata_supplied__returns_400(
+    staff_client: APIClient,
+    dynamo_enabled_project: Project,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_project_permissions: WithProjectPermissionsCallable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions(  # type: ignore[call-arg]
+        [MANAGE_SEGMENTS], project_id=dynamo_enabled_project.id
+    )
+    with_environment_permissions(  # type: ignore[call-arg]
+        [VIEW_ENVIRONMENT, MANAGE_SEGMENT_OVERRIDES],
+        environment_id=edge_cohort.environment_id,
+    )
+    url = reverse(
+        "api-v1:environments:cohorts:cohorts-detail",
+        args=[edge_cohort.environment.api_key, edge_cohort.id],
+    )
+
+    # When
+    response = staff_client.patch(
+        url, data={"name": "renamed", "metadata": []}, format="json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"metadata": ["Metadata cannot be updated."]}
+    edge_cohort.segment.refresh_from_db()
+    assert edge_cohort.segment.name != "renamed"
 
 
 def test_update_cohort__staff_without_permission__returns_403(

--- a/api/tests/unit/cohorts/test_views.py
+++ b/api/tests/unit/cohorts/test_views.py
@@ -6,6 +6,7 @@ from common.environments.permissions import (
     VIEW_ENVIRONMENT,
 )
 from common.projects.permissions import MANAGE_SEGMENTS
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils import timezone
@@ -171,12 +172,12 @@ def test_list_cohorts__deletion_requested_cohort__excluded(
     assert response.json()[0]["name"] == edge_cohort.segment.name
 
 
-def test_list_cohorts__multiple_cohorts__membership_counts_in_constant_queries(
+def _assert_list_cohorts_membership_counts_in_constant_queries(
     staff_client: APIClient,
     edge_cohort: Cohort,
-    dynamodb_identity_wrapper: DynamoIdentityWrapper,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     django_assert_num_queries: "DjangoAssertNumQueries",
+    num_queries: int,
 ) -> None:
     # Given
     environment = edge_cohort.environment
@@ -202,7 +203,7 @@ def test_list_cohorts__multiple_cohorts__membership_counts_in_constant_queries(
     )
 
     # When
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(num_queries):
         response = staff_client.get(url)
 
     # Then
@@ -211,6 +212,51 @@ def test_list_cohorts__multiple_cohorts__membership_counts_in_constant_queries(
         {"applied": 1, "pending_add": 0, "pending_remove": 0},
         {"applied": 0, "pending_add": 1, "pending_remove": 1},
     ]
+
+
+@pytest.mark.skipif(
+    settings.IS_RBAC_INSTALLED is True,
+    reason="Skip this test if RBAC is installed",
+)
+def test_list_cohorts__multiple_cohorts_without_rbac__membership_counts_in_constant_queries(
+    staff_client: APIClient,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+    django_assert_num_queries: "DjangoAssertNumQueries",
+) -> None:
+    # Given / When
+    # Then
+    _assert_list_cohorts_membership_counts_in_constant_queries(
+        staff_client,
+        edge_cohort,
+        with_environment_permissions,
+        django_assert_num_queries,
+        num_queries=10,
+    )
+
+
+@pytest.mark.skipif(
+    settings.IS_RBAC_INSTALLED is False,
+    reason="Skip this test if RBAC is not installed",
+)
+def test_list_cohorts__multiple_cohorts_with_rbac__membership_counts_in_constant_queries(
+    staff_client: APIClient,
+    edge_cohort: Cohort,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+    django_assert_num_queries: "DjangoAssertNumQueries",
+) -> None:  # pragma: no cover
+    # Given / When
+    # Then
+    # RBAC's runtime role checks add two permission queries.
+    _assert_list_cohorts_membership_counts_in_constant_queries(
+        staff_client,
+        edge_cohort,
+        with_environment_permissions,
+        django_assert_num_queries,
+        num_queries=12,
+    )
 
 
 def test_retrieve_cohort__mixed_membership_states__returns_membership_counts(

--- a/api/tests/unit/cohorts/test_views.py
+++ b/api/tests/unit/cohorts/test_views.py
@@ -288,11 +288,12 @@ def test_update_cohort__staff_with_manage_segments__updates_segment_fields(
     assert response.json()["description"] == "Updated description"
 
 
-def test_update_cohort__metadata_supplied__returns_400(
+def test_update_cohort__metadata_supplied__updates_segment_metadata(
     staff_client: APIClient,
     dynamo_enabled_project: Project,
     edge_cohort: Cohort,
     dynamodb_identity_wrapper: DynamoIdentityWrapper,
+    required_segment_metadata_field_for_dynamo_project: MetadataModelField,
     with_project_permissions: WithProjectPermissionsCallable,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
@@ -311,14 +312,25 @@ def test_update_cohort__metadata_supplied__returns_400(
 
     # When
     response = staff_client.patch(
-        url, data={"name": "renamed", "metadata": []}, format="json"
+        url,
+        data={
+            "metadata": [
+                {
+                    "model_field": required_segment_metadata_field_for_dynamo_project.id,
+                    "field_value": 10,
+                },
+            ],
+        },
+        format="json",
     )
 
     # Then
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {"metadata": ["Metadata cannot be updated."]}
-    edge_cohort.segment.refresh_from_db()
-    assert edge_cohort.segment.name != "renamed"
+    assert response.status_code == status.HTTP_200_OK
+    metadata = Metadata.objects.get(
+        model_field=required_segment_metadata_field_for_dynamo_project
+    )
+    assert metadata.object_id == edge_cohort.segment_id
+    assert metadata.field_value == "10"
 
 
 def test_update_cohort__staff_without_permission__returns_403(

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -86,7 +86,7 @@ Attributes:
 ### `cohorts.cohort.deleted`
 
 Logged at `info` from:
- - `api/cohorts/services.py:457`
+ - `api/cohorts/services.py:459`
 
 Attributes:
  - `cohort.id`
@@ -95,7 +95,7 @@ Attributes:
 ### `cohorts.cohort.deletion_requested`
 
 Logged at `info` from:
- - `api/cohorts/services.py:441`
+ - `api/cohorts/services.py:443`
 
 Attributes:
  - `cohort.id`
@@ -104,7 +104,7 @@ Attributes:
 ### `cohorts.csv.synced`
 
 Logged at `info` from:
- - `api/cohorts/services.py:413`
+ - `api/cohorts/services.py:415`
 
 Attributes:
  - `adds.count`

--- a/frontend/common/services/useCohort.ts
+++ b/frontend/common/services/useCohort.ts
@@ -67,13 +67,16 @@ export const cohortService = service
           { id: arg.segmentId, type: 'Segment' },
           { id: `LIST${arg.projectId}`, type: 'Segment' },
         ],
-        query: (query) => ({
-          body: {
-            description: query.description,
-            name: query.name,
-          },
+        query: ({
+          cohortId,
+          environmentApiKey,
+          projectId: _projectId,
+          segmentId: _segmentId,
+          ...body
+        }) => ({
+          body,
           method: 'PATCH',
-          url: `environments/${query.environmentApiKey}/cohorts/${query.cohortId}/`,
+          url: `environments/${environmentApiKey}/cohorts/${cohortId}/`,
         }),
       }),
       // END OF ENDPOINTS

--- a/frontend/common/services/useCohort.ts
+++ b/frontend/common/services/useCohort.ts
@@ -32,6 +32,12 @@ export const cohortService = service
           url: `environments/${query.environmentApiKey}/cohorts/${query.cohortId}/`,
         }),
       }),
+      getCohort: builder.query<Res['cohort'], Req['getCohort']>({
+        providesTags: (res, e, arg) => [{ id: arg.cohortId, type: 'Cohort' }],
+        query: (query) => ({
+          url: `environments/${query.environmentApiKey}/cohorts/${query.cohortId}/`,
+        }),
+      }),
       syncCohortCsv: builder.mutation<
         Res['cohortCsvSync'],
         Req['syncCohortCsv']
@@ -55,6 +61,21 @@ export const cohortService = service
           }
         },
       }),
+      updateCohort: builder.mutation<Res['cohort'], Req['updateCohort']>({
+        invalidatesTags: (q, e, arg) => [
+          { id: arg.cohortId, type: 'Cohort' },
+          { id: arg.segmentId, type: 'Segment' },
+          { id: `LIST${arg.projectId}`, type: 'Segment' },
+        ],
+        query: (query) => ({
+          body: {
+            description: query.description,
+            name: query.name,
+          },
+          method: 'PATCH',
+          url: `environments/${query.environmentApiKey}/cohorts/${query.cohortId}/`,
+        }),
+      }),
       // END OF ENDPOINTS
     }),
   })
@@ -72,7 +93,9 @@ export async function deleteCohort(
 export const {
   useCreateCohortMutation,
   useDeleteCohortMutation,
+  useGetCohortQuery,
   useSyncCohortCsvMutation,
+  useUpdateCohortMutation,
   // END OF EXPORTS
 } = cohortService
 

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -186,6 +186,18 @@ export type Req = {
     cohortId: number
     projectId: number
   }
+  getCohort: {
+    environmentApiKey: string
+    cohortId: number
+  }
+  updateCohort: {
+    environmentApiKey: string
+    cohortId: number
+    projectId: number
+    segmentId: number
+    name?: string
+    description?: string
+  }
   syncCohortCsv: {
     environmentApiKey: string
     cohortId: number

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -197,6 +197,7 @@ export type Req = {
     segmentId: number
     name?: string
     description?: string
+    metadata?: Metadata[]
   }
   syncCohortCsv: {
     environmentApiKey: string

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -179,7 +179,7 @@ export type SegmentCohort = {
   environment: number
   environment_api_key: string
   environment_name: string
-  source_type: 'csv'
+  source_type: 'csv' | 'amplitude'
   version: number
   deletion_requested_at: string | null
 }
@@ -1016,15 +1016,23 @@ export type Metadata = {
   field_value: string
 }
 
+export type CohortMembershipCounts = {
+  applied: number
+  pending_add: number
+  pending_remove: number
+}
+
 export type Cohort = {
   id: number
   uuid: string
   name: string
   description: string | null
   segment: number
-  source_type: 'csv'
+  source_type: 'csv' | 'amplitude'
   version: number
   created_at: string
+  last_synced_at: string | null
+  membership_counts: CohortMembershipCounts
 }
 
 export type CohortCsvSyncResult = {

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -174,12 +174,14 @@ export type SegmentMembersResponse = PagedResponse<SegmentMember> & {
   // Pass as `cursor` to fetch the next page; null when there are no more rows.
   next_cursor: string | null
 }
+export type CohortSourceType = 'csv' | 'amplitude' | 'mixpanel'
+
 export type SegmentCohort = {
   id: number
   environment: number
   environment_api_key: string
   environment_name: string
-  source_type: 'csv' | 'amplitude'
+  source_type: CohortSourceType
   version: number
   deletion_requested_at: string | null
 }
@@ -1028,7 +1030,7 @@ export type Cohort = {
   name: string
   description: string | null
   segment: number
-  source_type: 'csv' | 'amplitude'
+  source_type: CohortSourceType
   version: number
   created_at: string
   last_synced_at: string | null

--- a/frontend/common/utils/csv.ts
+++ b/frontend/common/utils/csv.ts
@@ -14,6 +14,9 @@ export type ExtractedIdentifiers = {
 // DynamoDB sort keys, capped at 1024 bytes).
 export const MAX_IDENTIFIER_BYTES = 1024
 
+// Mirrors the API's COHORT_CSV_MAX_FILE_SIZE_BYTES.
+export const MAX_CSV_FILE_SIZE_BYTES = 10 * 1024 * 1024
+
 export function parseCsvText(text: string): string[][] {
   const rows: string[][] = []
   let row: string[] = []

--- a/frontend/web/components/CsvPreview/CsvPreview.scss
+++ b/frontend/web/components/CsvPreview/CsvPreview.scss
@@ -18,17 +18,9 @@
       white-space: nowrap;
     }
 
-    thead th {
-      background: var(--color-surface-muted);
-    }
-
     tbody tr {
       border-top: 1px solid var(--color-border-default);
       color: var(--color-text-secondary);
-    }
-
-    .csv-preview__cell--selected {
-      background: var(--color-surface-action-tint);
     }
   }
 }

--- a/frontend/web/components/CsvPreview/CsvPreview.scss
+++ b/frontend/web/components/CsvPreview/CsvPreview.scss
@@ -1,0 +1,34 @@
+.csv-preview {
+  &__section-label {
+    font-size: 12px;
+    letter-spacing: 0.05em;
+  }
+
+  &__table {
+    border: 1px solid var(--color-border-default);
+
+    table {
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 12px 16px;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    thead th {
+      background: var(--color-surface-muted);
+    }
+
+    tbody tr {
+      border-top: 1px solid var(--color-border-default);
+      color: var(--color-text-secondary);
+    }
+
+    .csv-preview__cell--selected {
+      background: var(--color-surface-action-tint);
+    }
+  }
+}

--- a/frontend/web/components/CsvPreview/CsvPreview.tsx
+++ b/frontend/web/components/CsvPreview/CsvPreview.tsx
@@ -28,9 +28,12 @@ const CsvPreview: FC<CsvPreviewType> = ({
             {columns.map((column, i) => (
               <th
                 key={i}
-                className={classNames('fw-semibold', {
-                  'csv-preview__cell--selected': i === selectedColumn,
-                })}
+                className={classNames(
+                  'fw-semibold',
+                  i === selectedColumn
+                    ? 'bg-surface-action-tint'
+                    : 'bg-surface-muted',
+                )}
               >
                 {column}
               </th>
@@ -44,7 +47,7 @@ const CsvPreview: FC<CsvPreviewType> = ({
                 <td
                   key={j}
                   className={classNames({
-                    'csv-preview__cell--selected': j === selectedColumn,
+                    'bg-surface-action-tint': j === selectedColumn,
                   })}
                 >
                   {row[j]}

--- a/frontend/web/components/CsvPreview/CsvPreview.tsx
+++ b/frontend/web/components/CsvPreview/CsvPreview.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react'
+import classNames from 'classnames'
+import './CsvPreview.scss'
+
+const DEFAULT_ROW_COUNT = 5
+
+export type CsvPreviewType = {
+  columns: string[]
+  rows: string[][]
+  selectedColumn: number | null
+  rowCount?: number
+}
+
+const CsvPreview: FC<CsvPreviewType> = ({
+  columns,
+  rowCount = DEFAULT_ROW_COUNT,
+  rows,
+  selectedColumn,
+}) => (
+  <div>
+    <div className='csv-preview__section-label fw-semibold text-secondary text-uppercase mb-2'>
+      Preview (first {rowCount} rows)
+    </div>
+    <div className='csv-preview__table rounded-lg overflow-auto'>
+      <table className='mb-0 w-100 fs-small'>
+        <thead>
+          <tr>
+            {columns.map((column, i) => (
+              <th
+                key={i}
+                className={classNames('fw-semibold', {
+                  'csv-preview__cell--selected': i === selectedColumn,
+                })}
+              >
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, rowCount).map((row, i) => (
+            <tr key={i}>
+              {columns.map((_, j) => (
+                <td
+                  key={j}
+                  className={classNames({
+                    'csv-preview__cell--selected': j === selectedColumn,
+                  })}
+                >
+                  {row[j]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+)
+
+export default CsvPreview

--- a/frontend/web/components/CsvPreview/index.ts
+++ b/frontend/web/components/CsvPreview/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CsvPreview'

--- a/frontend/web/components/CsvUpload/CsvUpload.scss
+++ b/frontend/web/components/CsvUpload/CsvUpload.scss
@@ -2,6 +2,11 @@
   &__droparea {
     padding: 32px;
     border: 1px dashed var(--color-border-action);
+
+    &--disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
   }
 
   &__file-card {

--- a/frontend/web/components/CsvUpload/CsvUpload.scss
+++ b/frontend/web/components/CsvUpload/CsvUpload.scss
@@ -2,11 +2,6 @@
   &__droparea {
     padding: 32px;
     border: 1px dashed var(--color-border-action);
-
-    &--disabled {
-      opacity: 0.5;
-      pointer-events: none;
-    }
   }
 
   &__file-card {

--- a/frontend/web/components/CsvUpload/CsvUpload.tsx
+++ b/frontend/web/components/CsvUpload/CsvUpload.tsx
@@ -98,7 +98,7 @@ const CsvUpload: FC<CsvUploadType> = ({
             className={classNames(
               'csv-upload__droparea text-center rounded-lg',
               {
-                'csv-upload__droparea--disabled': disabled,
+                'opacity-50 pe-none': disabled,
               },
             )}
           >

--- a/frontend/web/components/CsvUpload/CsvUpload.tsx
+++ b/frontend/web/components/CsvUpload/CsvUpload.tsx
@@ -1,4 +1,5 @@
 import { FC, useCallback, useState } from 'react'
+import classNames from 'classnames'
 import { useDropzone } from 'react-dropzone'
 import { colorIconAction } from 'common/theme/tokens'
 import DropIcon from 'components/icons/DropIcon'
@@ -11,6 +12,7 @@ export type CsvUploadType = {
   value: File | null
   maxSizeBytes?: number
   rowCount?: number
+  disabled?: boolean
   onChange: (file: File, text: string) => void
 }
 
@@ -22,6 +24,7 @@ const formatFileSize = (bytes: number) => {
 }
 
 const CsvUpload: FC<CsvUploadType> = ({
+  disabled,
   maxSizeBytes,
   onChange,
   rowCount,
@@ -52,6 +55,7 @@ const CsvUpload: FC<CsvUploadType> = ({
     accept: {
       'text/csv': ['.csv'],
     },
+    disabled,
     maxSize: maxSizeBytes,
     multiple: false,
     noClick: true,
@@ -90,7 +94,14 @@ const CsvUpload: FC<CsvUploadType> = ({
             </Button>
           </div>
         ) : (
-          <div className='csv-upload__droparea text-center rounded-lg'>
+          <div
+            className={classNames(
+              'csv-upload__droparea text-center rounded-lg',
+              {
+                'csv-upload__droparea--disabled': disabled,
+              },
+            )}
+          >
             <DropIcon />
             <div className='mt-2 mb-2'>
               <strong>Drag and drop your CSV here</strong>
@@ -98,7 +109,9 @@ const CsvUpload: FC<CsvUploadType> = ({
             <div className='text-secondary fs-small mb-3'>
               or browse it from your computer
             </div>
-            <Button onClick={open}>Select file</Button>
+            <Button disabled={disabled} onClick={open}>
+              Select file
+            </Button>
           </div>
         )}
       </div>

--- a/frontend/web/components/SegmentSelect.tsx
+++ b/frontend/web/components/SegmentSelect.tsx
@@ -6,6 +6,7 @@ import { Req } from 'common/types/requests'
 import { components } from 'react-select'
 import Utils from 'common/utils/utils'
 import Button from './base/forms/Button'
+import Chip from './base/Chip'
 
 type SegmentSelectType = {
   disabled: boolean
@@ -31,12 +32,19 @@ const SegmentSelect: FC<SegmentSelectType> = ({
 
   let filteredResults: Res['segments']['results'] = []
   if (data) {
-    filteredResults = filter
-      ? (data.results.filter(filter) as Res['segments']['results'])
-      : data.results
+    // A cohort awaiting deletion is already gone from the user's point of view.
+    filteredResults = data.results.filter(
+      (segment) => !segment.cohort?.deletion_requested_at,
+    )
+    if (filter) {
+      filteredResults = filteredResults.filter(
+        filter,
+      ) as Res['segments']['results']
+    }
   }
   const options = filteredResults.map(
-    ({ feature, id: value, name: label }) => ({
+    ({ cohort, feature, id: value, name: label }) => ({
+      cohort,
       feature,
       label,
       value,
@@ -83,6 +91,11 @@ const SegmentSelect: FC<SegmentSelectType> = ({
             {children}
             {!!data.feature && (
               <div className='unread ml-2 px-2'>Feature-Specific</div>
+            )}
+            {!!data.cohort && (
+              <Chip className='ml-2' size='xs' variant='accent'>
+                {data.cohort.source_type.toUpperCase()}
+              </Chip>
             )}
           </div>
         ),

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -28,6 +28,7 @@ import {
 } from 'common/services/useSegment'
 import Utils from 'common/utils/utils'
 import AssociatedSegmentOverrides from 'components/segments/AssociatedSegmentOverrides'
+import CohortSegmentDetail from 'components/segments/CohortSegmentDetail'
 import { SegmentMembershipTotalBadge } from 'components/segments/SegmentMembershipBadge'
 import Button from 'components/base/forms/Button'
 import InfoMessage from 'components/InfoMessage'
@@ -648,7 +649,8 @@ const CreateSegment: FC<CreateSegmentType> = ({
             tabLabelString='Basic configuration'
             tabLabel={'Basic configuration'}
           >
-            <div className={className || 'my-3 mx-4'}>
+            {/* Horizontal padding comes from the surrounding tab-item. */}
+            <div className={className || 'my-3'}>
               <CreateSegmentRulesTabForm
                 save={save}
                 is4Eyes={is4Eyes}
@@ -684,7 +686,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
               <Row className='justify-content-center'>Custom Fields</Row>
             }
           >
-            <div className={className || 'my-3 mx-4'}>{MetadataTab}</div>
+            <div className={className || 'my-3'}>{MetadataTab}</div>
           </TabItem>
         </Tabs>
       )}
@@ -792,11 +794,22 @@ const LoadingCreateSegment: FC<LoadingCreateSegmentType> = (props) => {
       },
     )
 
-  return isLoading ? (
-    <div className='text-center'>
-      <Loader />
-    </div>
-  ) : (
+  if (isLoading) {
+    return (
+      <div className='text-center'>
+        <Loader />
+      </div>
+    )
+  }
+
+  // CSV cohort segments have no editable rules; show the sync detail view.
+  if (segmentData?.cohort?.source_type === 'csv') {
+    return (
+      <CohortSegmentDetail projectId={props.projectId} segment={segmentData} />
+    )
+  }
+
+  return (
     <CreateSegment
       {...props}
       segment={segmentData || undefined}

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -26,6 +26,7 @@ import {
   useGetSegmentsQuery,
   useUpdateSegmentMutation,
 } from 'common/services/useSegment'
+import { useUpdateCohortMutation } from 'common/services/useCohort'
 import Utils from 'common/utils/utils'
 import AssociatedSegmentOverrides from 'components/segments/AssociatedSegmentOverrides'
 import CohortSegmentDetail from 'components/segments/CohortSegmentDetail'
@@ -146,6 +147,8 @@ const CreateSegment: FC<CreateSegmentType> = ({
   const [segment, setSegment] = useState(_segment || defaultSegment)
   // A cohort owns its segment's rules, and the API rejects updating one.
   const isCohortManaged = !!_segment?.cohort
+  // CSV cohorts swap the rules form for the synchronisation detail view.
+  const isCsvCohort = _segment?.cohort?.source_type === 'csv'
   const isReadOnly = readOnly || isCohortManaged
   const readOnlyMessage = isCohortManaged
     ? 'This segment is managed by a cohort. Its rules follow the cohort membership and cannot be edited.'
@@ -193,6 +196,8 @@ const CreateSegment: FC<CreateSegmentType> = ({
     },
   ] = useUpdateSegmentMutation()
   const [createChangeRequest] = useCreateProjectChangeRequestMutation({})
+  const [updateCohort, { isLoading: isSavingCohortMetadata }] =
+    useUpdateCohortMutation()
   const isSaving = creating || updating
   const [showDescriptions, setShowDescriptions] = useState(false)
   const [tab, setTab] = useState(UserTabs.RULES)
@@ -300,6 +305,27 @@ const CreateSegment: FC<CreateSegmentType> = ({
 
   const [valueChanged, setValueChanged] = useState(false)
   const [metadataValueChanged, setMetadataValueChanged] = useState(false)
+
+  // A managed segment rejects direct updates; its metadata is saved through
+  // the cohort instead.
+  const saveCohortMetadata = async () => {
+    if (!_segment?.cohort) {
+      return
+    }
+    try {
+      await updateCohort({
+        cohortId: _segment.cohort.id,
+        environmentApiKey: _segment.cohort.environment_api_key,
+        metadata,
+        projectId: Number(projectId),
+        segmentId: _segment.id,
+      }).unwrap()
+      setMetadataValueChanged(false)
+      toast('Updated segment')
+    } catch (error: any) {
+      toast(error?.data?.metadata?.[0] || 'Error updating segment', 'danger')
+    }
+  }
   const onClosing = useCallback(() => {
     return new Promise<boolean>((resolve) => {
       if (valueChanged) {
@@ -549,6 +575,16 @@ const CreateSegment: FC<CreateSegmentType> = ({
           />
         }
       />
+      {isCsvCohort && metadataValueChanged && !readOnly && (
+        <div className='text-right'>
+          <Button
+            disabled={isSavingCohortMetadata}
+            onClick={saveCohortMetadata}
+          >
+            {isSavingCohortMetadata ? 'Saving...' : 'Save Changes'}
+          </Button>
+        </div>
+      )}
     </FormGroup>
   )
 
@@ -570,33 +606,42 @@ const CreateSegment: FC<CreateSegmentType> = ({
         >
           <TabItem tabLabel='General' isDirty={valueChanged}>
             <div className='my-4'>
-              <CreateSegmentRulesTabForm
-                is4Eyes={is4Eyes}
-                onCreateChangeRequest={onCreateChangeRequest}
-                save={save}
-                condensed={condensed}
-                segmentsLimitAlert={segmentsLimitAlert}
-                name={name}
-                setName={setName}
-                setValueChanged={setValueChanged}
-                description={description}
-                setDescription={setDescription}
-                identity={identity}
-                readOnly={isReadOnly}
-                readOnlyMessage={readOnlyMessage}
-                showDescriptions={showDescriptions}
-                setShowDescriptions={setShowDescriptions}
-                allWarnings={allWarnings}
-                rulesEl={rulesEl}
-                isEdit={isEdit}
-                segment={segment}
-                isSaving={isSaving}
-                isValid={isValid}
-                isLimitReached={isLimitReached}
-                onCancel={handleCancel}
-                topLevelRuleType={topLevelRuleType}
-                setTopLevelRuleType={setTopLevelRuleType}
-              />
+              {isCsvCohort && _segment ? (
+                <CohortSegmentDetail
+                  hideHeader
+                  projectId={projectId}
+                  segment={_segment}
+                  readOnly={readOnly}
+                />
+              ) : (
+                <CreateSegmentRulesTabForm
+                  is4Eyes={is4Eyes}
+                  onCreateChangeRequest={onCreateChangeRequest}
+                  save={save}
+                  condensed={condensed}
+                  segmentsLimitAlert={segmentsLimitAlert}
+                  name={name}
+                  setName={setName}
+                  setValueChanged={setValueChanged}
+                  description={description}
+                  setDescription={setDescription}
+                  identity={identity}
+                  readOnly={isReadOnly}
+                  readOnlyMessage={readOnlyMessage}
+                  showDescriptions={showDescriptions}
+                  setShowDescriptions={setShowDescriptions}
+                  allWarnings={allWarnings}
+                  rulesEl={rulesEl}
+                  isEdit={isEdit}
+                  segment={segment}
+                  isSaving={isSaving}
+                  isValid={isValid}
+                  isLimitReached={isLimitReached}
+                  onCancel={handleCancel}
+                  topLevelRuleType={topLevelRuleType}
+                  setTopLevelRuleType={setTopLevelRuleType}
+                />
+              )}
             </div>
           </TabItem>
           <TabItem tabLabel={segment.feature ? 'Feature' : 'Features'}>
@@ -651,10 +696,65 @@ const CreateSegment: FC<CreateSegmentType> = ({
           >
             {/* Horizontal padding comes from the surrounding tab-item. */}
             <div className={className || 'my-3'}>
+              {isCsvCohort && _segment ? (
+                <CohortSegmentDetail
+                  projectId={projectId}
+                  segment={_segment}
+                  readOnly={readOnly}
+                />
+              ) : (
+                <CreateSegmentRulesTabForm
+                  save={save}
+                  is4Eyes={is4Eyes}
+                  onCreateChangeRequest={onCreateChangeRequest}
+                  condensed={condensed}
+                  segmentsLimitAlert={segmentsLimitAlert}
+                  name={name}
+                  setName={setName}
+                  setValueChanged={setValueChanged}
+                  description={description}
+                  setDescription={setDescription}
+                  identity={identity}
+                  readOnly={isReadOnly}
+                  readOnlyMessage={readOnlyMessage}
+                  showDescriptions={showDescriptions}
+                  setShowDescriptions={setShowDescriptions}
+                  allWarnings={allWarnings}
+                  rulesEl={rulesEl}
+                  isEdit={isEdit}
+                  segment={segment}
+                  isSaving={isSaving}
+                  isValid={isValid}
+                  isLimitReached={isLimitReached}
+                  onCancel={handleCancel}
+                  topLevelRuleType={topLevelRuleType}
+                  setTopLevelRuleType={setTopLevelRuleType}
+                />
+              )}
+            </div>
+          </TabItem>
+          <TabItem
+            tabLabelString='Custom Fields'
+            tabLabel={
+              <Row className='justify-content-center'>Custom Fields</Row>
+            }
+          >
+            <div className={className || 'my-3'}>{MetadataTab}</div>
+          </TabItem>
+        </Tabs>
+      )}
+      {!(isEdit && !condensed) &&
+        !(metadataEnable && segmentContentType?.id) && (
+          <div className={className || 'my-3 mx-4'}>
+            {isCsvCohort && _segment ? (
+              <CohortSegmentDetail
+                projectId={projectId}
+                segment={_segment}
+                readOnly={readOnly}
+              />
+            ) : (
               <CreateSegmentRulesTabForm
                 save={save}
-                is4Eyes={is4Eyes}
-                onCreateChangeRequest={onCreateChangeRequest}
                 condensed={condensed}
                 segmentsLimitAlert={segmentsLimitAlert}
                 name={name}
@@ -678,46 +778,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 topLevelRuleType={topLevelRuleType}
                 setTopLevelRuleType={setTopLevelRuleType}
               />
-            </div>
-          </TabItem>
-          <TabItem
-            tabLabelString='Custom Fields'
-            tabLabel={
-              <Row className='justify-content-center'>Custom Fields</Row>
-            }
-          >
-            <div className={className || 'my-3'}>{MetadataTab}</div>
-          </TabItem>
-        </Tabs>
-      )}
-      {!(isEdit && !condensed) &&
-        !(metadataEnable && segmentContentType?.id) && (
-          <div className={className || 'my-3 mx-4'}>
-            <CreateSegmentRulesTabForm
-              save={save}
-              condensed={condensed}
-              segmentsLimitAlert={segmentsLimitAlert}
-              name={name}
-              setName={setName}
-              setValueChanged={setValueChanged}
-              description={description}
-              setDescription={setDescription}
-              identity={identity}
-              readOnly={isReadOnly}
-              readOnlyMessage={readOnlyMessage}
-              showDescriptions={showDescriptions}
-              setShowDescriptions={setShowDescriptions}
-              allWarnings={allWarnings}
-              rulesEl={rulesEl}
-              isEdit={isEdit}
-              segment={segment}
-              isSaving={isSaving}
-              isValid={isValid}
-              isLimitReached={isLimitReached}
-              onCancel={handleCancel}
-              topLevelRuleType={topLevelRuleType}
-              setTopLevelRuleType={setTopLevelRuleType}
-            />
+            )}
           </div>
         )}
     </>
@@ -799,17 +860,6 @@ const LoadingCreateSegment: FC<LoadingCreateSegmentType> = (props) => {
       <div className='text-center'>
         <Loader />
       </div>
-    )
-  }
-
-  // CSV cohort segments have no editable rules; show the sync detail view.
-  if (segmentData?.cohort?.source_type === 'csv') {
-    return (
-      <CohortSegmentDetail
-        projectId={props.projectId}
-        segment={segmentData}
-        readOnly={props.readOnly}
-      />
     )
   }
 

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -805,7 +805,11 @@ const LoadingCreateSegment: FC<LoadingCreateSegmentType> = (props) => {
   // CSV cohort segments have no editable rules; show the sync detail view.
   if (segmentData?.cohort?.source_type === 'csv') {
     return (
-      <CohortSegmentDetail projectId={props.projectId} segment={segmentData} />
+      <CohortSegmentDetail
+        projectId={props.projectId}
+        segment={segmentData}
+        readOnly={props.readOnly}
+      />
     )
   }
 

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -612,6 +612,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                   projectId={projectId}
                   segment={_segment}
                   readOnly={readOnly}
+                  onDirtyChange={setValueChanged}
                 />
               ) : (
                 <CreateSegmentRulesTabForm
@@ -701,6 +702,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                   projectId={projectId}
                   segment={_segment}
                   readOnly={readOnly}
+                  onDirtyChange={setValueChanged}
                 />
               ) : (
                 <CreateSegmentRulesTabForm
@@ -751,6 +753,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 projectId={projectId}
                 segment={_segment}
                 readOnly={readOnly}
+                onDirtyChange={setValueChanged}
               />
             ) : (
               <CreateSegmentRulesTabForm

--- a/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.scss
+++ b/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.scss
@@ -2,37 +2,4 @@
   &__select {
     width: 220px;
   }
-
-  &__section-label {
-    font-size: 12px;
-    letter-spacing: 0.05em;
-  }
-
-  &__preview {
-    border: 1px solid var(--color-border-default);
-
-    table {
-      border-collapse: collapse;
-    }
-
-    th,
-    td {
-      padding: 12px 16px;
-      text-align: left;
-      white-space: nowrap;
-    }
-
-    thead th {
-      background: var(--color-surface-muted);
-    }
-
-    tbody tr {
-      border-top: 1px solid var(--color-border-default);
-      color: var(--color-text-secondary);
-    }
-
-    .create-segment-from-csv__cell--selected {
-      background: var(--color-surface-action-tint);
-    }
-  }
 }

--- a/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.tsx
+++ b/frontend/web/components/modals/CreateSegmentFromCsv/CreateSegmentFromCsv.tsx
@@ -1,10 +1,10 @@
 import React, { FC, FormEvent, useMemo, useState } from 'react'
-import classNames from 'classnames'
 import Constants from 'common/constants'
 import Format from 'common/utils/format'
 import Utils from 'common/utils/utils'
 import {
   extractIdentifiers,
+  MAX_CSV_FILE_SIZE_BYTES,
   MAX_IDENTIFIER_BYTES,
   parseCsvText,
   toCsvColumn,
@@ -22,6 +22,7 @@ import Button from 'components/base/forms/Button'
 import Checkbox from 'components/base/forms/Checkbox'
 import FieldLabel from 'components/base/forms/FieldLabel'
 import InputGroup from 'components/base/forms/InputGroup'
+import CsvPreview from 'components/CsvPreview'
 import CsvUpload from 'components/CsvUpload'
 import EnvironmentSelect from 'components/EnvironmentSelect'
 import ErrorMessage from 'components/ErrorMessage'
@@ -31,10 +32,6 @@ import TabItem from 'components/navigation/TabMenu/TabItem'
 import Tabs from 'components/navigation/TabMenu/Tabs'
 import { CreatedCohort, submitCohortCsv } from './submitCohortCsv'
 import './CreateSegmentFromCsv.scss'
-
-const PREVIEW_ROW_COUNT = 5
-// Mirrors the API's COHORT_CSV_MAX_FILE_SIZE_BYTES.
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
 type CreateSegmentFromCsvType = {
   projectId: number | string
@@ -89,7 +86,7 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
   )
   // Quoting can expand values, so the generated upload needs its own check.
   const isUploadTooLarge = useMemo(
-    () => new Blob([csvColumn]).size > MAX_FILE_SIZE_BYTES,
+    () => new Blob([csvColumn]).size > MAX_CSV_FILE_SIZE_BYTES,
     [csvColumn],
   )
 
@@ -173,11 +170,7 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
   }
 
   const form = (
-    <form
-      className='px-4 pt-4'
-      id='create-segment-from-csv-modal'
-      onSubmit={save}
-    >
+    <form className='pt-4' id='create-segment-from-csv-modal' onSubmit={save}>
       <InputGroup
         className='mb-4'
         id='segmentID'
@@ -185,6 +178,7 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
         title='Name*'
         value={name}
         inputProps={{
+          className: 'full-width',
           maxLength: Constants.forms.maxLength.SEGMENT_ID,
           name: 'id',
         }}
@@ -226,7 +220,7 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
       <div className='mb-4'>
         <CsvUpload
           value={file}
-          maxSizeBytes={MAX_FILE_SIZE_BYTES}
+          maxSizeBytes={MAX_CSV_FILE_SIZE_BYTES}
           rowCount={file ? parsed.rows.length : undefined}
           onChange={onFile}
         />
@@ -276,45 +270,11 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
         <>
           {!!parsed.rows.length && (
             <div className='mb-4'>
-              <div className='create-segment-from-csv__section-label fw-semibold text-secondary text-uppercase mb-2'>
-                Preview (first {PREVIEW_ROW_COUNT} rows)
-              </div>
-              <div className='create-segment-from-csv__preview rounded-lg overflow-auto'>
-                <table className='mb-0 w-100 fs-small'>
-                  <thead>
-                    <tr>
-                      {parsed.columns.map((column, i) => (
-                        <th
-                          key={i}
-                          className={classNames('fw-semibold', {
-                            'create-segment-from-csv__cell--selected':
-                              i === columnIndex,
-                          })}
-                        >
-                          {column}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {parsed.rows.slice(0, PREVIEW_ROW_COUNT).map((row, i) => (
-                      <tr key={i}>
-                        {parsed.columns.map((_, j) => (
-                          <td
-                            key={j}
-                            className={classNames({
-                              'create-segment-from-csv__cell--selected':
-                                j === columnIndex,
-                            })}
-                          >
-                            {row[j]}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <CsvPreview
+                columns={parsed.columns}
+                rows={parsed.rows}
+                selectedColumn={columnIndex}
+              />
               {!!extraction && !isBlocked && (
                 <div className='d-flex align-items-center gap-2 mt-2 fs-small text-secondary'>
                   <Icon
@@ -363,7 +323,8 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
   )
 
   if (!metadataEnable || !segmentContentType?.id) {
-    return form
+    // Outside tabs there is no tab-item padding, so the form provides it.
+    return <div className='px-4'>{form}</div>
   }
 
   return (
@@ -375,7 +336,7 @@ const CreateSegmentFromCsv: FC<CreateSegmentFromCsvType> = ({ projectId }) => {
         {form}
       </TabItem>
       <TabItem tabLabelString='Custom Fields' tabLabel='Custom Fields'>
-        <FormGroup className='px-4 pt-4 setting'>
+        <FormGroup className='pt-4 setting'>
           <InputGroup
             component={
               <AddMetadataToEntity

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortCsvSync.tsx
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortCsvSync.tsx
@@ -1,0 +1,231 @@
+import React, { FC, useMemo, useState } from 'react'
+import {
+  extractIdentifiers,
+  MAX_CSV_FILE_SIZE_BYTES,
+  MAX_IDENTIFIER_BYTES,
+  parseCsvText,
+  toCsvColumn,
+  toParsedCsv,
+} from 'common/utils/csv'
+import { useSyncCohortCsvMutation } from 'common/services/useCohort'
+import { colorIconSuccess, colorIconWarning } from 'common/theme/tokens'
+import Button from 'components/base/forms/Button'
+import Checkbox from 'components/base/forms/Checkbox'
+import FieldLabel from 'components/base/forms/FieldLabel'
+import CsvPreview from 'components/CsvPreview'
+import CsvUpload from 'components/CsvUpload'
+import ErrorMessage from 'components/ErrorMessage'
+import Icon from 'components/icons/Icon'
+
+type CohortCsvSyncType = {
+  cohortId: number
+  environmentApiKey: string
+  projectId: number | string
+  isSyncing: boolean
+}
+
+const CohortCsvSync: FC<CohortCsvSyncType> = ({
+  cohortId,
+  environmentApiKey,
+  isSyncing,
+  projectId,
+}) => {
+  const [file, setFile] = useState<File | null>(null)
+  const [rawRows, setRawRows] = useState<string[][]>([])
+  const [hasHeaders, setHasHeaders] = useState(true)
+  const [selectedColumn, setSelectedColumn] = useState<number | null>(null)
+
+  const [syncCohortCsv, { error: syncError, isLoading: isSaving }] =
+    useSyncCohortCsvMutation()
+
+  const parsed = useMemo(
+    () => toParsedCsv(rawRows, hasHeaders),
+    [rawRows, hasHeaders],
+  )
+  const columnIndex = parsed.columns.length === 1 ? 0 : selectedColumn
+  const extraction = useMemo(
+    () =>
+      columnIndex === null
+        ? null
+        : extractIdentifiers(parsed.rows, columnIndex),
+    [parsed.rows, columnIndex],
+  )
+
+  // Only the identifier column leaves the browser.
+  const csvColumn = useMemo(
+    () => (extraction ? toCsvColumn(extraction.identifiers) : ''),
+    [extraction],
+  )
+  // Quoting can expand values, so the generated upload needs its own check.
+  const isUploadTooLarge = useMemo(
+    () => new Blob([csvColumn]).size > MAX_CSV_FILE_SIZE_BYTES,
+    [csvColumn],
+  )
+
+  const ignoredRowCount = extraction
+    ? extraction.emptyCount +
+      extraction.duplicateCount +
+      extraction.tooLongCount
+    : 0
+  const isBlocked = !!extraction && !extraction.identifiers.length
+  const canSubmit =
+    !!file && !!extraction && !isBlocked && !isUploadTooLarge && !isSyncing
+
+  const onFile = (newFile: File, text: string) => {
+    setFile(newFile)
+    setRawRows(parseCsvText(text))
+    setSelectedColumn(null)
+  }
+
+  const reset = () => {
+    setFile(null)
+    setRawRows([])
+    setSelectedColumn(null)
+    setHasHeaders(true)
+  }
+
+  const submit = async () => {
+    if (!canSubmit) {
+      return
+    }
+    try {
+      const result = await syncCohortCsv({
+        cohortId,
+        environmentApiKey,
+        file: new File([csvColumn], 'identifiers.csv', { type: 'text/csv' }),
+        has_header: false,
+        projectId: Number(projectId),
+      }).unwrap()
+      toast(
+        `Synchronisation started: ${result.added.toLocaleString()} to add, ${result.removed.toLocaleString()} to remove`,
+        'success',
+        10000,
+      )
+      reset()
+    } catch (error) {
+      console.error('Cohort CSV sync failed:', error)
+    }
+  }
+
+  const columnName = columnIndex === null ? '' : parsed.columns[columnIndex]
+  let fileError = null
+  if (file && !parsed.columns.length) {
+    fileError = 'The file appears to be empty.'
+  } else if (file && !parsed.rows.length) {
+    fileError =
+      'No data rows found. If the first row is data rather than a header, untick "First row contains headers".'
+  }
+
+  return (
+    <div className='d-flex flex-column mx-0 gap-2'>
+      <div>
+        <FieldLabel>Update the list</FieldLabel>
+        <div className='fs-small text-muted'>
+          {isSyncing
+            ? 'Uploads are disabled while a synchronisation is in progress.'
+            : "Uploading a new file re-synchronises this segment's identities."}
+        </div>
+      </div>
+      <CsvUpload
+        value={file}
+        disabled={isSyncing}
+        maxSizeBytes={MAX_CSV_FILE_SIZE_BYTES}
+        rowCount={file ? parsed.rows.length : undefined}
+        onChange={onFile}
+      />
+      {!!file && !!parsed.columns.length && (
+        <div className='d-flex align-items-end justify-content-between gap-3 flex-wrap'>
+          {fileError ? (
+            <div />
+          ) : (
+            <div>
+              <FieldLabel htmlFor='identifier-column-select'>
+                Identifier column
+              </FieldLabel>
+              <div className='cohort-segment-detail__select'>
+                <Select
+                  inputId='identifier-column-select'
+                  isDisabled={parsed.columns.length === 1}
+                  placeholder='Select column'
+                  value={
+                    columnIndex === null
+                      ? null
+                      : { label: columnName, value: columnIndex }
+                  }
+                  options={parsed.columns.map((label, value) => ({
+                    label,
+                    value,
+                  }))}
+                  onChange={(option: { value: number }) =>
+                    setSelectedColumn(option.value)
+                  }
+                />
+              </div>
+            </div>
+          )}
+          <div className='mb-2'>
+            <Checkbox
+              label='First row contains headers'
+              checked={hasHeaders}
+              onChange={setHasHeaders}
+            />
+          </div>
+        </div>
+      )}
+      {!!fileError && <ErrorMessage error={fileError} />}
+      {!!file && !fileError && !!parsed.rows.length && (
+        <CsvPreview
+          columns={parsed.columns}
+          rows={parsed.rows}
+          selectedColumn={columnIndex}
+        />
+      )}
+      {!!extraction && !fileError && !isBlocked && (
+        <div className='cohort-segment-detail__review rounded-lg bg-surface-muted p-3 d-flex flex-column mx-0 gap-2 fs-small'>
+          <div className='d-flex align-items-center gap-2'>
+            <Icon name='checkmark-circle' width={16} fill={colorIconSuccess} />
+            <span className='text-secondary'>
+              {extraction.identifiers.length.toLocaleString()}{' '}
+              {extraction.identifiers.length === 1
+                ? 'identifier'
+                : 'identifiers'}{' '}
+              detected.
+              {!!ignoredRowCount &&
+                ` ${ignoredRowCount.toLocaleString()} ${
+                  ignoredRowCount === 1 ? 'row' : 'rows'
+                } ignored (empty, duplicate, or over ${MAX_IDENTIFIER_BYTES.toLocaleString()} bytes).`}
+            </span>
+          </div>
+          <div className='d-flex align-items-center gap-2'>
+            <Icon name='warning' width={16} fill={colorIconWarning} />
+            <span className='text-muted'>
+              Identities missing from the new file lose this segment on
+              synchronisation.
+            </span>
+          </div>
+        </div>
+      )}
+      {isBlocked && (
+        <ErrorMessage
+          error={`No valid identifiers found in "${columnName}". Choose a different column or check your file.`}
+        />
+      )}
+      {isUploadTooLarge && (
+        <ErrorMessage error='The extracted identifiers exceed the 10MB upload limit. Reduce the number of rows and try again.' />
+      )}
+      {!!syncError && <ErrorMessage error={syncError} />}
+      {!!file && (
+        <div className='d-flex justify-content-end gap-2 mt-2'>
+          <Button theme='secondary' onClick={reset}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || isSaving} onClick={submit}>
+            {isSaving ? 'Synchronising...' : 'Synchronise'}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CohortCsvSync

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.scss
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.scss
@@ -1,5 +1,7 @@
 .cohort-segment-detail {
-  border: 1px solid var(--color-border-default);
+  &--card {
+    border: 1px solid var(--color-border-default);
+  }
 
   &__header {
     border-bottom: 1px solid var(--color-border-default);
@@ -31,7 +33,6 @@
     height: 6px;
     border-radius: 3px;
     overflow: hidden;
-    background: var(--color-surface-default);
   }
 
   &__progress-bar {

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.scss
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.scss
@@ -26,7 +26,7 @@
   &__status-dot {
     width: 6px;
     height: 6px;
-    background: currentColor;
+    background: currentcolor;
   }
 
   &__progress-track {

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.scss
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.scss
@@ -1,0 +1,46 @@
+.cohort-segment-detail {
+  border: 1px solid var(--color-border-default);
+
+  &__header {
+    border-bottom: 1px solid var(--color-border-default);
+  }
+
+  &__info-panel,
+  &__review {
+    border: 1px solid var(--color-border-default);
+  }
+
+  &__info-label {
+    width: 150px;
+    flex-shrink: 0;
+  }
+
+  &__status {
+    font-size: 11px;
+    padding: 3px 10px;
+    border-radius: 10px;
+  }
+
+  &__status-dot {
+    width: 6px;
+    height: 6px;
+    background: currentColor;
+  }
+
+  &__progress-track {
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    background: var(--color-surface-default);
+  }
+
+  &__progress-bar {
+    height: 100%;
+    border-radius: 3px;
+    transition: width var(--duration-normal, 200ms) ease;
+  }
+
+  &__select {
+    width: 220px;
+  }
+}

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
@@ -19,6 +19,8 @@ import './CohortSegmentDetail.scss'
 const SYNC_POLL_INTERVAL_MS = 3000
 
 type CohortSegmentDetailType = {
+  // The page context already names the segment via its breadcrumb.
+  hideHeader?: boolean
   projectId: number | string
   readOnly?: boolean
   segment: Segment
@@ -37,6 +39,7 @@ const InfoRow: FC<{ label: string; children: ReactNode }> = ({
 )
 
 const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
+  hideHeader,
   projectId,
   readOnly,
   segment,
@@ -107,14 +110,27 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
   }
 
   return (
-    <div className='cohort-segment-detail rounded-lg bg-surface-default'>
-      <div className='cohort-segment-detail__header d-flex align-items-center gap-2 px-4 py-3'>
-        <h5 className='mb-0'>{segment.name}</h5>
-        <Chip size='xs' variant='accent'>
-          CSV list
-        </Chip>
-      </div>
-      <div className='p-4 d-flex flex-column mx-0 gap-4'>
+    <div
+      className={classNames(
+        'cohort-segment-detail',
+        !hideHeader &&
+          'cohort-segment-detail--card rounded-lg bg-surface-default',
+      )}
+    >
+      {!hideHeader && (
+        <div className='cohort-segment-detail__header d-flex align-items-center gap-2 px-4 py-3'>
+          <h5 className='mb-0'>{segment.name}</h5>
+          <Chip size='xs' variant='accent'>
+            CSV list
+          </Chip>
+        </div>
+      )}
+      <div
+        className={classNames(
+          'd-flex flex-column mx-0 gap-4',
+          hideHeader ? 'py-4' : 'p-4',
+        )}
+      >
         <div className='d-flex flex-column mx-0 gap-3'>
           <InputGroup
             className='mb-0'
@@ -192,7 +208,7 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
                 {syncDone.toLocaleString()} of {syncTotal.toLocaleString()}{' '}
                 applied
               </div>
-              <div className='cohort-segment-detail__progress-track'>
+              <div className='cohort-segment-detail__progress-track bg-surface-default'>
                 <div
                   className='cohort-segment-detail__progress-bar bg-surface-action'
                   style={{

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
@@ -165,9 +165,9 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
             placeholder="e.g. 'People who have spent over $100' "
           />
           {!!updateError && <ErrorMessage error={updateError} />}
-          {isDirty && !readOnly && (
+          {!readOnly && (
             <div className='text-right'>
-              <Button disabled={!name || isUpdating} onClick={save}>
+              <Button disabled={!isDirty || !name || isUpdating} onClick={save}>
                 {isUpdating ? 'Saving...' : 'Save Changes'}
               </Button>
             </div>
@@ -190,17 +190,21 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
             </InfoRow>
           )}
           <InfoRow label='Status'>
-            <span
-              className={classNames(
-                'cohort-segment-detail__status d-inline-flex align-items-center gap-1 fw-bold',
-                isSyncing
-                  ? 'bg-surface-action-tint text-action'
-                  : 'bg-surface-success text-success',
-              )}
-            >
-              <span className='cohort-segment-detail__status-dot rounded-circle' />
-              {isSyncing ? 'Synchronising' : 'Import completed'}
-            </span>
+            {counts ? (
+              <span
+                className={classNames(
+                  'cohort-segment-detail__status d-inline-flex align-items-center gap-1 fw-bold',
+                  isSyncing
+                    ? 'bg-surface-action-tint text-action'
+                    : 'bg-surface-success text-success',
+                )}
+              >
+                <span className='cohort-segment-detail__status-dot rounded-circle' />
+                {isSyncing ? 'Synchronising' : 'Import completed'}
+              </span>
+            ) : (
+              <span className='fw-semibold'>…</span>
+            )}
           </InfoRow>
           {isSyncing && (
             <div className='d-flex flex-column mx-0 gap-1'>

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
@@ -21,6 +21,7 @@ const SYNC_POLL_INTERVAL_MS = 3000
 type CohortSegmentDetailType = {
   // The page context already names the segment via its breadcrumb.
   hideHeader?: boolean
+  onDirtyChange?: (dirty: boolean) => void
   projectId: number | string
   readOnly?: boolean
   segment: Segment
@@ -40,6 +41,7 @@ const InfoRow: FC<{ label: string; children: ReactNode }> = ({
 
 const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
   hideHeader,
+  onDirtyChange,
   projectId,
   readOnly,
   segment,
@@ -86,12 +88,16 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
     setDescription(segment.description || '')
   }, [segment.name, segment.description])
 
+  const isDirty =
+    name !== segment.name || description !== (segment.description || '')
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+
   if (!cohort) {
     return null
   }
-
-  const isDirty =
-    name !== segment.name || description !== (segment.description || '')
 
   const save = async () => {
     try {

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
@@ -1,0 +1,208 @@
+import React, { FC, ReactNode, useEffect, useState } from 'react'
+import classNames from 'classnames'
+import moment from 'moment'
+import Constants from 'common/constants'
+import Format from 'common/utils/format'
+import Utils from 'common/utils/utils'
+import { Segment } from 'common/types/responses'
+import {
+  useGetCohortQuery,
+  useUpdateCohortMutation,
+} from 'common/services/useCohort'
+import Button from 'components/base/forms/Button'
+import Chip from 'components/base/Chip'
+import ErrorMessage from 'components/ErrorMessage'
+import InputGroup from 'components/base/forms/InputGroup'
+import CohortCsvSync from './CohortCsvSync'
+import './CohortSegmentDetail.scss'
+
+const SYNC_POLL_INTERVAL_MS = 3000
+
+type CohortSegmentDetailType = {
+  projectId: number | string
+  segment: Segment
+}
+
+const InfoRow: FC<{ label: string; children: ReactNode }> = ({
+  children,
+  label,
+}) => (
+  <div className='d-flex align-items-center fs-small'>
+    <div className='cohort-segment-detail__info-label text-secondary'>
+      {label}
+    </div>
+    {children}
+  </div>
+)
+
+const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
+  projectId,
+  segment,
+}) => {
+  const cohort = segment.cohort
+  const [name, setName] = useState(segment.name)
+  const [description, setDescription] = useState(segment.description || '')
+  // Poll while a synchronisation is in flight; the interval derives from the
+  // response.
+  const [pollingInterval, setPollingInterval] = useState(0)
+  const { data } = useGetCohortQuery(
+    {
+      cohortId: cohort?.id ?? 0,
+      environmentApiKey: cohort?.environment_api_key ?? '',
+    },
+    { pollingInterval, skip: !cohort },
+  )
+  const [updateCohort, { error: updateError, isLoading: isUpdating }] =
+    useUpdateCohortMutation()
+
+  const counts = data?.membership_counts
+  const appliedCount = counts?.applied ?? 0
+  const pendingCount =
+    (counts?.pending_add ?? 0) + (counts?.pending_remove ?? 0)
+  const isSyncing = pendingCount > 0
+  const identityCount = appliedCount + (counts?.pending_add ?? 0)
+  const progressTotal = appliedCount + pendingCount
+
+  useEffect(() => {
+    setPollingInterval(isSyncing ? SYNC_POLL_INTERVAL_MS : 0)
+  }, [isSyncing])
+
+  useEffect(() => {
+    setName(segment.name)
+    setDescription(segment.description || '')
+  }, [segment.name, segment.description])
+
+  if (!cohort) {
+    return null
+  }
+
+  const isDirty =
+    name !== segment.name || description !== (segment.description || '')
+
+  const save = async () => {
+    try {
+      await updateCohort({
+        cohortId: cohort.id,
+        description,
+        environmentApiKey: cohort.environment_api_key,
+        name,
+        projectId: Number(projectId),
+        segmentId: segment.id,
+      }).unwrap()
+      toast('Segment updated')
+    } catch (error) {
+      console.error('Cohort update failed:', error)
+    }
+  }
+
+  return (
+    <div className='cohort-segment-detail rounded-lg bg-surface-default'>
+      <div className='cohort-segment-detail__header d-flex align-items-center gap-2 px-4 py-3'>
+        <h5 className='mb-0'>{segment.name}</h5>
+        <Chip size='xs' variant='accent'>
+          CSV list
+        </Chip>
+      </div>
+      <div className='p-4 d-flex flex-column mx-0 gap-4'>
+        <div className='d-flex flex-column mx-0 gap-3'>
+          <InputGroup
+            className='mb-0'
+            title='Name*'
+            value={name}
+            inputProps={{
+              className: 'full-width',
+              maxLength: Constants.forms.maxLength.SEGMENT_ID,
+            }}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setName(
+                Format.enumeration
+                  .set(Utils.safeParseEventValue(e))
+                  .toLowerCase(),
+              )
+            }}
+            isValid={!!name?.length}
+            type='text'
+            placeholder='E.g. power_users'
+          />
+          <InputGroup
+            className='mb-0'
+            title='Description'
+            value={description}
+            inputProps={{ className: 'full-width' }}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setDescription(Utils.safeParseEventValue(e))
+            }}
+            type='text'
+            placeholder="e.g. 'People who have spent over $100' "
+          />
+          {!!updateError && <ErrorMessage error={updateError} />}
+          {isDirty && (
+            <div className='text-right'>
+              <Button disabled={!name || isUpdating} onClick={save}>
+                {isUpdating ? 'Saving...' : 'Save Changes'}
+              </Button>
+            </div>
+          )}
+        </div>
+        <div className='cohort-segment-detail__info-panel rounded-lg bg-surface-muted p-3 d-flex flex-column mx-0 gap-2'>
+          <InfoRow label='Environment'>
+            <span className='fw-semibold'>{cohort.environment_name}</span>
+          </InfoRow>
+          <InfoRow label='Identities'>
+            <span className='fw-semibold'>
+              {counts ? identityCount.toLocaleString() : '…'}
+            </span>
+          </InfoRow>
+          {!!data?.last_synced_at && (
+            <InfoRow label='Last synchronisation'>
+              <span className='fw-semibold'>
+                {moment(data.last_synced_at).fromNow()}
+              </span>
+            </InfoRow>
+          )}
+          <InfoRow label='Status'>
+            <span
+              className={classNames(
+                'cohort-segment-detail__status d-inline-flex align-items-center gap-1 fw-bold',
+                isSyncing
+                  ? 'bg-surface-action-tint text-action'
+                  : 'bg-surface-success text-success',
+              )}
+            >
+              <span className='cohort-segment-detail__status-dot rounded-circle' />
+              {isSyncing ? 'Synchronising' : 'Import completed'}
+            </span>
+          </InfoRow>
+          {isSyncing && (
+            <div className='d-flex flex-column mx-0 gap-1'>
+              <div className='fs-small text-secondary'>
+                {appliedCount.toLocaleString()} of{' '}
+                {progressTotal.toLocaleString()} applied
+              </div>
+              <div className='cohort-segment-detail__progress-track'>
+                <div
+                  className='cohort-segment-detail__progress-bar bg-surface-action'
+                  style={{
+                    width: `${
+                      progressTotal
+                        ? Math.round((appliedCount / progressTotal) * 100)
+                        : 0
+                    }%`,
+                  }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        <CohortCsvSync
+          cohortId={cohort.id}
+          environmentApiKey={cohort.environment_api_key}
+          projectId={projectId}
+          isSyncing={isSyncing}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default CohortSegmentDetail

--- a/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
+++ b/frontend/web/components/segments/CohortSegmentDetail/CohortSegmentDetail.tsx
@@ -20,6 +20,7 @@ const SYNC_POLL_INTERVAL_MS = 3000
 
 type CohortSegmentDetailType = {
   projectId: number | string
+  readOnly?: boolean
   segment: Segment
 }
 
@@ -37,6 +38,7 @@ const InfoRow: FC<{ label: string; children: ReactNode }> = ({
 
 const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
   projectId,
+  readOnly,
   segment,
 }) => {
   const cohort = segment.cohort
@@ -61,11 +63,20 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
     (counts?.pending_add ?? 0) + (counts?.pending_remove ?? 0)
   const isSyncing = pendingCount > 0
   const identityCount = appliedCount + (counts?.pending_add ?? 0)
-  const progressTotal = appliedCount + pendingCount
+
+  // Snapshot the pending work when a synchronisation starts; applied totals
+  // shrink on removals so they cannot measure progress.
+  const [syncTotal, setSyncTotal] = useState(0)
+  const syncDone = Math.max(syncTotal - pendingCount, 0)
 
   useEffect(() => {
     setPollingInterval(isSyncing ? SYNC_POLL_INTERVAL_MS : 0)
-  }, [isSyncing])
+    if (isSyncing) {
+      setSyncTotal((total) => Math.max(total, pendingCount))
+    } else {
+      setSyncTotal(0)
+    }
+  }, [isSyncing, pendingCount])
 
   useEffect(() => {
     setName(segment.name)
@@ -108,6 +119,7 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
           <InputGroup
             className='mb-0'
             title='Name*'
+            disabled={readOnly}
             value={name}
             inputProps={{
               className: 'full-width',
@@ -127,6 +139,7 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
           <InputGroup
             className='mb-0'
             title='Description'
+            disabled={readOnly}
             value={description}
             inputProps={{ className: 'full-width' }}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -136,7 +149,7 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
             placeholder="e.g. 'People who have spent over $100' "
           />
           {!!updateError && <ErrorMessage error={updateError} />}
-          {isDirty && (
+          {isDirty && !readOnly && (
             <div className='text-right'>
               <Button disabled={!name || isUpdating} onClick={save}>
                 {isUpdating ? 'Saving...' : 'Save Changes'}
@@ -176,17 +189,15 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
           {isSyncing && (
             <div className='d-flex flex-column mx-0 gap-1'>
               <div className='fs-small text-secondary'>
-                {appliedCount.toLocaleString()} of{' '}
-                {progressTotal.toLocaleString()} applied
+                {syncDone.toLocaleString()} of {syncTotal.toLocaleString()}{' '}
+                applied
               </div>
               <div className='cohort-segment-detail__progress-track'>
                 <div
                   className='cohort-segment-detail__progress-bar bg-surface-action'
                   style={{
                     width: `${
-                      progressTotal
-                        ? Math.round((appliedCount / progressTotal) * 100)
-                        : 0
+                      syncTotal ? Math.round((syncDone / syncTotal) * 100) : 0
                     }%`,
                   }}
                 />
@@ -194,12 +205,14 @@ const CohortSegmentDetail: FC<CohortSegmentDetailType> = ({
             </div>
           )}
         </div>
-        <CohortCsvSync
-          cohortId={cohort.id}
-          environmentApiKey={cohort.environment_api_key}
-          projectId={projectId}
-          isSyncing={isSyncing}
-        />
+        {!readOnly && (
+          <CohortCsvSync
+            cohortId={cohort.id}
+            environmentApiKey={cohort.environment_api_key}
+            projectId={projectId}
+            isSyncing={isSyncing}
+          />
+        )}
       </div>
     </div>
   )

--- a/frontend/web/components/segments/CohortSegmentDetail/index.ts
+++ b/frontend/web/components/segments/CohortSegmentDetail/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CohortSegmentDetail'

--- a/frontend/web/components/segments/SegmentRow/SegmentRow.tsx
+++ b/frontend/web/components/segments/SegmentRow/SegmentRow.tsx
@@ -98,11 +98,6 @@ const SegmentRow: FC<SegmentRowProps> = ({ index, projectId, segment }) => {
               {cohort.source_type.toUpperCase()}
             </Chip>
           )}
-          {!!cohort && (
-            <Chip className='ml-2' size='xs'>
-              {cohort.environment_name}
-            </Chip>
-          )}
           {isPendingDeletion && (
             <Chip className='ml-2' size='xs'>
               Deleting

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2481,6 +2481,45 @@ paths:
       tags:
         - Environments
       x-flagsmith-minimum-plan: START_UP
+    patch:
+      operationId: api_v1_environments_cohorts_partial_update
+      description: Update the cohort's managed segment name and description.
+      parameters:
+        - name: cohort_id
+          in: path
+          description: A unique integer value identifying this cohort.
+          required: true
+          schema:
+            type: integer
+        - name: environment_api_key
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCohort'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCohort'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCohort'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cohort'
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Environments
+      x-flagsmith-minimum-plan: START_UP
     delete:
       operationId: api_v1_environments_cohorts_destroy
       description: Request cohort deletion. Memberships are drained from identity data first; the cohort and its segment are deleted once drained.
@@ -19558,6 +19597,16 @@ components:
           type: string
           format: date-time
           readOnly: true
+        last_synced_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          readOnly: true
+        membership_counts:
+          allOf:
+            - $ref: '#/components/schemas/CohortMembershipCounts'
+          readOnly: true
       required:
         - name
     CohortCsvSync:
@@ -19614,6 +19663,22 @@ components:
         - removed
         - unchanged
         - version
+    CohortMembershipCounts:
+      type: object
+      properties:
+        applied:
+          type: integer
+          minimum: 0
+        pending_add:
+          type: integer
+          minimum: 0
+        pending_remove:
+          type: integer
+          minimum: 0
+      required:
+        - applied
+        - pending_add
+        - pending_remove
     CohortSyncKey:
       type: object
       properties:
@@ -24507,6 +24572,52 @@ components:
             $ref: '#/components/schemas/VersionChangeSet'
         ignore_conflicts:
           type: boolean
+    PatchedCohort:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 2000
+        description:
+          type:
+            - string
+            - 'null'
+        metadata:
+          type: array
+          items:
+            $ref: '#/components/schemas/Metadata'
+          writeOnly: true
+        segment:
+          type: integer
+          readOnly: true
+        source_type:
+          allOf:
+            - $ref: '#/components/schemas/SourceTypeEnum'
+          readOnly: true
+        version:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        last_synced_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          readOnly: true
+        membership_counts:
+          allOf:
+            - $ref: '#/components/schemas/CohortMembershipCounts'
+          readOnly: true
     PatchedCreateUpdateUserEnvironmentPermission:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2483,7 +2483,7 @@ paths:
       x-flagsmith-minimum-plan: START_UP
     patch:
       operationId: api_v1_environments_cohorts_partial_update
-      description: Update the cohort's managed segment name and description.
+      description: 'Update the cohort''s managed segment name, description and metadata.'
       parameters:
         - name: cohort_id
           in: path


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Detail view for CSV cohort-managed segments, replacing the read-only rules editor:

- Sync status chip, progress bar and last-synchronisation time, polled while a synchronisation is in flight.
- Editable name and description via the new cohort `PATCH` endpoint.
- Re-upload flow reusing `CsvUpload` and the new shared `CsvPreview`, with a review summary before synchronising.
- `SegmentSelect` shows the CSV chip and hides segments pending deletion.
- Fixed double horizontal padding in the tabbed segment drawers.

Stacked on #8386.

## How did you test this code?

Manually: created a CSV segment, re-uploaded a smaller file and verified the add/remove counts, progress and status against a running task processor; renamed the segment and checked list/breadcrumb refresh. Unit tests, eslint and typecheck (no new errors) pass.

<img width="697" height="556" alt="image" src="https://github.com/user-attachments/assets/633a3efc-1525-47fe-ac3a-6e1c36446837" />


<img width="2248" height="1206" alt="image" src="https://github.com/user-attachments/assets/39b65942-dae4-482a-9f02-5851645b7976" />

<img width="1436" height="754" alt="image" src="https://github.com/user-attachments/assets/2da9ccf3-e5e2-4ad2-8d49-35fb45926699" />

<img width="1098" height="740" alt="image" src="https://github.com/user-attachments/assets/ab33aa25-3b90-4816-aadd-c6d5d172a3f5" />

<img width="1139" height="210" alt="image" src="https://github.com/user-attachments/assets/a22724c8-2ecc-41f2-ad6e-50d84d399c8a" />

<img width="911" height="744" alt="image" src="https://github.com/user-attachments/assets/dad65c15-6462-4220-a647-65f03152de79" />
