### PR TITLE
fix(identities): flag when an identity override diverges from its variation

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -856,6 +856,9 @@ export type FeatureState = {
   feature_state_value: FlagsmithValue
   id: number
   identity?: number
+  // Edge only: edge-featurestates returns the identity on the feature state
+  // itself, where core's featurestates returns the numeric `identity` above.
+  identity_uuid?: string
   live_from?: string
   multivariate_feature_state_values: MultivariateFeatureStateValue[]
   updated_at: string

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -856,8 +856,7 @@ export type FeatureState = {
   feature_state_value: FlagsmithValue
   id: number
   identity?: number
-  // Edge only: edge-featurestates returns the identity on the feature state
-  // itself, where core's featurestates returns the numeric `identity` above.
+  // Edge only. Core returns the numeric `identity` above instead.
   identity_uuid?: string
   live_from?: string
   multivariate_feature_state_values: MultivariateFeatureStateValue[]

--- a/frontend/common/utils/__tests__/multivariate.test.ts
+++ b/frontend/common/utils/__tests__/multivariate.test.ts
@@ -1,5 +1,6 @@
 import {
   getDefaultVariantKey,
+  getDivergedVariantOverride,
   hasUnmatchedIdentityOverride,
   resolveUnmatchedOverride,
   sortMultivariateOptions,
@@ -134,6 +135,104 @@ describe('multivariate', () => {
         ).toBe(expected)
       },
     )
+  })
+
+  describe('getDivergedVariantOverride', () => {
+    const variants = [
+      { id: 1, key: 'variant_a', value: 'old_a' },
+      { id: 2, key: 'variant_b', value: 'current_b' },
+    ]
+    const pinnedToVariant2 = [
+      { multivariate_feature_option: 2, percentage_allocation: 100 },
+    ]
+
+    it('reports the served value when the pinned variation has since changed', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: 'stale_b',
+          variants,
+          variationOverrides: pinnedToVariant2,
+        }),
+      ).toEqual({ key: 'variant_b', servedValue: 'stale_b' })
+    })
+
+    it('reports nothing when the served value matches the pinned variation', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: 'current_b',
+          variants,
+          variationOverrides: pinnedToVariant2,
+        }),
+      ).toBeUndefined()
+    })
+
+    it('reports nothing when no variation is pinned', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: 'stale_b',
+          variants,
+          variationOverrides: [
+            { multivariate_feature_option: 1, percentage_allocation: 50 },
+            { multivariate_feature_option: 2, percentage_allocation: 50 },
+          ],
+        }),
+      ).toBeUndefined()
+    })
+
+    it('reports nothing when the pinned variation no longer exists', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: 'stale_b',
+          variants,
+          variationOverrides: [
+            { multivariate_feature_option: 99, percentage_allocation: 100 },
+          ],
+        }),
+      ).toBeUndefined()
+    })
+
+    it('withholds a verdict while the feature state has not loaded', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: undefined,
+          variants,
+          variationOverrides: pinnedToVariant2,
+        }),
+      ).toBeUndefined()
+    })
+
+    it('withholds a verdict while the variations have not loaded', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: 'stale_b',
+          variants: undefined,
+          variationOverrides: pinnedToVariant2,
+        }),
+      ).toBeUndefined()
+    })
+
+    it('treats a null served value as a value, not as unloaded', () => {
+      expect(
+        getDivergedVariantOverride({
+          overrideValue: null,
+          variants,
+          variationOverrides: pinnedToVariant2,
+        }),
+      ).toEqual({ key: 'variant_b', servedValue: null })
+    })
+
+    it('leaves the save-path predicate untouched for a diverged pin', () => {
+      // hasUnmatchedIdentityOverride also decides whether saving preserves the
+      // override's own value. Reporting a diverged pin there would write the
+      // stale value into the record.
+      expect(
+        hasUnmatchedIdentityOverride({
+          controlValue: 'control',
+          overrideValue: 'stale_b',
+          variationOverrides: pinnedToVariant2,
+        }),
+      ).toBe(false)
+    })
   })
 
   describe('resolveUnmatchedOverride', () => {

--- a/frontend/common/utils/__tests__/multivariate.test.ts
+++ b/frontend/common/utils/__tests__/multivariate.test.ts
@@ -346,10 +346,7 @@ describe('multivariate', () => {
       ).toEqual({ key: 'variant_b', servedValue: null })
     })
 
-    it('leaves the save-path predicate untouched for a diverged pin', () => {
-      // hasUnmatchedIdentityOverride also decides whether saving preserves the
-      // override's own value. Reporting a diverged pin there would write the
-      // stale value into the record.
+    it('leaves the save-path predicate untouched for a diverged override', () => {
       expect(
         hasUnmatchedIdentityOverride({
           controlValue: 'control',

--- a/frontend/common/utils/featureStateToValue.ts
+++ b/frontend/common/utils/featureStateToValue.ts
@@ -35,7 +35,6 @@ export function featureStateToValue(
   const type = 'value_type' in value ? value.value_type : value.type
   switch (type) {
     case 'bool':
-      // Optional on multivariate options, so it can be absent.
       return value.boolean_value ?? null
     case 'float':
       // Only traits carry a float. Feature state values and variations do not.

--- a/frontend/common/utils/featureStateToValue.ts
+++ b/frontend/common/utils/featureStateToValue.ts
@@ -1,6 +1,7 @@
 import type {
   FeatureStateValue,
   FlagsmithValue,
+  MultivariateOption,
   TraitValue,
 } from 'common/types/responses'
 
@@ -9,12 +10,20 @@ import type {
  *
  * Accepts either the nested `{ type, string_value, ... }` shape returned by the
  * featurestates endpoint or an already-flat value, and returns the flat value.
+ * Multivariate options carry that same nested shape, so they are accepted too.
  *
  * Kept in its own module, free of `common/utils` imports, so consumers (and
  * their unit tests) don't pull the Flux stores in through `utils.tsx`.
  */
+export type FeatureStateToValueInput =
+  | FlagsmithValue
+  | FeatureStateValue
+  | MultivariateOption
+  | TraitValue
+  | undefined
+
 export function featureStateToValue(
-  value: FlagsmithValue | FeatureStateValue | TraitValue | undefined,
+  value: FeatureStateToValueInput,
 ): FlagsmithValue {
   if (value === null || value === undefined) {
     return null
@@ -26,9 +35,11 @@ export function featureStateToValue(
   const type = 'value_type' in value ? value.value_type : value.type
   switch (type) {
     case 'bool':
-      return value.boolean_value
+      // Optional on multivariate options, so it can be absent.
+      return value.boolean_value ?? null
     case 'float':
-      return value.float_value ?? null
+      // Only traits carry a float. Feature state values and variations do not.
+      return 'float_value' in value ? value.float_value ?? null : null
     case 'int':
       return value.integer_value ?? null
     default:

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -183,7 +183,7 @@ export const hasApprovableChanges = ({
   !same(editedValue, storedValue)
 
 // Separate from hasUnmatchedIdentityOverride, which also decides whether saving
-// keeps the override's own value: reporting a diverged pin there would write the
+// keeps the override's own value: reporting a divergence there would write the
 // stale value into the record.
 export type DivergedVariantOverride = {
   key: string
@@ -206,8 +206,8 @@ export const getDivergedVariantOverride = ({
   variants: PinnableVariant[] | undefined
   variationOverrides: VariationOverrides
 }): DivergedVariantOverride | undefined => {
-  // `undefined` means the feature state has not loaded, which is not the same as an
-  // override of `null`. Answering from absent data would report every pin as diverged.
+  // `undefined` means not loaded, unlike an override of `null`. Answering from
+  // absent data would report every override as diverged.
   if (overrideValue === undefined || !variants?.length) {
     return undefined
   }
@@ -217,7 +217,7 @@ export const getDivergedVariantOverride = ({
   if (!pinned) {
     return undefined
   }
-  // An unsaved variant has no id either, so an absent id would match on both sides.
+  // An unsaved variation has no id either, so absent would match absent.
   const pinnedOptionId = pinned.multivariate_feature_option
   if (pinnedOptionId === null || pinnedOptionId === undefined) {
     return undefined

--- a/frontend/common/utils/multivariate.ts
+++ b/frontend/common/utils/multivariate.ts
@@ -20,10 +20,12 @@ export const getDefaultVariantKey = (index: number): string =>
 // is only gone once saved.
 // Only the allocation matters here: a variation pinned at 100% is what makes
 // an override expressible as a variation rather than a free-form value.
-export type VariationOverrides =
-  | { percentage_allocation: number }[]
-  | null
-  | undefined
+export type VariationOverride = {
+  multivariate_feature_option?: number | null
+  percentage_allocation: number
+}
+
+export type VariationOverrides = VariationOverride[] | null | undefined
 
 // An override the variation radios cannot express, and whether it is still the
 // value in play.
@@ -76,6 +78,56 @@ export const resolveUnmatchedOverride = ({
   const value =
     latchedValue === undefined && isSelected ? overrideValue : latchedValue
   return value === undefined ? undefined : { selected: isSelected, value }
+}
+
+// Separate from hasUnmatchedIdentityOverride, which also decides whether saving
+// keeps the override's own value: reporting a diverged pin there would write the
+// stale value into the record.
+export type DivergedVariantOverride = {
+  key: string
+  servedValue: FlagsmithValue
+}
+
+// Value resolved by the caller, so this module stays free of Utils.
+export type PinnableVariant = {
+  id?: number | null
+  key: string
+  value: FlagsmithValue
+}
+
+export const getDivergedVariantOverride = ({
+  overrideValue,
+  variants,
+  variationOverrides,
+}: {
+  overrideValue: FlagsmithValue | undefined
+  variants: PinnableVariant[] | undefined
+  variationOverrides: VariationOverrides
+}): DivergedVariantOverride | undefined => {
+  // `undefined` means the feature state has not loaded, which is not the same as an
+  // override of `null`. Answering from absent data would report every pin as diverged.
+  if (overrideValue === undefined || !variants?.length) {
+    return undefined
+  }
+  const pinned = variationOverrides?.find(
+    (variation) => variation.percentage_allocation === 100,
+  )
+  if (!pinned) {
+    return undefined
+  }
+  // An unsaved variant has no id either, so an absent id would match on both sides.
+  const pinnedOptionId = pinned.multivariate_feature_option
+  if (pinnedOptionId === null || pinnedOptionId === undefined) {
+    return undefined
+  }
+  const variant = variants.find((candidate) => candidate.id === pinnedOptionId)
+  if (!variant || variant.value === undefined) {
+    return undefined
+  }
+  if (variant.value === overrideValue) {
+    return undefined
+  }
+  return { key: variant.key, servedValue: overrideValue }
 }
 
 // Options not yet saved have no id and sort last, in input order.

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -674,9 +674,6 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       noPermissions={!!noPermissions}
                       freeze={freeze}
                       featureState={environmentFlag}
-                      storedFeatureState={
-                        props.identityFlag || props.environmentFlag
-                      }
                       projectFlag={projectFlag}
                       environmentFlag={props.environmentFlag}
                       environmentId={environmentId}
@@ -874,6 +871,9 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                   projectId={projectId}
                   error={error}
                   featureState={props.environmentFlag || environmentFlag}
+                  storedFeatureState={
+                    props.identityFlag || props.environmentFlag
+                  }
                   projectFlag={projectFlag}
                   identity={identity}
                   overrideFeatureState={

--- a/frontend/web/components/modals/create-feature/index.tsx
+++ b/frontend/web/components/modals/create-feature/index.tsx
@@ -674,6 +674,9 @@ const CreateFeatureModal: FC<CreateFeatureModalProps> = (props) => {
                       noPermissions={!!noPermissions}
                       freeze={freeze}
                       featureState={environmentFlag}
+                      storedFeatureState={
+                        props.identityFlag || props.environmentFlag
+                      }
                       projectFlag={projectFlag}
                       environmentFlag={props.environmentFlag}
                       environmentId={environmentId}

--- a/frontend/web/components/modals/create-feature/tabs/CreateFeatureTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/CreateFeatureTab.tsx
@@ -13,6 +13,7 @@ type CreateFeatureTabProps = {
   projectId: number
   error: any
   featureState: FeatureState
+  storedFeatureState?: FeatureState
   overrideFeatureState?: FeatureState
   projectFlag: ProjectFlag | null
   identity?: string
@@ -45,6 +46,7 @@ const CreateFeatureTab: FC<CreateFeatureTabProps> = ({
   ownerIds,
   projectFlag,
   projectId,
+  storedFeatureState,
 }) => {
   const { permission: createFeature } = useHasPermission({
     id: projectId,
@@ -83,6 +85,7 @@ const CreateFeatureTab: FC<CreateFeatureTabProps> = ({
             noPermissions={noPermissions}
             projectFlag={projectFlag}
             featureState={overrideFeatureState || featureState}
+            storedFeatureState={storedFeatureState}
             onEnvironmentFlagChange={onEnvironmentFlagChange}
             onProjectFlagChange={onProjectFlagChange}
             onRemoveMultivariateOption={onRemoveMultivariateOption}

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -467,7 +467,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
             )}
             {!!divergedVariantOverride && (
               <WarningMessage
-                warningMessage={`This identity is served an out of date copy of variation '${divergedVariantOverride.key}', taken when the override was saved. Select the variation again to update it to the current value.`}
+                warningMessage={`This identity is served a stale copy of variation '${divergedVariantOverride.key}', taken when the override was saved. Press Update Feature to refresh it.`}
               />
             )}
             <VariationOptions

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -21,6 +21,8 @@ import {
   ProjectFlag,
 } from 'common/types/responses'
 import {
+  getDefaultVariantKey,
+  getDivergedVariantOverride,
   hasUnmatchedIdentityOverride,
   LatchedOverrideValue,
   resolveUnmatchedOverride,
@@ -310,6 +312,26 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   })
   latchedOverrideValue.current = unmatchedOverride?.value
 
+  // Only edge-featurestates returns identity_uuid, and only it returns the value
+  // the identity is served. Core returns the stored value, which here is the
+  // control value, so comparing that would report every override as diverged.
+  const isEdgeIdentity = !!featureState.identity_uuid
+
+  // An override keeps its own copy of the variation's value, so editing the
+  // variation leaves the identity on the old one.
+  const divergedVariantOverride =
+    identity && hasVariations && isEdgeIdentity
+      ? getDivergedVariantOverride({
+          overrideValue: featureState.feature_state_value,
+          variants: multivariate_options.map((option, index) => ({
+            id: option.id,
+            key: option.key || getDefaultVariantKey(index),
+            value: Utils.featureStateToValue(option),
+          })),
+          variationOverrides: identityVariations,
+        })
+      : undefined
+
   if (compareOpen && canCompareValue && environmentId) {
     return (
       <div className={`${identity ? 'mx-3' : ''}`}>
@@ -443,10 +465,16 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
             {unmatchedOverrideSelected && (
               <WarningMessage warningMessage="This identity override contains a value that is not one of this flag's variations. We recommend changing it." />
             )}
+            {!!divergedVariantOverride && (
+              <WarningMessage
+                warningMessage={`This identity is served an out of date copy of variation '${divergedVariantOverride.key}', taken when the override was saved. Select the variation again to update it to the current value.`}
+              />
+            )}
             <VariationOptions
               canCreateFeature={false}
               disabled
               select
+              divergedOverride={divergedVariantOverride}
               unmatchedOverride={unmatchedOverride}
               controlValue={controlValue ?? null}
               controlPercentage={controlPercentage}

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -52,8 +52,7 @@ type FeatureValueTabProps = {
   noPermissions: boolean
   freeze?: FeatureExperimentFreeze
   featureState: FeatureState
-  // The feature state as saved. featureState is the editor's copy, which moves
-  // with every radio click.
+  // As saved. featureState is the editor's copy, which moves with every click.
   storedFeatureState?: FeatureState
   projectFlag: ProjectFlag
   environmentFlag?: FeatureState
@@ -320,15 +319,12 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   })
   latchedOverrideValue.current = unmatchedOverride?.value
 
-  // Only edge-featurestates returns identity_uuid, and only it returns the value
-  // the identity is served. Core returns the stored value, which here is the
-  // control value, so comparing that would report every override as diverged.
+  // Only edge returns the value the identity is served. Core returns the
+  // control value, which would report every override as diverged.
   const isEdgeIdentity = !!storedFeatureState?.identity_uuid
 
-  // An override keeps its own copy of the variation's value, so editing the
-  // variation leaves the identity on the old one. Read from the saved state,
-  // not the editor's: picking a variation moves the selection without moving
-  // the value, which would read as a divergence the user just created.
+  // From the saved state, not the editor's: picking a variation moves the
+  // selection without moving the value.
   const divergedVariantOverride =
     identity && hasVariations && isEdgeIdentity
       ? getDivergedVariantOverride({

--- a/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
+++ b/frontend/web/components/modals/create-feature/tabs/FeatureValueTab.tsx
@@ -50,6 +50,9 @@ type FeatureValueTabProps = {
   noPermissions: boolean
   freeze?: FeatureExperimentFreeze
   featureState: FeatureState
+  // The feature state as saved. featureState is the editor's copy, which moves
+  // with every radio click.
+  storedFeatureState?: FeatureState
   projectFlag: ProjectFlag
   environmentFlag?: FeatureState
   environmentId?: string
@@ -97,6 +100,7 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   originalMultivariateOptions,
   projectFlag,
   projectId,
+  storedFeatureState,
 }) => {
   const isEdit = !!projectFlag?.id
   const isDisabled = !!noPermissions || !!freeze?.isFrozen
@@ -315,20 +319,23 @@ const FeatureValueTab: FC<FeatureValueTabProps> = ({
   // Only edge-featurestates returns identity_uuid, and only it returns the value
   // the identity is served. Core returns the stored value, which here is the
   // control value, so comparing that would report every override as diverged.
-  const isEdgeIdentity = !!featureState.identity_uuid
+  const isEdgeIdentity = !!storedFeatureState?.identity_uuid
 
   // An override keeps its own copy of the variation's value, so editing the
-  // variation leaves the identity on the old one.
+  // variation leaves the identity on the old one. Read from the saved state,
+  // not the editor's: picking a variation moves the selection without moving
+  // the value, which would read as a divergence the user just created.
   const divergedVariantOverride =
     identity && hasVariations && isEdgeIdentity
       ? getDivergedVariantOverride({
-          overrideValue: featureState.feature_state_value,
+          overrideValue: storedFeatureState?.feature_state_value,
           variants: multivariate_options.map((option, index) => ({
             id: option.id,
             key: option.key || getDefaultVariantKey(index),
             value: Utils.featureStateToValue(option),
           })),
-          variationOverrides: identityVariations,
+          variationOverrides:
+            storedFeatureState?.multivariate_feature_state_values,
         })
       : undefined
 

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -4,7 +4,10 @@ import ErrorMessage from 'components/ErrorMessage'
 import { VariationValueInput } from './VariationValueInput'
 import Utils from 'common/utils/utils'
 import { FlagsmithValue, MultivariateOption } from 'common/types/responses'
-import { UnmatchedOverride } from 'common/utils/multivariate'
+import {
+  DivergedVariantOverride,
+  UnmatchedOverride,
+} from 'common/utils/multivariate'
 
 type VariationOverride = {
   id?: number
@@ -19,6 +22,7 @@ interface VariationOptionsProps {
   controlPercentage: number
   controlValue: FlagsmithValue
   disabled: boolean
+  divergedOverride?: DivergedVariantOverride
   multivariateOptions: MultivariateOption[]
   readOnly?: boolean
   removeVariation: (i: number) => void
@@ -56,6 +60,7 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
   controlPercentage,
   controlValue,
   disabled,
+  divergedOverride,
   multivariateOptions,
   readOnly,
   removeVariation,
@@ -83,6 +88,19 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
           errorMessageClass='mt-2'
           error='Your variation percentage splits total to over 100%'
         />
+      )}
+      {/* No radio, unlike the row below: selecting it would save the stale
+          value as a literal override. */}
+      {select && !!divergedOverride && (
+        <div className='panel panel--flat panel-without-heading mb-2'>
+          <div className='panel-content'>
+            <ValueRowLabel>Currently served</ValueRowLabel>
+            <ValueEditor
+              disabled
+              value={Utils.getTypedValue(divergedOverride.servedValue)}
+            />
+          </div>
+        </div>
       )}
       {select && !!unmatchedOverride && (
         <div className='panel panel--flat panel-without-heading mb-2'>

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -92,9 +92,13 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
       {/* No radio, unlike the row below: selecting it would save the stale
           value as a literal override. */}
       {select && !!divergedOverride && (
-        <div className='panel panel--flat panel-without-heading mb-2'>
+        <div className='panel panel--flat panel-without-heading mb-2 bg-surface-warning border-warning'>
           <div className='panel-content'>
-            <ValueRowLabel>Currently served</ValueRowLabel>
+            <ValueRowLabel>
+              <span className='text-warning'>
+                Currently served, a stale copy of {divergedOverride.key}
+              </span>
+            </ValueRowLabel>
             <ValueEditor
               disabled
               value={Utils.getTypedValue(divergedOverride.servedValue)}

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -92,20 +92,16 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
       {/* No radio, unlike the row below: selecting it would save the stale
           value as a literal override. */}
       {select && !!divergedOverride && (
-        <div className='panel panel--flat panel-without-heading mb-2 bg-surface-warning border-warning'>
-          <div className='panel-content'>
-            <ValueRowLabel>
-              <span className='text-warning'>Currently served</span>
-            </ValueRowLabel>
-            <div className='panel panel--flat panel-without-heading border-warning mb-0'>
-              <div className='panel-content'>
-                <ValueRowLabel>{divergedOverride.key}</ValueRowLabel>
-                <ValueEditor
-                  disabled
-                  value={Utils.getTypedValue(divergedOverride.servedValue)}
-                />
-              </div>
-            </div>
+        <div className='border border-warning bg-surface-warning rounded p-3 mb-2'>
+          <ValueRowLabel>
+            <span className='text-warning'>Currently served</span>
+          </ValueRowLabel>
+          <div className='border border-warning rounded p-3'>
+            <ValueRowLabel>{divergedOverride.key}</ValueRowLabel>
+            <ValueEditor
+              disabled
+              value={Utils.getTypedValue(divergedOverride.servedValue)}
+            />
           </div>
         </div>
       )}

--- a/frontend/web/components/mv/VariationOptions.tsx
+++ b/frontend/web/components/mv/VariationOptions.tsx
@@ -95,14 +95,17 @@ export const VariationOptions: FC<VariationOptionsProps> = ({
         <div className='panel panel--flat panel-without-heading mb-2 bg-surface-warning border-warning'>
           <div className='panel-content'>
             <ValueRowLabel>
-              <span className='text-warning'>
-                Currently served, a stale copy of {divergedOverride.key}
-              </span>
+              <span className='text-warning'>Currently served</span>
             </ValueRowLabel>
-            <ValueEditor
-              disabled
-              value={Utils.getTypedValue(divergedOverride.servedValue)}
-            />
+            <div className='panel panel--flat panel-without-heading border-warning mb-0'>
+              <div className='panel-content'>
+                <ValueRowLabel>{divergedOverride.key}</ValueRowLabel>
+                <ValueEditor
+                  disabled
+                  value={Utils.getTypedValue(divergedOverride.servedValue)}
+                />
+              </div>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8488, option (2) from that issue.

An identity override set to a variation keeps its own copy of that variation's value, taken when the override was saved. Editing the variation afterwards leaves the identity on the old value while the editor shows the new one beside a selected radio.

The editor now says so, and shows the value the identity is actually served read-only so it can be compared without querying the API. Edge only, gated on `identity_uuid`: core's `featurestates` returns the stored value, which here is the control value, so comparing it would report every override as diverged.

Second commit is types only. `featureStateToValue` already flattened the multivariate option shape at runtime and three call sites were already passing one, so this names it in the signature. No behaviour change.

**Does not fix:** the identity is still served the stale value until the override is saved again, and the warning only appears inside one identity's editor, so it cannot help find affected identities on a feature with thousands of overrides.

## Screenshots

The override is set to `Variant_b_updated`, whose value has since changed from `2` to `2-updated`.

| Light | Dark |
|---|---|
|<img width="641" height="872" alt="image" src="https://github.com/user-attachments/assets/6433039b-dd19-48f9-ab9b-4b86484cb464" />|<img width="639" height="869" alt="image" src="https://github.com/user-attachments/assets/2ec00ea6-cf28-46ce-9c94-21912ff91fa0" />|

## How to verify

```bash
npm run test:unit -- --testPathPatterns="multivariate|featureStateToValue"   # 52 pass
npm run typecheck                                                            # 937; main is 940
```

### On a project without Edge identities

The regression test. The check must stay invisible here.

1. Create a multivariate flag with two variations, `variant_a` and `variant_b`, each with a different value.
2. Identities → open any identity → click that flag.
3. Select `variant_b` → **Update Feature**.
4. Go back to the feature and change `variant_b`'s value. Save.
5. Reopen the flag on that identity.

**Expect: no warning, and no "Currently served" row.** If either appears the Edge gate is wrong, and every healthy override would be flagged.

### On an Edge project

The feature itself. Same five steps as above, then:

6. **Expect:** a warning naming `variant_b`, a read-only **"Currently served"** row holding the **old** value, and `variant_b`'s own row showing the **new** value.
7. Press **Update Feature**, then reload.
8. **Expect:** both the warning and the row are gone, because saving re-reads the variation from the database.

### Smoke test, either project

`featureStateToValue` is shared, so check values still render in the flag list, a segment override, an identity's traits, and the diff view.

> [!NOTE]
> Exercised in the browser on an Edge project, in both themes, including renaming the variation while an override points at it. No E2E yet: the gate reads `identity_uuid` from the payload rather than project config, so a single route intercept would cover it.
