### PR TITLE
fix(docs): scope homepage section styles so they don't break the search modal

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -233,7 +233,7 @@ main.container {
 
 
 /* Section background alternation for dark mode */
-[data-theme='dark'] section:nth-child(even) {
+[data-theme='dark'] section[data-section]:nth-child(even) {
   background: var(--ifm-background-surface-color);
   padding: 3rem 0;
   margin: 0;
@@ -245,7 +245,7 @@ main.container {
   margin-right: -50vw;
 }
 
-[data-theme='dark'] section:nth-child(odd) {
+[data-theme='dark'] section[data-section]:nth-child(odd) {
   background: #111111;
   padding: 3rem 0;
   margin: 0;
@@ -257,8 +257,8 @@ main.container {
   margin-right: -50vw;
 }
 
-[data-theme='dark'] section:nth-child(4n+1),
-[data-theme='dark'] section:nth-child(4n+2) {
+[data-theme='dark'] section[data-section]:nth-child(4n+1),
+[data-theme='dark'] section[data-section]:nth-child(4n+2) {
   background: #111111;
   padding: 3rem 0;
   margin: 0;
@@ -270,8 +270,8 @@ main.container {
   margin-right: -50vw;
 }
 
-[data-theme='dark'] section:nth-child(4n+3),
-[data-theme='dark'] section:nth-child(4n+4) {
+[data-theme='dark'] section[data-section]:nth-child(4n+3),
+[data-theme='dark'] section[data-section]:nth-child(4n+4) {
   background: var(--ifm-background-surface-color);
   padding: 3rem 0;
   margin: 0;
@@ -283,15 +283,15 @@ main.container {
   margin-right: -50vw;
 }
 
-section > div,
-section > h2 {
+section[data-section] > div,
+section[data-section] > h2 {
   margin: 0 auto;
   max-width: var(--ifm-container-width);
   padding: 0 var(--ifm-spacing-horizontal);
   width: 100%;
 }
 
-section > h2 {
+section[data-section] > h2 {
   padding-left: var(--ifm-spacing-horizontal);
 }
 
@@ -303,12 +303,12 @@ section > h2 {
 }
 
 @media (max-width: 996px) {
-  [data-theme='dark'] section:nth-child(4n+1),
-  [data-theme='dark'] section:nth-child(4n+2),
-  [data-theme='dark'] section:nth-child(4n+3),
-  [data-theme='dark'] section:nth-child(4n+4),
-  [data-theme='dark'] section:nth-child(odd),
-  [data-theme='dark'] section:nth-child(even) {
+  [data-theme='dark'] section[data-section]:nth-child(4n+1),
+  [data-theme='dark'] section[data-section]:nth-child(4n+2),
+  [data-theme='dark'] section[data-section]:nth-child(4n+3),
+  [data-theme='dark'] section[data-section]:nth-child(4n+4),
+  [data-theme='dark'] section[data-section]:nth-child(odd),
+  [data-theme='dark'] section[data-section]:nth-child(even) {
     width: 100%;
     left: auto;
     right: auto;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The Algolia search modal is unreadable in dark mode on docs.flagsmith.com: result titles disappear, the groups get alternating dark bands, and a horizontal scrollbar appears.

The homepage's dark-mode section styling in `docs/src/css/custom.css` uses a bare `section` selector:

```css
[data-theme='dark'] section:nth-child(even) { … width: 100vw; left: 50%; margin-left: -50vw; }
```

DocSearch renders each result group as `<section class="DocSearch-Hits">`, so those rules also apply inside the modal, pushing the hit content half a viewport to the left and repainting the group backgrounds. Light mode is unaffected because the rules are `[data-theme='dark']`-scoped.

Homepage sections already carry a `data-section` attribute (`docs/src/pages/index.tsx`), so this scopes every rule to `section[data-section]` — including the `@media (max-width: 996px)` block and the unscoped `section > div` / `section > h2` rules, which were adding stray max-width and padding to `.DocSearch-Hit-source` in both themes.

## How did you test this code?

Manually, against a local docs dev server (`cd docs && make serve`):

1. Switch the site to dark mode.
2. Press `Cmd+K` and search for e.g. `test` — results now render with titles, group headers and highlighting, no horizontal scrollbar and no alternating background bands.
3. Homepage in dark mode still alternates section backgrounds as before, at both desktop and <996px widths.
