### PR TITLE
feat: experiment conversions over time chart

### DIFF
--- a/frontend/web/components/charts/BarChart.tsx
+++ b/frontend/web/components/charts/BarChart.tsx
@@ -35,90 +35,20 @@ type BarChartProps = {
   barSize?: number
   /** Render vertical grid lines (one per x tick). Default `true`. */
   verticalGrid?: boolean
-  /** Chart height in pixels. Default 400. */
-  height?: number
-  /**
-   * dataKey → stack id, for part-of-whole bars: series sharing a stack id
-   * stack together, distinct ids sit side by side (e.g. converted/remainder
-   * segments stacked per variant, variants grouped). Default: all series
-   * share one stack.
-   */
-  stackMap?: Record<string, string>
-  /**
-   * dataKey → fill opacity (0–1). Colours are CSS `var()` strings, so
-   * transparency must come from SVG fill-opacity, not an alpha channel.
-   */
-  opacityMap?: Record<string, number>
-  /**
-   * Per-entry tooltip value renderer, threaded to ChartTooltip. Skipped for
-   * missing or non-numeric values, which render blank.
-   */
-  tooltipValueFormatter?: (
-    value: number,
-    seriesKey: string,
-    label: string,
-  ) => string
-  /**
-   * Hide the tooltip's total row — required when `tooltipValueFormatter`
-   * renders a non-additive unit such as a percentage.
-   */
-  tooltipHideTotal?: boolean
 }
-
-type LegendValue = string | number
-
-type FadedSwatchLegendProps = {
-  opacityMap: Record<string, number>
-  seriesLabels?: Record<string, string>
-  // Injected by recharts' <Legend content={...}>.
-  payload?: { value?: LegendValue; color?: string }[]
-}
-
-const FadedSwatchLegend: FC<FadedSwatchLegendProps> = ({
-  opacityMap,
-  payload,
-  seriesLabels,
-}) => (
-  <div className='d-flex justify-content-center flex-wrap gap-3'>
-    {payload?.map((entry) => {
-      const key = String(entry.value)
-      return (
-        <span className='d-flex align-items-center gap-1' key={key}>
-          <span
-            style={{
-              backgroundColor: entry.color,
-              display: 'inline-block',
-              height: 10,
-              opacity: opacityMap[key] ?? 1,
-              width: 10,
-            }}
-          />
-          <span style={{ color: entry.color, fontSize: 12 }}>
-            {seriesLabels?.[key] ?? key}
-          </span>
-        </span>
-      )
-    })}
-  </div>
-)
 
 const BarChart: FC<BarChartProps> = ({
   barSize,
   colorMap,
   data,
-  height = 400,
-  opacityMap,
   series,
   seriesLabels,
   showLegend = false,
-  stackMap,
-  tooltipHideTotal,
-  tooltipValueFormatter,
   verticalGrid = true,
   xAxisInterval = 0,
 }) => {
   return (
-    <ResponsiveContainer height={height} width='100%'>
+    <ResponsiveContainer height={400} width='100%'>
       <RawBarChart data={data}>
         <CartesianGrid
           strokeDasharray='3 5'
@@ -145,13 +75,7 @@ const BarChart: FC<BarChartProps> = ({
         />
         <Tooltip
           cursor={{ fill: 'transparent' }}
-          content={
-            <ChartTooltip
-              hideTotal={tooltipHideTotal}
-              seriesLabels={seriesLabels}
-              valueFormatter={tooltipValueFormatter}
-            />
-          }
+          content={<ChartTooltip seriesLabels={seriesLabels} />}
         />
         {showLegend && (
           <Legend
@@ -159,25 +83,14 @@ const BarChart: FC<BarChartProps> = ({
             formatter={(value) =>
               seriesLabels?.[String(value)] ?? String(value)
             }
-            content={
-              // The default legend swatch ignores fillOpacity, so faded
-              // series need their own renderer to match the bars.
-              opacityMap ? (
-                <FadedSwatchLegend
-                  opacityMap={opacityMap}
-                  seriesLabels={seriesLabels}
-                />
-              ) : undefined
-            }
           />
         )}
         {series.map((label, index) => (
           <Bar
             key={label}
             dataKey={label}
-            stackId={stackMap?.[label] ?? 'series'}
+            stackId='series'
             fill={colorMap[label]}
-            fillOpacity={opacityMap?.[label]}
             barSize={barSize}
             animationBegin={index * 80}
             animationDuration={600}

--- a/frontend/web/components/charts/ChartTooltip.tsx
+++ b/frontend/web/components/charts/ChartTooltip.tsx
@@ -25,16 +25,9 @@ type ChartTooltipProps = TooltipProps<ValueType, NameType> & {
   /**
    * Hide the total row at the bottom. Useful for single-entry payloads
    * (e.g. a pie-slice hover) where the total just repeats the entry value.
-   * Also required when `valueFormatter` renders a non-additive unit such as a
-   * percentage, since the total row stays plain-number formatted.
    * Default: false.
    */
   hideTotal?: boolean
-  /**
-   * Optional per-entry value renderer, e.g. to append units ("8.3%") or
-   * counts ("120 of 1,450"). Falls back to localised number formatting.
-   */
-  valueFormatter?: (value: number, seriesKey: string, label: string) => string
 }
 
 const ChartTooltip: FC<ChartTooltipProps> = ({
@@ -43,7 +36,6 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   label,
   payload,
   seriesLabels,
-  valueFormatter,
 }) => {
   if (!active || !payload || payload.length === 0) return null
   const total = payload.reduce<number>(
@@ -74,9 +66,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
             <ColorSwatch color={entry.color ?? ''} size='sm' />
             <span className='text-default'>{displayName}:</span>
             <span className='fw-semibold text-default'>
-              {typeof entry.value === 'number' && valueFormatter
-                ? valueFormatter(entry.value, key, String(label ?? ''))
-                : formatNumber(entry.value)}
+              {formatNumber(entry.value)}
             </span>
           </div>
         )

--- a/frontend/web/components/experiments/results/ExperimentConversionRateCard/ExperimentConversionRateCard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentConversionRateCard/ExperimentConversionRateCard.tsx
@@ -1,6 +1,6 @@
-import { FC, useCallback, useMemo, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 import moment from 'moment'
-import { BarChart } from 'components/charts'
+import { LineChart } from 'components/charts'
 import ContentCard from 'components/base/grid/ContentCard'
 import InlinePillToggle from 'components/base/forms/InlinePillToggle'
 import { BayesianResultsSummary, Experiment } from 'common/types/responses'
@@ -10,10 +10,8 @@ import {
   getVariantIdentities,
 } from 'components/experiments/results/derive'
 import {
-  ConversionStackMode,
-  REST_SUFFIX,
-  buildConversionRateChartData,
-  buildConversionStackChartData,
+  ConversionMode,
+  buildConversionChartData,
 } from 'components/experiments/results/deriveConversionRate'
 
 type ExperimentConversionRateCardProps = {
@@ -27,7 +25,7 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
   experiment,
   results,
 }) => {
-  const [mode, setMode] = useState<ConversionStackMode>('cumulative')
+  const [mode, setMode] = useState<ConversionMode>('cumulative')
   const metric = getPrimaryMetric(experiment)
   const identities = useMemo(
     () => getVariantIdentities(experiment.feature),
@@ -36,45 +34,12 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
   const chart = useMemo(
     () =>
       metric && results
-        ? buildConversionStackChartData(
-            results,
-            metric.metric,
-            identities,
-            mode,
-          )
+        ? buildConversionChartData(results, metric.metric, identities, mode)
         : null,
     [metric, results, identities, mode],
   )
-  // Running counts and rates, for the cumulative tooltip ("x of y (z%)").
-  const rateChart = useMemo(
-    () =>
-      metric && results
-        ? buildConversionRateChartData(results, metric.metric, identities)
-        : null,
-    [metric, results, identities],
-  )
 
-  const formatTooltipValue = useCallback(
-    (value: number, seriesKey: string, label: string) => {
-      if (mode === 'daily') return value.toLocaleString()
-      if (seriesKey.endsWith(REST_SUFFIX)) {
-        // The faded segment is labelled "exposures", so report the full bar
-        // total rather than the plotted remainder (exposures − conversions).
-        const variantKey = seriesKey.slice(0, -REST_SUFFIX.length)
-        const counts = rateChart?.countsByDay[label]?.[variantKey]
-        return (counts?.exposed ?? value).toLocaleString()
-      }
-      const counts = rateChart?.countsByDay[label]?.[seriesKey]
-      if (!counts) return value.toLocaleString()
-      const rate = rateChart?.points.find((p) => p.day === label)?.[seriesKey]
-      return `${counts.converted.toLocaleString()} of ${counts.exposed.toLocaleString()}${
-        typeof rate === 'number' ? ` (${rate}%)` : ''
-      }`
-    },
-    [mode, rateChart],
-  )
-
-  // Hidden entirely when no rate can be charted: value metrics, and
+  // Hidden entirely when no conversions can be charted: value metrics, and
   // payloads stored before the backend shipped the timeseries.
   if (!metric || !results || !chart) return null
 
@@ -99,13 +64,13 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
           </div>
         ) : undefined
       }
-      title='Conversion rate over time'
+      title='Conversions over time'
     >
       {hasConversions ? (
         <>
           {/* mt-n2 halves the card's 16px child gap after the title. */}
           <div className='d-flex mt-n2'>
-            <InlinePillToggle<ConversionStackMode>
+            <InlinePillToggle<ConversionMode>
               size='small'
               options={[
                 { label: 'Cumulative', value: 'cumulative' },
@@ -115,17 +80,13 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
               onChange={setMode}
             />
           </div>
-          <BarChart
+          <LineChart
             colorMap={chart.colorMap}
             data={chart.points}
             height={260}
-            opacityMap={chart.opacityMap}
             series={chart.series}
             seriesLabels={chart.seriesLabels}
             showLegend
-            stackMap={chart.stackMap}
-            tooltipHideTotal
-            tooltipValueFormatter={formatTooltipValue}
           />
           <span className='text-muted fs-caption'>
             {asOf

--- a/frontend/web/components/experiments/results/__tests__/deriveConversionRate.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/deriveConversionRate.test.ts
@@ -1,8 +1,5 @@
-import {
-  REST_SUFFIX,
-  buildConversionRateChartData,
-  buildConversionStackChartData,
-} from 'components/experiments/results/deriveConversionRate'
+import moment from 'moment'
+import { buildConversionChartData } from 'components/experiments/results/deriveConversionRate'
 import type { VariantIdentity } from 'components/experiments/results/derive'
 import {
   BayesianMetricResult,
@@ -54,157 +51,7 @@ const conversionsTs = (
   points: ConversionsTimeseries['points'],
 ): ConversionsTimeseries => ({ granularity: 'day', points })
 
-describe('buildConversionRateChartData', () => {
-  const exposures = exposuresTs([
-    {
-      bucket: '2026-06-01T00:00:00+00:00',
-      new_identities: { control: 600, variant_a: 1000 },
-    },
-    {
-      bucket: '2026-06-03T00:00:00+00:00',
-      new_identities: { control: 400 },
-    },
-  ])
-
-  it('returns null when exposures_timeseries is absent', () => {
-    const results = summary({
-      metrics: [metricResult({ conversions_timeseries: conversionsTs([]) })],
-    })
-    expect(buildConversionRateChartData(results, 7, identities)).toBeNull()
-  })
-
-  it('returns null when the metric has a null conversions_timeseries', () => {
-    const results = summary({
-      exposures_timeseries: exposures,
-      metrics: [metricResult()],
-    })
-    expect(buildConversionRateChartData(results, 7, identities)).toBeNull()
-  })
-
-  it('returns null when no metric matches the requested id', () => {
-    const results = summary({
-      exposures_timeseries: exposures,
-      metrics: [
-        metricResult({
-          conversions_timeseries: conversionsTs([
-            {
-              bucket: '2026-06-01T00:00:00+00:00',
-              converted_identities: { control: 60 },
-            },
-          ]),
-        }),
-      ],
-    })
-    expect(buildConversionRateChartData(results, 999, identities)).toBeNull()
-  })
-
-  it('divides running conversions by running exposures over the bucket union', () => {
-    const results = summary({
-      exposures_timeseries: exposures,
-      metrics: [
-        metricResult({
-          conversions_timeseries: conversionsTs([
-            {
-              bucket: '2026-06-01T00:00:00+00:00',
-              converted_identities: { control: 60, variant_a: 100 },
-            },
-            {
-              // Bucket absent from the exposures series: conversions with no
-              // new enrollments that day.
-              bucket: '2026-06-02T00:00:00+00:00',
-              converted_identities: { control: 30 },
-            },
-          ]),
-        }),
-      ],
-    })
-    const chart = buildConversionRateChartData(results, 7, identities)
-    expect(chart?.points).toEqual([
-      // 60/600, 100/1000
-      { control: 10, day: '1 Jun', variant_a: 10 },
-      // 90/600, 100/1000 — exposures carried forward
-      { control: 15, day: '2 Jun', variant_a: 10 },
-      // 90/1000, 100/1000 — conversions carried forward
-      { control: 9, day: '3 Jun', variant_a: 10 },
-    ])
-    expect(chart?.countsByDay['2 Jun']).toEqual({
-      control: { converted: 90, exposed: 600 },
-      variant_a: { converted: 100, exposed: 1000 },
-    })
-  })
-
-  it('omits a variant from points until it has exposures', () => {
-    const results = summary({
-      exposures_timeseries: exposuresTs([
-        {
-          bucket: '2026-06-01T00:00:00+00:00',
-          new_identities: { control: 600 },
-        },
-      ]),
-      metrics: [
-        metricResult({
-          conversions_timeseries: conversionsTs([
-            {
-              bucket: '2026-06-01T00:00:00+00:00',
-              converted_identities: { control: 60 },
-            },
-          ]),
-        }),
-      ],
-    })
-    const chart = buildConversionRateChartData(results, 7, identities)
-    expect(chart?.points).toEqual([{ control: 10, day: '1 Jun' }])
-  })
-
-  it('adds the year to labels when the series spans calendar years', () => {
-    const results = summary({
-      exposures_timeseries: exposuresTs([
-        {
-          bucket: '2026-06-01T00:00:00+00:00',
-          new_identities: { control: 600 },
-        },
-        {
-          bucket: '2027-06-01T00:00:00+00:00',
-          new_identities: { control: 400 },
-        },
-      ]),
-      metrics: [
-        metricResult({
-          conversions_timeseries: conversionsTs([
-            {
-              bucket: '2026-06-01T00:00:00+00:00',
-              converted_identities: { control: 60 },
-            },
-          ]),
-        }),
-      ],
-    })
-    const chart = buildConversionRateChartData(results, 7, identities)
-    expect(chart?.points.map((p) => p.day)).toEqual([
-      '1 Jun 2026',
-      '1 Jun 2027',
-    ])
-    expect(chart?.countsByDay['1 Jun 2026'].control).toEqual({
-      converted: 60,
-      exposed: 600,
-    })
-    expect(chart?.countsByDay['1 Jun 2027'].control).toEqual({
-      converted: 60,
-      exposed: 1000,
-    })
-  })
-
-  it('yields flat 0% lines for an empty conversions series', () => {
-    const results = summary({
-      exposures_timeseries: exposures,
-      metrics: [metricResult({ conversions_timeseries: conversionsTs([]) })],
-    })
-    const chart = buildConversionRateChartData(results, 7, identities)
-    expect(chart?.points.map((p) => p.control)).toEqual([0, 0])
-  })
-})
-
-describe('buildConversionStackChartData', () => {
+describe('buildConversionChartData', () => {
   const exposures = exposuresTs([
     {
       bucket: '2026-06-01T00:00:00+00:00',
@@ -221,6 +68,8 @@ describe('buildConversionStackChartData', () => {
       converted_identities: { control: 60, variant_a: 100 },
     },
     {
+      // Bucket absent from the exposures series: conversions with no new
+      // enrollments that day.
       bucket: '2026-06-02T00:00:00+00:00',
       converted_identities: { control: 30 },
     },
@@ -238,83 +87,85 @@ describe('buildConversionStackChartData', () => {
     ],
   ])('returns null when %s', (_, res) => {
     expect(
-      buildConversionStackChartData(res, 7, identities, 'cumulative'),
+      buildConversionChartData(res, 7, identities, 'cumulative'),
     ).toBeNull()
   })
 
-  it('stacks cumulative conversions inside cumulative exposures', () => {
-    const chart = buildConversionStackChartData(
-      results,
-      7,
-      identities,
-      'cumulative',
-    )
-    expect(chart?.points).toEqual([
-      {
-        control: 60,
-        [`control${REST_SUFFIX}`]: 540,
-        day: '1 Jun',
-        variant_a: 100,
-        [`variant_a${REST_SUFFIX}`]: 900,
-      },
-      {
-        control: 90,
-        [`control${REST_SUFFIX}`]: 510,
-        day: '2 Jun',
-        variant_a: 100,
-        [`variant_a${REST_SUFFIX}`]: 900,
-      },
-      {
-        control: 90,
-        [`control${REST_SUFFIX}`]: 910,
-        day: '3 Jun',
-        variant_a: 100,
-        [`variant_a${REST_SUFFIX}`]: 900,
-      },
-    ])
-    // Segments stack per variant; the remainder fades the variant colour.
-    expect(chart?.stackMap[`control${REST_SUFFIX}`]).toBe('control')
-    expect(chart?.stackMap.control).toBe('control')
-    expect(chart?.opacityMap[`control${REST_SUFFIX}`]).toBe(0.25)
-    expect(chart?.seriesLabels[`control${REST_SUFFIX}`]).toBe(
-      'Control exposures',
-    )
+  it('returns null when no metric matches the requested id', () => {
+    expect(
+      buildConversionChartData(results, 999, identities, 'daily'),
+    ).toBeNull()
   })
 
-  it('plots raw per-bucket increments side by side in daily mode', () => {
-    const chart = buildConversionStackChartData(results, 7, identities, 'daily')
+  it('accumulates running totals over the bucket union in cumulative mode', () => {
+    const chart = buildConversionChartData(results, 7, identities, 'cumulative')
     expect(chart?.points).toEqual([
-      {
-        control: 60,
-        [`control${REST_SUFFIX}`]: 600,
-        day: '1 Jun',
-        variant_a: 100,
-        [`variant_a${REST_SUFFIX}`]: 1000,
-      },
-      {
-        control: 30,
-        [`control${REST_SUFFIX}`]: 0,
-        day: '2 Jun',
-        variant_a: 0,
-        [`variant_a${REST_SUFFIX}`]: 0,
-      },
-      {
-        control: 0,
-        [`control${REST_SUFFIX}`]: 400,
-        day: '3 Jun',
-        variant_a: 0,
-        [`variant_a${REST_SUFFIX}`]: 0,
-      },
+      { control: 60, day: '1 Jun', variant_a: 100 },
+      { control: 90, day: '2 Jun', variant_a: 100 },
+      // Carried forward across a bucket with exposures but no conversions.
+      { control: 90, day: '3 Jun', variant_a: 100 },
     ])
-    // Daily quantities are not part-of-whole (a day's first conversions can
-    // exceed its new exposures), so each series gets its own stack
-    // (side-by-side bars) and the faded series becomes "new exposures".
-    expect(chart?.stackMap.control).toBe('control')
-    expect(chart?.stackMap[`control${REST_SUFFIX}`]).toBe(
-      `control${REST_SUFFIX}`,
+    expect(chart?.seriesLabels.control).toBe('Control converted')
+  })
+
+  it('plots raw per-bucket increments in daily mode', () => {
+    const chart = buildConversionChartData(results, 7, identities, 'daily')
+    expect(chart?.points).toEqual([
+      { control: 60, day: '1 Jun', variant_a: 100 },
+      { control: 30, day: '2 Jun', variant_a: 0 },
+      { control: 0, day: '3 Jun', variant_a: 0 },
+    ])
+    expect(chart?.seriesLabels.control).toBe('Control conversions')
+  })
+
+  it('adds the year to labels when the series spans calendar years', () => {
+    const res = summary({
+      exposures_timeseries: exposuresTs([
+        {
+          bucket: '2026-06-01T00:00:00+00:00',
+          new_identities: { control: 600 },
+        },
+        {
+          bucket: '2027-06-01T00:00:00+00:00',
+          new_identities: { control: 400 },
+        },
+      ]),
+      metrics: [metricResult({ conversions_timeseries: conversions })],
+    })
+    const chart = buildConversionChartData(res, 7, identities, 'cumulative')
+    expect(chart?.points.map((p) => p.day)).toEqual([
+      '1 Jun 2026',
+      '2 Jun 2026',
+      '1 Jun 2027',
+    ])
+  })
+
+  it('renders the last 30 day buckets, still accumulating from the start', () => {
+    const days = Array.from({ length: 40 }, (_, i) =>
+      moment.utc('2026-06-01').add(i, 'days').toISOString(true),
     )
-    expect(chart?.seriesLabels[`control${REST_SUFFIX}`]).toBe(
-      'Control new exposures',
-    )
+    const res = summary({
+      exposures_timeseries: exposuresTs(
+        days.map((bucket) => ({ bucket, new_identities: { control: 10 } })),
+      ),
+      metrics: [
+        metricResult({
+          conversions_timeseries: conversionsTs(
+            days.map((bucket) => ({
+              bucket,
+              converted_identities: { control: 1 },
+            })),
+          ),
+        }),
+      ],
+    })
+    const chart = buildConversionChartData(res, 7, identities, 'cumulative')
+    expect(chart?.points).toHaveLength(30)
+    // The window opens on day 11, carrying the 11 conversions to date.
+    expect(chart?.points[0]).toEqual({
+      control: 11,
+      day: '11 Jun',
+      variant_a: 0,
+    })
   })
 })

--- a/frontend/web/components/experiments/results/deriveConversionRate.ts
+++ b/frontend/web/components/experiments/results/deriveConversionRate.ts
@@ -14,30 +14,25 @@ import {
 
 type AccumulatedBucket = {
   day: string
-  exposed: Record<string, number>
   converted: Record<string, number>
   // Raw per-bucket increments, for discrete (per-day) displays. Never divide
   // these — a bucket's first conversions can exceed its new exposures.
-  newExposed: Record<string, number>
   newConverted: Record<string, number>
 }
 
-// Walks the union of both series' buckets in time order, carrying running
-// totals forward across buckets missing from either series. Exposures bucket
-// by first exposure and conversions by first conversion, so only these
-// running totals may be divided (see ResultsSummary.exposures_timeseries in
-// api/experimentation/dataclasses.py).
+// The backend returns every bucket since the experiment started, uncapped.
+const MAX_DAY_BUCKETS = 30
+
+// Walks the union of both series' buckets in time order, so a bucket carrying
+// exposures but no conversions still appears, and carries the running
+// conversion total forward across it.
 const accumulateBuckets = (
   exposures: ExposuresTimeseries,
   identities: VariantIdentity[],
-  conversions?: ConversionsTimeseries | null,
+  conversions: ConversionsTimeseries,
 ): AccumulatedBucket[] => {
-  const exposedByBucket: Record<string, Record<string, number>> = {}
-  exposures.points.forEach((p) => {
-    exposedByBucket[p.bucket] = p.new_identities
-  })
   const convertedByBucket: Record<string, Record<string, number>> = {}
-  conversions?.points.forEach((p) => {
+  conversions.points.forEach((p) => {
     convertedByBucket[p.bucket] = p.converted_identities
   })
 
@@ -46,16 +41,23 @@ const accumulateBuckets = (
   // labelling).
   const buckets = Array.from(
     new Set([
-      ...Object.keys(exposedByBucket),
+      ...exposures.points.map((p) => p.bucket),
       ...Object.keys(convertedByBucket),
     ]),
   ).sort()
 
-  // Labels key countsByDay and the chart category, so they must be unique:
-  // a series spanning calendar years adds the year to avoid '1 Jun'
-  // colliding with the same day a year later.
+  // Only the rendered window is trimmed: running totals still accumulate from
+  // the experiment start.
+  const from =
+    exposures.granularity === 'day'
+      ? Math.max(0, buckets.length - MAX_DAY_BUCKETS)
+      : 0
+
+  // Labels key the chart category, so they must be unique: a window spanning
+  // calendar years adds the year to avoid '1 Jun' colliding with the same day
+  // a year later.
   const spansYears =
-    new Set(buckets.map((bucket) => bucket.slice(0, 4))).size > 1
+    new Set(buckets.slice(from).map((bucket) => bucket.slice(0, 4))).size > 1
   const toLabel = (bucket: string) =>
     spansYears
       ? moment
@@ -67,114 +69,38 @@ const accumulateBuckets = (
           )
       : formatBucketLabel(bucket, exposures.granularity)
 
-  const cumExposed: Record<string, number> = {}
   const cumConverted: Record<string, number> = {}
   identities.forEach((v) => {
-    cumExposed[v.key] = 0
     cumConverted[v.key] = 0
   })
 
-  return buckets.map((bucket) => {
-    const newExposed: Record<string, number> = {}
+  const accumulated: AccumulatedBucket[] = []
+  buckets.forEach((bucket, index) => {
     const newConverted: Record<string, number> = {}
     identities.forEach((v) => {
-      newExposed[v.key] = exposedByBucket[bucket]?.[v.key] ?? 0
       newConverted[v.key] = convertedByBucket[bucket]?.[v.key] ?? 0
-      cumExposed[v.key] += newExposed[v.key]
       cumConverted[v.key] += newConverted[v.key]
     })
-    return {
+    if (index < from) return
+    accumulated.push({
       converted: { ...cumConverted },
       day: toLabel(bucket),
-      exposed: { ...cumExposed },
       newConverted,
-      newExposed,
-    }
-  })
-}
-
-// Rounded to one decimal for stable display.
-const toRatePct = (converted: number, exposed: number): number =>
-  Math.round((converted / exposed) * 1000) / 10
-
-const seriesMeta = (identities: VariantIdentity[]) => {
-  const seriesLabels: Record<string, string> = {}
-  const colorMap: Record<string, string> = {}
-  identities.forEach((v) => {
-    seriesLabels[v.key] = v.name
-    colorMap[v.key] = v.colour
-  })
-  return { colorMap, seriesLabels }
-}
-
-export type ConversionCounts = Record<
-  string,
-  { converted: number; exposed: number }
->
-
-export type ConversionRateChartData = ExposuresChartData & {
-  // Running numerator/denominator per bucket label, for tooltips.
-  countsByDay: Record<string, ConversionCounts>
-}
-
-// Cumulative conversion rate per variant: running conversions over running
-// exposures. A variant with no exposures yet is omitted from the point rather
-// than shown as 0%.
-export const buildConversionRateChartData = (
-  results: BayesianResultsSummary,
-  metricId: number,
-  identities: VariantIdentity[],
-): ConversionRateChartData | null => {
-  const exposures = results.exposures_timeseries
-  const conversions = getMetricResult(results, metricId)?.conversions_timeseries
-  if (!exposures || !conversions) return null
-
-  const series = identities.map((v) => v.key)
-  const countsByDay: Record<string, ConversionCounts> = {}
-  const points: ChartDataPoint[] = accumulateBuckets(
-    exposures,
-    identities,
-    conversions,
-  ).map((b) => {
-    const point: ChartDataPoint = { day: b.day }
-    const counts: ConversionCounts = {}
-    identities.forEach((v) => {
-      const exposed = b.exposed[v.key]
-      if (exposed === 0) return
-      point[v.key] = toRatePct(b.converted[v.key], exposed)
-      counts[v.key] = { converted: b.converted[v.key], exposed }
     })
-    countsByDay[b.day] = counts
-    return point
   })
-  return { countsByDay, points, series, ...seriesMeta(identities) }
+  return accumulated
 }
 
-export const REST_SUFFIX = '__rest'
+export type ConversionMode = 'cumulative' | 'daily'
 
-export type ConversionStackMode = 'cumulative' | 'daily'
-
-export type ConversionStackChartData = {
-  points: ChartDataPoint[]
-  series: string[]
-  seriesLabels: Record<string, string>
-  colorMap: Record<string, string>
-  opacityMap: Record<string, number>
-  stackMap: Record<string, string>
-}
-
-// Stacked-bar encodings of exposures vs conversions per variant.
-// 'cumulative': part-of-whole — the full bar is running exposures and the
-// solid segment is running conversions (always a subset, since a first
-// conversion can't precede a first exposure). 'daily': the raw per-bucket
-// increments side by side — NOT part-of-whole, because a day's first
-// conversions can exceed its new exposures, so no rate is implied.
-export const buildConversionStackChartData = (
+// Conversions per variant over time: 'cumulative' plots running totals,
+// 'daily' the raw per-bucket increments.
+export const buildConversionChartData = (
   results: BayesianResultsSummary,
   metricId: number,
   identities: VariantIdentity[],
-  mode: ConversionStackMode,
-): ConversionStackChartData | null => {
+  mode: ConversionMode,
+): ExposuresChartData | null => {
   const exposures = results.exposures_timeseries
   const conversions = getMetricResult(results, metricId)?.conversions_timeseries
   if (!exposures || !conversions) return null
@@ -183,24 +109,12 @@ export const buildConversionStackChartData = (
   const series: string[] = []
   const seriesLabels: Record<string, string> = {}
   const colorMap: Record<string, string> = {}
-  const opacityMap: Record<string, number> = {}
-  const stackMap: Record<string, string> = {}
   identities.forEach((v) => {
-    const restKey = `${v.key}${REST_SUFFIX}`
-    series.push(v.key, restKey)
+    series.push(v.key)
+    colorMap[v.key] = v.colour
     seriesLabels[v.key] = daily
       ? `${v.name} conversions`
       : `${v.name} converted`
-    seriesLabels[restKey] = daily
-      ? `${v.name} new exposures`
-      : `${v.name} exposures`
-    colorMap[v.key] = v.colour
-    // The faded series reuses the variant colour via fill-opacity (palette
-    // colours are CSS var() strings, so no alpha channel can be appended).
-    colorMap[restKey] = v.colour
-    opacityMap[restKey] = 0.25
-    stackMap[v.key] = v.key
-    stackMap[restKey] = daily ? restKey : v.key
   })
 
   const points: ChartDataPoint[] = accumulateBuckets(
@@ -211,11 +125,8 @@ export const buildConversionStackChartData = (
     const point: ChartDataPoint = { day: b.day }
     identities.forEach((v) => {
       point[v.key] = daily ? b.newConverted[v.key] : b.converted[v.key]
-      point[`${v.key}${REST_SUFFIX}`] = daily
-        ? b.newExposed[v.key]
-        : b.exposed[v.key] - b.converted[v.key]
     })
     return point
   })
-  return { colorMap, opacityMap, points, series, seriesLabels, stackMap }
+  return { colorMap, points, series, seriesLabels }
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

- Drops exposures from the chart. Cumulative exposures run ~10x the conversions, which flattened the conversion series; the card now plots conversions alone.
- Replaces the stacked bars with one line per variant, keeping the Cumulative/Daily toggle: Cumulative plots running conversion totals, Daily the raw per-bucket increments.
- Renames the card to "Conversions over time", since no rate is displayed any more.
- Caps the rendered window at the last 30 day-buckets. The backend returns every bucket since the experiment started (49 and counting on the QA experiment), which was ~200 bars. Running totals still accumulate from the experiment start, and hourly series are left uncapped since the backend already bounds them to 72h.
- Reverts `BarChart` and `ChartTooltip` to their pre-#8463 state. Every prop that PR added to them (`height`, `grouped`, `stackMap`, `opacityMap`, `yAxis`, `tooltipValueFormatter`, `tooltipHideTotal`, `FadedSwatchLegend`) is gone, and no chart component gains new props here.

## How did you test this code?

- Derive-module tests trimmed to the 7 that still apply: null guards, bucket union with carry-forward, cumulative vs daily, year-spanning labels, the 30-bucket window. Full suite 610 passing; typecheck delta zero.
- Manually against production data on a 49-day running experiment: both toggle modes, the 30-day window, legend and tooltips.


<img width="1094" height="432" alt="image" src="https://github.com/user-attachments/assets/9c77ea4c-dd09-4fd2-8bd8-b9d39a5206bf" />

<img width="1116" height="432" alt="image" src="https://github.com/user-attachments/assets/3fb6d8cd-260d-46c8-9f28-c7ab205f5fa5" />

