### PR TITLE
fix(features): darken placeholder text and move copy inside the value editor field

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -61,6 +61,7 @@ window.Row = Row
 window.FormGroup = FormGroup
 // isMobile is set at app boot; stub it so components that read it render in Storybook.
 window.isMobile = false
+window.toast = (message) => console.log('[toast]', message)
 
 /** @type { import('storybook').Preview } */
 const preview = {

--- a/frontend/common/theme/tokens.json
+++ b/frontend/common/theme/tokens.json
@@ -103,7 +103,7 @@
     "text": {
       "default": { "cssVar": "--color-text-default", "light": "#1a2634", "dark": "#ffffff" },
       "secondary": { "cssVar": "--color-text-secondary", "light": "#656d7b", "dark": "#9da4ae" },
-      "tertiary": { "cssVar": "--color-text-tertiary", "light": "#9da4ae", "dark": "rgba(255, 255, 255, 0.48)" },
+      "tertiary": { "cssVar": "--color-text-tertiary", "light": "#656d7b", "dark": "rgba(255, 255, 255, 0.48)", "description": "Placeholders and hint text. In light mode, dark enough to clear 4.5:1 on surface-default." },
       "disabled": { "cssVar": "--color-text-disabled", "light": "#9da4ae", "dark": "rgba(255, 255, 255, 0.32)" },
       "action": { "cssVar": "--color-text-action", "light": "#6837fc", "dark": "#906af6" },
       "danger": { "cssVar": "--color-text-danger", "light": "#bb1720", "dark": "#ef4d56", "description": "In light mode, darker than border/icon danger to clear 4.5:1 on the tint." },

--- a/frontend/common/theme/tokens.ts
+++ b/frontend/common/theme/tokens.ts
@@ -206,7 +206,7 @@ export const colorTextDisabled = 'var(--color-text-disabled, #9da4ae)'
 export const colorTextInfo = 'var(--color-text-info, #0aaddf)'
 export const colorTextSecondary = 'var(--color-text-secondary, #656d7b)'
 export const colorTextSuccess = 'var(--color-text-success, #13787b)'
-export const colorTextTertiary = 'var(--color-text-tertiary, #9da4ae)'
+export const colorTextTertiary = 'var(--color-text-tertiary, #656d7b)'
 export const colorTextWarning = 'var(--color-text-warning, #9f5208)'
 
 // Chart

--- a/frontend/documentation/TokenReference.generated.stories.tsx
+++ b/frontend/documentation/TokenReference.generated.stories.tsx
@@ -189,7 +189,7 @@ export const AllTokens: StoryObj = {
               <code>--color-text-tertiary</code>
             </td>
             <td>
-              <code>var(--slate-300)</code>
+              <code>var(--slate-500)</code>
             </td>
           </tr>
           <tr>

--- a/frontend/documentation/components/ValueEditor.stories.tsx
+++ b/frontend/documentation/components/ValueEditor.stories.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from 'storybook'
+
+import ValueEditor from 'components/ValueEditor'
+import FieldLabel from 'components/base/forms/FieldLabel'
+import Constants from 'common/constants'
+
+const meta: Meta = {
+  parameters: { chromatic: { disableSnapshot: false } },
+  title: 'Components/Forms/ValueEditor',
+}
+export default meta
+
+type Story = StoryObj
+
+const DEFAULT_TOOLTIP = Constants.strings.REMOTE_CONFIG_DESCRIPTION
+
+const Interactive = ({
+  initialValue = '',
+  label,
+  tooltip = DEFAULT_TOOLTIP,
+  ...props
+}: Record<string, any>) => {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <div style={{ maxWidth: 640, paddingTop: 24 }}>
+      {label && <FieldLabel tooltip={tooltip}>{label}</FieldLabel>}
+      <ValueEditor {...props} value={value} onChange={setValue} />
+    </div>
+  )
+}
+
+export const Default: Story = {
+  render: () => <Interactive label='Value' />,
+}
+
+export const WithValue: Story = {
+  render: () => <Interactive label='Value' initialValue='DEFAULT_VALUE' />,
+}
+
+export const Multiline: Story = {
+  render: () => (
+    <Interactive
+      label='Value'
+      initialValue={
+        'a-long-single-line-value-that-runs-under-the-copy-button-if-unpadded\nsecond line\nthird line'
+      }
+    />
+  ),
+}
+
+export const Json: Story = {
+  render: () => (
+    <Interactive
+      label='Value'
+      language='json'
+      initialValue='{ "colour": "blue", "size": 12 }'
+    />
+  ),
+}
+
+export const InvalidJson: Story = {
+  render: () => (
+    <Interactive label='Value' language='json' initialValue='{ "colour": ' />
+  ),
+}
+
+export const CodeMedium: Story = {
+  render: () => (
+    <Interactive
+      label='Variation Value'
+      tooltip={Constants.strings.REMOTE_CONFIG_DESCRIPTION_VARIATION}
+      className='code-medium'
+      initialValue='variant-a'
+    />
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <Interactive label='Control value' disabled initialValue='DEFAULT_VALUE' />
+  ),
+}
+
+export const OnlyOneLang: Story = {
+  render: () => (
+    <Interactive
+      label='IDP metadata XML'
+      onlyOneLang
+      language='xml'
+      initialValue={'<EntityDescriptor entityID="https://example.com" />'}
+    />
+  ),
+}

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react'
 import cx from 'classnames'
 import Highlight from './Highlight'
-import ConfigProvider from 'common/providers/ConfigProvider'
 import { Clipboard } from 'polyfill-react-native'
 import Icon from './icons/Icon'
-import { IonIcon } from '@ionic/react'
-import { checkmarkCircle, warning } from 'ionicons/icons'
+import BareButton from './base/forms/BareButton'
 
 import toml from 'toml'
 import yaml from 'yaml'
@@ -95,23 +93,24 @@ class Validation extends Component {
       this.props.language === 'ini' ? 'toml' : this.props.language
     return this.state.error ? (
       <Tooltip
-        position='top'
         title={
-          <IonIcon
+          <span
             id='language-validation-error'
             className='language-icon text-danger'
-            icon={warning}
-          />
+          >
+            <Icon name='warning' width={14} fill='currentColor' />
+          </span>
         }
       >
         {`${displayLanguage} validation error, please check your value.<br/>Error: ${this.state.error}`}
       </Tooltip>
     ) : (
-      <IonIcon
+      <span
         id='language-validation-success'
         className='language-icon text-success'
-        icon={checkmarkCircle}
-      />
+      >
+        <Icon name='checkmark-circle' width={14} />
+      </span>
     )
   }
 }
@@ -141,8 +140,17 @@ class ValueEditor extends Component {
     />
   )
 
+  copyValue = () => {
+    const res = Clipboard.setString(this.props.value)
+    toast(
+      res ? 'Clipboard set' : 'Could not set clipboard :(',
+      res ? '' : 'danger',
+    )
+  }
+
   render() {
     const { ...rest } = this.props
+    const showCopy = !this.props.onlyOneLang && !this.props.disabled
     return (
       <div
         className={cx(
@@ -207,20 +215,17 @@ class ValueEditor extends Component {
             >
               .yaml {this.state.language === 'yaml' && this.renderValidation()}
             </span>
-            <span
-              onMouseDown={() => {
-                const res = Clipboard.setString(this.props.value)
-                toast(
-                  res ? 'Clipboard set' : 'Could not set clipboard :(',
-                  res ? '' : 'danger',
-                )
-              }}
-              className={cx('txt primary')}
-            >
-              <Icon name='copy-outlined' fill={'#6837fc'} />
-              copy
-            </span>
           </Row>
+        )}
+
+        {showCopy && (
+          <BareButton
+            className='value-editor__copy position-absolute rounded-sm icon-secondary'
+            aria-label='Copy value'
+            onClick={this.copyValue}
+          >
+            <Icon name='copy-outlined' width={20} />
+          </BareButton>
         )}
 
         {E2E ? (
@@ -243,4 +248,4 @@ class ValueEditor extends Component {
   }
 }
 
-export default ConfigProvider(ValueEditor)
+export default ValueEditor

--- a/frontend/web/components/base/forms/FieldLabel.tsx
+++ b/frontend/web/components/base/forms/FieldLabel.tsx
@@ -27,7 +27,11 @@ const FieldLabel: FC<FieldLabelProps> = ({
   tooltip,
   tooltipPlace = 'top',
 }) => (
-  <label id={id} htmlFor={htmlFor} className={cn('control-label', className)}>
+  <label
+    id={id}
+    htmlFor={htmlFor}
+    className={cn('control-label d-flex align-items-center', className)}
+  >
     {children}
     {required && (
       <span className='text-danger ml-1' aria-hidden>
@@ -36,7 +40,7 @@ const FieldLabel: FC<FieldLabelProps> = ({
     )}
     {tooltip && (
       <Tooltip
-        title={<Icon name='info-outlined' width={12} height={12} />}
+        title={<Icon name='info-outlined' width={16} height={16} />}
         place={tooltipPlace}
         titleClassName='cursor-pointer ml-1 d-inline-flex align-items-center'
       >

--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -43,6 +43,23 @@
       padding: 9px 12px 9px 16px;
       min-height: $input-height;
     }
+    .value-editor__copy {
+      top: 11px;
+    }
+  }
+
+  .value-editor__copy {
+    top: 18px;
+    right: 12px;
+    z-index: 1;
+    padding: 2px;
+    &:hover {
+      color: var(--color-icon-action);
+    }
+  }
+
+  &:has(.value-editor__copy) .hljs {
+    padding-right: 44px;
   }
   textarea {
     min-height: 50px;
@@ -77,9 +94,6 @@
       &.active {
         color: var(--color-text-default);
         font-weight: 500;
-      }
-      &.primary {
-        color: var(--color-text-action);
       }
     }
   }

--- a/frontend/web/styles/3rdParty/_react-select.scss
+++ b/frontend/web/styles/3rdParty/_react-select.scss
@@ -48,7 +48,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-weight: normal;
-    color: $input-placeholder-color;
+    color: var(--color-text-tertiary);
   }
   &__indicator {
     color: $text-icon-light-grey;

--- a/frontend/web/styles/_tokens.scss
+++ b/frontend/web/styles/_tokens.scss
@@ -112,7 +112,7 @@
   --color-text-info: var(--blue-500);
   --color-text-secondary: var(--slate-500);
   --color-text-success: var(--green-600);
-  --color-text-tertiary: var(--slate-300);
+  --color-text-tertiary: var(--slate-500);
   --color-text-warning: var(--orange-800);
 
   // Code

--- a/frontend/web/styles/_variables.scss
+++ b/frontend/web/styles/_variables.scss
@@ -246,7 +246,6 @@ $input-border-color: $basic-alpha-16;
 $input-border-color-dark: $bg-dark400;
 $input-focus-border-color-dark: $primary;
 $input-hover-border-color-dark: $white-alpha-8;
-$input-placeholder-color: $text-icon-light-grey;
 $input-padding: 12px 12px 12px 16px;
 $input-padding-sm: 8px 12px 8px 14px;
 $input-padding-xsm: 6px 8px;
@@ -256,7 +255,6 @@ $textarea-height-sm: 100px;
 $textarea-height-xsm: 86px;
 $textarea-height-lg: 128px;
 $input-border-highlight-color: $primary400;
-$input-placeholder-color-dark: $text-icon-light-grey;
 
 //Switch
 $switch-height: 24px;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8441
Closes #8442

Both from the same [design](https://www.figma.com/design/M8qD6EGP36Doq4kwEy6Ahf/Flagsmith---DEV-Ready?node-id=1-3).

- **Placeholder contrast.** Every placeholder resolves to `--color-text-tertiary`, which was Neutrals/300 in light mode: 2.26:1 on white. Now Neutrals/500, measured at 5.22:1. Dark mode already passed. The same token also fixes two hint texts that were failing for the same reason. `react-select`'s placeholder was the last one reading raw SCSS instead of the token, so it moves across too.
- **Copy moves inside the input**, out of the `.txt/.json/.xml/.toml/.yaml` row. It is a real `<button>` with an `aria-label` now, so it is keyboard reachable.
- **Info icon** was 12px and sat 2px above the label text. It is 16px and centred, per the design.

## Screenshots

| | Light | Dark |
| --- | --- | --- |
| Before | <img width="596" height="85" alt="image" src="https://github.com/user-attachments/assets/daee7c96-eb94-4a18-97ed-4d89b12f0364" /> |<img width="590" height="83" alt="image" src="https://github.com/user-attachments/assets/8d13878f-1516-443e-ae34-639702b3cf2f" />|
| After | <img width="772" height="108" alt="image" src="https://github.com/user-attachments/assets/ce785407-5740-4a69-8f11-64132bda46b5" />| <img width="791" height="104" alt="image" src="https://github.com/user-attachments/assets/a81a87a4-a387-4e14-811d-9cd7fa52c933" /> |

## How did you test this code?

New Storybook story (`Components/Forms/ValueEditor`) covering the empty, filled, multiline, JSON, invalid JSON, code-medium and disabled states, snapshotted by Chromatic in both themes.

Contrast measured in the browser rather than calculated: computed `color` against computed `background-color` on the rendered placeholder.

Manually through Create feature → Value, MV variation values, segment overrides and the SAML metadata field.

## Worth a look

- `FieldLabel` is shared, so the icon change touches every form label in the app. The flex sits on `FieldLabel`'s own element rather than `.control-label`, since nine hand-written labels elsewhere use that class and have no icon to align.
- Copy stays hidden on read-only editors. That was never a decision, it fell out of copy living in the row that gets hidden. Three of the eight call sites are permanently read-only, which is arguably where it is most useful.
- The design shows the placeholder as `enter a value`; we render `Enter a value...` from `Highlight`'s hardcoded default. Left alone as a copy change for @dragos-bubu to confirm.
