### PR TITLE
fix(tests): avoid flaky password_too_similar registration failures

### DIFF
--- a/api/users/models.py
+++ b/api/users/models.py
@@ -110,7 +110,7 @@ class UserManager(BaseUserManager):  # type: ignore[type-arg]
 
     def make_random_password(
         self,
-        length: int = 10,
+        length: int = 14,
         allowed_chars: str = string.ascii_letters + string.digits,
     ) -> str:
         return "".join(secrets.choice(allowed_chars) for _ in range(length))

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -1,5 +1,4 @@
 import logging
-import secrets
 import string
 import typing
 import uuid
@@ -12,6 +11,7 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models import Count, QuerySet
 from django.utils import timezone
+from django.utils.crypto import get_random_string
 from django_lifecycle import (  # type: ignore[import-untyped]
     AFTER_SAVE,
     LifecycleModel,
@@ -113,7 +113,7 @@ class UserManager(BaseUserManager):  # type: ignore[type-arg]
         length: int = 14,
         allowed_chars: str = string.ascii_letters + string.digits,
     ) -> str:
-        return "".join(secrets.choice(allowed_chars) for _ in range(length))
+        return get_random_string(length, allowed_chars)
 
 
 class FFAdminUser(LifecycleModel, AbstractUser):  # type: ignore[django-manager-missing,misc]


### PR DESCRIPTION
Registration tests intermittently fail with `password_too_similar`:

- [run 33851459349](https://github.com/Flagsmith/flagsmith/actions/runs/33851459349/job/100954982281) — `test_register_and_login__activation_flow_enabled__succeeds_after_activation`
- [run 33853003915](https://github.com/Flagsmith/flagsmith/actions/runs/33853003915/job/100959834442) — `test_register__superuser_flag_on_saas__does_not_create_superuser`

```
{'password': [ErrorDetail(string='The password is too similar to the email.',
                          code='password_too_similar')]}
```

The tests register with `test-{uuid4}@example.com` and a 10 character `make_random_password()`. `UserAttributeSimilarityValidator` compares the password against each part of the email, and the part that matches is nearly always `example`: with a 7 character part, `quick_ratio = 2M/(len(pw)+7) >= 0.7` is satisfiable at `M = 6`.

Raising the default length to 14 makes that arithmetically impossible, since `M` cannot exceed 7. Measured over 100k samples per length:

| password length | collision rate |
|---|---|
| 10 (current) | 0.043% |
| 13 | 0.013% |
| **14** | **0.000%** |

`make_random_password` has no callers outside tests.
