### PR TITLE
fix: refresh Flagsmith organisation traits when the selected organisation changes

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -350,6 +350,14 @@ const controller = {
     API.setCookie('organisation', `${id}`)
     store.organisation = find(store.model.organisations, { id })
     getStore().dispatch(setSelectedOrganisationId(id))
+    // Keep the org-scoped traits pointing at the organisation on screen, so
+    // org-scoped segments are evaluated against it. setTraits rather than
+    // identify: the identity is unchanged, so bucketing is undisturbed.
+    flagsmith.setTraits({
+      'organisation.id': String(id),
+      'organisation.name': store.organisation?.name ?? '',
+      'subscription.plan': store.organisation?.subscription?.plan ?? '',
+    })
     store.changed()
     identifyChatUser()
   },

--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -353,11 +353,13 @@ const controller = {
     // Keep the org-scoped traits pointing at the organisation on screen, so
     // org-scoped segments are evaluated against it. setTraits rather than
     // identify: the identity is unchanged, so bucketing is undisturbed.
-    flagsmith.setTraits({
-      'organisation.id': String(id),
-      'organisation.name': store.organisation?.name ?? '',
-      'subscription.plan': store.organisation?.subscription?.plan ?? '',
-    })
+    flagsmith
+      .setTraits({
+        'organisation.id': String(id),
+        'organisation.name': store.organisation?.name ?? '',
+        'subscription.plan': store.organisation?.subscription?.plan ?? '',
+      })
+      .catch(() => {})
     store.changed()
     identifyChatUser()
   },


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Flagsmith traits were only sent on login, so org-scoped segments were evaluated against whichever org you logged in under. `selectOrganisation` now refreshes them via `setTraits` (not `identify` — keeps bucketing intact). Covers org creation too, which routes through the same action.

## How did you test this code?

Manually: with a flag segmented on `organisation.id`, switching orgs now flips the gated UI without a refresh.
