### PR TITLE
feat: Exclude verified Edge Proxy requests from API usage tracking

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1160,6 +1160,10 @@ if SCIM_INSTALLED:
         "USER_FILTER_PARSER": "scim.filters.UserFilterQuery",
     }
 
+EDGE_PROXY_INSTALLED = importlib.util.find_spec("edge_proxy") is not None
+if EDGE_PROXY_INSTALLED:
+    INSTALLED_APPS.append("edge_proxy")
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Used to keep edge identities in sync by forwarding the http requests

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -1,6 +1,7 @@
 import importlib
 
 from common.core.urls import urlpatterns as core_urlpatterns
+from common.core.utils import is_saas
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
@@ -122,6 +123,16 @@ if settings.SCIM_INSTALLED:  # pragma: no cover
             "api/v1/organisations/<int:organisation_pk>/scim/",
             include("scim.urls"),
         ),
+    ]
+
+# SaaS images ship the private wheel, so is_saas() is the gate, not module presence.
+if settings.EDGE_PROXY_INSTALLED and not is_saas():  # pragma: no cover
+    urlpatterns += [
+        path(
+            "api/v1/organisations/<int:organisation_pk>/edge-proxy/",
+            include("edge_proxy.management_urls"),
+        ),
+        path("api/v1/proxy/", include("edge_proxy.urls")),
     ]
 
 if settings.WORKFLOWS_LOGIC_INSTALLED:  # pragma: no cover

--- a/api/app_analytics/middleware.py
+++ b/api/app_analytics/middleware.py
@@ -1,3 +1,4 @@
+import importlib
 from typing import Callable
 
 from common.core.utils import is_saas
@@ -39,9 +40,14 @@ class APIUsageMiddleware:
         # header presence is never trusted.
         self.is_edge_proxy_request: Callable[[HttpRequest], bool] | None = None
         if settings.EDGE_PROXY_INSTALLED and not is_saas():
-            from edge_proxy.authentication import is_edge_proxy_request
-
-            self.is_edge_proxy_request = is_edge_proxy_request
+            # getattr, not a hard import: the installed edge_proxy app may
+            # predate the helper — the proxy's fetches are then counted as
+            # before.
+            self.is_edge_proxy_request = getattr(
+                importlib.import_module("edge_proxy.authentication"),
+                "is_edge_proxy_request",
+                None,
+            )
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         if (environment_key := request.headers.get("X-Environment-Key")) and not (

--- a/api/app_analytics/middleware.py
+++ b/api/app_analytics/middleware.py
@@ -38,21 +38,21 @@ class APIUsageMiddleware:
         # edge_proxy app decides what counts as the proxy's own: a verified
         # X-Proxy-Key whose grants cover the presented environment — bare
         # header presence is never trusted.
-        self.is_edge_proxy_request: Callable[[HttpRequest], bool] | None = None
+        self.is_valid_edge_proxy_request: Callable[[HttpRequest], bool] | None = None
         if settings.EDGE_PROXY_INSTALLED and not is_saas():
             # getattr, not a hard import: the installed edge_proxy app may
             # predate the helper — the proxy's fetches are then counted as
             # before.
-            self.is_edge_proxy_request = getattr(
+            self.is_valid_edge_proxy_request = getattr(
                 importlib.import_module("edge_proxy.authentication"),
-                "is_edge_proxy_request",
+                "is_valid_edge_proxy_request",
                 None,
             )
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         if (environment_key := request.headers.get("X-Environment-Key")) and not (
-            self.is_edge_proxy_request is not None
-            and self.is_edge_proxy_request(request)
+            self.is_valid_edge_proxy_request is not None
+            and self.is_valid_edge_proxy_request(request)
         ):
             track_usage_by_resource_host_and_environment(
                 resource=get_resource_from_uri(request.path),

--- a/api/app_analytics/middleware.py
+++ b/api/app_analytics/middleware.py
@@ -1,5 +1,7 @@
 from typing import Callable
 
+from common.core.utils import is_saas
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
 from app_analytics.mappers import map_request_to_labels
@@ -30,9 +32,22 @@ class APIUsageMiddleware:
         get_response: Callable[[HttpRequest], HttpResponse],
     ) -> None:
         self.get_response = get_response
+        # An Edge Proxy reports the requests it serves itself, so its own
+        # requests to core must not also be counted here. The private
+        # edge_proxy app decides what counts as the proxy's own: a verified
+        # X-Proxy-Key whose grants cover the presented environment — bare
+        # header presence is never trusted.
+        self.is_edge_proxy_request: Callable[[HttpRequest], bool] | None = None
+        if settings.EDGE_PROXY_INSTALLED and not is_saas():
+            from edge_proxy.authentication import is_edge_proxy_request
+
+            self.is_edge_proxy_request = is_edge_proxy_request
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
-        if environment_key := request.headers.get("X-Environment-Key"):
+        if (environment_key := request.headers.get("X-Environment-Key")) and not (
+            self.is_edge_proxy_request is not None
+            and self.is_edge_proxy_request(request)
+        ):
             track_usage_by_resource_host_and_environment(
                 resource=get_resource_from_uri(request.path),
                 host=request.get_host(),

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -243,6 +243,10 @@ module = ["rbac.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["edge_proxy.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["saml.*"]
 ignore_missing_imports = true
 

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from django.test import RequestFactory
 from pytest_django.fixtures import SettingsWrapper
@@ -6,6 +8,13 @@ from pytest_mock import MockerFixture
 from app_analytics.middleware import APIUsageMiddleware
 from app_analytics.models import Resource
 from tests.types import EnableFeaturesFixture
+
+
+@pytest.fixture(autouse=True)
+def edge_proxy_not_installed(settings: SettingsWrapper) -> None:
+    # Keep these tests hermetic: whether the private edge_proxy wheel is
+    # installed in the test environment must not change middleware wiring.
+    settings.EDGE_PROXY_INSTALLED = False
 
 
 @pytest.mark.parametrize(
@@ -131,3 +140,92 @@ def test_api_usage_middleware__request_not_tracked__not_calls_expected(
 
     # Then
     mocked_track_request.delay.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "edge_proxy_installed, saas, expect_wired",
+    [
+        (True, False, True),
+        (True, True, False),
+        (False, False, False),
+    ],
+)
+def test_api_usage_middleware__edge_proxy_check__wired_only_where_expected(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    edge_proxy_installed: bool,
+    saas: bool,
+    expect_wired: bool,
+) -> None:
+    # Given a deployment with/without the private edge_proxy app
+    settings.EDGE_PROXY_INSTALLED = edge_proxy_installed
+    mocker.patch("app_analytics.middleware.is_saas", return_value=saas)
+    is_edge_proxy_request = mocker.MagicMock()
+    mocker.patch.dict(
+        sys.modules,
+        {
+            "edge_proxy": mocker.MagicMock(),
+            "edge_proxy.authentication": mocker.MagicMock(
+                is_edge_proxy_request=is_edge_proxy_request
+            ),
+        },
+    )
+
+    # When
+    middleware = APIUsageMiddleware(mocker.MagicMock())
+
+    # Then the verifier is wired only where the proxy reports usage
+    # itself: a non-SaaS deployment with the edge_proxy app installed
+    assert middleware.is_edge_proxy_request is (
+        is_edge_proxy_request if expect_wired else None
+    )
+
+
+@pytest.mark.parametrize("is_verified_proxy_request", [True, False])
+def test_api_usage_middleware__edge_proxy_check_wired__tracks_unverified_only(
+    rf: RequestFactory,
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+    is_verified_proxy_request: bool,
+) -> None:
+    # Given a request bearing proxy headers the edge_proxy app does or
+    # does not verify
+    headers = {"HTTP_X-Environment-Key": "test", "HTTP_X-Proxy-Key": "pk.key"}
+    request = rf.get("/api/v1/environment-document", **headers)  # type: ignore[arg-type]
+    settings.EDGE_PROXY_INSTALLED = False
+    mocked_track_usage = mocker.patch(
+        "app_analytics.middleware.track_usage_by_resource_host_and_environment"
+    )
+    middleware = APIUsageMiddleware(mocker.MagicMock())
+    middleware.is_edge_proxy_request = mocker.MagicMock(
+        return_value=is_verified_proxy_request
+    )
+
+    # When
+    middleware(request)
+
+    # Then only a verified proxy request is exempt — a spoofed header is not
+    middleware.is_edge_proxy_request.assert_called_once_with(request)
+    assert mocked_track_usage.called is not is_verified_proxy_request
+
+
+def test_api_usage_middleware__edge_proxy_check_not_wired__proxy_header_still_tracked(
+    rf: RequestFactory,
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+) -> None:
+    # Given a request bearing an X-Proxy-Key on a deployment with no
+    # edge_proxy app to verify it
+    headers = {"HTTP_X-Environment-Key": "test", "HTTP_X-Proxy-Key": "pk.key"}
+    request = rf.get("/api/v1/environment-document", **headers)  # type: ignore[arg-type]
+    settings.EDGE_PROXY_INSTALLED = False
+    mocked_track_usage = mocker.patch(
+        "app_analytics.middleware.track_usage_by_resource_host_and_environment"
+    )
+
+    # When
+    middleware = APIUsageMiddleware(mocker.MagicMock())
+    middleware(request)
+
+    # Then
+    mocked_track_usage.assert_called_once()

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -196,16 +196,15 @@ def test_api_usage_middleware__edge_proxy_check_wired__tracks_unverified_only(
     mocked_track_usage = mocker.patch(
         "app_analytics.middleware.track_usage_by_resource_host_and_environment"
     )
+    is_edge_proxy_request = mocker.MagicMock(return_value=is_verified_proxy_request)
     middleware = APIUsageMiddleware(mocker.MagicMock())
-    middleware.is_edge_proxy_request = mocker.MagicMock(
-        return_value=is_verified_proxy_request
-    )
+    middleware.is_edge_proxy_request = is_edge_proxy_request
 
     # When
     middleware(request)
 
     # Then only a verified proxy request is exempt — a spoofed header is not
-    middleware.is_edge_proxy_request.assert_called_once_with(request)
+    is_edge_proxy_request.assert_called_once_with(request)
     assert mocked_track_usage.called is not is_verified_proxy_request
 
 

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -160,13 +160,13 @@ def test_api_usage_middleware__edge_proxy_check__wired_only_where_expected(
     # Given a deployment with/without the private edge_proxy app
     settings.EDGE_PROXY_INSTALLED = edge_proxy_installed
     mocker.patch("app_analytics.middleware.is_saas", return_value=saas)
-    is_edge_proxy_request = mocker.MagicMock()
+    is_valid_edge_proxy_request = mocker.MagicMock()
     mocker.patch.dict(
         sys.modules,
         {
             "edge_proxy": mocker.MagicMock(),
             "edge_proxy.authentication": mocker.MagicMock(
-                is_edge_proxy_request=is_edge_proxy_request
+                is_valid_edge_proxy_request=is_valid_edge_proxy_request
             ),
         },
     )
@@ -176,8 +176,8 @@ def test_api_usage_middleware__edge_proxy_check__wired_only_where_expected(
 
     # Then the verifier is wired only where the proxy reports usage
     # itself: a non-SaaS deployment with the edge_proxy app installed
-    assert middleware.is_edge_proxy_request is (
-        is_edge_proxy_request if expect_wired else None
+    assert middleware.is_valid_edge_proxy_request is (
+        is_valid_edge_proxy_request if expect_wired else None
     )
 
 
@@ -185,7 +185,7 @@ def test_api_usage_middleware__edge_proxy_app_predates_helper__not_wired(
     mocker: MockerFixture,
     settings: SettingsWrapper,
 ) -> None:
-    # Given an installed edge_proxy app without is_edge_proxy_request
+    # Given an installed edge_proxy app without is_valid_edge_proxy_request
     settings.EDGE_PROXY_INSTALLED = True
     mocker.patch("app_analytics.middleware.is_saas", return_value=False)
     mocker.patch.dict(
@@ -200,7 +200,7 @@ def test_api_usage_middleware__edge_proxy_app_predates_helper__not_wired(
     middleware = APIUsageMiddleware(mocker.MagicMock())
 
     # Then requests are counted as before
-    assert middleware.is_edge_proxy_request is None
+    assert middleware.is_valid_edge_proxy_request is None
 
 
 @pytest.mark.parametrize("is_verified_proxy_request", [True, False])
@@ -218,15 +218,17 @@ def test_api_usage_middleware__edge_proxy_check_wired__tracks_unverified_only(
     mocked_track_usage = mocker.patch(
         "app_analytics.middleware.track_usage_by_resource_host_and_environment"
     )
-    is_edge_proxy_request = mocker.MagicMock(return_value=is_verified_proxy_request)
+    is_valid_edge_proxy_request = mocker.MagicMock(
+        return_value=is_verified_proxy_request
+    )
     middleware = APIUsageMiddleware(mocker.MagicMock())
-    middleware.is_edge_proxy_request = is_edge_proxy_request
+    middleware.is_valid_edge_proxy_request = is_valid_edge_proxy_request
 
     # When
     middleware(request)
 
     # Then only a verified proxy request is exempt — a spoofed header is not
-    is_edge_proxy_request.assert_called_once_with(request)
+    is_valid_edge_proxy_request.assert_called_once_with(request)
     assert mocked_track_usage.called is not is_verified_proxy_request
 
 

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -181,6 +181,28 @@ def test_api_usage_middleware__edge_proxy_check__wired_only_where_expected(
     )
 
 
+def test_api_usage_middleware__edge_proxy_app_predates_helper__not_wired(
+    mocker: MockerFixture,
+    settings: SettingsWrapper,
+) -> None:
+    # Given an installed edge_proxy app without is_edge_proxy_request
+    settings.EDGE_PROXY_INSTALLED = True
+    mocker.patch("app_analytics.middleware.is_saas", return_value=False)
+    mocker.patch.dict(
+        sys.modules,
+        {
+            "edge_proxy": mocker.MagicMock(),
+            "edge_proxy.authentication": mocker.MagicMock(spec=[]),
+        },
+    )
+
+    # When
+    middleware = APIUsageMiddleware(mocker.MagicMock())
+
+    # Then requests are counted as before
+    assert middleware.is_edge_proxy_request is None
+
+
 @pytest.mark.parametrize("is_verified_proxy_request", [True, False])
 def test_api_usage_middleware__edge_proxy_check_wired__tracks_unverified_only(
     rf: RequestFactory,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9819,6 +9819,179 @@ paths:
         - Master API Key: []
       tags:
         - Audit
+  '/api/v1/organisations/{organisation_pk}/edge-proxy/keys/':
+    get:
+      operationId: api_v1_organisations_edge_proxy_keys_list
+      parameters:
+        - name: organisation_pk
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProxyKey'
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Organisations
+    post:
+      operationId: api_v1_organisations_edge_proxy_keys_create
+      parameters:
+        - name: organisation_pk
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProxyKey'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ProxyKey'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ProxyKey'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyKey'
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Organisations
+  '/api/v1/organisations/{organisation_pk}/edge-proxy/keys/{prefix}/':
+    get:
+      operationId: api_v1_organisations_edge_proxy_keys_retrieve
+      parameters:
+        - name: organisation_pk
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyKey'
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Organisations
+    put:
+      operationId: api_v1_organisations_edge_proxy_keys_update
+      parameters:
+        - name: organisation_pk
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProxyKey'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ProxyKey'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ProxyKey'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyKey'
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Organisations
+    patch:
+      operationId: api_v1_organisations_edge_proxy_keys_partial_update
+      parameters:
+        - name: organisation_pk
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProxyKey'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedProxyKey'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedProxyKey'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyKey'
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Organisations
+    delete:
+      operationId: api_v1_organisations_edge_proxy_keys_destroy
+      parameters:
+        - name: organisation_pk
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No response body
+      security:
+        - tokenAuth: []
+        - Master API Key: []
+      tags:
+        - Organisations
   '/api/v1/organisations/{organisation_pk}/github/create-cleanup-issue/':
     post:
       operationId: api_v1_organisations_github_create_cleanup_issue_create
@@ -18644,6 +18817,20 @@ paths:
         - Master API Key: []
       tags:
         - Projects
+  /api/v1/proxy/config/:
+    get:
+      operationId: api_v1_proxy_config_list
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EdgeProxyEnvironment'
+      tags:
+        - Other
   '/api/v1/segments/get-by-uuid/{uuid}/':
     get:
       operationId: api_v1_segments_get_by_uuid_retrieve
@@ -20542,6 +20729,48 @@ components:
       required:
         - multivariate_feature_option
         - percentage_allocation
+    EdgeProxyEnvironment:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 2000
+        client_side_key:
+          type: string
+        server_side_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdgeProxyServerSideKey'
+        updated_at:
+          description: 'Tracks changes to self and related entities, e.g. FeatureStates.'
+          type: string
+          format: date-time
+        project_id:
+          type: integer
+          readOnly: true
+        organisation_id:
+          type: integer
+          readOnly: true
+      required:
+        - client_side_key
+        - name
+        - server_side_keys
+    EdgeProxyServerSideKey:
+      type: object
+      properties:
+        key:
+          type: string
+          maxLength: 100
+        active:
+          type: boolean
+        expires_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
     EdgeV2MigrationStatusEnum:
       description: |-
         * `NOT_STARTED` - Not Started
@@ -25549,6 +25778,47 @@ components:
         enforce_feature_owners:
           description: Require at least one user or group owner when creating a feature.
           type: boolean
+    PatchedProxyKey:
+      type: object
+      properties:
+        prefix:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        name:
+          description: A free-form name for the API key. Need not be unique. 50 characters max.
+          type: string
+          maxLength: 50
+        revoked:
+          description: 'If the API key is revoked, clients cannot use it anymore. (This cannot be undone.)'
+          type: boolean
+        expiry_date:
+          description: 'Once API key expires, clients cannot use it anymore.'
+          type:
+            - string
+            - 'null'
+          format: date-time
+          title: Expires
+        key:
+          description: 'Only the key hash is stored, so the full key is returned on create and is unavailable from every other endpoint.'
+          type: string
+          readOnly: true
+        has_expired:
+          type: boolean
+          readOnly: true
+        created_by_user:
+          type:
+            - integer
+            - 'null'
+          readOnly: true
+        created_by_master_api_key:
+          type:
+            - string
+            - 'null'
+          readOnly: true
     PatchedReleasePipeline:
       type: object
       properties:
@@ -27080,6 +27350,47 @@ components:
           type: boolean
       required:
         - name
+    ProxyKey:
+      type: object
+      properties:
+        prefix:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        name:
+          description: A free-form name for the API key. Need not be unique. 50 characters max.
+          type: string
+          maxLength: 50
+        revoked:
+          description: 'If the API key is revoked, clients cannot use it anymore. (This cannot be undone.)'
+          type: boolean
+        expiry_date:
+          description: 'Once API key expires, clients cannot use it anymore.'
+          type:
+            - string
+            - 'null'
+          format: date-time
+          title: Expires
+        key:
+          description: 'Only the key hash is stored, so the full key is returned on create and is unavailable from every other endpoint.'
+          type: string
+          readOnly: true
+        has_expired:
+          type: boolean
+          readOnly: true
+        created_by_user:
+          type:
+            - integer
+            - 'null'
+          readOnly: true
+        created_by_master_api_key:
+          type:
+            - string
+            - 'null'
+          readOnly: true
     ReleasePipeline:
       type: object
       properties:


### PR DESCRIPTION
## Changes

Contributes to Flagsmith/flagsmith-private#256

An Edge Proxy reports the requests it serves through its own usage endpoint, so counting its `/environment-document/` fetches here would double-count. `APIUsageMiddleware` now skips a request when the private `edge_proxy` app verifies it as the proxy's own — `is_edge_proxy_request()` checks the `X-Proxy-Key` value and that the key's grants cover the presented environment. Bare header presence is never trusted, so the header can't be spoofed to dodge metering.

Wired only on non-SaaS deployments with the `edge_proxy` app installed; SaaS behaviour is untouched.

Stacked on #8305. **Before merge:** bump the `flagsmith-private` pin to the release that ships `is_edge_proxy_request`.

## How did you test this code?

19 middleware unit tests: verifier wired only when installed + non-SaaS; verified requests untracked, unverified tracked; a proxy header with no verifier available still tracked (spoof regression); existing tracking cases unchanged. The verifier itself is tested against a real database in flagsmith-private.
