### PR TITLE
feat: allow uppercase characters in trait keys

### DIFF
--- a/frontend/web/components/modals/CreateTrait.tsx
+++ b/frontend/web/components/modals/CreateTrait.tsx
@@ -8,10 +8,8 @@ import React, {
 } from 'react'
 import Highlight from 'components/Highlight'
 import Constants from 'common/constants'
-import Format from 'common/utils/format'
 import ErrorMessage from 'components/ErrorMessage'
 import ModalHR from './ModalHR'
-import IdentityProvider from 'common/providers/IdentityProvider'
 import find from 'lodash/find'
 import ProjectProvider from 'common/providers/ProjectProvider'
 import Button from 'components/base/forms/Button'
@@ -122,11 +120,7 @@ const CreateTrait: FC<CreateTraitProps> = ({
                 }}
                 value={traitKey}
                 onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  setTraitKey(
-                    Format.enumeration
-                      .set(Utils.safeParseEventValue(e))
-                      .toLowerCase(),
-                  )
+                  setTraitKey(Utils.safeParseEventValue(e).replace(/ /g, '_'))
                 }
                 isValid={!!traitKey && traitKey.length > 0}
                 type='text'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

- Stop lowercasing the trait key input — the API and SDKs are case-sensitive,
  so `appVersion` couldn't be created from the dashboard. Spaces still become underscores.

## How did you test this code?

- Manually: the Trait ID field keeps typed casing and saves it; spaces still convert to underscores.
