### PR TITLE
docs(OpenFeature): update references to OpenFeature ecosystem

### DIFF
--- a/docs/docs/integrating-with-flagsmith/openfeature.md
+++ b/docs/docs/integrating-with-flagsmith/openfeature.md
@@ -21,12 +21,14 @@ We currently offer [OpenFeature Providers](https://docs.openfeature.dev/docs/ref
 - [.Net](https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Flagsmith)
 - [JavaScript/Web](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagsmith-client)
 - [JavaScript/Server](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagsmith)
+- [Kotlin](https://github.com/Flagsmith/flagsmith-openfeature-provider-kotlin)
 - [Python](https://github.com/Flagsmith/flagsmith-openfeature-provider-python)
+- [Ruby](https://github.com/open-feature/ruby-sdk-contrib/tree/main/providers/openfeature-flagsmith-provider)
+- [Rust](https://github.com/open-feature/rust-sdk-contrib/tree/main/crates/flagsmith)
+- [Swift](https://github.com/Flagsmith/flagsmith-openfeature-swift-provider)
 
 ### Planned Providers
 
 We plan on implementing providers for the following languages as soon as we can:
 
 - PHP
-- Kotlin
-- Swift


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith-ios-client/issues/99

Adds the new Swift OF provider to documentation, and update stale references. 💅 

## How did you test this code?

Checking out the docs at https://docs-git-docs-swift-openfeature-provider-flagsmith.vercel.app/integrating-with-flagsmith/openfeature

<img width="880" height="539" alt="image" src="https://github.com/user-attachments/assets/d12ed8d5-25b2-4de8-9aca-e2af4d6a42e6" />
Poor PHP 😓 