### PR TITLE
fix: hypothesis textarea dark mode focus

### DIFF
--- a/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
+++ b/frontend/web/components/experiments/results/ExperimentDetailHeader.tsx
@@ -205,7 +205,6 @@ const ExperimentDetailHeader: FC<ExperimentDetailHeaderProps> = ({
             <textarea
               autoFocus
               disabled={isUpdating}
-              className='form-control'
               rows={3}
               value={hypothesisDraft}
               onChange={(e) => setHypothesisDraft(e.target.value)}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The hypothesis textarea on the experiment detail page turned white-on-white when focused in dark mode.

It carried Bootstrap's `form-control` class, whose `.form-control:focus` rule (specificity 0,2,0) overrides our `.dark textarea` rule (0,1,1) and forces `background-color: #fff; color: #212529`. Unfocused was fine because plain `.form-control` (0,1,0) loses to `.dark textarea`.

Removed the class. Our own `textarea` element styles already provide width, border, radius, padding, height and colour, and `.dark textarea` provides the dark background — the same styling path `InputGroup`'s textarea uses, which is why every other multiline field renders correctly. Light mode is unchanged: the base rule sets no `background-color`, so the textarea inherits the card surface that Bootstrap was painting `#fff`.

## How did you test this code?

Manually, on the experiment detail page:

1. Switch the dashboard to dark mode.
2. Open an experiment, click the edit icon next to **Hypothesis**.
3. The textarea keeps the dark surface and light text on focus (previously white-on-white).
4. Repeat in light mode to confirm it is unchanged.
