### PR TITLE
fix: Handle null values from Influx

### DIFF
--- a/api/app_analytics/mappers.py
+++ b/api/app_analytics/mappers.py
@@ -143,13 +143,15 @@ def map_flux_tables_to_usage_data(
                     day=date,
                     labels=labels,
                 )
-            if (resource := Resource.get_from_name(values["resource"])) and (
-                resource_attr := resource.column_name
+            if (
+                (value := values["_value"]) is not None
+                and (resource := Resource.get_from_name(values["resource"]))
+                and (resource_attr := resource.column_name)
             ):
                 setattr(
                     data_by_key[key],
                     resource_attr,
-                    values["_value"],
+                    value,
                 )
     return list(data_by_key.values())
 
@@ -190,7 +192,7 @@ def map_flux_tables_to_feature_evaluation_data(
     return [
         FeatureEvaluationData(
             day=(values := record.values)["_time"].date(),
-            count=values["_value"],
+            count=values["_value"] or 0,
             labels=map_influx_record_values_to_labels(values),
         )
         for flux_table in flux_tables

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_mappers.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_mappers.py
@@ -43,6 +43,36 @@ def test_map_flux_tables_to_feature_evaluation_data__single_record__returns_expe
     ]
 
 
+def test_map_flux_tables_to_feature_evaluation_data__null_value__returns_zero_count() -> (
+    None
+):
+    # Given
+    flux_table = FluxTable()
+    flux_table.records.append(
+        FluxRecord(
+            flux_table,
+            values={
+                "_time": datetime.fromisoformat("2023-10-01T00:00:00Z"),
+                "_value": None,
+                "feature_name": "feature_1",
+                "client_application_name": "test-app",
+            },
+        )
+    )
+
+    # When
+    result = map_flux_tables_to_feature_evaluation_data(flux_tables=[flux_table])
+
+    # Then
+    assert result == [
+        FeatureEvaluationData(
+            day=date(2023, 10, 1),
+            count=0,
+            labels={"client_application_name": "test-app"},
+        )
+    ]
+
+
 def test_map_flux_tables_to_usage_data__multiple_resources__returns_aggregated_data() -> (
     None
 ):
@@ -67,6 +97,18 @@ def test_map_flux_tables_to_usage_data__multiple_resources__returns_aggregated_d
                 "_time": datetime.fromisoformat("2023-10-01T00:00:00Z"),
                 "_value": 10,
                 "resource": "identities",
+                "client_application_name": "test-app",
+                "unrelated": "value",
+            },
+        ),
+    )
+    flux_table.records.append(
+        FluxRecord(
+            flux_table,
+            values={
+                "_time": datetime.fromisoformat("2023-10-01T00:00:00Z"),
+                "_value": None,
+                "resource": "traits",
                 "client_application_name": "test-app",
                 "unrelated": "value",
             },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Influx sends null values for resources (e.g. endpoints) without any records. This change handles that with type safety.  

## How did you test this code?

Added / updated unit tests. 

