### PR TITLE
chore(frontend): keep jest and tsc out of storybook-static

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -18,6 +18,9 @@ module.exports = {
   roots: ['<rootDir>'],
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
+  // A Storybook build copies the source into storybook-static, so without
+  // this jest runs a stale second copy of every test.
+  testPathIgnorePatterns: ['/node_modules/', '/storybook-static/'],
   transform: {
     // Code-help snippet templates are ESM .js, so they need transforming too.
     // node_modules stays untransformed, hence the ignore pattern below.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -29,7 +29,8 @@
     }
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "storybook-static"
   ],
   "include": [
     "global.d.ts",


### PR DESCRIPTION
## Changes

`npm run build-storybook` writes a copy of the source into `storybook-static/`. It is gitignored, but neither jest nor tsc reads gitignore, so both walk into it and pick up a stale second copy of every test and every file.

Once the real source moves on, that copy stops compiling, and `npm run typecheck` and `npm run test:unit` start failing locally on code you never touched. CI checks out clean, so it never saw it.

## How did you test this code?

Ran a Storybook build, confirmed `npm run test:unit` and `npm run typecheck` both reported failures from `storybook-static/`, then applied this and confirmed both are clean with the directory still present.