### PR TITLE
feat: format action for JSON feature values

### DIFF
--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -141,6 +141,15 @@ class ValueEditor extends Component {
     />
   )
 
+  formatJson = () => {
+    if (this.props.disabled || !this.props.onChange) return
+    try {
+      this.props.onChange(JSON.stringify(JSON.parse(this.props.value), null, 2))
+    } catch (e) {
+      toast('Cannot format invalid JSON', 'danger')
+    }
+  }
+
   render() {
     const { ...rest } = this.props
     return (
@@ -207,6 +216,21 @@ class ValueEditor extends Component {
             >
               .yaml {this.state.language === 'yaml' && this.renderValidation()}
             </span>
+            {this.state.language === 'json' &&
+              !this.props.disabled &&
+              !!this.props.value && (
+                <span
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    this.formatJson()
+                  }}
+                  className={cx('txt primary')}
+                >
+                  <Icon name='code' fill={'#6837fc'} />
+                  format
+                </span>
+              )}
             <span
               onMouseDown={() => {
                 const res = Clipboard.setString(this.props.value)

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -145,7 +145,11 @@ class ValueEditor extends Component {
   formatJson = () => {
     if (this.props.disabled || !this.props.onChange) return
     try {
-      this.props.onChange(JSON.stringify(JSON.parse(this.props.value), null, 2))
+      const formatted = JSON.stringify(JSON.parse(this.props.value), null, 2)
+      // Don't emit a no-op change; the parent flags dirty on any onChange.
+      if (formatted !== this.props.value) {
+        this.props.onChange(formatted)
+      }
     } catch (e) {
       toast('Cannot format invalid JSON', 'danger')
     }

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -4,6 +4,7 @@ import Highlight from './Highlight'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import { Clipboard } from 'polyfill-react-native'
 import Icon from './icons/Icon'
+import BareButton from './base/forms/BareButton'
 import { IonIcon } from '@ionic/react'
 import { checkmarkCircle, warning } from 'ionicons/icons'
 
@@ -152,6 +153,10 @@ class ValueEditor extends Component {
 
   render() {
     const { ...rest } = this.props
+    const showFormat =
+      this.state.language === 'json' &&
+      !this.props.disabled &&
+      !!this.props.value
     return (
       <div
         className={cx(
@@ -216,21 +221,21 @@ class ValueEditor extends Component {
             >
               .yaml {this.state.language === 'yaml' && this.renderValidation()}
             </span>
-            {this.state.language === 'json' &&
-              !this.props.disabled &&
-              !!this.props.value && (
-                <span
-                  onMouseDown={(e) => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    this.formatJson()
-                  }}
-                  className={cx('txt primary')}
-                >
-                  <Icon name='code' />
-                  format
-                </span>
-              )}
+            <BareButton
+              disabled={!showFormat}
+              onMouseDown={(e) => {
+                // Keep the editor focused; the click still fires the format.
+                e.preventDefault()
+                e.stopPropagation()
+              }}
+              onClick={this.formatJson}
+              className={cx('primary format-action', {
+                'is-visible': showFormat,
+              })}
+            >
+              <Icon name='code' />
+              format
+            </BareButton>
             <span
               onMouseDown={() => {
                 const res = Clipboard.setString(this.props.value)

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -227,7 +227,7 @@ class ValueEditor extends Component {
                   }}
                   className={cx('txt primary')}
                 >
-                  <Icon name='code' fill={'#6837fc'} />
+                  <Icon name='code' />
                   format
                 </span>
               )}

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -223,11 +223,9 @@ class ValueEditor extends Component {
             </span>
             <BareButton
               disabled={!showFormat}
-              onMouseDown={(e) => {
-                // Keep the editor focused; the click still fires the format.
-                e.preventDefault()
-                e.stopPropagation()
-              }}
+              // Don't blur the editor (which would fire its onBlur commit);
+              // onClick still runs the format.
+              onMouseDown={(e) => e.preventDefault()}
               onClick={this.formatJson}
               className={cx('primary format-action', {
                 'is-visible': showFormat,

--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -65,7 +65,8 @@
         color: var(--color-text-default);
       }
     }
-    span {
+    span,
+    .bare-btn {
       display: flex;
       align-items: center;
       gap: 2px;
@@ -79,6 +80,24 @@
       }
       &.primary {
         color: var(--color-text-action);
+      }
+    }
+    // Slides and fades in when JSON is selected, collapses out otherwise.
+    .format-action {
+      max-width: 0;
+      overflow: hidden;
+      opacity: 0;
+      white-space: nowrap;
+      pointer-events: none;
+      transition: max-width var(--duration-normal, 200ms) ease,
+        opacity var(--duration-normal, 200ms) ease;
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
+      &.is-visible {
+        max-width: 6rem;
+        opacity: 1;
+        pointer-events: auto;
       }
     }
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The `.json` toggle on the value editor only validates and syntax-highlights; the stored value is rendered verbatim. So a pasted, minified JSON blob stays on one unreadable line with no way to indent it.

Adds a **Format** action next to `copy`, shown only when the language is JSON and there is a value. It pretty-prints via `JSON.stringify(JSON.parse(value), null, 2)` and calls the same `onChange` the editor already uses for typing, so every consumer of `ValueEditor` (feature value, multivariate variations, segment overrides) gets it for free. Invalid JSON is left untouched with a toast.

Draft: raising for a quick design/product check before finalising.

Open questions for the team:
- Label/affordance: `format` text + `code` icon, or an icon-only button?
- Scope: JSON only for now. Worth extending to yaml/toml/xml later (each lib can re-serialise)?
- Any concern about pretty-printing enlarging the stored value string? (Functionally identical for `JSON.parse` consumers.)

## How did you test this code?

**Not yet run in a live app** — this is a draft for design/product validation. What I have done:
- `eslint --fix` passes (the one remaining `!=` warning is pre-existing, on an untouched line).
- Verified the `onChange` contract by tracing callers: `Highlight` already emits a plain string to `onChange`, and callers run it through `Utils.safeParseEventValue`, so a formatted string follows the exact same path as typed input.

Suggested manual test before merge:
1. Paste a minified JSON object into the Edit Feature value editor, switch to the `.json` tab.
2. Click **Format** — value should re-indent with 2 spaces.
3. Paste invalid JSON and click Format — value left as-is, "Cannot format invalid JSON" toast.
4. Confirm the action is hidden for non-JSON languages, empty values, and read-only (disabled) editors.