### PR TITLE
fix(experiments): audience card spacing and dark theme borders

### DIFF
--- a/frontend/web/components/experiments/AudiencePicker/AudiencePicker.tsx
+++ b/frontend/web/components/experiments/AudiencePicker/AudiencePicker.tsx
@@ -72,7 +72,7 @@ const AudiencePicker: FC<AudiencePickerProps> = ({
   )
 
   return (
-    <div className='d-flex flex-column gap-3'>
+    <div className='d-flex flex-column gap-3 mx-0'>
       {segments.length ? (
         <AudienceSegmentList
           segments={segments.map((segment) => ({

--- a/frontend/web/components/experiments/AudienceSegmentList/AudienceSegmentList.scss
+++ b/frontend/web/components/experiments/AudienceSegmentList/AudienceSegmentList.scss
@@ -1,0 +1,11 @@
+.audience-segment-row {
+  min-height: 60px; // 44px icon button + 8px vertical padding
+  padding: 8px 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-default);
+
+  &__remove {
+    margin-right: -8px;
+  }
+}

--- a/frontend/web/components/experiments/AudienceSegmentList/AudienceSegmentList.tsx
+++ b/frontend/web/components/experiments/AudienceSegmentList/AudienceSegmentList.tsx
@@ -6,6 +6,7 @@ import Icon from 'components/icons/Icon'
 import SegmentsIcon from 'components/icons/SegmentsIcon'
 import { CohortSourceType } from 'common/types/responses'
 import { colorIconSecondary } from 'common/theme/tokens'
+import './AudienceSegmentList.scss'
 
 export type AudienceSegmentItem = {
   id: number
@@ -25,11 +26,11 @@ const AudienceSegmentList: FC<AudienceSegmentListProps> = ({
   onRemove,
   segments,
 }) => (
-  <div className='d-flex flex-column gap-2'>
+  <div className='d-flex flex-column gap-2 mx-0'>
     {segments.map((segment) => (
       <div
         key={segment.id}
-        className='d-flex align-items-center gap-3 py-2 ps-3 pe-1 border border-default rounded-md bg-surface-default'
+        className='audience-segment-row d-flex align-items-center gap-3'
       >
         <SegmentsIcon
           className='flex-shrink-0'
@@ -70,7 +71,7 @@ const AudienceSegmentList: FC<AudienceSegmentListProps> = ({
         )}
         {onRemove && (
           <Button
-            className='btn btn-with-icon'
+            className='btn btn-with-icon audience-segment-row__remove'
             type='button'
             aria-label={`Remove ${segment.name} from audience`}
             onClick={() => onRemove(segment.id)}

--- a/frontend/web/components/experiments/steps/MeasurementStep.tsx
+++ b/frontend/web/components/experiments/steps/MeasurementStep.tsx
@@ -27,7 +27,7 @@ const MeasurementStep: FC<MeasurementStepProps> = ({
   const [isCreateMetricOpen, setIsCreateMetricOpen] = useState(false)
 
   return (
-    <div className='d-flex flex-column gap-4'>
+    <div className='d-flex flex-column gap-4 mx-0'>
       <ContentCard
         background='white'
         title='Metrics'

--- a/frontend/web/components/experiments/steps/ReviewStep.tsx
+++ b/frontend/web/components/experiments/steps/ReviewStep.tsx
@@ -48,7 +48,7 @@ const ReviewStep: FC<ReviewStepProps> = ({
   variationSplit,
 }) => {
   return (
-    <div className='d-flex flex-column gap-4'>
+    <div className='d-flex flex-column gap-4 mx-0'>
       <ContentCard
         background='white'
         title='Setup'

--- a/frontend/web/components/experiments/steps/RolloutStep.tsx
+++ b/frontend/web/components/experiments/steps/RolloutStep.tsx
@@ -50,7 +50,7 @@ const RolloutStep: FC<RolloutStepProps> = ({
   }
 
   return (
-    <div className='d-flex flex-column gap-4'>
+    <div className='d-flex flex-column gap-4 mx-0'>
       <ContentCard
         background='white'
         title='Targeted audience'

--- a/frontend/web/components/experiments/steps/SetupStep.tsx
+++ b/frontend/web/components/experiments/steps/SetupStep.tsx
@@ -65,7 +65,7 @@ const SetupStep: FC<SetupStepProps> = ({
   }, [experimentsData])
 
   return (
-    <div className='d-flex flex-column gap-4'>
+    <div className='d-flex flex-column gap-4 mx-0'>
       <ContentCard
         background='white'
         title='Experiment details'

--- a/frontend/web/styles/3rdParty/_bootstrap.scss
+++ b/frontend/web/styles/3rdParty/_bootstrap.scss
@@ -99,3 +99,9 @@ $utilities: map-merge($utilities, ("shadow": $_shadow-util));
 .modal-footer {
   padding: 0;
 }
+
+// Bootstrap's `.border*` utilities paint `--bs-border-color` with `!important`,
+// so `.border-default` can never win. Point the Bootstrap variable at the token.
+:root {
+  --bs-border-color: var(--color-border-default);
+}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

- Audience segment card: fixed padding (`8px 16px`), delete button no longer hugs the edge, review-step summary reuses the identical card.
- Removed stray horizontal insets in the wizard steps and audience picker (legacy `.flex-column` margin).
- Bootstrap `.border*` utilities now use the `--color-border-default` token, so borders follow the dark theme (experiment wizard, warehouse connection card).

## How did you test this code?

Manually in dark mode: experiment wizard Rollout and Review steps, warehouse connection card. `npm run lint`, experiments unit tests pass.