### PR TITLE
fix: 500 creating a cohort sync key with a master API key

### DIFF
--- a/api/cohorts/views.py
+++ b/api/cohorts/views.py
@@ -20,6 +20,7 @@ from cohorts.serializers import (
 )
 from environments.models import Environment
 from environments.views import NestedEnvironmentViewSet
+from users.models import FFAdminUser
 
 
 @extend_schema_view(
@@ -128,7 +129,13 @@ class CohortSyncKeyViewSet(
         environment = Environment.objects.get(
             api_key=self.kwargs.get("environment_api_key")
         )
-        serializer.save(environment=environment, created_by=self.request.user)
+        user = self.request.user
+        # A master API key caller has no user to record: assigning its
+        # APIKeyUser to the foreign key raises a server error.
+        serializer.save(
+            environment=environment,
+            created_by=user if isinstance(user, FFAdminUser) else None,
+        )
 
     def perform_destroy(self, instance: CohortSyncKey) -> None:
         instance.revoked = True

--- a/api/tests/unit/cohorts/test_views.py
+++ b/api/tests/unit/cohorts/test_views.py
@@ -271,29 +271,22 @@ def test_create_cohort__non_edge_project__returns_201(
     assert Cohort.objects.get(id=response.json()["id"]).environment == environment
 
 
-def test_create_sync_key__staff_with_permissions__returns_201_with_plaintext_key(
-    staff_client: APIClient,
+def test_create_sync_key__user_or_master_api_key__returns_201_with_plaintext_key(
+    admin_client_new: APIClient,
     dynamo_enabled_project: Project,
     dynamo_enabled_project_environment_one: Environment,
     dynamodb_identity_wrapper: DynamoIdentityWrapper,
-    with_project_permissions: WithProjectPermissionsCallable,
-    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
     environment = dynamo_enabled_project_environment_one
-    with_project_permissions(  # type: ignore[call-arg]
-        [MANAGE_SEGMENTS], project_id=dynamo_enabled_project.id
-    )
-    with_environment_permissions(  # type: ignore[call-arg]
-        [VIEW_ENVIRONMENT, MANAGE_SEGMENT_OVERRIDES],
-        environment_id=environment.id,
-    )
     url = reverse(
         "api-v1:environments:cohorts:sync-keys-list", args=[environment.api_key]
     )
 
     # When
-    response = staff_client.post(url, data={"name": "Amplitude prod"}, format="json")
+    response = admin_client_new.post(
+        url, data={"name": "Amplitude prod"}, format="json"
+    )
 
     # Then
     assert response.status_code == status.HTTP_201_CREATED
@@ -320,12 +313,10 @@ def test_create_sync_key__staff_without_permission__returns_403(
 
 
 def test_list_sync_keys__revoked_key__excluded_and_plaintext_never_returned(
-    staff_client: APIClient,
+    admin_client_new: APIClient,
     environment: Environment,
-    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
-    with_environment_permissions([VIEW_ENVIRONMENT])  # type: ignore[call-arg]
     CohortSyncKey.objects.create_key(name="live", environment=environment)
     revoked, _ = CohortSyncKey.objects.create_key(
         name="revoked", environment=environment
@@ -337,7 +328,7 @@ def test_list_sync_keys__revoked_key__excluded_and_plaintext_never_returned(
     )
 
     # When
-    response = staff_client.get(url)
+    response = admin_client_new.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK
@@ -345,16 +336,10 @@ def test_list_sync_keys__revoked_key__excluded_and_plaintext_never_returned(
 
 
 def test_delete_sync_key__existing_key__revokes(
-    staff_client: APIClient,
+    admin_client_new: APIClient,
     environment: Environment,
-    with_project_permissions: WithProjectPermissionsCallable,
-    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
-    with_project_permissions([MANAGE_SEGMENTS])  # type: ignore[call-arg]
-    with_environment_permissions(  # type: ignore[call-arg]
-        [VIEW_ENVIRONMENT, MANAGE_SEGMENT_OVERRIDES]
-    )
     key, _ = CohortSyncKey.objects.create_key(name="old", environment=environment)
     url = reverse(
         "api-v1:environments:cohorts:sync-keys-detail",
@@ -362,7 +347,7 @@ def test_delete_sync_key__existing_key__revokes(
     )
 
     # When
-    response = staff_client.delete(url)
+    response = admin_client_new.delete(url)
 
     # Then
     assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -371,28 +356,17 @@ def test_delete_sync_key__existing_key__revokes(
 
 
 def test_create_sync_key__missing_name__returns_400(
-    staff_client: APIClient,
-    dynamo_enabled_project: Project,
-    dynamo_enabled_project_environment_one: Environment,
-    dynamodb_identity_wrapper: DynamoIdentityWrapper,
-    with_project_permissions: WithProjectPermissionsCallable,
-    with_environment_permissions: WithEnvironmentPermissionsCallable,
+    admin_client_new: APIClient,
+    environment: Environment,
 ) -> None:
     # Given
-    with_project_permissions(  # type: ignore[call-arg]
-        [MANAGE_SEGMENTS], project_id=dynamo_enabled_project.id
-    )
-    with_environment_permissions(  # type: ignore[call-arg]
-        [VIEW_ENVIRONMENT, MANAGE_SEGMENT_OVERRIDES],
-        environment_id=dynamo_enabled_project_environment_one.id,
-    )
     url = reverse(
         "api-v1:environments:cohorts:sync-keys-list",
-        args=[dynamo_enabled_project_environment_one.api_key],
+        args=[environment.api_key],
     )
 
     # When
-    response = staff_client.post(url, data={}, format="json")
+    response = admin_client_new.post(url, data={}, format="json")
 
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`POST /environments/{key}/cohorts/sync-keys/` with master API key auth returns a 500: `perform_create` assigns the request's `APIKeyUser` to `CohortSyncKey.created_by`, which must be an `FFAdminUser`. Found testing the deployed Amplitude sync against production.

- Record `created_by` only for real users; master key callers leave it null.
- The sync key CRUD tests now use `admin_client_new`, so each runs under both user token and master API key auth.

## How did you test this code?

Reproduced the 500 locally with a master API key, then verified the fix via the dual-auth tests. Cohorts app remains at 100% coverage.