### PR TITLE
ci(frontend-deploy): name what is being deployed

### DIFF
--- a/.github/actions/notify-slack-deploy/action.yml
+++ b/.github/actions/notify-slack-deploy/action.yml
@@ -30,6 +30,14 @@ inputs:
   run_url:
     description: Link to the deploy run, not to the run posting this.
     required: true
+  repo_url:
+    description: Repository URL, used to link the pull request. Omit to leave the title unlinked.
+    required: false
+  commit_message:
+    description: >
+      The deployed commit's message. Only its first line is used, which on a
+      squash merge is the pull request title. Omitted from the card if absent.
+    required: false
   started_at:
     description: When the deploy run started, ISO 8601. Omitted from the message if absent.
     required: false
@@ -52,10 +60,25 @@ runs:
         COMMIT_SHA: ${{ inputs.commit_sha }}
         ACTOR: ${{ inputs.actor }}
         RUN_URL: ${{ inputs.run_url }}
+        REPO_URL: ${{ inputs.repo_url }}
+        COMMIT_MESSAGE: ${{ inputs.commit_message }}
         STARTED_AT: ${{ inputs.started_at }}
         ENDED_AT: ${{ inputs.ended_at }}
       run: |
         set -euo pipefail
+
+        # A squash merge puts the pull request title and number in the first
+        # line, as "title (#123)". A direct push or a merge commit will not
+        # match, so the number is optional and the title falls back to the
+        # whole line.
+        subject="$(printf '%s' "${COMMIT_MESSAGE:-}" | head -1)"
+        pr_number="$(printf '%s' "$subject" | sed -n 's/.*(#\([0-9]\{1,\}\))$/\1/p')"
+        title="$subject"
+        pr_url=''
+        if [ -n "$pr_number" ]; then
+          title="$(printf '%s' "$subject" | sed 's/ *(#[0-9]\{1,\})$//')"
+          [ -n "${REPO_URL:-}" ] && pr_url="$REPO_URL/pull/$pr_number"
+        fi
 
         # Best effort: a timestamp that will not parse costs the message two
         # fields rather than failing the run.
@@ -83,6 +106,8 @@ runs:
           --arg actor "$ACTOR" \
           --arg app_url "$APP_URL" \
           --arg run_url "$RUN_URL" \
+          --arg title "$title" \
+          --arg pr_url "$pr_url" \
           --arg started_epoch "$started_epoch" \
           --arg started_label "$started_label" \
           --arg duration "$duration" \

--- a/.github/actions/notify-slack-deploy/payload.jq
+++ b/.github/actions/notify-slack-deploy/payload.jq
@@ -43,11 +43,22 @@ end) as $copy |
   # comes from the icon set on the Slack app itself.
   username: "\($service) Deploy",
   text: $copy.headline,
-  blocks: [
+  blocks: (
+  [
     {
       type: "header",
       text: { type: "plain_text", text: $copy.headline }
-    },
+    }
+  ]
+  # What shipped, full width rather than in the field grid below, which is two
+  # narrow columns and would wrap a real title badly.
+  + (if $title == "" then []
+     elif $pr_url == "" then
+       [{ type: "context", elements: [{ type: "mrkdwn", text: $title }] }]
+     else
+       [{ type: "context", elements: [{ type: "mrkdwn", text: "<\($pr_url)|\($title)>" }] }]
+     end)
+  + [
     {
       type: "section",
       text: { type: "mrkdwn", text: $copy.body }
@@ -87,4 +98,5 @@ end) as $copy |
       )
     }
   ]
+  )
 }

--- a/.github/actions/notify-slack-deploy/payload.jq
+++ b/.github/actions/notify-slack-deploy/payload.jq
@@ -1,6 +1,12 @@
 # Slack Block Kit payload for a deploy notification.
 # Run with jq -n and the --arg values listed in action.yml.
 
+# Slack only needs these three escaped, ampersand first so the entities the
+# other two produce are not re-encoded. Without it a commit subject reading
+# "<!channel>" would ping the channel, and "<url|text>" would render as a
+# disguised link.
+def mrkdwn: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
+
 ($environment | (.[0:1] | ascii_upcase) + .[1:]) as $env_name |
 
 # Only in_progress, success and cancelled need their own words. Everything
@@ -54,9 +60,9 @@ end) as $copy |
   # narrow columns and would wrap a real title badly.
   + (if $title == "" then []
      elif $pr_url == "" then
-       [{ type: "context", elements: [{ type: "mrkdwn", text: $title }] }]
+       [{ type: "context", elements: [{ type: "mrkdwn", text: ($title | mrkdwn) }] }]
      else
-       [{ type: "context", elements: [{ type: "mrkdwn", text: "<\($pr_url)|\($title)>" }] }]
+       [{ type: "context", elements: [{ type: "mrkdwn", text: "<\($pr_url)|\($title | mrkdwn)>" }] }]
      end)
   + [
     {

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -37,6 +37,8 @@ jobs:
           commit_sha: ${{ github.sha }}
           actor: ${{ github.actor }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          repo_url: ${{ github.server_url }}/${{ github.repository }}
+          commit_message: ${{ github.event.head_commit.message }}
 
   run-unit-tests:
     runs-on: ubuntu-latest
@@ -169,6 +171,8 @@ jobs:
           commit_sha: ${{ github.sha }}
           actor: ${{ github.actor }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          repo_url: ${{ github.server_url }}/${{ github.repository }}
+          commit_message: ${{ github.event.head_commit.message }}
           started_at: ${{ steps.outcome.outputs.started_at }}
           ended_at: ${{ steps.outcome.outputs.ended_at }}
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The deploy cards identify a deploy by short sha, which tells you nothing about what is in it. This adds the pull request title under the headline, linked to the pull request.

No API call and no extra permission. A squash merge puts the title and number in the first line of the commit message as `title (#123)`, and **all forty** of the last forty commits on `main` match that shape. A direct push or a merge commit will not, so the number is optional: the title then falls back to the whole first line, unlinked, rather than producing a broken link.

The title goes full width as a `context` block rather than into the field grid, which is two narrow columns and would wrap a real title badly.

### Deploying

<img width="587" height="319" alt="image" src="https://github.com/user-attachments/assets/f413ac2d-126e-47b1-96b9-0f4412e422c9" />

### Deployed

<img width="580" height="353" alt="image" src="https://github.com/user-attachments/assets/63ab229f-203a-4bd3-aee0-d3ffe637f35f" />

## How did you test this code?

The parsing, against five commit message shapes:

| commit message | title | link |
| --- | --- | --- |
| `refactor(styles): diff view and code theme on shared tokens (#8069)` | title without the number | `/pull/8069` |
| `chore: a direct push with no pull request` | whole line | none |
| squash title plus a multi-line body | first line only | `/pull/8420` |
| empty | none, line omitted | none |
| `fix: mentions (#123) mid-sentence and ends plainly` | whole line | none, correctly not treated as a reference |

That last case is why the pattern is anchored to the end of the line.

The rendering, across all four states with and without a title, confirming the `context` block appears only when there is one and the block order is otherwise unchanged:

```
in_progress  no-title: header>section>section>actions   with-title: header>context>section>section>actions
success      no-title: header>section>section>actions   with-title: header>context>section>section>actions
cancelled    no-title: header>section>section>actions   with-title: header>context>section>section>actions
failure      no-title: header>section>section>actions   with-title: header>context>section>section>actions
```

Both files parse as YAML. Not exercised end to end, since this workflow only runs on push to `main`. The steps are `continue-on-error: true`, so nothing here can hold up or fail a deploy.
