### PR TITLE
feat: cohort synchronisation keys and provider connect modals

### DIFF
--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -198,6 +198,8 @@ const Constants = {
       'React Native': 'javascript',
     },
   },
+  cohortSyncKeyPermissions:
+    'To manage cohort synchronisation keys you need the <i>Manage segment overrides</i> permission for this environment and the <i>Manage segments</i> permission for this project.<br/>Please contact an administrator.',
   colours: {
     primary: '#6837fc',
     white: '#ffffff',

--- a/frontend/common/services/useCohort.ts
+++ b/frontend/common/services/useCohort.ts
@@ -23,7 +23,7 @@ export const cohortService = service
         }),
       }),
       createCohortSyncKey: builder.mutation<
-        Res['cohortSyncKey'],
+        Res['cohortSyncKeyCreated'],
         Req['createCohortSyncKey']
       >({
         invalidatesTags: [{ id: 'LIST', type: 'CohortSyncKey' }],

--- a/frontend/common/services/useCohort.ts
+++ b/frontend/common/services/useCohort.ts
@@ -4,7 +4,7 @@ import { service } from 'common/service'
 import toFormData from 'common/utils/toFormData'
 
 export const cohortService = service
-  .enhanceEndpoints({ addTagTypes: ['Cohort', 'Segment'] })
+  .enhanceEndpoints({ addTagTypes: ['Cohort', 'CohortSyncKey', 'Segment'] })
   .injectEndpoints({
     endpoints: (builder) => ({
       createCohort: builder.mutation<Res['cohort'], Req['createCohort']>({
@@ -22,6 +22,17 @@ export const cohortService = service
           url: `environments/${query.environmentApiKey}/cohorts/`,
         }),
       }),
+      createCohortSyncKey: builder.mutation<
+        Res['cohortSyncKey'],
+        Req['createCohortSyncKey']
+      >({
+        invalidatesTags: [{ id: 'LIST', type: 'CohortSyncKey' }],
+        query: (query) => ({
+          body: { name: query.name },
+          method: 'POST',
+          url: `environments/${query.environmentApiKey}/cohorts/sync-keys/`,
+        }),
+      }),
       deleteCohort: builder.mutation<void, Req['deleteCohort']>({
         invalidatesTags: (q, e, arg) => [
           { id: 'LIST', type: 'Cohort' },
@@ -36,6 +47,22 @@ export const cohortService = service
         providesTags: (res, e, arg) => [{ id: arg.cohortId, type: 'Cohort' }],
         query: (query) => ({
           url: `environments/${query.environmentApiKey}/cohorts/${query.cohortId}/`,
+        }),
+      }),
+      getCohortSyncKeys: builder.query<
+        Res['cohortSyncKeys'],
+        Req['getCohortSyncKeys']
+      >({
+        providesTags: [{ id: 'LIST', type: 'CohortSyncKey' }],
+        query: (query) => ({
+          url: `environments/${query.environmentApiKey}/cohorts/sync-keys/`,
+        }),
+      }),
+      revokeCohortSyncKey: builder.mutation<void, Req['revokeCohortSyncKey']>({
+        invalidatesTags: [{ id: 'LIST', type: 'CohortSyncKey' }],
+        query: (query) => ({
+          method: 'DELETE',
+          url: `environments/${query.environmentApiKey}/cohorts/sync-keys/${query.prefix}/`,
         }),
       }),
       syncCohortCsv: builder.mutation<
@@ -95,8 +122,11 @@ export async function deleteCohort(
 
 export const {
   useCreateCohortMutation,
+  useCreateCohortSyncKeyMutation,
   useDeleteCohortMutation,
   useGetCohortQuery,
+  useGetCohortSyncKeysQuery,
+  useRevokeCohortSyncKeyMutation,
   useSyncCohortCsvMutation,
   useUpdateCohortMutation,
   // END OF EXPORTS

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -207,6 +207,17 @@ export type Req = {
     identifier_column?: number
     has_header?: boolean
   }
+  getCohortSyncKeys: {
+    environmentApiKey: string
+  }
+  createCohortSyncKey: {
+    environmentApiKey: string
+    name: string
+  }
+  revokeCohortSyncKey: {
+    environmentApiKey: string
+    prefix: string
+  }
   cloneSegment: {
     projectId: number
     segmentId: number

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1037,6 +1037,13 @@ export type Cohort = {
   membership_counts: CohortMembershipCounts
 }
 
+export type CohortSyncKey = {
+  prefix: string
+  name: string
+  created: string
+  key: string | null
+}
+
 export type CohortCsvSyncResult = {
   version: number
   added: number
@@ -1379,6 +1386,8 @@ export type Res = {
   segments: PagedResponse<Segment>
   segment: Segment
   cohort: Cohort
+  cohortSyncKeys: CohortSyncKey[]
+  cohortSyncKey: CohortSyncKey
   cohortCsvSync: CohortCsvSyncResult
   segmentMembers: SegmentMembersResponse
   auditLogs: PagedResponse<AuditLogItem>

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -1044,6 +1044,9 @@ export type CohortSyncKey = {
   key: string | null
 }
 
+// The plaintext key only exists in the create response.
+export type CohortSyncKeyCreated = CohortSyncKey & { key: string }
+
 export type CohortCsvSyncResult = {
   version: number
   added: number
@@ -1387,7 +1390,7 @@ export type Res = {
   segment: Segment
   cohort: Cohort
   cohortSyncKeys: CohortSyncKey[]
-  cohortSyncKey: CohortSyncKey
+  cohortSyncKeyCreated: CohortSyncKeyCreated
   cohortCsvSync: CohortCsvSyncResult
   segmentMembers: SegmentMembersResponse
   auditLogs: PagedResponse<AuditLogItem>

--- a/frontend/e2e/tests/cohort-sync-keys-test.pw.ts
+++ b/frontend/e2e/tests/cohort-sync-keys-test.pw.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '../test-setup'
+import {
+  byId,
+  log,
+  createHelpers,
+  getFlagsmith,
+  LONG_TIMEOUT,
+} from '../helpers'
+import { E2E_USER, PASSWORD, E2E_TEST_PROJECT } from '../config'
+
+const COHORT_PROVIDERS = ['amplitude', 'mixpanel'] as const
+
+type CohortProvider = (typeof COHORT_PROVIDERS)[number]
+
+type SegmentSourceFlagEntry = {
+  active?: boolean
+  name?: string
+  visible?: boolean
+}
+
+// Mirrors `getSegmentSources` in CreateSegmentSourcesModal: only an entry that
+// is visible AND active opens the connect modal (and shows the environment tab).
+const getActiveCohortProviders = (config: unknown): CohortProvider[] => {
+  if (!Array.isArray(config)) {
+    return []
+  }
+  return (config as SegmentSourceFlagEntry[])
+    .filter(
+      (entry) =>
+        COHORT_PROVIDERS.includes(entry?.name as CohortProvider) &&
+        entry?.visible !== false &&
+        entry?.active === true,
+    )
+    .map((entry) => entry.name as CohortProvider)
+}
+
+test.describe('Cohort Synchronisation Keys Tests', () => {
+  test('Cohort synchronisation keys can be created from a provider connection and revoked in Environment Settings @oss', async ({
+    page,
+  }) => {
+    const {
+      click,
+      gotoProject,
+      gotoSegments,
+      login,
+      setText,
+      waitForElementVisible,
+      waitForModalToClose,
+    } = createHelpers(page)
+
+    const flagsmith = await getFlagsmith()
+    const activeProviders = flagsmith.hasFeature(
+      'create_segment_with_external_sources',
+    )
+      ? getActiveCohortProviders(
+          flagsmith.getValue('create_segment_with_external_sources', {
+            fallback: null,
+            json: true,
+          }),
+        )
+      : []
+    test.skip(
+      activeProviders.length === 0,
+      'No active Amplitude or Mixpanel entry in `create_segment_with_external_sources`, so the cohort synchronisation UI is unreachable',
+    )
+
+    // With both providers active each key goes through a different provider;
+    // with one, the second key goes through its "Create a new key" state.
+    const firstProvider = activeProviders[0]
+    const secondProvider = activeProviders[1] ?? activeProviders[0]
+
+    const runId = Date.now()
+    const keyOne = `e2e key one ${runId}`
+    const keyTwo = `e2e key two ${runId}`
+    const keyThree = `e2e key three ${runId}`
+
+    const connectModal = page.locator('.connect-cohort-provider')
+    const envSelect = connectModal.locator(byId('connect-provider-env-select'))
+
+    const openConnectModal = async (provider: CohortProvider) => {
+      await click(byId('show-create-segment-btn'))
+      await click(byId(`segment-source-${provider}`))
+      await waitForElementVisible(byId('connect-provider-done'))
+      await expect(envSelect).toBeVisible({ timeout: LONG_TIMEOUT })
+      // The modal defaults to the alphabetically first environment; assert it
+      // resolved so both keys are created against the same environment.
+      const label = (await envSelect.innerText()).trim()
+      expect(label).not.toBe('')
+      expect(label).not.toBe('Select an Environment')
+      return label
+    }
+
+    const createKeyInConnectModal = async (name: string) => {
+      // Step 1 renders either the create form or the existing-keys state,
+      // depending on whether this environment already has keys.
+      await connectModal
+        .locator(
+          `${byId('connect-provider-key-name')}, ${byId(
+            'connect-provider-new-key',
+          )}`,
+        )
+        .first()
+        .waitFor({ state: 'visible', timeout: LONG_TIMEOUT })
+      const newKeyButton = connectModal.locator(
+        byId('connect-provider-new-key'),
+      )
+      if (await newKeyButton.isVisible()) {
+        await click(byId('connect-provider-new-key'))
+      }
+      await setText(byId('connect-provider-key-name'), name)
+      await click(byId('connect-provider-create-key'))
+      await expect(
+        connectModal.locator(byId('connect-provider-key-value')),
+      ).toHaveValue(/.+/, { timeout: LONG_TIMEOUT })
+      await click(byId('connect-provider-done'))
+      await waitForModalToClose()
+    }
+
+    log('Login')
+    await login(E2E_USER, PASSWORD)
+    await gotoProject(E2E_TEST_PROJECT)
+    await gotoSegments()
+
+    log(`Create the first key while connecting ${firstProvider}`)
+    const environmentLabel = await openConnectModal(firstProvider)
+    await createKeyInConnectModal(keyOne)
+
+    log(`Create the second key while connecting ${secondProvider}`)
+    expect(await openConnectModal(secondProvider)).toBe(environmentLabel)
+    await waitForElementVisible(byId('connect-provider-new-key'))
+    await expect(connectModal).toContainText(keyOne)
+    // This link carries the environment the modal is working against, so
+    // following it guarantees we inspect the keys we just created.
+    const settingsLink = connectModal.locator(
+      'a[href*="tab=cohort-synchronisation"]',
+    )
+    await expect(settingsLink).toBeVisible()
+    const settingsHref = (await settingsLink.getAttribute('href')) ?? ''
+    expect(settingsHref).not.toBe('')
+    await createKeyInConnectModal(keyTwo)
+
+    log('Open the Cohort Synchronisation tab in Environment Settings')
+    await page.goto(settingsHref)
+    await waitForElementVisible('#cohort-sync-keys-list')
+    const keysList = page.locator('#cohort-sync-keys-list')
+    await expect(keysList).toContainText(keyOne)
+    await expect(keysList).toContainText(keyTwo)
+
+    log('Create a third key from Environment Settings')
+    await click(byId('create-cohort-sync-key'))
+    await setText(byId('cohort-sync-key-name'), keyThree)
+    await click(byId('cohort-sync-key-create'))
+    await expect(page.locator(byId('cohort-sync-key-value'))).toHaveValue(
+      /.+/,
+      { timeout: LONG_TIMEOUT },
+    )
+    await click(byId('cohort-sync-key-done'))
+    await waitForModalToClose()
+    await expect(keysList).toContainText(keyThree)
+
+    log('Revoke every key for this environment')
+    const revokeButtons = keysList.locator('[aria-label^="Revoke "]')
+    for (
+      let remaining = await revokeButtons.count();
+      remaining > 0;
+      remaining--
+    ) {
+      await revokeButtons.first().click()
+      await click('#confirm-btn-yes')
+      await expect(page.locator('#confirm-btn-yes')).toHaveCount(0, {
+        timeout: LONG_TIMEOUT,
+      })
+      await expect(revokeButtons).toHaveCount(remaining - 1, {
+        timeout: LONG_TIMEOUT,
+      })
+    }
+
+    log('Verify no keys remain')
+    // PanelSearch drops the list entirely and renders its empty state instead.
+    await expect(page.locator('#cohort-sync-keys-list')).toHaveCount(0)
+    for (const name of [keyOne, keyTwo, keyThree]) {
+      await expect(page.getByText(name, { exact: true })).toHaveCount(0)
+    }
+  })
+})

--- a/frontend/e2e/tests/cohort-sync-keys-test.pw.ts
+++ b/frontend/e2e/tests/cohort-sync-keys-test.pw.ts
@@ -132,7 +132,7 @@ test.describe('Cohort Synchronisation Keys Tests', () => {
     // This link carries the environment the modal is working against, so
     // following it guarantees we inspect the keys we just created.
     const settingsLink = connectModal.locator(
-      'a[href*="tab=cohort-synchronisation"]',
+      'a[href*="tab=cohorts"]',
     )
     await expect(settingsLink).toBeVisible()
     const settingsHref = (await settingsLink.getAttribute('href')) ?? ''

--- a/frontend/e2e/tests/cohort-sync-keys-test.pw.ts
+++ b/frontend/e2e/tests/cohort-sync-keys-test.pw.ts
@@ -158,26 +158,15 @@ test.describe('Cohort Synchronisation Keys Tests', () => {
     await waitForModalToClose()
     await expect(keysList).toContainText(keyThree)
 
-    log('Revoke every key for this environment')
-    const revokeButtons = keysList.locator('[aria-label^="Revoke "]')
-    for (
-      let remaining = await revokeButtons.count();
-      remaining > 0;
-      remaining--
-    ) {
-      await revokeButtons.first().click()
+    log('Revoke the keys created by this test')
+    for (const name of [keyOne, keyTwo, keyThree]) {
+      const row = keysList.locator('.list-item').filter({ hasText: name })
+      await row.locator('[aria-label^="Revoke "]').click()
       await click('#confirm-btn-yes')
-      await expect(page.locator('#confirm-btn-yes')).toHaveCount(0, {
-        timeout: LONG_TIMEOUT,
-      })
-      await expect(revokeButtons).toHaveCount(remaining - 1, {
-        timeout: LONG_TIMEOUT,
-      })
+      await expect(row).toHaveCount(0, { timeout: LONG_TIMEOUT })
     }
 
-    log('Verify no keys remain')
-    // PanelSearch drops the list entirely and renders its empty state instead.
-    await expect(page.locator('#cohort-sync-keys-list')).toHaveCount(0)
+    log('Verify the test keys are gone')
     for (const name of [keyOne, keyTwo, keyThree]) {
       await expect(page.getByText(name, { exact: true })).toHaveCount(0)
     }

--- a/frontend/web/components/PanelSearch.tsx
+++ b/frontend/web/components/PanelSearch.tsx
@@ -319,7 +319,12 @@ const PanelSearch = <T,>(props: PanelSearchProps<T>): ReactElement => {
               </Row>
             )}
             {onRefresh && (
-              <Button theme='text' size='xSmall' onClick={onRefresh}>
+              <Button
+                theme='text'
+                size='xSmall'
+                className='mr-2'
+                onClick={onRefresh}
+              >
                 <Icon name='refresh' fill='#6837FC' width={16} /> Refresh
               </Button>
             )}

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -739,6 +739,12 @@ class TheComponent extends Component {
     const filter = (segment) => {
       if (segment.feature && segment.feature !== this.props.feature)
         return false
+      // A cohort-managed segment only has members in its own environment.
+      if (
+        segment.cohort &&
+        segment.cohort.environment_api_key !== this.props.environmentId
+      )
+        return false
       if (this.props.id && this.props.id !== segment.id) return null
       const foundSegment = find(value, (v) => v.segment === segment.id)
       return !value || !foundSegment || (foundSegment && foundSegment.toRemove)

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -1,16 +1,19 @@
 import React, { FC, useState } from 'react'
 import moment from 'moment'
 import { Link } from 'react-router-dom'
+import Constants from 'common/constants'
+import { useHasPermission } from 'common/providers/Permission'
 import {
   useCreateCohortSyncKeyMutation,
   useGetCohortSyncKeysQuery,
 } from 'common/services/useCohort'
+import { EnvironmentPermission } from 'common/types/permissions.types'
 import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
 import InputGroup from 'components/base/forms/InputGroup'
 import CopyField from 'components/CopyField'
 import ErrorMessage from 'components/ErrorMessage'
-import Loader from 'components/Loader'
+import Tooltip from 'components/Tooltip'
 import WarningMessage from 'components/WarningMessage'
 import ConnectCohortProviderStep from './ConnectCohortProviderStep'
 
@@ -32,6 +35,13 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
   const [name, setName] = useState('')
   const [createdKey, setCreatedKey] = useState<string | null>(null)
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false)
+
+  const { isLoading: isLoadingPermission, permission: canManage } =
+    useHasPermission({
+      id: environmentApiKey,
+      level: 'environment',
+      permission: EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
+    })
 
   const { data: syncKeys, isLoading } = useGetCohortSyncKeysQuery(
     { environmentApiKey },
@@ -56,11 +66,12 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
   const getTitle = () => {
     if (createdKey) return 'Synchronisation key'
     if (hasKeys && !isCreateFormOpen) return 'Use your existing key'
+    if (!canManage) return 'Synchronisation key'
     return 'Create a synchronisation key'
   }
 
   const renderBody = () => {
-    if (isLoading && !syncKeys) {
+    if ((isLoading && !syncKeys) || isLoadingPermission) {
       return <Loader />
     }
 
@@ -77,6 +88,15 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
             warningMessageClass='mt-4'
           />
         </>
+      )
+    }
+
+    if (!hasKeys && !canManage) {
+      return (
+        <div className='fs-small text-secondary'>
+          You do not have permission to create synchronisation keys in this
+          environment.
+        </div>
       )
     }
 
@@ -127,7 +147,8 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
           ))}
         </div>
         <div className='fs-small text-secondary mt-2'>
-          Key values are shown only at creation. Lost it? Create a new key.
+          Key values are shown only at creation.
+          {canManage && ' Lost it? Create a new key.'}
         </div>
         <div className='fs-small text-secondary'>
           You can revoke keys in{' '}
@@ -139,14 +160,29 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
           </Link>
           .
         </div>
-        <Button
-          theme='secondary'
-          className='mt-3'
-          onClick={() => setIsCreateFormOpen(true)}
-          data-test='connect-provider-new-key'
-        >
-          Create a new key
-        </Button>
+        {canManage ? (
+          <Button
+            theme='secondary'
+            className='mt-3'
+            onClick={() => setIsCreateFormOpen(true)}
+            data-test='connect-provider-new-key'
+          >
+            Create a new key
+          </Button>
+        ) : (
+          <Tooltip
+            title={
+              <Button theme='secondary' className='mt-3' disabled>
+                Create a new key
+              </Button>
+            }
+            place='right'
+          >
+            {Constants.environmentPermissions(
+              EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
+            )}
+          </Tooltip>
+        )}
       </>
     )
   }

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -1,13 +1,15 @@
 import React, { FC, useState } from 'react'
 import moment from 'moment'
-import { Link } from 'react-router-dom'
 import Constants from 'common/constants'
 import { useHasPermission } from 'common/providers/Permission'
 import {
   useCreateCohortSyncKeyMutation,
   useGetCohortSyncKeysQuery,
 } from 'common/services/useCohort'
-import { EnvironmentPermission } from 'common/types/permissions.types'
+import {
+  EnvironmentPermission,
+  ProjectPermission,
+} from 'common/types/permissions.types'
 import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
 import InputGroup from 'components/base/forms/InputGroup'
@@ -36,12 +38,24 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
   const [createdKey, setCreatedKey] = useState<string | null>(null)
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false)
 
-  const { isLoading: isLoadingPermission, permission: canManage } =
+  // Key writes need both permissions; mirrors the API's CohortPermission.
+  const { isLoading: isLoadingEnvPermission, permission: canManageOverrides } =
     useHasPermission({
       id: environmentApiKey,
       level: 'environment',
       permission: EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
     })
+  const {
+    isLoading: isLoadingProjectPermission,
+    permission: canManageSegments,
+  } = useHasPermission({
+    id: `${projectId}`,
+    level: 'project',
+    permission: ProjectPermission.MANAGE_SEGMENTS,
+  })
+  const isLoadingPermission =
+    isLoadingEnvPermission || isLoadingProjectPermission
+  const canManage = !!canManageOverrides && !!canManageSegments
 
   const { data: syncKeys, isLoading } = useGetCohortSyncKeysQuery(
     { environmentApiKey },
@@ -152,12 +166,13 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
         </div>
         <div className='fs-small text-secondary'>
           You can revoke keys in{' '}
-          <Link
-            to={`/project/${projectId}/environment/${environmentApiKey}/settings?tab=cohort-synchronisation`}
+          {/* Plain anchor: this renders in the modal root, outside the Router. */}
+          <a
+            href={`/project/${projectId}/environment/${environmentApiKey}/settings?tab=cohort-synchronisation`}
             onClick={() => closeModal()}
           >
             Environment Settings
-          </Link>
+          </a>
           .
         </div>
         {canManage ? (

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -169,7 +169,7 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
           You can revoke keys in{' '}
           {/* Plain anchor: this renders in the modal root, outside the Router. */}
           <a
-            href={`/project/${projectId}/environment/${environmentApiKey}/settings?tab=cohort-synchronisation`}
+            href={`/project/${projectId}/environment/${environmentApiKey}/settings?tab=cohorts`}
             onClick={() => closeModal()}
           >
             Environment Settings

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -81,7 +81,7 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
     if (createdKey) return 'Synchronisation key'
     if (hasKeys && !isCreateFormOpen) return 'Use your existing key'
     if (!canManage) return 'Synchronisation key'
-    return 'Create a synchronisation key'
+    return 'Generate a synchronisation key'
   }
 
   const renderBody = () => {
@@ -97,10 +97,9 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
             className='font-monospace'
             data-test='connect-provider-key-value'
           />
-          <WarningMessage
-            warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.'
-            warningMessageClass='mt-4'
-          />
+          <div className='mt-4'>
+            <WarningMessage warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.' />
+          </div>
         </>
       )
     }
@@ -119,6 +118,7 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
       return (
         <form onSubmit={handleSubmit}>
           <InputGroup
+            title='Name'
             value={name}
             data-test='connect-provider-key-name'
             inputProps={{

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -108,8 +108,9 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
     if (!hasKeys && !canManage) {
       return (
         <div className='fs-small text-secondary'>
-          You do not have permission to create synchronisation keys in this
-          environment.
+          Creating synchronisation keys needs the Manage segment overrides
+          permission for this environment and the Manage segments permission for
+          this project.
         </div>
       )
     }
@@ -193,9 +194,7 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
             }
             place='right'
           >
-            {Constants.environmentPermissions(
-              EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
-            )}
+            {Constants.cohortSyncKeyPermissions}
           </Tooltip>
         )}
       </>

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -13,6 +13,7 @@ import {
 import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
 import InputGroup from 'components/base/forms/InputGroup'
+import Link from 'components/base/link/Link'
 import CopyField from 'components/CopyField'
 import ErrorMessage from 'components/ErrorMessage'
 import Tooltip from 'components/Tooltip'
@@ -167,13 +168,13 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
         </div>
         <div className='fs-small text-secondary'>
           You can revoke keys in{' '}
-          {/* Plain anchor: this renders in the modal root, outside the Router. */}
-          <a
+          {/* href, not to: this renders in the modal root, outside the Router. */}
+          <Link
             href={`/project/${projectId}/environment/${environmentApiKey}/settings?tab=cohorts`}
             onClick={() => closeModal()}
           >
             Environment Settings
-          </a>
+          </Link>
           .
         </div>
         {canManage ? (

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -97,7 +97,7 @@ const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
             className='font-monospace'
             data-test='connect-provider-key-value'
           />
-          <div className='mt-4'>
+          <div className='mt-2'>
             <WarningMessage warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.' />
           </div>
         </>

--- a/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/CohortSyncKeyStep.tsx
@@ -1,0 +1,161 @@
+import React, { FC, useState } from 'react'
+import moment from 'moment'
+import { Link } from 'react-router-dom'
+import {
+  useCreateCohortSyncKeyMutation,
+  useGetCohortSyncKeysQuery,
+} from 'common/services/useCohort'
+import { CohortSyncKey } from 'common/types/responses'
+import Button from 'components/base/forms/Button'
+import InputGroup from 'components/base/forms/InputGroup'
+import CopyField from 'components/CopyField'
+import ErrorMessage from 'components/ErrorMessage'
+import Loader from 'components/Loader'
+import WarningMessage from 'components/WarningMessage'
+import ConnectCohortProviderStep from './ConnectCohortProviderStep'
+
+const NAME_MAX_LENGTH = 50
+
+type CohortSyncKeyStepProps = {
+  environmentApiKey: string
+  index: number
+  projectId: number | string
+  providerLabel: string
+}
+
+const CohortSyncKeyStep: FC<CohortSyncKeyStepProps> = ({
+  environmentApiKey,
+  index,
+  projectId,
+  providerLabel,
+}) => {
+  const [name, setName] = useState('')
+  const [createdKey, setCreatedKey] = useState<string | null>(null)
+  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false)
+
+  const { data: syncKeys, isLoading } = useGetCohortSyncKeysQuery(
+    { environmentApiKey },
+    { skip: !environmentApiKey },
+  )
+  const [createCohortSyncKey, { error, isLoading: isCreating }] =
+    useCreateCohortSyncKeyMutation()
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    createCohortSyncKey({ environmentApiKey, name: name.trim() })
+      .unwrap()
+      .then((syncKey) => {
+        setCreatedKey(syncKey.key)
+        setIsCreateFormOpen(false)
+        setName('')
+      })
+      .catch(() => {})
+  }
+
+  const hasKeys = !!syncKeys?.length
+  const getTitle = () => {
+    if (createdKey) return 'Synchronisation key'
+    if (hasKeys && !isCreateFormOpen) return 'Use your existing key'
+    return 'Create a synchronisation key'
+  }
+
+  const renderBody = () => {
+    if (isLoading && !syncKeys) {
+      return <Loader />
+    }
+
+    if (createdKey) {
+      return (
+        <>
+          <CopyField
+            value={createdKey}
+            className='font-monospace'
+            data-test='connect-provider-key-value'
+          />
+          <WarningMessage
+            warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.'
+            warningMessageClass='mt-4'
+          />
+        </>
+      )
+    }
+
+    if (!hasKeys || isCreateFormOpen) {
+      return (
+        <form onSubmit={handleSubmit}>
+          <InputGroup
+            value={name}
+            data-test='connect-provider-key-name'
+            inputProps={{
+              className: 'full-width',
+              maxLength: NAME_MAX_LENGTH,
+              name: 'name',
+            }}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              setName(event.target.value)
+            }
+            isValid={!!name.trim().length}
+            type='text'
+            placeholder={`e.g. ${providerLabel} production`}
+          />
+          <ErrorMessage error={error} />
+          <Button
+            type='submit'
+            disabled={!name.trim() || isCreating}
+            data-test='connect-provider-create-key'
+          >
+            {isCreating ? 'Creating' : 'Create Synchronisation Key'}
+          </Button>
+        </form>
+      )
+    }
+
+    return (
+      <>
+        <div className='rounded border-1 d-flex flex-column'>
+          {syncKeys?.map((syncKey: CohortSyncKey) => (
+            <div
+              key={syncKey.prefix}
+              className='d-flex align-items-center justify-content-between gap-3 px-3 py-2'
+            >
+              <span className='fw-semibold'>{syncKey.name}</span>
+              <span className='fs-small text-secondary d-flex align-items-center gap-3'>
+                <span className='font-monospace'>{syncKey.prefix}</span>
+                <span>{moment(syncKey.created).format('D MMM YYYY')}</span>
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className='fs-small text-secondary mt-2'>
+          Key values are shown only at creation. Lost it? Create a new key.
+        </div>
+        <div className='fs-small text-secondary'>
+          You can revoke keys in{' '}
+          <Link
+            to={`/project/${projectId}/environment/${environmentApiKey}/settings?tab=cohort-synchronisation`}
+            onClick={() => closeModal()}
+          >
+            Environment Settings
+          </Link>
+          .
+        </div>
+        <Button
+          theme='secondary'
+          className='mt-3'
+          onClick={() => setIsCreateFormOpen(true)}
+          data-test='connect-provider-new-key'
+        >
+          Create a new key
+        </Button>
+      </>
+    )
+  }
+
+  return (
+    <ConnectCohortProviderStep index={index} title={getTitle()}>
+      {renderBody()}
+    </ConnectCohortProviderStep>
+  )
+}
+
+export default CohortSyncKeyStep

--- a/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.scss
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.scss
@@ -1,0 +1,11 @@
+.connect-cohort-provider {
+  &__step-number {
+    width: 24px;
+    height: 24px;
+  }
+
+  &__auth-label {
+    width: 120px;
+    flex-shrink: 0;
+  }
+}

--- a/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
@@ -26,6 +26,7 @@ const ConnectCohortProviderModal: FC<ConnectCohortProviderModalProps> = ({
   provider,
 }) => {
   const config = COHORT_PROVIDERS[provider]
+  const endpointUrl = getCohortProviderEndpoint(provider)
   const [selectedEnvironment, setSelectedEnvironment] = useState('')
 
   const { data: environments, isLoading } = useGetEnvironmentsQuery({
@@ -76,12 +77,19 @@ const ConnectCohortProviderModal: FC<ConnectCohortProviderModalProps> = ({
               index={2}
               title={config.endpointStepTitle}
             >
-              <CopyField
-                title={config.endpointFieldTitle}
-                value={getCohortProviderEndpoint(provider)}
-                className='font-monospace'
-                data-test='connect-provider-url'
-              />
+              {!!config.endpointStepBody && (
+                <p className='fs-small text-secondary lh-sm mb-0'>
+                  {config.endpointStepBody}
+                </p>
+              )}
+              {!!endpointUrl && (
+                <CopyField
+                  title={config.endpoint?.fieldTitle}
+                  value={endpointUrl}
+                  className='font-monospace'
+                  data-test='connect-provider-url'
+                />
+              )}
               <div className='d-flex flex-column mx-0 gap-1 mt-3'>
                 {config.authRows.map((row) => (
                   <div
@@ -101,10 +109,12 @@ const ConnectCohortProviderModal: FC<ConnectCohortProviderModalProps> = ({
                   </div>
                 ))}
               </div>
-              <div className='fs-small text-secondary mt-3'>
-                This URL is the same for every environment — your key decides
-                where cohort members land.
-              </div>
+              {!!endpointUrl && (
+                <div className='fs-small text-secondary mt-3'>
+                  This URL is the same for every environment — your key decides
+                  where cohort members land.
+                </div>
+              )}
             </ConnectCohortProviderStep>
             <ConnectCohortProviderStep index={3} title={config.exportStepTitle}>
               <p className='fs-small text-secondary lh-sm mb-0'>

--- a/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo, useState } from 'react'
 import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
 import Button from 'components/base/forms/Button'
 import FieldLabel from 'components/base/forms/FieldLabel'
+import Link from 'components/base/link/Link'
 import CopyField from 'components/CopyField'
 import EnvironmentSelect from 'components/EnvironmentSelect'
 import ModalHR from 'components/modals/ModalHR'
@@ -126,14 +127,9 @@ const ConnectCohortProviderModal: FC<ConnectCohortProviderModalProps> = ({
       </div>
       <ModalHR />
       <div className='modal-footer d-flex align-items-center justify-content-between'>
-        <Button
-          theme='text'
-          href={SEGMENTS_DOCS_URL}
-          target='_blank'
-          className='fw-normal'
-        >
+        <Link href={SEGMENTS_DOCS_URL} target='_blank'>
           Learn about Segments
-        </Button>
+        </Link>
         <Button onClick={() => closeModal()} data-test='connect-provider-done'>
           Done
         </Button>

--- a/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
@@ -4,7 +4,6 @@ import Button from 'components/base/forms/Button'
 import FieldLabel from 'components/base/forms/FieldLabel'
 import CopyField from 'components/CopyField'
 import EnvironmentSelect from 'components/EnvironmentSelect'
-import Loader from 'components/Loader'
 import ModalHR from 'components/modals/ModalHR'
 import CohortSyncKeyStep from './CohortSyncKeyStep'
 import ConnectCohortProviderStep from './ConnectCohortProviderStep'
@@ -78,6 +77,7 @@ const ConnectCohortProviderModal: FC<ConnectCohortProviderModalProps> = ({
               title={config.endpointStepTitle}
             >
               <CopyField
+                title={config.endpointFieldTitle}
                 value={getCohortProviderEndpoint(provider)}
                 className='font-monospace'
                 data-test='connect-provider-url'

--- a/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderModal.tsx
@@ -1,0 +1,135 @@
+import React, { FC, useMemo, useState } from 'react'
+import { useGetEnvironmentsQuery } from 'common/services/useEnvironment'
+import Button from 'components/base/forms/Button'
+import FieldLabel from 'components/base/forms/FieldLabel'
+import CopyField from 'components/CopyField'
+import EnvironmentSelect from 'components/EnvironmentSelect'
+import Loader from 'components/Loader'
+import ModalHR from 'components/modals/ModalHR'
+import CohortSyncKeyStep from './CohortSyncKeyStep'
+import ConnectCohortProviderStep from './ConnectCohortProviderStep'
+import {
+  COHORT_PROVIDERS,
+  CohortProviderKey,
+  getCohortProviderEndpoint,
+} from './providers'
+import './ConnectCohortProviderModal.scss'
+
+const SEGMENTS_DOCS_URL = 'https://docs.flagsmith.com/basic-features/segments'
+
+type ConnectCohortProviderModalProps = {
+  projectId: number | string
+  provider: CohortProviderKey
+}
+
+const ConnectCohortProviderModal: FC<ConnectCohortProviderModalProps> = ({
+  projectId,
+  provider,
+}) => {
+  const config = COHORT_PROVIDERS[provider]
+  const [selectedEnvironment, setSelectedEnvironment] = useState('')
+
+  const { data: environments, isLoading } = useGetEnvironmentsQuery({
+    projectId: Number(projectId),
+  })
+
+  // EnvironmentSelect orders alphabetically, so the default matches its first option.
+  const defaultEnvironment = useMemo(
+    () =>
+      [...(environments?.results || [])].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      )[0]?.api_key,
+    [environments?.results],
+  )
+  const environmentApiKey = selectedEnvironment || defaultEnvironment || ''
+
+  return (
+    <div className='connect-cohort-provider'>
+      <div className='modal-body'>
+        {isLoading && !environments ? (
+          <Loader />
+        ) : (
+          <div className='d-flex flex-column gap-4'>
+            <div>
+              <FieldLabel htmlFor='connect-provider-environment-select'>
+                Environment
+              </FieldLabel>
+              <EnvironmentSelect
+                inputId='connect-provider-environment-select'
+                data-test='connect-provider-env-select'
+                projectId={Number(projectId)}
+                size='default'
+                value={environmentApiKey}
+                onChange={(value) => setSelectedEnvironment(`${value}`)}
+              />
+              <div className='fs-small text-secondary mt-1'>
+                Cohort members are synchronised into this environment only.
+              </div>
+            </div>
+            <CohortSyncKeyStep
+              key={environmentApiKey}
+              environmentApiKey={environmentApiKey}
+              index={1}
+              projectId={projectId}
+              providerLabel={config.label}
+            />
+            <ConnectCohortProviderStep
+              index={2}
+              title={config.endpointStepTitle}
+            >
+              <CopyField
+                value={getCohortProviderEndpoint(provider)}
+                className='font-monospace'
+                data-test='connect-provider-url'
+              />
+              <div className='d-flex flex-column mx-0 gap-1 mt-3'>
+                {config.authRows.map((row) => (
+                  <div
+                    key={row.label}
+                    className='d-flex align-items-center fs-small'
+                  >
+                    <div className='connect-cohort-provider__auth-label text-secondary'>
+                      {row.label}
+                    </div>
+                    {row.mono ? (
+                      <span className='font-monospace fs-small text-muted bg-surface-muted rounded-sm px-2 py-1'>
+                        {row.value}
+                      </span>
+                    ) : (
+                      <span className='fw-semibold'>{row.value}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className='fs-small text-secondary mt-3'>
+                This URL is the same for every environment — your key decides
+                where cohort members land.
+              </div>
+            </ConnectCohortProviderStep>
+            <ConnectCohortProviderStep index={3} title={config.exportStepTitle}>
+              <p className='fs-small text-secondary lh-sm mb-0'>
+                {config.exportStepBody}
+              </p>
+            </ConnectCohortProviderStep>
+          </div>
+        )}
+      </div>
+      <ModalHR />
+      <div className='modal-footer d-flex align-items-center justify-content-between'>
+        <Button
+          theme='text'
+          href={SEGMENTS_DOCS_URL}
+          target='_blank'
+          className='fw-normal'
+        >
+          Learn about Segments
+        </Button>
+        <Button onClick={() => closeModal()} data-test='connect-provider-done'>
+          Done
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default ConnectCohortProviderModal

--- a/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderStep.tsx
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/ConnectCohortProviderStep.tsx
@@ -1,0 +1,25 @@
+import React, { FC, ReactNode } from 'react'
+
+type ConnectCohortProviderStepProps = {
+  index: number
+  title: string
+  children: ReactNode
+}
+
+const ConnectCohortProviderStep: FC<ConnectCohortProviderStepProps> = ({
+  children,
+  index,
+  title,
+}) => (
+  <div className='d-flex gap-3'>
+    <span className='connect-cohort-provider__step-number bg-surface-action-subtle text-action rounded-full fs-captionSmall fw-bold d-flex align-items-center justify-content-center flex-shrink-0'>
+      {index}
+    </span>
+    <div className='flex-fill'>
+      <div className='fw-bold text-default mb-2'>{title}</div>
+      {children}
+    </div>
+  </div>
+)
+
+export default ConnectCohortProviderStep

--- a/frontend/web/components/modals/ConnectCohortProviderModal/index.ts
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/index.ts
@@ -1,0 +1,3 @@
+export { default } from './ConnectCohortProviderModal'
+export { COHORT_PROVIDERS } from './providers'
+export type { CohortProviderConfig, CohortProviderKey } from './providers'

--- a/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
@@ -11,6 +11,7 @@ export type CohortProviderAuthRow = {
 export type CohortProviderConfig = {
   label: string
   authRows: CohortProviderAuthRow[]
+  endpointFieldTitle: string
   endpointPath: string
   endpointStepTitle: string
   exportStepTitle: string
@@ -24,7 +25,10 @@ export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
         { label: 'Authentication', value: 'Bearer token' },
         { label: 'Token', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
       ],
-      endpointPath: 'cohort-sync/amplitude',
+      // Amplitude posts cohort list creation here, then adds and removes
+      // members under `lists/{list_id}/add` and `lists/{list_id}/remove`.
+      endpointFieldTitle: 'List endpoint URL',
+      endpointPath: 'cohort-sync/amplitude/lists/',
       endpointStepTitle: 'Add Flagsmith as a destination in Amplitude',
       exportStepBody:
         'In Amplitude, open the cohort you want to target and synchronise it to the Flagsmith destination. Flagsmith creates the managed segment automatically on the first synchronisation, then keeps its members up to date as people enter and leave the cohort.',
@@ -37,6 +41,7 @@ export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
         { label: 'Username', value: 'Any value' },
         { label: 'Password', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
       ],
+      endpointFieldTitle: 'Webhook URL',
       endpointPath: 'cohort-sync/mixpanel/webhook/',
       endpointStepTitle: 'Create a webhook in Mixpanel',
       exportStepBody:

--- a/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
@@ -11,9 +11,14 @@ export type CohortProviderAuthRow = {
 export type CohortProviderConfig = {
   label: string
   authRows: CohortProviderAuthRow[]
-  endpointFieldTitle: string
-  endpointPath: string
+  // Providers where the user pastes a URL themselves carry an endpoint;
+  // Amplitude calls Flagsmith's portal-registered endpoints instead.
+  endpoint?: {
+    fieldTitle: string
+    path: string
+  }
   endpointStepTitle: string
+  endpointStepBody?: string
   exportStepTitle: string
   exportStepBody: string
 }
@@ -22,13 +27,10 @@ export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
   {
     amplitude: {
       authRows: [
-        { label: 'Authentication', value: 'Bearer token' },
-        { label: 'Token', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
+        { label: 'API key', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
       ],
-      // Amplitude posts cohort list creation here, then adds and removes
-      // members under `lists/{list_id}/add` and `lists/{list_id}/remove`.
-      endpointFieldTitle: 'List endpoint URL',
-      endpointPath: 'cohort-sync/amplitude/lists/',
+      endpointStepBody:
+        'In Amplitude, open Data → Destinations and add Flagsmith as a cohort destination. Paste your synchronisation key when asked for the API key.',
       endpointStepTitle: 'Add Flagsmith as a destination in Amplitude',
       exportStepBody:
         'In Amplitude, open the cohort you want to target and synchronise it to the Flagsmith destination. Flagsmith creates the managed segment automatically on the first synchronisation, then keeps its members up to date as people enter and leave the cohort.',
@@ -41,8 +43,10 @@ export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
         { label: 'Username', value: 'Any value' },
         { label: 'Password', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
       ],
-      endpointFieldTitle: 'Webhook URL',
-      endpointPath: 'cohort-sync/mixpanel/webhook/',
+      endpoint: {
+        fieldTitle: 'Webhook URL',
+        path: 'cohort-sync/mixpanel/webhook/',
+      },
       endpointStepTitle: 'Create a webhook in Mixpanel',
       exportStepBody:
         'In Mixpanel, open the cohort you want to target and export it to the webhook you just created. Flagsmith creates the managed segment automatically on the first synchronisation, then keeps its members up to date as people enter and leave the cohort.',
@@ -55,8 +59,13 @@ export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
 // providers need an absolute callback URL, so resolve against the page origin.
 export const getCohortProviderEndpoint = (
   provider: CohortProviderKey,
-): string =>
-  new URL(
-    COHORT_PROVIDERS[provider].endpointPath,
+): string | null => {
+  const endpoint = COHORT_PROVIDERS[provider].endpoint
+  if (!endpoint) {
+    return null
+  }
+  return new URL(
+    endpoint.path,
     new URL(Project.api, window.location.origin),
   ).toString()
+}

--- a/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
@@ -51,6 +51,12 @@ export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
     },
   }
 
+// Proxied self-hosted deployments configure a relative Project.api ('/api/v1/');
+// providers need an absolute callback URL, so resolve against the page origin.
 export const getCohortProviderEndpoint = (
   provider: CohortProviderKey,
-): string => `${Project.api}${COHORT_PROVIDERS[provider].endpointPath}`
+): string =>
+  new URL(
+    COHORT_PROVIDERS[provider].endpointPath,
+    new URL(Project.api, window.location.origin),
+  ).toString()

--- a/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
+++ b/frontend/web/components/modals/ConnectCohortProviderModal/providers.ts
@@ -1,0 +1,51 @@
+import Project from 'common/project'
+
+export type CohortProviderKey = 'amplitude' | 'mixpanel'
+
+export type CohortProviderAuthRow = {
+  label: string
+  value: string
+  mono?: boolean
+}
+
+export type CohortProviderConfig = {
+  label: string
+  authRows: CohortProviderAuthRow[]
+  endpointPath: string
+  endpointStepTitle: string
+  exportStepTitle: string
+  exportStepBody: string
+}
+
+export const COHORT_PROVIDERS: Record<CohortProviderKey, CohortProviderConfig> =
+  {
+    amplitude: {
+      authRows: [
+        { label: 'Authentication', value: 'Bearer token' },
+        { label: 'Token', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
+      ],
+      endpointPath: 'cohort-sync/amplitude',
+      endpointStepTitle: 'Add Flagsmith as a destination in Amplitude',
+      exportStepBody:
+        'In Amplitude, open the cohort you want to target and synchronise it to the Flagsmith destination. Flagsmith creates the managed segment automatically on the first synchronisation, then keeps its members up to date as people enter and leave the cohort.',
+      exportStepTitle: 'Synchronise your cohort to Flagsmith',
+      label: 'Amplitude',
+    },
+    mixpanel: {
+      authRows: [
+        { label: 'Authentication', value: 'Basic auth' },
+        { label: 'Username', value: 'Any value' },
+        { label: 'Password', mono: true, value: '{YOUR_SYNCHRONISATION_KEY}' },
+      ],
+      endpointPath: 'cohort-sync/mixpanel/webhook/',
+      endpointStepTitle: 'Create a webhook in Mixpanel',
+      exportStepBody:
+        'In Mixpanel, open the cohort you want to target and export it to the webhook you just created. Flagsmith creates the managed segment automatically on the first synchronisation, then keeps its members up to date as people enter and leave the cohort.',
+      exportStepTitle: 'Export your cohort to the webhook',
+      label: 'Mixpanel',
+    },
+  }
+
+export const getCohortProviderEndpoint = (
+  provider: CohortProviderKey,
+): string => `${Project.api}${COHORT_PROVIDERS[provider].endpointPath}`

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -827,6 +827,9 @@ const LoadingCreateSegment: FC<LoadingCreateSegmentType> = (props) => {
   useEffect(() => {
     if (segmentData) {
       props.onSegmentRetrieved?.(segmentData)
+      if (segmentData.cohort?.environment_api_key) {
+        setEnvironmentId(segmentData.cohort.environment_api_key)
+      }
     }
     //eslint-disable-next-line
   }, [segmentData])

--- a/frontend/web/components/modals/CreateSegmentSourcesModal/CreateSegmentSourcesModal.tsx
+++ b/frontend/web/components/modals/CreateSegmentSourcesModal/CreateSegmentSourcesModal.tsx
@@ -76,20 +76,26 @@ export function getSegmentSources(): SegmentSource[] {
 
 type CreateSegmentSourcesModalType = {
   onManual: () => void
+  onAmplitude?: () => void
   onCsv?: () => void
+  onMixpanel?: () => void
   sources: SegmentSource[]
 }
 
 const CreateSegmentSourcesModal: FC<CreateSegmentSourcesModalType> = ({
+  onAmplitude,
   onCsv,
   onManual,
+  onMixpanel,
   sources,
 }) => {
   const [selected, setSelected] = useState<SelectedSegmentSource>(null)
   const [requested, setRequested] = useState<string[]>([])
 
   const sourceHandlers: Partial<Record<string, () => void>> = {
+    amplitude: onAmplitude,
     csv: onCsv,
+    mixpanel: onMixpanel,
   }
 
   const trackSourceEvent = (event: string, source: SegmentSource) => {

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -18,6 +18,10 @@ import CreateSegmentFromCsv from 'components/modals/CreateSegmentFromCsv'
 import CreateSegmentSourcesModal, {
   getSegmentSources,
 } from 'components/modals/CreateSegmentSourcesModal'
+import ConnectCohortProviderModal, {
+  COHORT_PROVIDERS,
+  CohortProviderKey,
+} from 'components/modals/ConnectCohortProviderModal'
 import PanelSearch from 'components/PanelSearch'
 import JSONReference from 'components/JSONReference'
 
@@ -117,6 +121,14 @@ const SegmentsPage: FC = () => {
     )
   }
 
+  const openConnectCohortProviderDrawer = (provider: CohortProviderKey) => {
+    openModal(
+      `Connect ${COHORT_PROVIDERS[provider].label}`,
+      <ConnectCohortProviderModal projectId={projectId} provider={provider} />,
+      'p-0 modal--wide',
+    )
+  }
+
   const newSegment = () => {
     const sources = getSegmentSources()
     if (
@@ -129,6 +141,8 @@ const SegmentsPage: FC = () => {
           sources={sources}
           onManual={openCreateSegmentDrawer}
           onCsv={openCreateSegmentFromCsvDrawer}
+          onMixpanel={() => openConnectCohortProviderDrawer('mixpanel')}
+          onAmplitude={() => openConnectCohortProviderDrawer('amplitude')}
         />,
         'p-0 modal--wide',
       )

--- a/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
@@ -928,7 +928,7 @@ const EnvironmentSettingsPage: React.FC = () => {
                     </TabItem>
                   )}
                   {cohortSyncEnabled && (
-                    <TabItem tabLabel='Cohort Sync'>
+                    <TabItem tabLabel='Cohort Synchronisation'>
                       <div className='mt-4'>
                         <CohortSyncTab
                           environmentApiKey={match.params.environmentId}

--- a/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
@@ -47,6 +47,8 @@ import { useRouteContext } from 'components/providers/RouteContext'
 import SettingTitle from 'components/SettingTitle'
 import ChangeRequestsSetting from 'components/ChangeRequestsSetting'
 import PlanBasedBanner from 'components/PlanBasedAccess'
+import { getSegmentSources } from 'components/modals/CreateSegmentSourcesModal'
+import CohortSyncTab from './tabs/cohort-sync-tab'
 import WarehouseTab from './tabs/warehouse-tab'
 
 const showDisabledFlagOptions: { label: string; value: boolean | null }[] = [
@@ -118,6 +120,11 @@ const EnvironmentSettingsPage: React.FC = () => {
   const metadataEnable = Utils.getPlansPermission('METADATA')
   const warehouseEnabled = Utils.getFlagsmithHasFeature(
     'experimentation_warehouse_connection',
+  )
+  const cohortSyncEnabled = getSegmentSources().some(
+    (source) =>
+      (source.key === 'amplitude' || source.key === 'mixpanel') &&
+      source.active,
   )
 
   const getEnvironment = useCallback(async () => {
@@ -918,6 +925,15 @@ const EnvironmentSettingsPage: React.FC = () => {
                           />
                         </div>
                       </PlanBasedBanner>
+                    </TabItem>
+                  )}
+                  {cohortSyncEnabled && (
+                    <TabItem tabLabel='Cohort Sync'>
+                      <div className='mt-4'>
+                        <CohortSyncTab
+                          environmentApiKey={match.params.environmentId}
+                        />
+                      </div>
                     </TabItem>
                   )}
                   {metadataEnable && environmentContentType?.id && (

--- a/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
@@ -799,7 +799,6 @@ const EnvironmentSettingsPage: React.FC = () => {
                     </FormGroup>
                   </TabItem>
                   <TabItem tabLabel='Webhooks'>
-                    <hr className='py-0 my-4' />
                     <FormGroup className='mt-4'>
                       <div className='col-md-8'>
                         <h5 className='mb-2'>Feature Webhooks</h5>
@@ -928,7 +927,7 @@ const EnvironmentSettingsPage: React.FC = () => {
                     </TabItem>
                   )}
                   {cohortSyncEnabled && (
-                    <TabItem tabLabel='Cohort Synchronisation'>
+                    <TabItem tabLabel='Cohorts'>
                       <div className='mt-4'>
                         <CohortSyncTab
                           environmentApiKey={match.params.environmentId}

--- a/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
+++ b/frontend/web/components/pages/environment-settings/EnvironmentSettingsPage.tsx
@@ -932,6 +932,7 @@ const EnvironmentSettingsPage: React.FC = () => {
                       <div className='mt-4'>
                         <CohortSyncTab
                           environmentApiKey={match.params.environmentId}
+                          projectId={projectId ?? ''}
                         />
                       </div>
                     </TabItem>

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -13,6 +13,7 @@ import {
 import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
 import ErrorMessage from 'components/ErrorMessage'
+import Link from 'components/base/link/Link'
 import Flex from 'components/base/grid/Flex'
 import FormGroup from 'components/base/grid/FormGroup'
 import Row from 'components/base/grid/Row'
@@ -122,14 +123,12 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({
         <p className='fs-small lh-sm mb-0'>
           Cohort synchronisation keys authenticate cohort synchronisation from
           providers such as Mixpanel and Amplitude into this environment.{' '}
-          <Button
-            theme='text'
+          <Link
             href='https://docs.flagsmith.com/basic-features/segments'
             target='_blank'
-            className='fw-normal'
           >
             Learn about Segments.
-          </Button>
+          </Link>
         </p>
         <p className='fs-small lh-sm mb-4'>
           Key values are shown only once at creation and cannot be recovered

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -12,6 +12,7 @@ import {
 } from 'common/types/permissions.types'
 import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
+import ErrorMessage from 'components/ErrorMessage'
 import Flex from 'components/base/grid/Flex'
 import FormGroup from 'components/base/grid/FormGroup'
 import Row from 'components/base/grid/Row'
@@ -42,7 +43,11 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({
   })
   const canManage = !!canManageOverrides && !!canManageSegments
 
-  const { data: syncKeys, isLoading } = useGetCohortSyncKeysQuery(
+  const {
+    data: syncKeys,
+    error,
+    isLoading,
+  } = useGetCohortSyncKeysQuery(
     { environmentApiKey },
     { skip: !environmentApiKey },
   )
@@ -131,9 +136,9 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({
           afterwards.
         </p>
       </div>
-      {isLoading && !syncKeys ? (
-        <Loader />
-      ) : (
+      {!!error && <ErrorMessage error={error} />}
+      {isLoading && !syncKeys && !error && <Loader />}
+      {!error && (!isLoading || !!syncKeys) && (
         <PanelSearch
           id='cohort-sync-keys-list'
           className='no-pad'

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -6,7 +6,10 @@ import {
   useGetCohortSyncKeysQuery,
   useRevokeCohortSyncKeyMutation,
 } from 'common/services/useCohort'
-import { EnvironmentPermission } from 'common/types/permissions.types'
+import {
+  EnvironmentPermission,
+  ProjectPermission,
+} from 'common/types/permissions.types'
 import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
 import Flex from 'components/base/grid/Flex'
@@ -20,14 +23,25 @@ import CreateCohortSyncKeyModal from './CreateCohortSyncKeyModal'
 
 type CohortSyncTabProps = {
   environmentApiKey: string
+  projectId: number | string
 }
 
-const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
-  const { permission: canManage } = useHasPermission({
+const CohortSyncTab: FC<CohortSyncTabProps> = ({
+  environmentApiKey,
+  projectId,
+}) => {
+  // Key writes need both permissions; mirrors the API's CohortPermission.
+  const { permission: canManageOverrides } = useHasPermission({
     id: environmentApiKey,
     level: 'environment',
     permission: EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
   })
+  const { permission: canManageSegments } = useHasPermission({
+    id: `${projectId}`,
+    level: 'project',
+    permission: ProjectPermission.MANAGE_SEGMENTS,
+  })
+  const canManage = !!canManageOverrides && !!canManageSegments
 
   const { data: syncKeys, isLoading } = useGetCohortSyncKeysQuery(
     { environmentApiKey },

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -1,0 +1,167 @@
+import React, { FC } from 'react'
+import moment from 'moment'
+import Constants from 'common/constants'
+import { useHasPermission } from 'common/providers/Permission'
+import {
+  useGetCohortSyncKeysQuery,
+  useRevokeCohortSyncKeyMutation,
+} from 'common/services/useCohort'
+import { EnvironmentPermission } from 'common/types/permissions.types'
+import { CohortSyncKey } from 'common/types/responses'
+import Button from 'components/base/forms/Button'
+import Flex from 'components/base/grid/Flex'
+import FormGroup from 'components/base/grid/FormGroup'
+import Panel from 'components/base/grid/Panel'
+import Row from 'components/base/grid/Row'
+import Icon from 'components/icons/Icon'
+import Loader from 'components/Loader'
+import PanelSearch from 'components/PanelSearch'
+import Tooltip from 'components/Tooltip'
+import CreateCohortSyncKeyModal from './CreateCohortSyncKeyModal'
+
+type CohortSyncTabProps = {
+  environmentApiKey: string
+}
+
+const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
+  const { permission: canManage } = useHasPermission({
+    id: environmentApiKey,
+    level: 'environment',
+    permission: EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
+  })
+
+  const { data: syncKeys, isLoading } = useGetCohortSyncKeysQuery(
+    { environmentApiKey },
+    { skip: !environmentApiKey },
+  )
+  const [revokeCohortSyncKey] = useRevokeCohortSyncKeyMutation()
+
+  const handleCreate = () => {
+    openModal(
+      'Create Cohort Sync Key',
+      <CreateCohortSyncKeyModal environmentApiKey={environmentApiKey} />,
+      'p-0',
+    )
+  }
+
+  const handleRevoke = (syncKey: CohortSyncKey) => {
+    openConfirm({
+      body: (
+        <div>
+          Any provider using <strong>{syncKey.name}</strong> will stop syncing
+          cohorts into this environment immediately. This cannot be undone.
+        </div>
+      ),
+      destructive: true,
+      onYes: () => {
+        revokeCohortSyncKey({ environmentApiKey, prefix: syncKey.prefix })
+          .unwrap()
+          .then(() => toast('Cohort sync key revoked'))
+          .catch(() => toast('Failed to revoke cohort sync key', 'danger'))
+      },
+      title: 'Revoke Cohort Sync Key',
+      yesText: 'Revoke',
+    })
+  }
+
+  const filterByName = (syncKey: CohortSyncKey, search: string) =>
+    syncKey.name.toLowerCase().includes(search.toLowerCase())
+
+  const renderRow = (syncKey: CohortSyncKey) => (
+    <Row className='list-item' key={syncKey.prefix}>
+      <Flex className='table-column px-3'>
+        <div className='font-weight-medium mb-1'>{syncKey.name}</div>
+        <div className='list-item-subtitle'>
+          Created {moment(syncKey.created).format('D MMM YYYY')}
+        </div>
+      </Flex>
+      <div className='table-column'>
+        <span className='font-monospace fs-small text-muted bg-surface-muted rounded-sm px-2 py-1'>
+          {syncKey.prefix}
+        </span>
+      </div>
+      <div className='table-column'>
+        <Button
+          type='button'
+          onClick={() => handleRevoke(syncKey)}
+          className='btn btn-with-icon'
+          aria-label={`Revoke ${syncKey.name}`}
+        >
+          <Icon name='trash-2' width={20} fill='#656D7B' />
+        </Button>
+      </div>
+    </Row>
+  )
+
+  return (
+    <FormGroup className='my-4'>
+      <div className='col-md-8'>
+        <h5 className='mb-2'>Cohort Sync Keys</h5>
+        <p className='fs-small lh-sm mb-0'>
+          Cohort sync keys authenticate cohort synchronisation from providers
+          such as Mixpanel and Amplitude into this environment.{' '}
+          <Button
+            theme='text'
+            href='https://docs.flagsmith.com/basic-features/segments'
+            target='_blank'
+            className='fw-normal'
+          >
+            Learn about Segments.
+          </Button>
+        </p>
+        <p className='fs-small lh-sm mb-0'>
+          Key values are shown only once at creation and cannot be recovered
+          afterwards.
+        </p>
+        {canManage ? (
+          <Button
+            onClick={handleCreate}
+            className='my-4'
+            data-test='create-cohort-sync-key'
+          >
+            Create Cohort Sync Key
+          </Button>
+        ) : (
+          <Tooltip
+            title={
+              <Button className='my-4' disabled>
+                Create Cohort Sync Key
+              </Button>
+            }
+            place='right'
+          >
+            {Constants.environmentPermissions(
+              EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
+            )}
+          </Tooltip>
+        )}
+      </div>
+      {isLoading && !syncKeys ? (
+        <Loader />
+      ) : (
+        <PanelSearch
+          id='cohort-sync-keys-list'
+          title='Cohort Sync Keys'
+          className='no-pad'
+          items={syncKeys}
+          filterRow={filterByName}
+          renderRow={renderRow}
+          renderNoResults={
+            <Panel className='no-pad' title='Cohort Sync Keys'>
+              <div className='search-list'>
+                <Row className='list-item p-3 text-muted'>
+                  You currently have no cohort sync keys for this environment.
+                </Row>
+              </div>
+            </Panel>
+          }
+          isLoading={isLoading}
+        />
+      )}
+    </FormGroup>
+  )
+}
+
+CohortSyncTab.displayName = 'CohortSyncTab'
+
+export default CohortSyncTab

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -14,7 +14,6 @@ import { CohortSyncKey } from 'common/types/responses'
 import Button from 'components/base/forms/Button'
 import Flex from 'components/base/grid/Flex'
 import FormGroup from 'components/base/grid/FormGroup'
-import Panel from 'components/base/grid/Panel'
 import Row from 'components/base/grid/Row'
 import Icon from 'components/icons/Icon'
 import PanelSearch from 'components/PanelSearch'
@@ -127,50 +126,48 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({
             Learn about Segments.
           </Button>
         </p>
-        <p className='fs-small lh-sm mb-0'>
+        <p className='fs-small lh-sm mb-4'>
           Key values are shown only once at creation and cannot be recovered
           afterwards.
         </p>
-        {canManage ? (
-          <Button
-            onClick={handleCreate}
-            className='my-4'
-            data-test='create-cohort-sync-key'
-          >
-            Create Cohort Synchronisation Key
-          </Button>
-        ) : (
-          <Tooltip
-            title={
-              <Button className='my-4' disabled>
-                Create Cohort Synchronisation Key
-              </Button>
-            }
-            place='right'
-          >
-            {Constants.cohortSyncKeyPermissions}
-          </Tooltip>
-        )}
       </div>
       {isLoading && !syncKeys ? (
         <Loader />
       ) : (
         <PanelSearch
           id='cohort-sync-keys-list'
-          title='Cohort Synchronisation Keys'
           className='no-pad'
           items={syncKeys}
           filterRow={filterByName}
           renderRow={renderRow}
+          renderSearchWithNoResults
+          actionButton={
+            canManage ? (
+              <Button
+                onClick={handleCreate}
+                className='ml-2'
+                data-test='create-cohort-sync-key'
+              >
+                Create Cohort Key
+              </Button>
+            ) : (
+              <Tooltip
+                title={
+                  <Button className='ml-2' disabled>
+                    Create Cohort Key
+                  </Button>
+                }
+                place='left'
+              >
+                {Constants.cohortSyncKeyPermissions}
+              </Tooltip>
+            )
+          }
           renderNoResults={
-            <Panel className='no-pad' title='Cohort Synchronisation Keys'>
-              <div className='search-list'>
-                <Row className='list-item p-3 text-muted'>
-                  You currently have no cohort synchronisation keys for this
-                  environment.
-                </Row>
-              </div>
-            </Panel>
+            <Row className='list-item p-3 text-muted'>
+              You currently have no cohort synchronisation keys for this
+              environment.
+            </Row>
           }
           isLoading={isLoading}
         />

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -14,7 +14,6 @@ import FormGroup from 'components/base/grid/FormGroup'
 import Panel from 'components/base/grid/Panel'
 import Row from 'components/base/grid/Row'
 import Icon from 'components/icons/Icon'
-import Loader from 'components/Loader'
 import PanelSearch from 'components/PanelSearch'
 import Tooltip from 'components/Tooltip'
 import CreateCohortSyncKeyModal from './CreateCohortSyncKeyModal'
@@ -84,14 +83,16 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
         </span>
       </div>
       <div className='table-column'>
-        <Button
-          type='button'
-          onClick={() => handleRevoke(syncKey)}
-          className='btn btn-with-icon'
-          aria-label={`Revoke ${syncKey.name}`}
-        >
-          <Icon name='trash-2' width={20} fill='#656D7B' />
-        </Button>
+        {canManage && (
+          <Button
+            type='button'
+            onClick={() => handleRevoke(syncKey)}
+            className='btn btn-with-icon'
+            aria-label={`Revoke ${syncKey.name}`}
+          >
+            <Icon name='trash-2' width={20} fill='#656D7B' />
+          </Button>
+        )}
       </div>
     </Row>
   )

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -38,7 +38,7 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
 
   const handleCreate = () => {
     openModal(
-      'Create Cohort Sync Key',
+      'Create Cohort Synchronisation Key',
       <CreateCohortSyncKeyModal environmentApiKey={environmentApiKey} />,
       'p-0',
     )
@@ -48,18 +48,21 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
     openConfirm({
       body: (
         <div>
-          Any provider using <strong>{syncKey.name}</strong> will stop syncing
-          cohorts into this environment immediately. This cannot be undone.
+          Any provider using <strong>{syncKey.name}</strong> will stop
+          synchronising cohorts into this environment immediately. This cannot
+          be undone.
         </div>
       ),
       destructive: true,
       onYes: () => {
         revokeCohortSyncKey({ environmentApiKey, prefix: syncKey.prefix })
           .unwrap()
-          .then(() => toast('Cohort sync key revoked'))
-          .catch(() => toast('Failed to revoke cohort sync key', 'danger'))
+          .then(() => toast('Cohort synchronisation key revoked'))
+          .catch(() =>
+            toast('Failed to revoke cohort synchronisation key', 'danger'),
+          )
       },
-      title: 'Revoke Cohort Sync Key',
+      title: 'Revoke Cohort Synchronisation Key',
       yesText: 'Revoke',
     })
   }
@@ -96,10 +99,10 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
   return (
     <FormGroup className='my-4'>
       <div className='col-md-8'>
-        <h5 className='mb-2'>Cohort Sync Keys</h5>
+        <h5 className='mb-2'>Cohort Synchronisation Keys</h5>
         <p className='fs-small lh-sm mb-0'>
-          Cohort sync keys authenticate cohort synchronisation from providers
-          such as Mixpanel and Amplitude into this environment.{' '}
+          Cohort synchronisation keys authenticate cohort synchronisation from
+          providers such as Mixpanel and Amplitude into this environment.{' '}
           <Button
             theme='text'
             href='https://docs.flagsmith.com/basic-features/segments'
@@ -119,13 +122,13 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
             className='my-4'
             data-test='create-cohort-sync-key'
           >
-            Create Cohort Sync Key
+            Create Cohort Synchronisation Key
           </Button>
         ) : (
           <Tooltip
             title={
               <Button className='my-4' disabled>
-                Create Cohort Sync Key
+                Create Cohort Synchronisation Key
               </Button>
             }
             place='right'
@@ -141,16 +144,17 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({ environmentApiKey }) => {
       ) : (
         <PanelSearch
           id='cohort-sync-keys-list'
-          title='Cohort Sync Keys'
+          title='Cohort Synchronisation Keys'
           className='no-pad'
           items={syncKeys}
           filterRow={filterByName}
           renderRow={renderRow}
           renderNoResults={
-            <Panel className='no-pad' title='Cohort Sync Keys'>
+            <Panel className='no-pad' title='Cohort Synchronisation Keys'>
               <div className='search-list'>
                 <Row className='list-item p-3 text-muted'>
-                  You currently have no cohort sync keys for this environment.
+                  You currently have no cohort synchronisation keys for this
+                  environment.
                 </Row>
               </div>
             </Panel>

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CohortSyncTab.tsx
@@ -148,9 +148,7 @@ const CohortSyncTab: FC<CohortSyncTabProps> = ({
             }
             place='right'
           >
-            {Constants.environmentPermissions(
-              EnvironmentPermission.MANAGE_SEGMENT_OVERRIDES,
-            )}
+            {Constants.cohortSyncKeyPermissions}
           </Tooltip>
         )}
       </div>

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
@@ -39,7 +39,7 @@ const CreateCohortSyncKeyModal: FC<CreateCohortSyncKeyModalProps> = ({
             className='font-monospace'
             data-test='cohort-sync-key-value'
           />
-          <div className='mt-4'>
+          <div className='mt-2'>
             <WarningMessage warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.' />
           </div>
         </div>

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
@@ -34,14 +34,14 @@ const CreateCohortSyncKeyModal: FC<CreateCohortSyncKeyModalProps> = ({
       <div>
         <div className='modal-body'>
           <CopyField
-            title='Cohort sync key'
+            title='Cohort synchronisation key'
             value={createdKey}
             className='font-monospace'
             data-test='cohort-sync-key-value'
           />
           <WarningMessage
             warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.'
-            warningMessageClass='mt-3'
+            warningMessageClass='mt-4'
           />
         </div>
         <ModalHR />

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
@@ -1,0 +1,95 @@
+import React, { FC, useState } from 'react'
+import { useCreateCohortSyncKeyMutation } from 'common/services/useCohort'
+import Button from 'components/base/forms/Button'
+import InputGroup from 'components/base/forms/InputGroup'
+import CopyField from 'components/CopyField'
+import ErrorMessage from 'components/ErrorMessage'
+import ModalHR from 'components/modals/ModalHR'
+import WarningMessage from 'components/WarningMessage'
+
+const NAME_MAX_LENGTH = 50
+
+type CreateCohortSyncKeyModalProps = {
+  environmentApiKey: string
+}
+
+const CreateCohortSyncKeyModal: FC<CreateCohortSyncKeyModalProps> = ({
+  environmentApiKey,
+}) => {
+  const [name, setName] = useState('')
+  const [createdKey, setCreatedKey] = useState<string | null>(null)
+  const [createCohortSyncKey, { error, isLoading }] =
+    useCreateCohortSyncKeyMutation()
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    createCohortSyncKey({ environmentApiKey, name: name.trim() })
+      .unwrap()
+      .then((syncKey) => setCreatedKey(syncKey.key))
+      .catch(() => {})
+  }
+
+  if (createdKey) {
+    return (
+      <div>
+        <div className='modal-body'>
+          <CopyField
+            title='Cohort sync key'
+            value={createdKey}
+            className='font-monospace'
+            data-test='cohort-sync-key-value'
+          />
+          <WarningMessage
+            warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.'
+            warningMessageClass='mt-3'
+          />
+        </div>
+        <ModalHR />
+        <div className='modal-footer'>
+          <Button onClick={() => closeModal()} data-test='cohort-sync-key-done'>
+            Done
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className='modal-body'>
+        <InputGroup
+          title='Name*'
+          value={name}
+          data-test='cohort-sync-key-name'
+          inputProps={{
+            className: 'full-width modal-input',
+            maxLength: NAME_MAX_LENGTH,
+            name: 'name',
+          }}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setName(event.target.value)
+          }
+          isValid={!!name.trim().length}
+          type='text'
+          placeholder='e.g. Mixpanel production'
+        />
+        <ErrorMessage error={error} />
+      </div>
+      <ModalHR />
+      <div className='modal-footer'>
+        <Button onClick={() => closeModal()} theme='secondary' className='mr-2'>
+          Cancel
+        </Button>
+        <Button
+          type='submit'
+          disabled={!name.trim() || isLoading}
+          data-test='cohort-sync-key-create'
+        >
+          {isLoading ? 'Creating' : 'Create'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export default CreateCohortSyncKeyModal

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/CreateCohortSyncKeyModal.tsx
@@ -39,10 +39,9 @@ const CreateCohortSyncKeyModal: FC<CreateCohortSyncKeyModalProps> = ({
             className='font-monospace'
             data-test='cohort-sync-key-value'
           />
-          <WarningMessage
-            warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.'
-            warningMessageClass='mt-4'
-          />
+          <div className='mt-4'>
+            <WarningMessage warningMessage='This key is shown only once. Store it securely — you will not be able to see it again.' />
+          </div>
         </div>
         <ModalHR />
         <div className='modal-footer'>

--- a/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/index.ts
+++ b/frontend/web/components/pages/environment-settings/tabs/cohort-sync-tab/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CohortSyncTab'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Frontend for connecting Mixpanel and Amplitude cohorts as managed segments, on top of the sync keys API (#8290, #8338).

- **Cohort Synchronisation tab in Environment Settings**: lists an environment's synchronisation keys (name, prefix, creation date), creates keys via a modal that shows the plaintext value once with a copy button, and revokes keys with a confirmation. Creating and revoking require the manage segment overrides permission.
- **Connect modals for Mixpanel and Amplitude**, opened from the segment creation sources modal: pick an environment, create or reuse a synchronisation key, copy the provider endpoint URL with structured authentication details, and follow provider-specific export instructions. The endpoint URL derives from the configured API host, so self-hosted installations get their own.
- **Real door**: the Mixpanel and Amplitude tiles in the sources modal open their connect modal when the corresponding `create_segment_with_external_sources` entry is `active`, replacing the beta fake door.

## How did you test this code?

Manually against staging:

1. Set `active: true` on the `mixpanel` and `amplitude` entries in the `create_segment_with_external_sources` flag.
2. Segments → Create Segment → Mixpanel/Amplitude opens the connect modal; verified the create-key flow (show-once value, copy), the existing-keys state, switching environments resets step 1, and the Environment Settings link.
3. Environment Settings → Cohort Synchronisation: created and revoked keys, verified the list refreshes and the revoke confirmation.

<img width="876" height="680" alt="image" src="https://github.com/user-attachments/assets/dd7b1c01-da77-4d78-b59d-3f6d9df6d964" />
<img width="984" height="726" alt="image" src="https://github.com/user-attachments/assets/0b232034-7b14-4189-952d-d295b77b4b79" />
<img width="845" height="761" alt="image" src="https://github.com/user-attachments/assets/186a9d14-7312-4fca-84be-864c7865f2b2" />
<img width="1122" height="426" alt="image" src="https://github.com/user-attachments/assets/c80b90da-1017-4dfc-b121-9f6f022ff151" />

