### PR TITLE
fix(auth): allow invite-based signup when PREVENT_SIGNUP is enabled

### DIFF
--- a/api/custom_auth/permissions.py
+++ b/api/custom_auth/permissions.py
@@ -3,6 +3,8 @@ from django.views import View
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 
+from organisations.invites.services import is_valid_registration_invite
+
 
 class CurrentUser(IsAuthenticated):
     """
@@ -18,7 +20,17 @@ class CurrentUser(IsAuthenticated):
 
 class IsSignupAllowed(AllowAny):
     def has_permission(self, request: Request, view: View) -> bool:
-        return not settings.PREVENT_SIGNUP
+        if not settings.PREVENT_SIGNUP:
+            return True
+
+        # Signups are otherwise prevented, but a valid invite should still
+        # let someone through: `PREVENT_SIGNUP` is meant to stop self-serve
+        # signup, not registration via an invite link or invited email.
+        return is_valid_registration_invite(
+            sign_up_type=request.data.get("sign_up_type"),
+            email=request.data.get("email") or "",
+            invite_hash=request.data.get("invite_hash"),
+        )
 
 
 class IsPasswordLoginAllowed(AllowAny):

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -7,10 +7,10 @@ from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import PermissionDenied
 
-from organisations.invites.models import Invite, InviteLink
+from organisations.invites.services import is_valid_registration_invite
 from users.auth_type import AuthType
 from users.constants import DEFAULT_DELETE_ORPHAN_ORGANISATIONS_VALUE
-from users.models import FFAdminUser, SignUpType
+from users.models import FFAdminUser
 
 from .constants import (
     FIELD_BLANK_ERROR,
@@ -32,17 +32,11 @@ class InviteLinkValidationMixin:
         if settings.ALLOW_REGISTRATION_WITHOUT_INVITE:
             return
 
-        valid = False
-
-        match sign_up_type:
-            case SignUpType.INVITE_LINK.value:
-                valid = InviteLink.objects.filter(
-                    hash=self.initial_data.get("invite_hash")  # type: ignore[attr-defined]
-                ).exists()
-            case SignUpType.INVITE_EMAIL.value:
-                valid = Invite.objects.filter(email__iexact=email.lower()).exists()
-
-        if not valid:
+        if not is_valid_registration_invite(
+            sign_up_type=sign_up_type,
+            email=email,
+            invite_hash=self.initial_data.get("invite_hash"),  # type: ignore[attr-defined]
+        ):
             raise PermissionDenied(USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE)
 
 

--- a/api/organisations/invites/services.py
+++ b/api/organisations/invites/services.py
@@ -1,0 +1,15 @@
+from users.models import SignUpType
+
+from .models import Invite, InviteLink
+
+
+def is_valid_registration_invite(
+    *, sign_up_type: str | None, email: str, invite_hash: str | None
+) -> bool:
+    match sign_up_type:
+        case SignUpType.INVITE_LINK.value:
+            return InviteLink.objects.filter(hash=invite_hash).exists()
+        case SignUpType.INVITE_EMAIL.value:
+            return Invite.objects.filter(email__iexact=email.lower()).exists()
+        case _:
+            return False

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
@@ -1,0 +1,107 @@
+from unittest import mock
+
+from pytest_django.fixtures import SettingsWrapper
+
+from custom_auth.permissions import IsSignupAllowed
+from organisations.invites.models import Invite, InviteLink
+from organisations.models import Organisation
+from users.models import SignUpType
+
+
+def test_is_signup_allowed__prevent_signup_disabled__returns_true(
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.PREVENT_SIGNUP = False
+    permission = IsSignupAllowed()
+    mock_request = mock.MagicMock(data={})
+
+    # When
+    result = permission.has_permission(mock_request, mock.MagicMock())
+
+    # Then
+    assert result is True
+
+
+def test_is_signup_allowed__prevent_signup_enabled_no_invite__returns_false(
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.PREVENT_SIGNUP = True
+    permission = IsSignupAllowed()
+    mock_request = mock.MagicMock(data={"email": "test@example.com"})
+
+    # When
+    result = permission.has_permission(mock_request, mock.MagicMock())
+
+    # Then
+    assert result is False
+
+
+def test_is_signup_allowed__prevent_signup_enabled_valid_invite_link__returns_true(
+    db: None,
+    settings: SettingsWrapper,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.PREVENT_SIGNUP = True
+    invite_link = InviteLink.objects.create(organisation=organisation)
+    permission = IsSignupAllowed()
+    mock_request = mock.MagicMock(
+        data={
+            "email": "test@example.com",
+            "sign_up_type": SignUpType.INVITE_LINK.value,
+            "invite_hash": invite_link.hash,
+        }
+    )
+
+    # When
+    result = permission.has_permission(mock_request, mock.MagicMock())
+
+    # Then
+    assert result is True
+
+
+def test_is_signup_allowed__prevent_signup_enabled_invalid_invite_hash__returns_false(
+    db: None,
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    settings.PREVENT_SIGNUP = True
+    permission = IsSignupAllowed()
+    mock_request = mock.MagicMock(
+        data={
+            "email": "test@example.com",
+            "sign_up_type": SignUpType.INVITE_LINK.value,
+            "invite_hash": "invalid-hash",
+        }
+    )
+
+    # When
+    result = permission.has_permission(mock_request, mock.MagicMock())
+
+    # Then
+    assert result is False
+
+
+def test_is_signup_allowed__prevent_signup_enabled_valid_invite_email__returns_true(
+    db: None,
+    settings: SettingsWrapper,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.PREVENT_SIGNUP = True
+    Invite.objects.create(email="test@example.com", organisation=organisation)
+    permission = IsSignupAllowed()
+    mock_request = mock.MagicMock(
+        data={
+            "email": "Test@Example.com",
+            "sign_up_type": SignUpType.INVITE_EMAIL.value,
+        }
+    )
+
+    # When
+    result = permission.has_permission(mock_request, mock.MagicMock())
+
+    # Then
+    assert result is True


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`IsSignupAllowed` blocked every registration once `PREVENT_SIGNUP` was enabled, including ones carrying a valid invite link or an invited email address. That meant the invite-validation logic already present in the registration serializer never even ran — self-hosted admins who turn on `PREVENT_SIGNUP` to stop self-serve signup could no longer onboard teammates via invite link either.

- [x] `IsSignupAllowed` now allows a registration request through when it carries a valid invite (link hash or invited email), matching the existing invite-validation behaviour used elsewhere during registration.
- [x] Extracted the invite-check into a small shared function (`organisations/invites/services.py`) so the permission gate and the serializer use the same logic instead of two separate implementations.

Closes https://github.com/Flagsmith/flagsmith/issues/5378

## How did you test this code?

Added unit tests for `IsSignupAllowed` covering: `PREVENT_SIGNUP` off, `PREVENT_SIGNUP` on with no invite, with a valid invite link, with an invalid/unknown invite hash, and with a valid invited email. Ran the full `custom_auth` serializer + permission test suite against a real local Postgres — all passing. Also ran `mypy` and the repo's `pre-commit` hooks (lint, format, doc generation, typecheck) clean.

Review effort: 2/5