### PR TITLE
refactor(experiments): drop conversions chart mode toggle

### DIFF
--- a/frontend/web/components/experiments/results/ExperimentConversionRateCard/ExperimentConversionRateCard.tsx
+++ b/frontend/web/components/experiments/results/ExperimentConversionRateCard/ExperimentConversionRateCard.tsx
@@ -1,18 +1,14 @@
-import { FC, useMemo, useState } from 'react'
+import { FC, useMemo } from 'react'
 import moment from 'moment'
 import { LineChart } from 'components/charts'
 import ContentCard from 'components/base/grid/ContentCard'
-import InlinePillToggle from 'components/base/forms/InlinePillToggle'
 import { BayesianResultsSummary, Experiment } from 'common/types/responses'
 import { getPrimaryMetric } from 'components/experiments/constants'
 import {
   getMetricResult,
   getVariantIdentities,
 } from 'components/experiments/results/derive'
-import {
-  ConversionMode,
-  buildConversionChartData,
-} from 'components/experiments/results/deriveConversionRate'
+import { buildConversionChartData } from 'components/experiments/results/deriveConversionRate'
 
 type ExperimentConversionRateCardProps = {
   experiment: Experiment
@@ -25,7 +21,6 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
   experiment,
   results,
 }) => {
-  const [mode, setMode] = useState<ConversionMode>('cumulative')
   const metric = getPrimaryMetric(experiment)
   const identities = useMemo(
     () => getVariantIdentities(experiment.feature),
@@ -34,9 +29,9 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
   const chart = useMemo(
     () =>
       metric && results
-        ? buildConversionChartData(results, metric.metric, identities, mode)
+        ? buildConversionChartData(results, metric.metric, identities)
         : null,
-    [metric, results, identities, mode],
+    [metric, results, identities],
   )
 
   // Hidden entirely when no conversions can be charted: value metrics, and
@@ -68,18 +63,6 @@ const ExperimentConversionRateCard: FC<ExperimentConversionRateCardProps> = ({
     >
       {hasConversions ? (
         <>
-          {/* mt-n2 halves the card's 16px child gap after the title. */}
-          <div className='d-flex mt-n2'>
-            <InlinePillToggle<ConversionMode>
-              size='small'
-              options={[
-                { label: 'Cumulative', value: 'cumulative' },
-                { label: 'Daily', value: 'daily' },
-              ]}
-              value={mode}
-              onChange={setMode}
-            />
-          </div>
           <LineChart
             colorMap={chart.colorMap}
             data={chart.points}

--- a/frontend/web/components/experiments/results/__tests__/deriveConversionRate.test.ts
+++ b/frontend/web/components/experiments/results/__tests__/deriveConversionRate.test.ts
@@ -86,19 +86,15 @@ describe('buildConversionChartData', () => {
       summary({ exposures_timeseries: exposures, metrics: [metricResult()] }),
     ],
   ])('returns null when %s', (_, res) => {
-    expect(
-      buildConversionChartData(res, 7, identities, 'cumulative'),
-    ).toBeNull()
+    expect(buildConversionChartData(res, 7, identities)).toBeNull()
   })
 
   it('returns null when no metric matches the requested id', () => {
-    expect(
-      buildConversionChartData(results, 999, identities, 'daily'),
-    ).toBeNull()
+    expect(buildConversionChartData(results, 999, identities)).toBeNull()
   })
 
-  it('accumulates running totals over the bucket union in cumulative mode', () => {
-    const chart = buildConversionChartData(results, 7, identities, 'cumulative')
+  it('accumulates running totals over the bucket union', () => {
+    const chart = buildConversionChartData(results, 7, identities)
     expect(chart?.points).toEqual([
       { control: 60, day: '1 Jun', variant_a: 100 },
       { control: 90, day: '2 Jun', variant_a: 100 },
@@ -106,16 +102,6 @@ describe('buildConversionChartData', () => {
       { control: 90, day: '3 Jun', variant_a: 100 },
     ])
     expect(chart?.seriesLabels.control).toBe('Control converted')
-  })
-
-  it('plots raw per-bucket increments in daily mode', () => {
-    const chart = buildConversionChartData(results, 7, identities, 'daily')
-    expect(chart?.points).toEqual([
-      { control: 60, day: '1 Jun', variant_a: 100 },
-      { control: 30, day: '2 Jun', variant_a: 0 },
-      { control: 0, day: '3 Jun', variant_a: 0 },
-    ])
-    expect(chart?.seriesLabels.control).toBe('Control conversions')
   })
 
   it('adds the year to labels when the series spans calendar years', () => {
@@ -132,7 +118,7 @@ describe('buildConversionChartData', () => {
       ]),
       metrics: [metricResult({ conversions_timeseries: conversions })],
     })
-    const chart = buildConversionChartData(res, 7, identities, 'cumulative')
+    const chart = buildConversionChartData(res, 7, identities)
     expect(chart?.points.map((p) => p.day)).toEqual([
       '1 Jun 2026',
       '2 Jun 2026',
@@ -159,7 +145,7 @@ describe('buildConversionChartData', () => {
         }),
       ],
     })
-    const chart = buildConversionChartData(res, 7, identities, 'cumulative')
+    const chart = buildConversionChartData(res, 7, identities)
     expect(chart?.points).toHaveLength(30)
     // The window opens on day 11, carrying the 11 conversions to date.
     expect(chart?.points[0]).toEqual({

--- a/frontend/web/components/experiments/results/deriveConversionRate.ts
+++ b/frontend/web/components/experiments/results/deriveConversionRate.ts
@@ -15,9 +15,6 @@ import {
 type AccumulatedBucket = {
   day: string
   converted: Record<string, number>
-  // Raw per-bucket increments, for discrete (per-day) displays. Never divide
-  // these — a bucket's first conversions can exceed its new exposures.
-  newConverted: Record<string, number>
 }
 
 // The backend returns every bucket since the experiment started, uncapped.
@@ -76,45 +73,35 @@ const accumulateBuckets = (
 
   const accumulated: AccumulatedBucket[] = []
   buckets.forEach((bucket, index) => {
-    const newConverted: Record<string, number> = {}
     identities.forEach((v) => {
-      newConverted[v.key] = convertedByBucket[bucket]?.[v.key] ?? 0
-      cumConverted[v.key] += newConverted[v.key]
+      cumConverted[v.key] += convertedByBucket[bucket]?.[v.key] ?? 0
     })
     if (index < from) return
     accumulated.push({
       converted: { ...cumConverted },
       day: toLabel(bucket),
-      newConverted,
     })
   })
   return accumulated
 }
 
-export type ConversionMode = 'cumulative' | 'daily'
-
-// Conversions per variant over time: 'cumulative' plots running totals,
-// 'daily' the raw per-bucket increments.
+// Conversions per variant over time, as running totals.
 export const buildConversionChartData = (
   results: BayesianResultsSummary,
   metricId: number,
   identities: VariantIdentity[],
-  mode: ConversionMode,
 ): ExposuresChartData | null => {
   const exposures = results.exposures_timeseries
   const conversions = getMetricResult(results, metricId)?.conversions_timeseries
   if (!exposures || !conversions) return null
 
-  const daily = mode === 'daily'
   const series: string[] = []
   const seriesLabels: Record<string, string> = {}
   const colorMap: Record<string, string> = {}
   identities.forEach((v) => {
     series.push(v.key)
     colorMap[v.key] = v.colour
-    seriesLabels[v.key] = daily
-      ? `${v.name} conversions`
-      : `${v.name} converted`
+    seriesLabels[v.key] = `${v.name} converted`
   })
 
   const points: ChartDataPoint[] = accumulateBuckets(
@@ -124,7 +111,7 @@ export const buildConversionChartData = (
   ).map((b) => {
     const point: ChartDataPoint = { day: b.day }
     identities.forEach((v) => {
-      point[v.key] = daily ? b.newConverted[v.key] : b.converted[v.key]
+      point[v.key] = b.converted[v.key]
     })
     return point
   })


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Removes the cumulative/daily toggle from the experiment "Conversions over time" chart — the chart is now always cumulative.

- Drops `InlinePillToggle` and its mode state from `ExperimentConversionRateCard`.
- Drops `ConversionMode` and the `mode` argument from `buildConversionChartData`; `AccumulatedBucket` no longer tracks per-bucket increments.
- Series labels are always `"<variant> converted"`.

## How did you test this code?

Updated `deriveConversionRate` unit tests (daily case removed); `results/__tests__` passes, 85 tests. Checked the card renders the cumulative series with the toggle gone.
