### PR TITLE
fix(usage): reword the plan hint when we have no billing period

### DIFF
--- a/frontend/web/components/pages/usage/__tests__/utils.test.ts
+++ b/frontend/web/components/pages/usage/__tests__/utils.test.ts
@@ -106,8 +106,8 @@ describe('UsageDashboard utils', () => {
 
       expect(basis).toEqual({ reason: 'free', window: 'rolling' })
       expect(allowanceWindow(basis)).toBeUndefined()
-      expect(planSectionCopy(basis, 50000).hint).not.toContain(
-        'no billing period',
+      expect(planSectionCopy(basis, 50000).hint).toBe(
+        'Usage against your plan limit over the last 30 days.',
       )
     })
 
@@ -119,7 +119,7 @@ describe('UsageDashboard utils', () => {
 
       expect(basis).toEqual({ reason: 'no-period', window: 'rolling' })
       expect(planSectionCopy(basis, 50000).hint).toContain(
-        'has no billing period',
+        'unable to show exact billing periods',
       )
     })
   })

--- a/frontend/web/components/pages/usage/utils.ts
+++ b/frontend/web/components/pages/usage/utils.ts
@@ -46,7 +46,7 @@ export const planSectionCopy = (
     return {
       hint: `Usage against your plan limit over ${allowanceWindowLabel(
         basis,
-      )}. This organisation has no billing period.`,
+      )}. We are unable to show exact billing periods for your subscription plan.`,
       title: 'Your plan',
     }
   }


### PR DESCRIPTION
## Changes

Copy only, follow-up to #8357. 

Before:
> Usage against your plan limit over the last 30 days. This organisation has no billing period.

After:
> Usage against your plan limit over the last 30 days. We are unable to show exact billing periods for your subscription plan.

The old line names an absence in the customer's account, so someone on a contract reads it as something being wrong with theirs. The limitation is ours: we only hold those dates for Chargebee subscriptions.

Free plans are unaffected, they keep the first sentence alone.

## How did you test this code?

`npm run test:unit -- --testPathPatterns="pages/usage"`, and the Pages/Usage Dashboard stories in Storybook.