### PR TITLE
docs: point Node.js SDK versions and migration note to @flagsmith/nodejs

### DIFF
--- a/docs/docs/integrating-with-flagsmith/sdks/server-side.mdx
+++ b/docs/docs/integrating-with-flagsmith/sdks/server-side.mdx
@@ -151,6 +151,13 @@ pip install flagsmith
 npm install @flagsmith/nodejs
 ```
 
+:::warning
+
+The Node.js SDK moved from `flagsmith-nodejs` to `@flagsmith/nodejs` in version 9.0.0. The `flagsmith-nodejs` package is
+deprecated and no longer receives updates. Replace it in your `package.json` and update your imports.
+
+:::
+
 </TabItem>
 <TabItem value="ruby" label="Ruby">
 

--- a/docs/plugins/flagsmith-versions/index.js
+++ b/docs/plugins/flagsmith-versions/index.js
@@ -88,7 +88,7 @@ export default async function fetchFlagsmithVersions(context, options) {
             const [js, nodejs, java, android, swiftpm, cocoapods, dotnet, rust, elixir, flutter] = await Promise.all(
                 [
                     fetchNpmVersions('@flagsmith/flagsmith'),
-                    fetchNpmVersions('flagsmith-nodejs'),
+                    fetchNpmVersions('@flagsmith/nodejs'),
                     fetchJavaVersions(),
                     fetchAndroidVersions(),
                     fetchSwiftPMVersions(),

--- a/docs/src/components/SdkVersions.js
+++ b/docs/src/components/SdkVersions.js
@@ -27,5 +27,5 @@ export const DotnetVersion = ({ spec = '~8' }) => Version({ sdk: 'dotnet', spec 
 export const ElixirVersion = ({ spec = '~2' }) => Version({ sdk: 'elixir', spec });
 export const RustVersion = ({ spec = '~2' }) => Version({ sdk: 'rust', spec });
 export const JsVersion = ({ spec = '^12' }) => Version({ sdk: 'js', spec });
-export const NodejsVersion = ({ spec } = { spec: '~6' }) => Version({ sdk: 'nodejs', spec });
+export const NodejsVersion = ({ spec = '^9' } = {}) => Version({ sdk: 'nodejs', spec });
 export const FlutterVersion = ({ spec = '~6' }) => Version({ sdk: 'flutter', spec });


### PR DESCRIPTION
## Summary

The Node.js SDK moved to `@flagsmith/nodejs` at 9.0.0, but the docs still resolved versions from the old `flagsmith-nodejs` package, so `NodejsVersion()` and every tsdocs link on the server-side page pointed at 8.1.2.

- Fetch Node.js versions from `@flagsmith/nodejs` in the `flagsmith-versions` plugin.
- Add a warning under the Node.js install block explaining the rename and deprecation of `flagsmith-nodejs`.

## Context

`flagsmith-nodejs` currently carries no npm deprecation notice (unlike `flagsmith` → `@flagsmith/flagsmith`), and it still gets ~25x the weekly downloads of `@flagsmith/nodejs`. Every published `flagsmith-nodejs` version sends an unusable user agent, so that install base is invisible in SDK usage analytics. This PR should land alongside an npm owner running:

```
npm deprecate flagsmith-nodejs@"*" "This package has moved to @flagsmith/nodejs. Please update your dependencies."
```