### PR TITLE
fix: return the Amplitude list ID at every depth their parsers read

### DIFF
--- a/api/cohorts/sync_views.py
+++ b/api/cohorts/sync_views.py
@@ -22,7 +22,18 @@ from cohorts.serializers import (
 )
 
 _LIST_RESPONSE = inline_serializer(
-    "AmplitudeListResponse", {"list_id": serializers.UUIDField()}
+    "AmplitudeListResponse",
+    {
+        "list_id": serializers.UUIDField(),
+        "listId": serializers.UUIDField(),
+        "response": inline_serializer(
+            "AmplitudeListResponseEnvelope",
+            {
+                "list_id": serializers.UUIDField(),
+                "listId": serializers.UUIDField(),
+            },
+        ),
+    },
 )
 
 _MIXPANEL_RESPONSE = inline_serializer(
@@ -73,7 +84,21 @@ class AmplitudeCohortSyncViewSet(viewsets.ViewSet):
             name=serializer.validated_data["name"],
             source_type=CohortSourceType.AMPLITUDE,
         )
-        return Response({"list_id": str(cohort.uuid)})
+        # Amplitude's Testing tab and production sync worker read the list
+        # ID from this body differently: the Testing tab wraps the body in a
+        # {"response": ...} envelope before applying the configured ID path,
+        # while the production worker appears to ignore the configured path
+        # and read the documented default key, camelCase "listId". Carrying
+        # the ID at every spelling and depth satisfies every parser
+        # observed.
+        list_id = str(cohort.uuid)
+        return Response(
+            {
+                "list_id": list_id,
+                "listId": list_id,
+                "response": {"list_id": list_id, "listId": list_id},
+            }
+        )
 
     @action(detail=True, methods=["POST"])
     def add(self, request: Request, pk: str) -> Response:

--- a/api/tests/unit/cohorts/test_sync_views.py
+++ b/api/tests/unit/cohorts/test_sync_views.py
@@ -51,6 +51,15 @@ def test_amplitude_create_list__valid_key__creates_amplitude_cohort(
     # Then
     assert response.status_code == status.HTTP_200_OK
     cohort = Cohort.objects.get(uuid=response.json()["list_id"])
+    # Amplitude's test and production parsers read the ID under different
+    # keys and depths; every copy must be present.
+    body = response.json()
+    assert (
+        body["listId"]
+        == body["response"]["list_id"]
+        == body["response"]["listId"]
+        == body["list_id"]
+    )
     assert cohort.environment == key.environment
     assert cohort.source_type == CohortSourceType.AMPLITUDE
     assert cohort.segment.name == "[Amplitude] Beta users: 1234"

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -166,7 +166,7 @@ Attributes:
 ### `cohorts.sync_webhook.rejected`
 
 Logged at `warning` from:
- - `api/cohorts/sync_views.py:214`
+ - `api/cohorts/sync_views.py:239`
 
 Attributes:
  - `action`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18907,7 +18907,26 @@ components:
         list_id:
           type: string
           format: uuid
+        listId:
+          type: string
+          format: uuid
+        response:
+          $ref: '#/components/schemas/AmplitudeListResponseEnvelope'
       required:
+        - listId
+        - list_id
+        - response
+    AmplitudeListResponseEnvelope:
+      type: object
+      properties:
+        list_id:
+          type: string
+          format: uuid
+        listId:
+          type: string
+          format: uuid
+      required:
+        - listId
         - list_id
     AuditLogList:
       type: object


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Amplitude's Testing tab and production sync worker parse the list-creation response differently: the Testing tab wraps the body in a `{"response": ...}` envelope before applying the configured ID path, while the production worker ignores the configured path and reads the documented default key `listId`. With our flat `{"list_id": ...}` body, production syncs fail after list creation with "a required response value was missing" — verified against staging with full request logging.

The create response now carries the ID under both spellings at both depths, satisfying every observed parser.

## How did you test this code?

Unit test asserts all four copies match. Real verification is re-running the production Amplitude sync against staging once deployed.