### PR TITLE
fix: Amplitude list creation response shape

### DIFF
--- a/api/cohorts/sync_views.py
+++ b/api/cohorts/sync_views.py
@@ -79,25 +79,14 @@ class AmplitudeCohortSyncViewSet(viewsets.ViewSet):
             name=serializer.validated_data["name"],
             source_type=CohortSourceType.AMPLITUDE,
         )
+        # Amplitude reads the list ID at the portal-configured path
+        # ("response.list_id"), but its two sides apply that path to
+        # different objects: the production sync worker reads this body as
+        # is, so it needs the nested copy, while the Testing tab first wraps
+        # the body in a {"response": ...} envelope of its own, so it finds
+        # the flat copy. Both verified against staging, 2026-08-31.
         list_id = str(cohort.uuid)
-        # TODO: temporary, while we pin down which copy of the list ID
-        # Amplitude's production sync worker actually reads. `?shape=`
-        # narrows the body to a single candidate so each portal-side retry
-        # tests one; the default carries every copy, which is known to work.
-        # Once the winning shape is confirmed, hardcode it and drop the
-        # parameter.
-        shapes = {
-            "flat_snake": {"list_id": list_id},
-            "flat_camel": {"listId": list_id},
-            "nested_snake": {"response": {"list_id": list_id}},
-            "nested_camel": {"response": {"listId": list_id}},
-        }
-        default = {
-            "list_id": list_id,
-            "listId": list_id,
-            "response": {"list_id": list_id, "listId": list_id},
-        }
-        return Response(shapes.get(request.query_params.get("shape", ""), default))
+        return Response({"list_id": list_id, "response": {"list_id": list_id}})
 
     @action(detail=True, methods=["POST"])
     def add(self, request: Request, pk: str) -> Response:

--- a/api/cohorts/sync_views.py
+++ b/api/cohorts/sync_views.py
@@ -79,15 +79,25 @@ class AmplitudeCohortSyncViewSet(viewsets.ViewSet):
             name=serializer.validated_data["name"],
             source_type=CohortSourceType.AMPLITUDE,
         )
-        # Amplitude reads the list ID from this body at the path configured
-        # in the Integration Portal, which their portal requires to start
-        # with "response." — but the two sides of Amplitude disagree on what
-        # that path is applied to. Their Testing tab wraps this body in a
-        # {"response": ...} envelope first, so it finds the flat copy; their
-        # production sync worker applies the same path to the raw body, so
-        # it needs the nested copy. Verified against both, 2026-08-28.
         list_id = str(cohort.uuid)
-        return Response({"list_id": list_id, "response": {"list_id": list_id}})
+        # TODO: temporary, while we pin down which copy of the list ID
+        # Amplitude's production sync worker actually reads. `?shape=`
+        # narrows the body to a single candidate so each portal-side retry
+        # tests one; the default carries every copy, which is known to work.
+        # Once the winning shape is confirmed, hardcode it and drop the
+        # parameter.
+        shapes = {
+            "flat_snake": {"list_id": list_id},
+            "flat_camel": {"listId": list_id},
+            "nested_snake": {"response": {"list_id": list_id}},
+            "nested_camel": {"response": {"listId": list_id}},
+        }
+        default = {
+            "list_id": list_id,
+            "listId": list_id,
+            "response": {"list_id": list_id, "listId": list_id},
+        }
+        return Response(shapes.get(request.query_params.get("shape", ""), default))
 
     @action(detail=True, methods=["POST"])
     def add(self, request: Request, pk: str) -> Response:

--- a/api/cohorts/sync_views.py
+++ b/api/cohorts/sync_views.py
@@ -79,12 +79,11 @@ class AmplitudeCohortSyncViewSet(viewsets.ViewSet):
             name=serializer.validated_data["name"],
             source_type=CohortSourceType.AMPLITUDE,
         )
-        # Amplitude reads the list ID at the portal-configured path
-        # ("response.list_id"), but its two sides apply that path to
-        # different objects: the production sync worker reads this body as
-        # is, so it needs the nested copy, while the Testing tab first wraps
-        # the body in a {"response": ...} envelope of its own, so it finds
-        # the flat copy. Both verified against staging, 2026-08-31.
+        # Two different Amplitude systems read this response, and they look
+        # for the list ID in different places: the real cohort sync reads
+        # body["response"]["list_id"], the portal's Testing tab reads
+        # body["list_id"]. Send both so neither breaks. Verified on
+        # staging, 2026-08-31.
         list_id = str(cohort.uuid)
         return Response({"list_id": list_id, "response": {"list_id": list_id}})
 

--- a/api/cohorts/sync_views.py
+++ b/api/cohorts/sync_views.py
@@ -22,7 +22,13 @@ from cohorts.serializers import (
 )
 
 _LIST_RESPONSE = inline_serializer(
-    "AmplitudeListResponse", {"listId": serializers.UUIDField()}
+    "AmplitudeListResponse",
+    {
+        "list_id": serializers.UUIDField(),
+        "response": inline_serializer(
+            "AmplitudeListResponseEnvelope", {"list_id": serializers.UUIDField()}
+        ),
+    },
 )
 
 _MIXPANEL_RESPONSE = inline_serializer(
@@ -73,10 +79,15 @@ class AmplitudeCohortSyncViewSet(viewsets.ViewSet):
             name=serializer.validated_data["name"],
             source_type=CohortSourceType.AMPLITUDE,
         )
-        # Amplitude's production sync worker reads the list ID from its
-        # documented default key, camelCase "listId", ignoring the response
-        # path configured in the Integration Portal.
-        return Response({"listId": str(cohort.uuid)})
+        # Amplitude reads the list ID from this body at the path configured
+        # in the Integration Portal, which their portal requires to start
+        # with "response." — but the two sides of Amplitude disagree on what
+        # that path is applied to. Their Testing tab wraps this body in a
+        # {"response": ...} envelope first, so it finds the flat copy; their
+        # production sync worker applies the same path to the raw body, so
+        # it needs the nested copy. Verified against both, 2026-08-28.
+        list_id = str(cohort.uuid)
+        return Response({"list_id": list_id, "response": {"list_id": list_id}})
 
     @action(detail=True, methods=["POST"])
     def add(self, request: Request, pk: str) -> Response:

--- a/api/tests/unit/cohorts/test_sync_views.py
+++ b/api/tests/unit/cohorts/test_sync_views.py
@@ -51,15 +51,9 @@ def test_amplitude_create_list__valid_key__creates_amplitude_cohort(
     # Then
     assert response.status_code == status.HTTP_200_OK
     cohort = Cohort.objects.get(uuid=response.json()["list_id"])
-    # Without ?shape=, the body carries the list ID at every spelling and
-    # depth Amplitude might read.
-    body = response.json()
-    assert (
-        body["listId"]
-        == body["response"]["list_id"]
-        == body["response"]["listId"]
-        == body["list_id"]
-    )
+    # Amplitude's production worker reads the nested copy, its Testing tab
+    # the flat one.
+    assert response.json()["response"]["list_id"] == response.json()["list_id"]
     assert cohort.environment == key.environment
     assert cohort.source_type == CohortSourceType.AMPLITUDE
     assert cohort.segment.name == "[Amplitude] Beta users: 1234"
@@ -1274,23 +1268,3 @@ def test_webhook_add_members__saas_free_plan__returns_403(
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-def test_amplitude_create_list__shape_param__returns_only_that_shape(
-    cohort_sync_key: _KeyAndPlaintext,
-    dynamodb_identity_wrapper: DynamoIdentityWrapper,
-) -> None:
-    # Given
-    _, plaintext = cohort_sync_key
-    client = _authenticated_client(plaintext)
-    url = reverse("api-v1:cohort-sync:amplitude-list")
-
-    # When
-    response = client.post(
-        f"{url}?shape=nested_camel", data={"name": "Beta users"}, format="json"
-    )
-
-    # Then
-    assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(source_type=CohortSourceType.AMPLITUDE)
-    assert response.json() == {"response": {"listId": str(cohort.uuid)}}

--- a/api/tests/unit/cohorts/test_sync_views.py
+++ b/api/tests/unit/cohorts/test_sync_views.py
@@ -50,7 +50,9 @@ def test_amplitude_create_list__valid_key__creates_amplitude_cohort(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["listId"])
+    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
+    # Amplitude's Testing tab reads the flat copy, production the nested one.
+    assert response.json()["response"]["list_id"] == response.json()["list_id"]
     assert cohort.environment == key.environment
     assert cohort.source_type == CohortSourceType.AMPLITUDE
     assert cohort.segment.name == "[Amplitude] Beta users: 1234"
@@ -74,7 +76,7 @@ def test_amplitude_create_list__postgres_environment__creates_cohort(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["listId"])
+    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
     assert cohort.environment == environment
 
 
@@ -350,7 +352,7 @@ def test_amplitude_create_list__valid_key__audits_and_queues_environment_update(
     # Then - the audit record carries no user, names the source, and is the
     # hook that rebuilds the environment document.
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["listId"])
+    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
     audit_log = AuditLog.objects.get(related_object_id=cohort.segment_id)
     assert audit_log.author is None
     assert audit_log.master_api_key is None
@@ -377,7 +379,7 @@ def test_amplitude_create_list__valid_key__history_records_no_user(
     # Then - a machine caller leaves no user on historical records; stamping
     # one would fail, since the sync key is not a Flagsmith user.
     assert response.status_code == status.HTTP_200_OK
-    cohort = Cohort.objects.get(uuid=response.json()["listId"])
+    cohort = Cohort.objects.get(uuid=response.json()["list_id"])
     history_record = cohort.segment.history.get()
     assert history_record.history_user is None
     assert history_record.master_api_key is None

--- a/api/tests/unit/cohorts/test_sync_views.py
+++ b/api/tests/unit/cohorts/test_sync_views.py
@@ -51,8 +51,15 @@ def test_amplitude_create_list__valid_key__creates_amplitude_cohort(
     # Then
     assert response.status_code == status.HTTP_200_OK
     cohort = Cohort.objects.get(uuid=response.json()["list_id"])
-    # Amplitude's Testing tab reads the flat copy, production the nested one.
-    assert response.json()["response"]["list_id"] == response.json()["list_id"]
+    # Without ?shape=, the body carries the list ID at every spelling and
+    # depth Amplitude might read.
+    body = response.json()
+    assert (
+        body["listId"]
+        == body["response"]["list_id"]
+        == body["response"]["listId"]
+        == body["list_id"]
+    )
     assert cohort.environment == key.environment
     assert cohort.source_type == CohortSourceType.AMPLITUDE
     assert cohort.segment.name == "[Amplitude] Beta users: 1234"
@@ -1267,3 +1274,23 @@ def test_webhook_add_members__saas_free_plan__returns_403(
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_amplitude_create_list__shape_param__returns_only_that_shape(
+    cohort_sync_key: _KeyAndPlaintext,
+    dynamodb_identity_wrapper: DynamoIdentityWrapper,
+) -> None:
+    # Given
+    _, plaintext = cohort_sync_key
+    client = _authenticated_client(plaintext)
+    url = reverse("api-v1:cohort-sync:amplitude-list")
+
+    # When
+    response = client.post(
+        f"{url}?shape=nested_camel", data={"name": "Beta users"}, format="json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    cohort = Cohort.objects.get(source_type=CohortSourceType.AMPLITUDE)
+    assert response.json() == {"response": {"listId": str(cohort.uuid)}}

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -166,7 +166,7 @@ Attributes:
 ### `cohorts.sync_webhook.rejected`
 
 Logged at `warning` from:
- - `api/cohorts/sync_views.py:227`
+ - `api/cohorts/sync_views.py:226`
 
 Attributes:
  - `action`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -166,7 +166,7 @@ Attributes:
 ### `cohorts.sync_webhook.rejected`
 
 Logged at `warning` from:
- - `api/cohorts/sync_views.py:217`
+ - `api/cohorts/sync_views.py:228`
 
 Attributes:
  - `action`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -166,7 +166,7 @@ Attributes:
 ### `cohorts.sync_webhook.rejected`
 
 Logged at `warning` from:
- - `api/cohorts/sync_views.py:228`
+ - `api/cohorts/sync_views.py:238`
 
 Attributes:
  - `action`

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -166,7 +166,7 @@ Attributes:
 ### `cohorts.sync_webhook.rejected`
 
 Logged at `warning` from:
- - `api/cohorts/sync_views.py:238`
+ - `api/cohorts/sync_views.py:227`
 
 Attributes:
  - `action`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18943,11 +18943,22 @@ components:
     AmplitudeListResponse:
       type: object
       properties:
-        listId:
+        list_id:
+          type: string
+          format: uuid
+        response:
+          $ref: '#/components/schemas/AmplitudeListResponseEnvelope'
+      required:
+        - list_id
+        - response
+    AmplitudeListResponseEnvelope:
+      type: object
+      properties:
+        list_id:
           type: string
           format: uuid
       required:
-        - listId
+        - list_id
     AuditLogList:
       type: object
       properties:


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Amplitude's production sync worker and its portal Testing tab read the list ID from our create response at the same configured path, but against different objects, so a single copy of the ID always fails one of them.

- The create response now carries the ID flat (read by the Testing tab) and nested under `response` (read by the production worker).
- Restores production syncs broken by #8400.

## How did you test this code?

Verified each shape against staging with real Amplitude syncs: nested-only passes production but fails the Testing tab, flat-only the reverse, both together pass both.