### PR TITLE
feat(ingestion): Deny non-HTTPS traffic to S3 buckets

### DIFF
--- a/api/experimentation/ingestion_infra_service.py
+++ b/api/experimentation/ingestion_infra_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import typing
 from functools import lru_cache
 
@@ -120,6 +121,27 @@ def _create_events_bucket(bucket_name: str, *, organisation_id: int) -> None:
             "BlockPublicPolicy": True,
             "RestrictPublicBuckets": True,
         },
+    )
+    s3.put_bucket_policy(
+        Bucket=bucket_name,
+        Policy=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "AllowSSLRequestsOnly",
+                        "Effect": "Deny",
+                        "Principal": "*",
+                        "Action": "s3:*",
+                        "Resource": [
+                            f"arn:aws:s3:::{bucket_name}",
+                            f"arn:aws:s3:::{bucket_name}/*",
+                        ],
+                        "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                    }
+                ],
+            }
+        ),
     )
     s3.put_bucket_lifecycle_configuration(
         Bucket=bucket_name,

--- a/api/tests/unit/experimentation/test_ingestion_infra_service.py
+++ b/api/tests/unit/experimentation/test_ingestion_infra_service.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterator
 from typing import Any
 
@@ -91,6 +92,21 @@ def test_provision_ingestion_infrastructure__fresh_account__creates_bucket_and_s
     ]
     tagging = s3.get_bucket_tagging(Bucket=result.bucket_name)
     assert tagging["TagSet"] == [{"Key": "organisation_id", "Value": "42"}]
+
+    policy = json.loads(s3.get_bucket_policy(Bucket=result.bucket_name)["Policy"])
+    assert policy["Statement"] == [
+        {
+            "Sid": "AllowSSLRequestsOnly",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": [
+                f"arn:aws:s3:::{result.bucket_name}",
+                f"arn:aws:s3:::{result.bucket_name}/*",
+            ],
+            "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+        }
+    ]
 
     firehose = boto3.client("firehose", region_name="eu-west-2")
     stream = firehose.describe_delivery_stream(DeliveryStreamName=result.stream_name)[

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -207,7 +207,7 @@ Attributes:
 ### `experimentation.ingestion_infra.bucket_created`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:110`
+ - `api/experimentation/ingestion_infra_service.py:111`
 
 Attributes:
  - `bucket.name`
@@ -216,7 +216,7 @@ Attributes:
 ### `experimentation.ingestion_infra.deprovisioned`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:267`
+ - `api/experimentation/ingestion_infra_service.py:289`
 
 Attributes:
  - `bucket.name`
@@ -245,7 +245,7 @@ Attributes:
 ### `experimentation.ingestion_infra.stream_created`
 
 Logged at `info` from:
- - `api/experimentation/ingestion_infra_service.py:221`
+ - `api/experimentation/ingestion_infra_service.py:243`
 
 Attributes:
  - `bucket.name`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

S3 buckets allow only HTTPS traffic (AWS)

## How did you test this code?

Added a test that checks that the policy is attached to the S3 bucket.