### PR TITLE
fix: return only listId from Amplitude list creation

### DIFF
--- a/api/cohorts/sync_views.py
+++ b/api/cohorts/sync_views.py
@@ -22,18 +22,7 @@ from cohorts.serializers import (
 )
 
 _LIST_RESPONSE = inline_serializer(
-    "AmplitudeListResponse",
-    {
-        "list_id": serializers.UUIDField(),
-        "listId": serializers.UUIDField(),
-        "response": inline_serializer(
-            "AmplitudeListResponseEnvelope",
-            {
-                "list_id": serializers.UUIDField(),
-                "listId": serializers.UUIDField(),
-            },
-        ),
-    },
+    "AmplitudeListResponse", {"listId": serializers.UUIDField()}
 )
 
 _MIXPANEL_RESPONSE = inline_serializer(
@@ -84,21 +73,10 @@ class AmplitudeCohortSyncViewSet(viewsets.ViewSet):
             name=serializer.validated_data["name"],
             source_type=CohortSourceType.AMPLITUDE,
         )
-        # Amplitude's Testing tab and production sync worker read the list
-        # ID from this body differently: the Testing tab wraps the body in a
-        # {"response": ...} envelope before applying the configured ID path,
-        # while the production worker appears to ignore the configured path
-        # and read the documented default key, camelCase "listId". Carrying
-        # the ID at every spelling and depth satisfies every parser
-        # observed.
-        list_id = str(cohort.uuid)
-        return Response(
-            {
-                "list_id": list_id,
-                "listId": list_id,
-                "response": {"list_id": list_id, "listId": list_id},
-            }
-        )
+        # Amplitude's production sync worker reads the list ID from its
+        # documented default key, camelCase "listId", ignoring the response
+        # path configured in the Integration Portal.
+        return Response({"listId": str(cohort.uuid)})
 
     @action(detail=True, methods=["POST"])
     def add(self, request: Request, pk: str) -> Response:

--- a/api/tests/unit/cohorts/test_sync_views.py
+++ b/api/tests/unit/cohorts/test_sync_views.py
@@ -50,16 +50,7 @@ def test_amplitude_create_list__valid_key__creates_amplitude_cohort(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
-    # Amplitude's test and production parsers read the ID under different
-    # keys and depths; every copy must be present.
-    body = response.json()
-    assert (
-        body["listId"]
-        == body["response"]["list_id"]
-        == body["response"]["listId"]
-        == body["list_id"]
-    )
+    cohort = Cohort.objects.get(uuid=response.json()["listId"])
     assert cohort.environment == key.environment
     assert cohort.source_type == CohortSourceType.AMPLITUDE
     assert cohort.segment.name == "[Amplitude] Beta users: 1234"
@@ -83,7 +74,7 @@ def test_amplitude_create_list__postgres_environment__creates_cohort(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
+    cohort = Cohort.objects.get(uuid=response.json()["listId"])
     assert cohort.environment == environment
 
 
@@ -359,7 +350,7 @@ def test_amplitude_create_list__valid_key__audits_and_queues_environment_update(
     # Then - the audit record carries no user, names the source, and is the
     # hook that rebuilds the environment document.
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
+    cohort = Cohort.objects.get(uuid=response.json()["listId"])
     audit_log = AuditLog.objects.get(related_object_id=cohort.segment_id)
     assert audit_log.author is None
     assert audit_log.master_api_key is None
@@ -386,7 +377,7 @@ def test_amplitude_create_list__valid_key__history_records_no_user(
     # Then - a machine caller leaves no user on historical records; stamping
     # one would fail, since the sync key is not a Flagsmith user.
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
+    cohort = Cohort.objects.get(uuid=response.json()["listId"])
     history_record = cohort.segment.history.get()
     assert history_record.history_user is None
     assert history_record.master_api_key is None

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -166,7 +166,7 @@ Attributes:
 ### `cohorts.sync_webhook.rejected`
 
 Logged at `warning` from:
- - `api/cohorts/sync_views.py:239`
+ - `api/cohorts/sync_views.py:217`
 
 Attributes:
  - `action`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18943,30 +18943,11 @@ components:
     AmplitudeListResponse:
       type: object
       properties:
-        list_id:
-          type: string
-          format: uuid
-        listId:
-          type: string
-          format: uuid
-        response:
-          $ref: '#/components/schemas/AmplitudeListResponseEnvelope'
-      required:
-        - listId
-        - list_id
-        - response
-    AmplitudeListResponseEnvelope:
-      type: object
-      properties:
-        list_id:
-          type: string
-          format: uuid
         listId:
           type: string
           format: uuid
       required:
         - listId
-        - list_id
     AuditLogList:
       type: object
       properties:


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #8399: verified against staging that Amplitude's production sync worker reads the list ID from the documented default key `listId` and ignores the configured response path. The compatibility body with the ID at four spellings/depths is no longer needed — the response is now just `{"listId": ...}`.

## How did you test this code?

Unit tests updated; verified end to end against staging with a real Amplitude production sync (create followed by four parallel add batches).