### PR TITLE
fix(clickhouse): Unblock `flagsmith migrate` when ClickHouse is configured

### DIFF
--- a/api/clickhouse/apps.py
+++ b/api/clickhouse/apps.py
@@ -1,6 +1,33 @@
+import importlib
+
 from django.apps import AppConfig
+from django.conf import settings
+
+# Importing this module applies `clickhouse-backend`'s monkeypatches to Django
+# internals as an import side effect.
+CLICKHOUSE_BACKEND_MODULE = "clickhouse_backend.backend"
 
 
 class ClickHouseConfig(AppConfig):
     name = "clickhouse"
     label = "clickhouse"
+
+    def ready(self) -> None:
+        if "clickhouse" not in settings.DATABASES:
+            # Postgres-only install. This app stays installed so the router can
+            # fence its migrations off the default database, but there is no
+            # ClickHouse connection to patch Django for.
+            return
+
+        # Django would otherwise import the backend -- and so apply the
+        # patches -- only when it first opens a ClickHouse connection. One of
+        # them replaces `MigrationRecorder.Migration` with a property that
+        # caches the model per recorder instance, whereas Django's own
+        # `classproperty` caches the Postgres-shaped model on the *class*. So
+        # if anything touches a Postgres recorder before the patch lands, the
+        # ClickHouse recorder is handed a model with no `deleted` column, and
+        # `migration_qs` -- which filters on `deleted` for ClickHouse
+        # connections -- fails with `FieldError: Cannot resolve keyword
+        # 'deleted' into field`. Patch during startup so ordering cannot
+        # matter.
+        importlib.import_module(CLICKHOUSE_BACKEND_MODULE)

--- a/api/tests/unit/clickhouse/test_unit_clickhouse_apps.py
+++ b/api/tests/unit/clickhouse/test_unit_clickhouse_apps.py
@@ -1,0 +1,39 @@
+from django.apps import apps
+from django.conf import settings
+from pytest_mock import MockerFixture
+
+from clickhouse.apps import CLICKHOUSE_BACKEND_MODULE, ClickHouseConfig
+
+
+def test_clickhouse_config_ready__clickhouse_configured__applies_backend_patches(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mocker.patch.dict(settings.DATABASES)
+    settings.DATABASES["clickhouse"] = {"ENGINE": "core.db_backends.clickhouse"}
+    import_module = mocker.patch("clickhouse.apps.importlib.import_module")
+    config = apps.get_app_config("clickhouse")
+    assert isinstance(config, ClickHouseConfig)
+
+    # When
+    config.ready()
+
+    # Then
+    import_module.assert_called_once_with(CLICKHOUSE_BACKEND_MODULE)
+
+
+def test_clickhouse_config_ready__clickhouse_not_configured__leaves_django_unpatched(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    mocker.patch.dict(settings.DATABASES)
+    settings.DATABASES.pop("clickhouse", None)
+    import_module = mocker.patch("clickhouse.apps.importlib.import_module")
+    config = apps.get_app_config("clickhouse")
+    assert isinstance(config, ClickHouseConfig)
+
+    # When
+    config.ready()
+
+    # Then
+    import_module.assert_not_called()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

On any install with `CLICKHOUSE_URL` or `CLICKHOUSE_HOST` set, `flagsmith migrate` exits 1 partway through with `FieldError: Cannot resolve keyword 'deleted' into field. Choices are: app, applied, id, name`, so migrations never complete.

`_migrate()` walks `FLAGSMITH_MIGRATE_DATABASES` in one process with `clickhouse` appended last, so `default` is migrated first. That resolves a Postgres `MigrationRecorder`, and Django's `classproperty` caches the Postgres-shaped model on the *class*. `clickhouse-backend` applies its monkeypatches as an import side effect of `clickhouse_backend.backend`, which Django only imports when it opens the ClickHouse connection — too late. Its replacement `Migration` property reads the stale class attribute, so the ClickHouse recorder gets a model with no `deleted` column and `migration_qs`, which filters on `deleted` for ClickHouse connections, raises.

This imports the backend from the app's `ready()` so the patches land before any recorder is resolved, behind a check on the `clickhouse` alias so Postgres-only installs stay unpatched as they are today.

The same stale cache breaks local `make test`, where each xdist worker sets up databases lazily — several hundred errors per run, varying with test order. CI never saw either symptom: no workflow runs migrations, and `--ci` builds every connection up front, importing the backend before any recorder exists.

## How did you test this code?

Two new unit tests cover both branches of the alias guard.

Manually, against throwaway Postgres and ClickHouse databases:

1. `CLICKHOUSE_HOST=localhost ... flagsmith migrate` on `main` → **exit 1**, dies on the first migration recorded against the `clickhouse` alias.
2. Same command with this change → **exit 0**, full run completes.
3. Reproduced the underlying ordering directly: resolving a Postgres recorder before the ClickHouse one yielded a `Migration` model with fields `['app', 'applied', 'id', 'name']` and a `FieldError`; with this change it yields `['app', 'applied', 'deleted', 'id', 'name']`.
4. Confirmed a Postgres-only install (no `CLICKHOUSE_*`) leaves `clickhouse_backend.backend` unimported.

Full suite locally with `-n auto`: **5022 passed, 24 skipped, 0 failed, 0 errors** — previously 1123 errors from this cause on the same machine.