### PR TITLE
chore(renovate): enable lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,16 @@
     "security:only-security-updates",
     ":semanticCommitTypeAll(deps)"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on monday"]
+  },
   "packageRules": [
+    {
+      "description": "Re-enable lock file maintenance, which security:only-security-updates disables via its blanket matchPackageNames ['*'] rule. Renovate raises security PRs from manifest entries, so a CVE in a package that appears only in a lock file is never actioned; refreshing the lock file within existing ranges is the only mechanism that reaches transitive pins.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "enabled": true
+    },
     {
       "matchManagers": ["pep621"],
       "matchFileNames": ["api/**"],


### PR DESCRIPTION
Enable [lock file maintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) in renovate which deletes and recreates all 4 lock files (`api/uv.lock`, `docs/package-lock.json`, `frontend/package-lock.json` and `mcp/uv.lock`) once a week. 

This exists in order to work around the lack of transitive dependency support in renovate. 

As I understand it, this will run as part of the self-hosted renovate flow that we are using, and hence should be correctly authenticated with code artifact, but that will need testing. 

Related PR to refresh (most of) `api/uv.lock` so we're not starting from scratch: #8469. 
