### PR TITLE
fix: project admin feature import permissions

### DIFF
--- a/api/features/import_export/permissions.py
+++ b/api/features/import_export/permissions.py
@@ -14,10 +14,11 @@ class FeatureImportPermissions(IsAuthenticated):
         if not super().has_permission(request, view):
             return False
 
-        environment = Environment.objects.select_related("project").get(
-            id=view.kwargs["environment_id"]
-        )
+        environment = Environment.objects.select_related(
+            "project__organisation",
+        ).get(id=view.kwargs["environment_id"])
 
+        # Since feature imports can be destructive, use project admin.
         return request.user.is_project_admin(environment.project)  # type: ignore[union-attr,no-any-return]
 
 

--- a/api/features/import_export/permissions.py
+++ b/api/features/import_export/permissions.py
@@ -14,12 +14,11 @@ class FeatureImportPermissions(IsAuthenticated):
         if not super().has_permission(request, view):
             return False
 
-        environment = Environment.objects.get(id=view.kwargs["environment_id"])
+        environment = Environment.objects.select_related("project").get(
+            id=view.kwargs["environment_id"]
+        )
 
-        # Since feature imports can be destructive, use environment admin.
-        # This mirrors the feature export permissions, and is satisfied by
-        # organisation and project admins too.
-        return request.user.is_environment_admin(environment)  # type: ignore[union-attr,no-any-return]
+        return request.user.is_project_admin(environment.project)  # type: ignore[union-attr,no-any-return]
 
 
 class CreateFeatureExportPermissions(IsAuthenticated):

--- a/api/features/import_export/permissions.py
+++ b/api/features/import_export/permissions.py
@@ -14,13 +14,12 @@ class FeatureImportPermissions(IsAuthenticated):
         if not super().has_permission(request, view):
             return False
 
-        environment = Environment.objects.select_related(
-            "project__organisation",
-        ).get(id=view.kwargs["environment_id"])
-        organisation = environment.project.organisation
+        environment = Environment.objects.get(id=view.kwargs["environment_id"])
 
-        # Since feature imports can be destructive, use org admin.
-        return request.user.is_organisation_admin(organisation)  # type: ignore[union-attr,no-any-return]
+        # Since feature imports can be destructive, use environment admin.
+        # This mirrors the feature export permissions, and is satisfied by
+        # organisation and project admins too.
+        return request.user.is_environment_admin(environment)  # type: ignore[union-attr,no-any-return]
 
 
 class CreateFeatureExportPermissions(IsAuthenticated):

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -23,7 +23,10 @@ from features.import_export.models import (
 )
 from projects.models import Project
 from projects.tags.models import Tag
-from tests.types import WithProjectPermissionsCallable
+from tests.types import (
+    WithEnvironmentPermissionsCallable,
+    WithProjectPermissionsCallable,
+)
 from users.models import FFAdminUser
 
 
@@ -252,6 +255,80 @@ def test_feature_import__already_processing__returns_bad_request(
     assert response.json() == [
         "Can't import features, since already processing a feature import."
     ]
+
+
+def test_feature_import__project_admin__creates_import(
+    staff_client: APIClient,
+    environment: Environment,
+    with_project_permissions: WithProjectPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions(admin=True)  # type: ignore[call-arg]
+    assert FeatureImport.objects.count() == 0
+    url = reverse(
+        "api-v1:features:feature-import",
+        args=[environment.id],
+    )
+
+    file_data = b"[]"
+    uploaded_file = SimpleUploadedFile("test.23.json", file_data)
+    data = {"file": uploaded_file, "strategy": OVERWRITE_DESTRUCTIVE}
+
+    # When
+    response = staff_client.post(url, data=data, format="multipart")
+
+    # Then
+    assert response.status_code == 201
+    assert FeatureImport.objects.count() == 1
+
+
+def test_feature_import__environment_admin__creates_import(
+    staff_client: APIClient,
+    environment: Environment,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    with_environment_permissions(admin=True)  # type: ignore[call-arg]
+    assert FeatureImport.objects.count() == 0
+    url = reverse(
+        "api-v1:features:feature-import",
+        args=[environment.id],
+    )
+
+    file_data = b"[]"
+    uploaded_file = SimpleUploadedFile("test.23.json", file_data)
+    data = {"file": uploaded_file, "strategy": OVERWRITE_DESTRUCTIVE}
+
+    # When
+    response = staff_client.post(url, data=data, format="multipart")
+
+    # Then
+    assert response.status_code == 201
+    assert FeatureImport.objects.count() == 1
+
+
+def test_feature_import__non_admin_project_permissions__returns_forbidden(
+    staff_client: APIClient,
+    environment: Environment,
+    with_project_permissions: WithProjectPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
+    url = reverse(
+        "api-v1:features:feature-import",
+        args=[environment.id],
+    )
+
+    file_data = b"[]"
+    uploaded_file = SimpleUploadedFile("test.23.json", file_data)
+    data = {"file": uploaded_file, "strategy": OVERWRITE_DESTRUCTIVE}
+
+    # When
+    response = staff_client.post(url, data=data, format="multipart")
+
+    # Then
+    assert response.status_code == 403
+    assert FeatureImport.objects.count() == 0
 
 
 def test_feature_import__unauthorized_user__returns_forbidden(

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -282,14 +282,13 @@ def test_feature_import__project_admin__creates_import(
     assert FeatureImport.objects.count() == 1
 
 
-def test_feature_import__environment_admin__creates_import(
+def test_feature_import__environment_admin__returns_forbidden(
     staff_client: APIClient,
     environment: Environment,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
     with_environment_permissions(admin=True)  # type: ignore[call-arg]
-    assert FeatureImport.objects.count() == 0
     url = reverse(
         "api-v1:features:feature-import",
         args=[environment.id],
@@ -303,8 +302,8 @@ def test_feature_import__environment_admin__creates_import(
     response = staff_client.post(url, data=data, format="multipart")
 
     # Then
-    assert response.status_code == 201
-    assert FeatureImport.objects.count() == 1
+    assert response.status_code == 403
+    assert FeatureImport.objects.count() == 0
 
 
 def test_feature_import__non_admin_project_permissions__returns_forbidden(

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -23,10 +23,7 @@ from features.import_export.models import (
 )
 from projects.models import Project
 from projects.tags.models import Tag
-from tests.types import (
-    WithEnvironmentPermissionsCallable,
-    WithProjectPermissionsCallable,
-)
+from tests.types import WithProjectPermissionsCallable
 from users.models import FFAdminUser
 
 
@@ -280,54 +277,6 @@ def test_feature_import__project_admin__creates_import(
     # Then
     assert response.status_code == 201
     assert FeatureImport.objects.count() == 1
-
-
-def test_feature_import__environment_admin__returns_forbidden(
-    staff_client: APIClient,
-    environment: Environment,
-    with_environment_permissions: WithEnvironmentPermissionsCallable,
-) -> None:
-    # Given
-    with_environment_permissions(admin=True)  # type: ignore[call-arg]
-    url = reverse(
-        "api-v1:features:feature-import",
-        args=[environment.id],
-    )
-
-    file_data = b"[]"
-    uploaded_file = SimpleUploadedFile("test.23.json", file_data)
-    data = {"file": uploaded_file, "strategy": OVERWRITE_DESTRUCTIVE}
-
-    # When
-    response = staff_client.post(url, data=data, format="multipart")
-
-    # Then
-    assert response.status_code == 403
-    assert FeatureImport.objects.count() == 0
-
-
-def test_feature_import__non_admin_project_permissions__returns_forbidden(
-    staff_client: APIClient,
-    environment: Environment,
-    with_project_permissions: WithProjectPermissionsCallable,
-) -> None:
-    # Given
-    with_project_permissions([VIEW_PROJECT])  # type: ignore[call-arg]
-    url = reverse(
-        "api-v1:features:feature-import",
-        args=[environment.id],
-    )
-
-    file_data = b"[]"
-    uploaded_file = SimpleUploadedFile("test.23.json", file_data)
-    data = {"file": uploaded_file, "strategy": OVERWRITE_DESTRUCTIVE}
-
-    # When
-    response = staff_client.post(url, data=data, format="multipart")
-
-    # Then
-    assert response.status_code == 403
-    assert FeatureImport.objects.count() == 0
 
 
 def test_feature_import__unauthorized_user__returns_forbidden(

--- a/frontend/web/components/import-export/FeatureImport.tsx
+++ b/frontend/web/components/import-export/FeatureImport.tsx
@@ -127,7 +127,7 @@ const FeatureExport: FC<FeatureExportType> = ({ projectId }) => {
           setFileData(null)
           refetch()
         } else {
-          toast('Failed to import flags')
+          toast('Failed to import flags', 'danger')
         }
       })
     }

--- a/frontend/web/components/import-export/ImportPage.tsx
+++ b/frontend/web/components/import-export/ImportPage.tsx
@@ -13,10 +13,10 @@ import Button from 'components/base/forms/Button'
 import PanelSearch from 'components/PanelSearch'
 import TabItem from 'components/navigation/TabMenu/TabItem'
 import FeatureImport from './FeatureImport'
-import AccountStore from 'common/stores/account-store'
 import Constants from 'common/constants'
 import { useHistory } from 'react-router-dom'
-import { OrganisationPermission } from 'common/types/permissions.types'
+import { ProjectPermission } from 'common/types/permissions.types'
+import { useHasPermission } from 'common/providers/Permission'
 
 type ImportPageType = {
   projectId: string
@@ -25,6 +25,12 @@ type ImportPageType = {
 
 const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
   const history = useHistory()
+  const { isLoading: isLoadingPermission, permission: isProjectAdmin } =
+    useHasPermission({
+      id: projectId,
+      level: 'project',
+      permission: ProjectPermission.ADMIN,
+    })
   const [LDKey, setLDKey] = useState<string>('')
   const [importId, setImportId] = useState<number>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -93,15 +99,19 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
     })
   }
 
-  const isAdmin = AccountStore.isAdmin()
+  if (isLoadingPermission) {
+    return (
+      <div className='text-center mt-4'>
+        <Loader />
+      </div>
+    )
+  }
 
-  if (!isAdmin) {
+  if (!isProjectAdmin) {
     return (
       <div
         dangerouslySetInnerHTML={{
-          __html: Constants.organisationPermissions(
-            OrganisationPermission.ADMIN,
-          ),
+          __html: Constants.projectPermissions(ProjectPermission.ADMIN),
         }}
         className='mt-4'
       />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [ ] I have filled in the "Changes" section below.
- [ ] I have filled in the "How did you test this code" section below.

## Changes

Closes #8237 

## How did you test this code?

Verified that you get the message "To manage this feature you need the Administrator permission for this organisation.
Please contact a member of this organisation who has administrator privileges." when trying to import features as a project admin.
After the fix verified that a project admin is allowed to import features.
