### PR TITLE
fix: hide Try it out until the project has 3+ flags

### DIFF
--- a/frontend/web/components/TryIt.js
+++ b/frontend/web/components/TryIt.js
@@ -3,6 +3,11 @@ import Highlight from './Highlight'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Constants from 'common/constants'
 
+// Running a test is a real SDK evaluation, which marks the environment as
+// integrated (environment.first_evaluated) — hide it until the project looks
+// genuinely in use.
+export const MIN_FLAGS_TO_SHOW_TRY_IT = 3
+
 const TryIt = class extends Component {
   static displayName = 'TryIt'
 
@@ -52,7 +57,8 @@ const TryIt = class extends Component {
   }
 
   render() {
-    return Utils.getFlagsmithHasFeature('try_it') ? (
+    return Utils.getFlagsmithHasFeature('try_it') &&
+      (E2E || (this.props.totalFeatures || 0) >= MIN_FLAGS_TO_SHOW_TRY_IT) ? (
       <div>
         <Row space>
           <Flex className='align-items-start'>

--- a/frontend/web/components/pages/IdentityPage.tsx
+++ b/frontend/web/components/pages/IdentityPage.tsx
@@ -71,7 +71,9 @@ const IdentityPage: FC = () => {
       { skip: !projectId },
     )
 
-  const { getEnvironmentIdFromKey } = useProjectEnvironments(projectId!)
+  const { getEnvironmentIdFromKey, project } = useProjectEnvironments(
+    projectId!,
+  )
 
   const apiParams = environmentId
     ? buildApiFilterParams(
@@ -423,7 +425,12 @@ const IdentityPage: FC = () => {
                         title='Check to see what features and traits are coming back for this user'
                         environmentId={environmentId}
                         userId={identityName}
-                        totalFeatures={paging?.count}
+                        totalFeatures={Math.max(
+                          // The list count is filter-aware but live; the
+                          // project total is unfiltered but cached.
+                          paging?.count ?? 0,
+                          project?.total_features ?? 0,
+                        )}
                       />
                     </FormGroup>
                     <FormGroup className='mt-5'>

--- a/frontend/web/components/pages/IdentityPage.tsx
+++ b/frontend/web/components/pages/IdentityPage.tsx
@@ -423,6 +423,7 @@ const IdentityPage: FC = () => {
                         title='Check to see what features and traits are coming back for this user'
                         environmentId={environmentId}
                         userId={identityName}
+                        totalFeatures={paging?.count}
                       />
                     </FormGroup>
                     <FormGroup className='mt-5'>

--- a/frontend/web/components/pages/features/FeaturesPage.tsx
+++ b/frontend/web/components/pages/features/FeaturesPage.tsx
@@ -413,6 +413,7 @@ const FeaturesPage: FC<FeaturesPageProps> = ({ forcedTagIds, pageTitle }) => {
             <FeaturesSDKIntegration
               projectId={projectId}
               environmentId={environmentId}
+              totalFeatures={data?.pagination?.count}
             />
           </>
         )}

--- a/frontend/web/components/pages/features/FeaturesPage.tsx
+++ b/frontend/web/components/pages/features/FeaturesPage.tsx
@@ -413,7 +413,12 @@ const FeaturesPage: FC<FeaturesPageProps> = ({ forcedTagIds, pageTitle }) => {
             <FeaturesSDKIntegration
               projectId={projectId}
               environmentId={environmentId}
-              totalFeatures={data?.pagination?.count}
+              totalFeatures={Math.max(
+                // The list count is filter-aware but live; the project
+                // total is unfiltered but cached.
+                data?.pagination?.count ?? 0,
+                project?.total_features ?? 0,
+              )}
             />
           </>
         )}

--- a/frontend/web/components/pages/features/components/FeaturesSDKIntegration.tsx
+++ b/frontend/web/components/pages/features/components/FeaturesSDKIntegration.tsx
@@ -9,11 +9,13 @@ import { openIntegrationModal } from 'components/integrations/openIntegrationMod
 type FeaturesSDKIntegrationProps = {
   projectId: number
   environmentId: string
+  totalFeatures?: number
 }
 
 export const FeaturesSDKIntegration: FC<FeaturesSDKIntegrationProps> = ({
   environmentId,
   projectId,
+  totalFeatures,
 }) => {
   const hasMcp = Utils.hasIntegration('mcp')
   return (
@@ -48,6 +50,7 @@ export const FeaturesSDKIntegration: FC<FeaturesSDKIntegrationProps> = ({
         <TryIt
           title='Test what values are being returned from the API on this environment'
           environmentId={environmentId}
+          totalFeatures={totalFeatures}
         />
       </FormGroup>
     </>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

"Run test" makes a real SDK call to `flags/`, marking the environment as integrated (`environment.first_evaluated`) from a single dashboard click. This skews onboarding conversion data for users who never wired an SDK.

- Hide the "Try it out" section (features page and identity page) until the project has 3+ flags.
- Bypass the gate under E2E so existing `tryItExpect` tests are unaffected.

## How did you test this code?

Manually: with fewer than 3 flags the section is hidden; creating the 3rd flag reveals it without a reload (gate reads the live feature list count). Lint and typecheck clean on touched files.