### PR TITLE
ci(frontend-deploy): announce a deploy when it starts

### DIFF
--- a/.github/actions/notify-slack-deploy/action.yml
+++ b/.github/actions/notify-slack-deploy/action.yml
@@ -15,10 +15,11 @@ inputs:
     description: The environment that was deployed to.
     required: false
     default: production
-  conclusion:
+  state:
     description: >
-      The deploy run's conclusion, straight from workflow_run. Only success and
-      cancelled get their own copy; anything else reads as a failure.
+      in_progress before the deploy runs, otherwise the production job's
+      result. Only in_progress, success and cancelled get their own copy;
+      anything else reads as a failure.
     required: true
   commit_sha:
     description: The commit that was deployed.
@@ -47,7 +48,7 @@ runs:
         SERVICE: ${{ inputs.service }}
         APP_URL: ${{ inputs.app_url }}
         ENVIRONMENT: ${{ inputs.environment }}
-        CONCLUSION: ${{ inputs.conclusion }}
+        STATE: ${{ inputs.state }}
         COMMIT_SHA: ${{ inputs.commit_sha }}
         ACTOR: ${{ inputs.actor }}
         RUN_URL: ${{ inputs.run_url }}
@@ -77,7 +78,7 @@ runs:
         jq -n \
           --arg service "$SERVICE" \
           --arg environment "$ENVIRONMENT" \
-          --arg conclusion "$CONCLUSION" \
+          --arg state "$STATE" \
           --arg short_sha "${COMMIT_SHA:0:7}" \
           --arg actor "$ACTOR" \
           --arg app_url "$APP_URL" \

--- a/.github/actions/notify-slack-deploy/payload.jq
+++ b/.github/actions/notify-slack-deploy/payload.jq
@@ -3,16 +3,23 @@
 
 ($environment | (.[0:1] | ascii_upcase) + .[1:]) as $env_name |
 
-# Only success and cancelled need their own words. Everything else GitHub
-# reports, timed_out and skipped included, means the deploy did not happen.
-(if $conclusion == "success" then
+# Only in_progress, success and cancelled need their own words. Everything
+# else, timed_out and skipped included, means the deploy did not happen.
+(if $state == "in_progress" then
+  {
+    headline: "⏳ \($service) deploying to \($environment)",
+    body: "Tests and deploy are running. \($env_name) is still on the previous release.",
+    actor_label: "Pushed by",
+    link_app: false
+  }
+elif $state == "success" then
   {
     headline: "🚀 \($service) deployed to \($environment)",
     body: "🧪 *\($env_name) smoke test required*\n\nPlease verify the application directly in \($environment).",
     actor_label: "Deployed by",
     link_app: true
   }
-elif $conclusion == "cancelled" then
+elif $state == "cancelled" then
   {
     headline: "⏭️ \($service) deploy to \($environment) stopped",
     # run-tests cancels itself in progress when the next commit lands on main,

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -9,6 +9,35 @@ on:
       - .github/**
 
 jobs:
+  notify-production-deploy-started:
+    name: Notify Production Deploy Started
+    # No needs, so this lands within seconds of the push. Knowing a deploy is
+    # in flight is only useful while it still is.
+    runs-on: ubuntu-latest
+    permissions:
+      # Enough to resolve the local action below.
+      contents: read
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # Nothing runs git after this, so the token need not persist.
+          persist-credentials: false
+
+      - name: Notify Slack
+        # A Slack outage must not hold up a deploy.
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_FRONTEND_DEPLOY_WEBHOOK }}
+          service: Frontend
+          app_url: https://app.flagsmith.com
+          state: in_progress
+          commit_sha: ${{ github.sha }}
+          actor: ${{ github.actor }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   run-unit-tests:
     runs-on: ubuntu-latest
     name: Run Unit Tests
@@ -136,7 +165,7 @@ jobs:
           webhook_url: ${{ secrets.SLACK_FRONTEND_DEPLOY_WEBHOOK }}
           service: Frontend
           app_url: https://app.flagsmith.com
-          conclusion: ${{ steps.outcome.outputs.conclusion }}
+          state: ${{ steps.outcome.outputs.conclusion }}
           commit_sha: ${{ github.sha }}
           actor: ${{ github.actor }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follows #8371. That PR collapsed the deploy channel to one message per run, at the end. The side effect is eleven minutes of silence between a push and its outcome, so there is no way to tell a deploy is in flight, which is exactly when it matters: that is the window in which pushing again supersedes someone.

- Adds a card at the start, carrying the commit and who pushed it, like the outcome card.
- The job has no `needs`, so it lands within seconds of the push rather than after the tests.
- The action's `conclusion` input becomes `state`, since `in_progress` is not a conclusion.

⏳ rather than 🚀, and no Open Production button: the two cards otherwise look alike while scanning the channel, and production is still on the previous release.

### Starting

<img width="583" height="235" alt="image" src="https://github.com/user-attachments/assets/eec1aeb9-5023-4bab-a6b4-892d651d8226" />

## How did you test this code?

Rendered all four states through Slack's Block Kit Builder using the action's real `payload.jq`:

| state | headline | actor label | buttons |
| --- | --- | --- | --- |
| `in_progress` | ⏳ Frontend deploying to production | Pushed by | Actions |
| `success` | 🚀 Frontend deployed to production | Deployed by | Open Production, Actions |
| `cancelled` | ⏭️ Frontend deploy to production stopped | Pushed by | Actions |
| `failure` | 🛑 Frontend deploy to production failed | Pushed by | Actions |

The start card passes no timings, so the Started and Duration fields drop out on their own, which the outcome card already relied on for its degraded path.

Both files parse as YAML. Not exercised end to end, since this workflow only runs on push to `main`. The step is `continue-on-error: true` and the job is independent of the deploy chain, so a Slack outage cannot hold up or fail a deploy.
