### PR TITLE
fix(errors): render the error banners that were being swallowed

### DIFF
--- a/frontend/web/components/EditIdentity.tsx
+++ b/frontend/web/components/EditIdentity.tsx
@@ -70,7 +70,7 @@ const EditIdentity: FC<EditIdentityType> = ({ data, environmentId }) => {
         Edit
         <Icon name='edit' width={16} />
       </Button>
-      <ErrorMessage>{error}</ErrorMessage>
+      <ErrorMessage error={error} />
     </>
   )
 }

--- a/frontend/web/components/import-export/FeatureImport.tsx
+++ b/frontend/web/components/import-export/FeatureImport.tsx
@@ -438,7 +438,7 @@ const FeatureExport: FC<FeatureExportType> = ({ projectId }) => {
             prevPage={() => setPage(page - 1)}
             goToPage={setPage}
           />
-          <ErrorMessage>{error}</ErrorMessage>
+          <ErrorMessage error={error} />
           <div className='mt-4 text-right'>
             <Button disabled={isLoading} onClick={onSubmit}>
               Import Features

--- a/frontend/web/components/modals/ForgotPasswordModal.tsx
+++ b/frontend/web/components/modals/ForgotPasswordModal.tsx
@@ -50,7 +50,7 @@ const ForgotPasswordModal: FC<ForgotPasswordModalType> = ({
           onChange={(e: InputEvent) => setEmail(Utils.safeParseEventValue(e))}
         />
 
-        <ErrorMessage>{error}</ErrorMessage>
+        <ErrorMessage error={error} />
       </div>
       <ModalHR />
       <div className='modal-footer'>

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -80,7 +80,7 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
     <>
       {invalid && (
         <ErrorMessage
-          className='mt-2'
+          errorMessageClass='mt-2'
           error='Your variation percentage splits total to over 100%'
         />
       )}

--- a/frontend/web/components/pages/AccountSettingsPage.tsx
+++ b/frontend/web/components/pages/AccountSettingsPage.tsx
@@ -263,7 +263,7 @@ const AccountSettingsPage: FC = () => {
                 isValid={lastName && lastName.length}
                 type='text'
               />
-              {error && <ErrorMessage>{error}</ErrorMessage>}
+              {error && <ErrorMessage error={error} />}
               <div className='text-right'>
                 <Button
                   type='submit'
@@ -395,9 +395,7 @@ const AccountSettingsPage: FC = () => {
                     isValid={newPassword2 && newPassword2.length}
                     type='password'
                   />
-                  {passwordError && (
-                    <ErrorMessage>{passwordError}</ErrorMessage>
-                  )}
+                  {passwordError && <ErrorMessage error={passwordError} />}
                   <div className='text-right mt-5'>
                     <Button
                       type='submit'

--- a/frontend/web/components/pages/AuditLogItemPage.tsx
+++ b/frontend/web/components/pages/AuditLogItemPage.tsx
@@ -79,7 +79,7 @@ const AuditLogItemPage: FC = () => {
         </div>
       ) : (
         <div>
-          <ErrorMessage>{error}</ErrorMessage>
+          <ErrorMessage error={error} />
           {!!data && (
             <>
               <Panel title={'Details'} className='no-pad mb-2'>

--- a/frontend/web/components/pages/FeatureHistoryDetailPage.tsx
+++ b/frontend/web/components/pages/FeatureHistoryDetailPage.tsx
@@ -90,7 +90,7 @@ const FeatureHistoryPage: FC = () => {
         </div>
       </PageTitle>
       {!!(error || versionsError) && (
-        <ErrorMessage>{error || versionsError}</ErrorMessage>
+        <ErrorMessage error={error || versionsError} />
       )}
 
       {(isLoading || versionsLoading) && (

--- a/frontend/web/components/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/web/components/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -104,7 +104,7 @@ const AdminDashboardPage: FC = () => {
         </div>
       )}
 
-      <ErrorMessage>{error}</ErrorMessage>
+      <ErrorMessage error={error} />
 
       {data && (
         <>


### PR DESCRIPTION
## Changes

`ErrorMessage` reads an `error` prop and returns `null` without one. Eight places passed the error as children instead, so nothing rendered at all: a failed password reset, a failed feature import, an identity edit, an audit log item, a feature history page, the admin dashboard and two spots in account settings all failed silently.

A ninth passed `className` where the component takes `errorMessageClass`, so the error showed but unstyled.

Found by typechecking those call sites: `npm run typecheck` went from 10 `ErrorMessage` misuse errors to 0.

No change to `ErrorMessage` itself.

## How did you test this code?

`npm run typecheck`, comparing the `ErrorMessage` errors before and after.

Worth exercising one by hand: submit the forgot-password form with an address that does not exist, and confirm the error now appears.