### PR TITLE
feat: experiment conversion rate chart

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -727,6 +727,16 @@ export type ExposuresSummary = {
   timeseries: ExposuresTimeseries
 }
 
+export type ConversionsTimeseriesPoint = {
+  bucket: string
+  converted_identities: Record<string, number>
+}
+
+export type ConversionsTimeseries = {
+  granularity: ExposureGranularity
+  points: ConversionsTimeseriesPoint[]
+}
+
 export type ExperimentExposures = {
   as_of: string | null
   last_error_at: string | null
@@ -760,11 +770,19 @@ export type BayesianMetricResult = {
   metric_id: number
   variants: Record<string, VariantStats>
   inference: Record<string, Inference | null>
+  // Occurrence metrics only; null for value metrics. Absent from payloads
+  // stored before the backend shipped it (finalised experiments never gain it).
+  conversions_timeseries?: ConversionsTimeseries | null
 }
 
 export type BayesianResultsSummary = {
   srm_p_value: number | null
   metrics: BayesianMetricResult[]
+  // Denominator for the conversion-rate charts, same warehouse run as the
+  // metrics. Exposures bucket by first exposure and conversions by first
+  // conversion, so only running totals may be divided — a per-bucket division
+  // can exceed 100%. Absent from payloads stored before the backend shipped it.
+  exposures_timeseries?: ExposuresTimeseries
 }
 
 export enum TagStrategy {

--- a/frontend/web/components/charts/BarChart.tsx
+++ b/frontend/web/components/charts/BarChart.tsx
@@ -35,20 +35,90 @@ type BarChartProps = {
   barSize?: number
   /** Render vertical grid lines (one per x tick). Default `true`. */
   verticalGrid?: boolean
+  /** Chart height in pixels. Default 400. */
+  height?: number
+  /**
+   * dataKey → stack id, for part-of-whole bars: series sharing a stack id
+   * stack together, distinct ids sit side by side (e.g. converted/remainder
+   * segments stacked per variant, variants grouped). Default: all series
+   * share one stack.
+   */
+  stackMap?: Record<string, string>
+  /**
+   * dataKey → fill opacity (0–1). Colours are CSS `var()` strings, so
+   * transparency must come from SVG fill-opacity, not an alpha channel.
+   */
+  opacityMap?: Record<string, number>
+  /**
+   * Per-entry tooltip value renderer, threaded to ChartTooltip. Skipped for
+   * missing or non-numeric values, which render blank.
+   */
+  tooltipValueFormatter?: (
+    value: number,
+    seriesKey: string,
+    label: string,
+  ) => string
+  /**
+   * Hide the tooltip's total row — required when `tooltipValueFormatter`
+   * renders a non-additive unit such as a percentage.
+   */
+  tooltipHideTotal?: boolean
 }
+
+type LegendValue = string | number
+
+type FadedSwatchLegendProps = {
+  opacityMap: Record<string, number>
+  seriesLabels?: Record<string, string>
+  // Injected by recharts' <Legend content={...}>.
+  payload?: { value?: LegendValue; color?: string }[]
+}
+
+const FadedSwatchLegend: FC<FadedSwatchLegendProps> = ({
+  opacityMap,
+  payload,
+  seriesLabels,
+}) => (
+  <div className='d-flex justify-content-center flex-wrap gap-3'>
+    {payload?.map((entry) => {
+      const key = String(entry.value)
+      return (
+        <span className='d-flex align-items-center gap-1' key={key}>
+          <span
+            style={{
+              backgroundColor: entry.color,
+              display: 'inline-block',
+              height: 10,
+              opacity: opacityMap[key] ?? 1,
+              width: 10,
+            }}
+          />
+          <span style={{ color: entry.color, fontSize: 12 }}>
+            {seriesLabels?.[key] ?? key}
+          </span>
+        </span>
+      )
+    })}
+  </div>
+)
 
 const BarChart: FC<BarChartProps> = ({
   barSize,
   colorMap,
   data,
+  height = 400,
+  opacityMap,
   series,
   seriesLabels,
   showLegend = false,
+  stackMap,
+  tooltipHideTotal,
+  tooltipValueFormatter,
   verticalGrid = true,
   xAxisInterval = 0,
 }) => {
   return (
-    <ResponsiveContainer height={400} width='100%'>
+    <ResponsiveContainer height={height} width='100%'>
       <RawBarChart data={data}>
         <CartesianGrid
           strokeDasharray='3 5'
@@ -75,7 +145,13 @@ const BarChart: FC<BarChartProps> = ({
         />
         <Tooltip
           cursor={{ fill: 'transparent' }}
-          content={<ChartTooltip seriesLabels={seriesLabels} />}
+          content={
+            <ChartTooltip
+              hideTotal={tooltipHideTotal}
+              seriesLabels={seriesLabels}
+              valueFormatter={tooltipValueFormatter}
+            />
+          }
         />
         {showLegend && (
           <Legend
@@ -83,14 +159,25 @@ const BarChart: FC<BarChartProps> = ({
             formatter={(value) =>
               seriesLabels?.[String(value)] ?? String(value)
             }
+            content={
+              // The default legend swatch ignores fillOpacity, so faded
+              // series need their own renderer to match the bars.
+              opacityMap ? (
+                <FadedSwatchLegend
+                  opacityMap={opacityMap}
+                  seriesLabels={seriesLabels}
+                />
+              ) : undefined
+            }
           />
         )}
         {series.map((label, index) => (
           <Bar
             key={label}
             dataKey={label}
-            stackId='series'
+            stackId={stackMap?.[label] ?? 'series'}
             fill={colorMap[label]}
+            fillOpacity={opacityMap?.[label]}
             barSize={barSize}
             animationBegin={index * 80}
             animationDuration={600}

--- a/frontend/web/components/charts/ChartTooltip.tsx
+++ b/frontend/web/components/charts/ChartTooltip.tsx
@@ -25,9 +25,16 @@ type ChartTooltipProps = TooltipProps<ValueType, NameType> & {
   /**
    * Hide the total row at the bottom. Useful for single-entry payloads
    * (e.g. a pie-slice hover) where the total just repeats the entry value.
+   * Also required when `valueFormatter` renders a non-additive unit such as a
+   * percentage, since the total row stays plain-number formatted.
    * Default: false.
    */
   hideTotal?: boolean
+  /**
+   * Optional per-entry value renderer, e.g. to append units ("8.3%") or
+   * counts ("120 of 1,450"). Falls back to localised number formatting.
+   */
+  valueFormatter?: (value: number, seriesKey: string, label: string) => string
 }
 
 const ChartTooltip: FC<ChartTooltipProps> = ({
@@ -36,6 +43,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   label,
   payload,
   seriesLabels,
+  valueFormatter,
 }) => {
   if (!active || !payload || payload.length === 0) return null
   const total = payload.reduce<number>(
@@ -66,7 +74,9 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
             <ColorSwatch color={entry.color ?? ''} size='sm' />
             <span className='text-default'>{displayName}:</span>
             <span className='fw-semibold text-default'>
-              {formatNumber(entry.value)}
+              {typeof entry.value === 'number' && valueFormatter
+                ? valueFormatter(entry.value, key, String(label ?? ''))
+                : formatNumber(entry.value)}
             </span>
           </div>
         )

--- a/frontend/web/components/experiments/results/ExperimentConversionRateCard/ExperimentConversionRateCard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentConversionRateCard/ExperimentConversionRateCard.tsx
@@ -1,0 +1,145 @@
+import { FC, useCallback, useMemo, useState } from 'react'
+import moment from 'moment'
+import { BarChart } from 'components/charts'
+import ContentCard from 'components/base/grid/ContentCard'
+import InlinePillToggle from 'components/base/forms/InlinePillToggle'
+import { BayesianResultsSummary, Experiment } from 'common/types/responses'
+import { getPrimaryMetric } from 'components/experiments/constants'
+import {
+  getMetricResult,
+  getVariantIdentities,
+} from 'components/experiments/results/derive'
+import {
+  ConversionStackMode,
+  REST_SUFFIX,
+  buildConversionRateChartData,
+  buildConversionStackChartData,
+} from 'components/experiments/results/deriveConversionRate'
+
+type ExperimentConversionRateCardProps = {
+  experiment: Experiment
+  results?: BayesianResultsSummary
+  asOf: string | null
+}
+
+const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
+  asOf,
+  experiment,
+  results,
+}) => {
+  const [mode, setMode] = useState<ConversionStackMode>('cumulative')
+  const metric = getPrimaryMetric(experiment)
+  const identities = useMemo(
+    () => getVariantIdentities(experiment.feature),
+    [experiment.feature],
+  )
+  const chart = useMemo(
+    () =>
+      metric && results
+        ? buildConversionStackChartData(
+            results,
+            metric.metric,
+            identities,
+            mode,
+          )
+        : null,
+    [metric, results, identities, mode],
+  )
+  // Running counts and rates, for the cumulative tooltip ("x of y (z%)").
+  const rateChart = useMemo(
+    () =>
+      metric && results
+        ? buildConversionRateChartData(results, metric.metric, identities)
+        : null,
+    [metric, results, identities],
+  )
+
+  const formatTooltipValue = useCallback(
+    (value: number, seriesKey: string, label: string) => {
+      if (mode === 'daily') return value.toLocaleString()
+      if (seriesKey.endsWith(REST_SUFFIX)) {
+        // The faded segment is labelled "exposures", so report the full bar
+        // total rather than the plotted remainder (exposures − conversions).
+        const variantKey = seriesKey.slice(0, -REST_SUFFIX.length)
+        const counts = rateChart?.countsByDay[label]?.[variantKey]
+        return (counts?.exposed ?? value).toLocaleString()
+      }
+      const counts = rateChart?.countsByDay[label]?.[seriesKey]
+      if (!counts) return value.toLocaleString()
+      const rate = rateChart?.points.find((p) => p.day === label)?.[seriesKey]
+      return `${counts.converted.toLocaleString()} of ${counts.exposed.toLocaleString()}${
+        typeof rate === 'number' ? ` (${rate}%)` : ''
+      }`
+    },
+    [mode, rateChart],
+  )
+
+  // Hidden entirely when no rate can be charted: value metrics, and
+  // payloads stored before the backend shipped the timeseries.
+  if (!metric || !results || !chart) return null
+
+  const conversions = getMetricResult(
+    results,
+    metric.metric,
+  )?.conversions_timeseries
+  const hasConversions = !!conversions && conversions.points.length > 0
+
+  return (
+    <ContentCard
+      action={
+        hasConversions ? (
+          // Single metric today — disabled until multi-metric ships.
+          <div style={{ minWidth: 180 }}>
+            <Select
+              isDisabled
+              size='select-sm'
+              value={{ label: metric.metric_name, value: metric.metric }}
+              options={[{ label: metric.metric_name, value: metric.metric }]}
+            />
+          </div>
+        ) : undefined
+      }
+      title='Conversion rate over time'
+    >
+      {hasConversions ? (
+        <>
+          {/* mt-n2 halves the card's 16px child gap after the title. */}
+          <div className='d-flex mt-n2'>
+            <InlinePillToggle<ConversionStackMode>
+              size='small'
+              options={[
+                { label: 'Cumulative', value: 'cumulative' },
+                { label: 'Daily', value: 'daily' },
+              ]}
+              value={mode}
+              onChange={setMode}
+            />
+          </div>
+          <BarChart
+            colorMap={chart.colorMap}
+            data={chart.points}
+            height={260}
+            opacityMap={chart.opacityMap}
+            series={chart.series}
+            seriesLabels={chart.seriesLabels}
+            showLegend
+            stackMap={chart.stackMap}
+            tooltipHideTotal
+            tooltipValueFormatter={formatTooltipValue}
+          />
+          <span className='text-muted fs-caption'>
+            {asOf
+              ? `As of ${moment.utc(asOf).format('D MMM YYYY, HH:mm')} UTC`
+              : ''}
+          </span>
+        </>
+      ) : (
+        <div className='text-muted text-center py-5'>
+          No conversions recorded yet.
+        </div>
+      )}
+    </ContentCard>
+  )
+}
+
+export default ExperimentConversionRateCard

--- a/frontend/web/components/experiments/results/ExperimentConversionRateCard/index.ts
+++ b/frontend/web/components/experiments/results/ExperimentConversionRateCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExperimentConversionRateCard'

--- a/frontend/web/components/experiments/results/__tests__/deriveConversionRate.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/deriveConversionRate.test.ts
@@ -1,0 +1,320 @@
+import {
+  REST_SUFFIX,
+  buildConversionRateChartData,
+  buildConversionStackChartData,
+} from 'components/experiments/results/deriveConversionRate'
+import type { VariantIdentity } from 'components/experiments/results/derive'
+import {
+  BayesianMetricResult,
+  BayesianResultsSummary,
+  ConversionsTimeseries,
+  ExposuresTimeseries,
+} from 'common/types/responses'
+
+const identities: VariantIdentity[] = [
+  {
+    colour: '#111111',
+    isControl: true,
+    key: 'control',
+    name: 'Control',
+    value: 'off',
+  },
+  {
+    colour: '#222222',
+    isControl: false,
+    key: 'variant_a',
+    name: 'variant_a',
+    value: 'on',
+  },
+]
+
+const summary = (
+  over: Partial<BayesianResultsSummary> = {},
+): BayesianResultsSummary => ({
+  metrics: [],
+  srm_p_value: null,
+  ...over,
+})
+
+const exposuresTs = (
+  points: ExposuresTimeseries['points'],
+): ExposuresTimeseries => ({ granularity: 'day', points })
+
+const metricResult = (
+  over: Partial<BayesianMetricResult> = {},
+): BayesianMetricResult => ({
+  conversions_timeseries: null,
+  inference: {},
+  metric_id: 7,
+  variants: {},
+  ...over,
+})
+
+const conversionsTs = (
+  points: ConversionsTimeseries['points'],
+): ConversionsTimeseries => ({ granularity: 'day', points })
+
+describe('buildConversionRateChartData', () => {
+  const exposures = exposuresTs([
+    {
+      bucket: '2026-06-01T00:00:00+00:00',
+      new_identities: { control: 600, variant_a: 1000 },
+    },
+    {
+      bucket: '2026-06-03T00:00:00+00:00',
+      new_identities: { control: 400 },
+    },
+  ])
+
+  it('returns null when exposures_timeseries is absent', () => {
+    const results = summary({
+      metrics: [metricResult({ conversions_timeseries: conversionsTs([]) })],
+    })
+    expect(buildConversionRateChartData(results, 7, identities)).toBeNull()
+  })
+
+  it('returns null when the metric has a null conversions_timeseries', () => {
+    const results = summary({
+      exposures_timeseries: exposures,
+      metrics: [metricResult()],
+    })
+    expect(buildConversionRateChartData(results, 7, identities)).toBeNull()
+  })
+
+  it('returns null when no metric matches the requested id', () => {
+    const results = summary({
+      exposures_timeseries: exposures,
+      metrics: [
+        metricResult({
+          conversions_timeseries: conversionsTs([
+            {
+              bucket: '2026-06-01T00:00:00+00:00',
+              converted_identities: { control: 60 },
+            },
+          ]),
+        }),
+      ],
+    })
+    expect(buildConversionRateChartData(results, 999, identities)).toBeNull()
+  })
+
+  it('divides running conversions by running exposures over the bucket union', () => {
+    const results = summary({
+      exposures_timeseries: exposures,
+      metrics: [
+        metricResult({
+          conversions_timeseries: conversionsTs([
+            {
+              bucket: '2026-06-01T00:00:00+00:00',
+              converted_identities: { control: 60, variant_a: 100 },
+            },
+            {
+              // Bucket absent from the exposures series: conversions with no
+              // new enrollments that day.
+              bucket: '2026-06-02T00:00:00+00:00',
+              converted_identities: { control: 30 },
+            },
+          ]),
+        }),
+      ],
+    })
+    const chart = buildConversionRateChartData(results, 7, identities)
+    expect(chart?.points).toEqual([
+      // 60/600, 100/1000
+      { control: 10, day: '1 Jun', variant_a: 10 },
+      // 90/600, 100/1000 — exposures carried forward
+      { control: 15, day: '2 Jun', variant_a: 10 },
+      // 90/1000, 100/1000 — conversions carried forward
+      { control: 9, day: '3 Jun', variant_a: 10 },
+    ])
+    expect(chart?.countsByDay['2 Jun']).toEqual({
+      control: { converted: 90, exposed: 600 },
+      variant_a: { converted: 100, exposed: 1000 },
+    })
+  })
+
+  it('omits a variant from points until it has exposures', () => {
+    const results = summary({
+      exposures_timeseries: exposuresTs([
+        {
+          bucket: '2026-06-01T00:00:00+00:00',
+          new_identities: { control: 600 },
+        },
+      ]),
+      metrics: [
+        metricResult({
+          conversions_timeseries: conversionsTs([
+            {
+              bucket: '2026-06-01T00:00:00+00:00',
+              converted_identities: { control: 60 },
+            },
+          ]),
+        }),
+      ],
+    })
+    const chart = buildConversionRateChartData(results, 7, identities)
+    expect(chart?.points).toEqual([{ control: 10, day: '1 Jun' }])
+  })
+
+  it('adds the year to labels when the series spans calendar years', () => {
+    const results = summary({
+      exposures_timeseries: exposuresTs([
+        {
+          bucket: '2026-06-01T00:00:00+00:00',
+          new_identities: { control: 600 },
+        },
+        {
+          bucket: '2027-06-01T00:00:00+00:00',
+          new_identities: { control: 400 },
+        },
+      ]),
+      metrics: [
+        metricResult({
+          conversions_timeseries: conversionsTs([
+            {
+              bucket: '2026-06-01T00:00:00+00:00',
+              converted_identities: { control: 60 },
+            },
+          ]),
+        }),
+      ],
+    })
+    const chart = buildConversionRateChartData(results, 7, identities)
+    expect(chart?.points.map((p) => p.day)).toEqual([
+      '1 Jun 2026',
+      '1 Jun 2027',
+    ])
+    expect(chart?.countsByDay['1 Jun 2026'].control).toEqual({
+      converted: 60,
+      exposed: 600,
+    })
+    expect(chart?.countsByDay['1 Jun 2027'].control).toEqual({
+      converted: 60,
+      exposed: 1000,
+    })
+  })
+
+  it('yields flat 0% lines for an empty conversions series', () => {
+    const results = summary({
+      exposures_timeseries: exposures,
+      metrics: [metricResult({ conversions_timeseries: conversionsTs([]) })],
+    })
+    const chart = buildConversionRateChartData(results, 7, identities)
+    expect(chart?.points.map((p) => p.control)).toEqual([0, 0])
+  })
+})
+
+describe('buildConversionStackChartData', () => {
+  const exposures = exposuresTs([
+    {
+      bucket: '2026-06-01T00:00:00+00:00',
+      new_identities: { control: 600, variant_a: 1000 },
+    },
+    {
+      bucket: '2026-06-03T00:00:00+00:00',
+      new_identities: { control: 400 },
+    },
+  ])
+  const conversions = conversionsTs([
+    {
+      bucket: '2026-06-01T00:00:00+00:00',
+      converted_identities: { control: 60, variant_a: 100 },
+    },
+    {
+      bucket: '2026-06-02T00:00:00+00:00',
+      converted_identities: { control: 30 },
+    },
+  ])
+  const results = summary({
+    exposures_timeseries: exposures,
+    metrics: [metricResult({ conversions_timeseries: conversions })],
+  })
+
+  it.each([
+    ['exposures_timeseries is absent', summary({ metrics: [metricResult()] })],
+    [
+      'the metric has no conversions_timeseries',
+      summary({ exposures_timeseries: exposures, metrics: [metricResult()] }),
+    ],
+  ])('returns null when %s', (_, res) => {
+    expect(
+      buildConversionStackChartData(res, 7, identities, 'cumulative'),
+    ).toBeNull()
+  })
+
+  it('stacks cumulative conversions inside cumulative exposures', () => {
+    const chart = buildConversionStackChartData(
+      results,
+      7,
+      identities,
+      'cumulative',
+    )
+    expect(chart?.points).toEqual([
+      {
+        control: 60,
+        [`control${REST_SUFFIX}`]: 540,
+        day: '1 Jun',
+        variant_a: 100,
+        [`variant_a${REST_SUFFIX}`]: 900,
+      },
+      {
+        control: 90,
+        [`control${REST_SUFFIX}`]: 510,
+        day: '2 Jun',
+        variant_a: 100,
+        [`variant_a${REST_SUFFIX}`]: 900,
+      },
+      {
+        control: 90,
+        [`control${REST_SUFFIX}`]: 910,
+        day: '3 Jun',
+        variant_a: 100,
+        [`variant_a${REST_SUFFIX}`]: 900,
+      },
+    ])
+    // Segments stack per variant; the remainder fades the variant colour.
+    expect(chart?.stackMap[`control${REST_SUFFIX}`]).toBe('control')
+    expect(chart?.stackMap.control).toBe('control')
+    expect(chart?.opacityMap[`control${REST_SUFFIX}`]).toBe(0.25)
+    expect(chart?.seriesLabels[`control${REST_SUFFIX}`]).toBe(
+      'Control exposures',
+    )
+  })
+
+  it('plots raw per-bucket increments side by side in daily mode', () => {
+    const chart = buildConversionStackChartData(results, 7, identities, 'daily')
+    expect(chart?.points).toEqual([
+      {
+        control: 60,
+        [`control${REST_SUFFIX}`]: 600,
+        day: '1 Jun',
+        variant_a: 100,
+        [`variant_a${REST_SUFFIX}`]: 1000,
+      },
+      {
+        control: 30,
+        [`control${REST_SUFFIX}`]: 0,
+        day: '2 Jun',
+        variant_a: 0,
+        [`variant_a${REST_SUFFIX}`]: 0,
+      },
+      {
+        control: 0,
+        [`control${REST_SUFFIX}`]: 400,
+        day: '3 Jun',
+        variant_a: 0,
+        [`variant_a${REST_SUFFIX}`]: 0,
+      },
+    ])
+    // Daily quantities are not part-of-whole (a day's first conversions can
+    // exceed its new exposures), so each series gets its own stack
+    // (side-by-side bars) and the faded series becomes "new exposures".
+    expect(chart?.stackMap.control).toBe('control')
+    expect(chart?.stackMap[`control${REST_SUFFIX}`]).toBe(
+      `control${REST_SUFFIX}`,
+    )
+    expect(chart?.seriesLabels[`control${REST_SUFFIX}`]).toBe(
+      'Control new exposures',
+    )
+  })
+})

--- a/frontend/web/components/experiments/results/deriveConversionRate.ts
+++ b/frontend/web/components/experiments/results/deriveConversionRate.ts
@@ -1,0 +1,221 @@
+import moment from 'moment'
+import { ChartDataPoint } from 'components/charts'
+import {
+  BayesianResultsSummary,
+  ConversionsTimeseries,
+  ExposuresTimeseries,
+} from 'common/types/responses'
+import {
+  ExposuresChartData,
+  VariantIdentity,
+  formatBucketLabel,
+  getMetricResult,
+} from './derive'
+
+type AccumulatedBucket = {
+  day: string
+  exposed: Record<string, number>
+  converted: Record<string, number>
+  // Raw per-bucket increments, for discrete (per-day) displays. Never divide
+  // these — a bucket's first conversions can exceed its new exposures.
+  newExposed: Record<string, number>
+  newConverted: Record<string, number>
+}
+
+// Walks the union of both series' buckets in time order, carrying running
+// totals forward across buckets missing from either series. Exposures bucket
+// by first exposure and conversions by first conversion, so only these
+// running totals may be divided (see ResultsSummary.exposures_timeseries in
+// api/experimentation/dataclasses.py).
+const accumulateBuckets = (
+  exposures: ExposuresTimeseries,
+  identities: VariantIdentity[],
+  conversions?: ConversionsTimeseries | null,
+): AccumulatedBucket[] => {
+  const exposedByBucket: Record<string, Record<string, number>> = {}
+  exposures.points.forEach((p) => {
+    exposedByBucket[p.bucket] = p.new_identities
+  })
+  const convertedByBucket: Record<string, Record<string, number>> = {}
+  conversions?.points.forEach((p) => {
+    convertedByBucket[p.bucket] = p.converted_identities
+  })
+
+  // Sorting the ISO keys is chronological only because the warehouse emits a
+  // uniform '+00:00' offset (the UTC invariant derive.ts documents for
+  // labelling).
+  const buckets = Array.from(
+    new Set([
+      ...Object.keys(exposedByBucket),
+      ...Object.keys(convertedByBucket),
+    ]),
+  ).sort()
+
+  // Labels key countsByDay and the chart category, so they must be unique:
+  // a series spanning calendar years adds the year to avoid '1 Jun'
+  // colliding with the same day a year later.
+  const spansYears =
+    new Set(buckets.map((bucket) => bucket.slice(0, 4))).size > 1
+  const toLabel = (bucket: string) =>
+    spansYears
+      ? moment
+          .utc(bucket)
+          .format(
+            exposures.granularity === 'hour'
+              ? 'D MMM YYYY HH:mm'
+              : 'D MMM YYYY',
+          )
+      : formatBucketLabel(bucket, exposures.granularity)
+
+  const cumExposed: Record<string, number> = {}
+  const cumConverted: Record<string, number> = {}
+  identities.forEach((v) => {
+    cumExposed[v.key] = 0
+    cumConverted[v.key] = 0
+  })
+
+  return buckets.map((bucket) => {
+    const newExposed: Record<string, number> = {}
+    const newConverted: Record<string, number> = {}
+    identities.forEach((v) => {
+      newExposed[v.key] = exposedByBucket[bucket]?.[v.key] ?? 0
+      newConverted[v.key] = convertedByBucket[bucket]?.[v.key] ?? 0
+      cumExposed[v.key] += newExposed[v.key]
+      cumConverted[v.key] += newConverted[v.key]
+    })
+    return {
+      converted: { ...cumConverted },
+      day: toLabel(bucket),
+      exposed: { ...cumExposed },
+      newConverted,
+      newExposed,
+    }
+  })
+}
+
+// Rounded to one decimal for stable display.
+const toRatePct = (converted: number, exposed: number): number =>
+  Math.round((converted / exposed) * 1000) / 10
+
+const seriesMeta = (identities: VariantIdentity[]) => {
+  const seriesLabels: Record<string, string> = {}
+  const colorMap: Record<string, string> = {}
+  identities.forEach((v) => {
+    seriesLabels[v.key] = v.name
+    colorMap[v.key] = v.colour
+  })
+  return { colorMap, seriesLabels }
+}
+
+export type ConversionCounts = Record<
+  string,
+  { converted: number; exposed: number }
+>
+
+export type ConversionRateChartData = ExposuresChartData & {
+  // Running numerator/denominator per bucket label, for tooltips.
+  countsByDay: Record<string, ConversionCounts>
+}
+
+// Cumulative conversion rate per variant: running conversions over running
+// exposures. A variant with no exposures yet is omitted from the point rather
+// than shown as 0%.
+export const buildConversionRateChartData = (
+  results: BayesianResultsSummary,
+  metricId: number,
+  identities: VariantIdentity[],
+): ConversionRateChartData | null => {
+  const exposures = results.exposures_timeseries
+  const conversions = getMetricResult(results, metricId)?.conversions_timeseries
+  if (!exposures || !conversions) return null
+
+  const series = identities.map((v) => v.key)
+  const countsByDay: Record<string, ConversionCounts> = {}
+  const points: ChartDataPoint[] = accumulateBuckets(
+    exposures,
+    identities,
+    conversions,
+  ).map((b) => {
+    const point: ChartDataPoint = { day: b.day }
+    const counts: ConversionCounts = {}
+    identities.forEach((v) => {
+      const exposed = b.exposed[v.key]
+      if (exposed === 0) return
+      point[v.key] = toRatePct(b.converted[v.key], exposed)
+      counts[v.key] = { converted: b.converted[v.key], exposed }
+    })
+    countsByDay[b.day] = counts
+    return point
+  })
+  return { countsByDay, points, series, ...seriesMeta(identities) }
+}
+
+export const REST_SUFFIX = '__rest'
+
+export type ConversionStackMode = 'cumulative' | 'daily'
+
+export type ConversionStackChartData = {
+  points: ChartDataPoint[]
+  series: string[]
+  seriesLabels: Record<string, string>
+  colorMap: Record<string, string>
+  opacityMap: Record<string, number>
+  stackMap: Record<string, string>
+}
+
+// Stacked-bar encodings of exposures vs conversions per variant.
+// 'cumulative': part-of-whole — the full bar is running exposures and the
+// solid segment is running conversions (always a subset, since a first
+// conversion can't precede a first exposure). 'daily': the raw per-bucket
+// increments side by side — NOT part-of-whole, because a day's first
+// conversions can exceed its new exposures, so no rate is implied.
+export const buildConversionStackChartData = (
+  results: BayesianResultsSummary,
+  metricId: number,
+  identities: VariantIdentity[],
+  mode: ConversionStackMode,
+): ConversionStackChartData | null => {
+  const exposures = results.exposures_timeseries
+  const conversions = getMetricResult(results, metricId)?.conversions_timeseries
+  if (!exposures || !conversions) return null
+
+  const daily = mode === 'daily'
+  const series: string[] = []
+  const seriesLabels: Record<string, string> = {}
+  const colorMap: Record<string, string> = {}
+  const opacityMap: Record<string, number> = {}
+  const stackMap: Record<string, string> = {}
+  identities.forEach((v) => {
+    const restKey = `${v.key}${REST_SUFFIX}`
+    series.push(v.key, restKey)
+    seriesLabels[v.key] = daily
+      ? `${v.name} conversions`
+      : `${v.name} converted`
+    seriesLabels[restKey] = daily
+      ? `${v.name} new exposures`
+      : `${v.name} exposures`
+    colorMap[v.key] = v.colour
+    // The faded series reuses the variant colour via fill-opacity (palette
+    // colours are CSS var() strings, so no alpha channel can be appended).
+    colorMap[restKey] = v.colour
+    opacityMap[restKey] = 0.25
+    stackMap[v.key] = v.key
+    stackMap[restKey] = daily ? restKey : v.key
+  })
+
+  const points: ChartDataPoint[] = accumulateBuckets(
+    exposures,
+    identities,
+    conversions,
+  ).map((b) => {
+    const point: ChartDataPoint = { day: b.day }
+    identities.forEach((v) => {
+      point[v.key] = daily ? b.newConverted[v.key] : b.converted[v.key]
+      point[`${v.key}${REST_SUFFIX}`] = daily
+        ? b.newExposed[v.key]
+        : b.exposed[v.key] - b.converted[v.key]
+    })
+    return point
+  })
+  return { colorMap, opacityMap, points, series, seriesLabels, stackMap }
+}

--- a/frontend/web/components/pages/ExperimentDetailPage.tsx
+++ b/frontend/web/components/pages/ExperimentDetailPage.tsx
@@ -17,6 +17,7 @@ import ExperimentSummaryScorecard from 'components/experiments/results/Experimen
 import ExperimentMetricScorecard from 'components/experiments/results/ExperimentMetricScorecard'
 import ExperimentExposuresPanel from 'components/experiments/results/ExperimentExposuresPanel'
 import ExperimentResultsRefreshControl from 'components/experiments/results/ExperimentResultsRefreshControl'
+import ExperimentConversionRateCard from 'components/experiments/results/ExperimentConversionRateCard'
 
 type ExperimentDetailParams = {
   projectId: string
@@ -118,6 +119,11 @@ const ExperimentDetailPage: FC = () => {
 
           <h5 className='mb-3 mt-5'>Analysis</h5>
           <ExperimentMetricScorecard
+            experiment={experiment}
+            results={results}
+          />
+          <ExperimentConversionRateCard
+            asOf={bayesianResults?.as_of ?? null}
             experiment={experiment}
             results={results}
           />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Frontend for the conversion timeseries added in #8451 (branched off it).

Adds a "Conversion rate over time" card to the experiment Analysis section: stacked bars per variant (cumulative exposures, conversions filled in), with a Cumulative/Daily toggle. Daily shows raw per-bucket counts side by side — no per-day rate, per the backend contract.

Derivation lives in a tested `deriveConversionRate.ts`; `BarChart`/`ChartTooltip` gained optional props only (existing consumers unchanged). The card hides itself on payloads that predate the backend change.

## How did you test this code?

- 10 Jest tests on the derive module (bucket union, carry-forward, div-by-zero, daily vs cumulative); 120 passing across experiments/charts. Typecheck delta zero.
- Manually against real payloads with fabricated timeseries: both toggle modes, tooltips, and the hidden state for value-metric/pre-deploy payloads.

<img width="2286" height="846" alt="image" src="https://github.com/user-attachments/assets/0af59d00-d444-49cd-ae3e-befef4907a07" />

<img width="2186" height="836" alt="image" src="https://github.com/user-attachments/assets/5fac8b7d-82a5-473a-9594-fc56463acbb4" />
