### PR TITLE
feat(usage): return the current billing period

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -633,10 +633,13 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
             return None
 
         elapsed = relativedelta(timezone.now(), starts_at)
-        period_starts_at = starts_at + relativedelta(
-            months=elapsed.years * 12 + elapsed.months
+        months = elapsed.years * 12 + elapsed.months
+        # Both ends count from the term start. Counting the second from the
+        # first loses the original day when a month is too short for it.
+        return (
+            starts_at + relativedelta(months=months),
+            starts_at + relativedelta(months=months + 1),
         )
-        return period_starts_at, period_starts_at + relativedelta(months=1)
 
 
 class OrganisationAPIUsageNotification(models.Model):

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -608,19 +608,8 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
         }
 
     def has_active_billing_periods(self) -> bool:
-        """
-        Returns True if current date is within the billing term.
-        If either start or end date is None, returns False.
-        """
-        starts_at, ends_at = (
-            self.current_billing_term_starts_at,
-            self.current_billing_term_ends_at,
-        )
-
-        if starts_at is None or ends_at is None:
-            return False
-
-        return starts_at <= timezone.now() <= ends_at
+        """Whether the organisation is inside a billing term."""
+        return self.current_billing_period() is not None
 
     def current_billing_period(self) -> tuple[datetime, datetime] | None:
         """
@@ -634,8 +623,8 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
             return None
 
         # One reading, so a clock crossing the term end mid-method cannot open
-        # a window past it. Exclusive of the end, which
-        # has_active_billing_periods admits.
+        # a window past it. The end is exclusive: at that instant the term is
+        # over and the next one has not been written yet.
         now = timezone.now()
         if not starts_at <= now < ends_at:
             return None

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -629,7 +629,12 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
         recent monthly anniversary of its start.
         """
         starts_at = self.current_billing_term_starts_at
-        if starts_at is None or not self.has_active_billing_periods():
+        ends_at = self.current_billing_term_ends_at
+        if starts_at is None or ends_at is None:
+            return None
+        # Exclusive of the term end, which has_active_billing_periods admits,
+        # so the last instant of a term does not open a window beyond it.
+        if not starts_at <= timezone.now() < ends_at:
             return None
 
         elapsed = relativedelta(timezone.now(), starts_at)

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -1,8 +1,9 @@
 import re
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from common.core.utils import is_enterprise, is_saas
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.cache import caches
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -322,6 +323,12 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         )
 
     @property
+    def current_billing_period(self) -> tuple[datetime, datetime] | None:
+        if not self.organisation.has_subscription_information_cache():
+            return None
+        return self.organisation.subscription_information_cache.current_billing_period()
+
+    @property
     def is_free_plan(self) -> bool:
         return self.subscription_plan_family == SubscriptionPlanFamily.FREE
 
@@ -614,6 +621,22 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
             return False
 
         return starts_at <= timezone.now() <= ends_at
+
+    def current_billing_period(self) -> tuple[datetime, datetime] | None:
+        """
+        Returns the monthly allowance window, or None outside a billing term.
+        A term can run longer than a month, so the window opens at the most
+        recent monthly anniversary of its start.
+        """
+        starts_at = self.current_billing_term_starts_at
+        if starts_at is None or not self.has_active_billing_periods():
+            return None
+
+        elapsed = relativedelta(timezone.now(), starts_at)
+        period_starts_at = starts_at + relativedelta(
+            months=elapsed.years * 12 + elapsed.months
+        )
+        return period_starts_at, period_starts_at + relativedelta(months=1)
 
 
 class OrganisationAPIUsageNotification(models.Model):

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -632,12 +632,15 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
         ends_at = self.current_billing_term_ends_at
         if starts_at is None or ends_at is None:
             return None
-        # Exclusive of the term end, which has_active_billing_periods admits,
-        # so the last instant of a term does not open a window beyond it.
-        if not starts_at <= timezone.now() < ends_at:
+
+        # One reading, so a clock crossing the term end mid-method cannot open
+        # a window past it. Exclusive of the end, which
+        # has_active_billing_periods admits.
+        now = timezone.now()
+        if not starts_at <= now < ends_at:
             return None
 
-        elapsed = relativedelta(timezone.now(), starts_at)
+        elapsed = relativedelta(now, starts_at)
         months = elapsed.years * 12 + elapsed.months
         # Both ends count from the term start. Counting the second from the
         # first loses the original day when a month is too short for it.

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -25,8 +25,19 @@ from .subscriptions.constants import CHARGEBEE
 logger = logging.getLogger(__name__)
 
 
+CURRENT_BILLING_PERIOD_SCHEMA = {
+    "type": "object",
+    "nullable": True,
+    "properties": {
+        "starts_at": {"type": "string", "format": "date-time"},
+        "ends_at": {"type": "string", "format": "date-time"},
+    },
+}
+
+
 class SubscriptionSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     has_active_billing_periods = serializers.SerializerMethodField()
+    current_billing_period = serializers.SerializerMethodField()
 
     class Meta:
         model = Subscription
@@ -35,6 +46,13 @@ class SubscriptionSerializer(serializers.ModelSerializer):  # type: ignore[type-
     @extend_schema_field({"type": "boolean"})
     def get_has_active_billing_periods(self, obj):  # type: ignore[no-untyped-def]
         return obj.has_active_billing_periods
+
+    @extend_schema_field(CURRENT_BILLING_PERIOD_SCHEMA)
+    def get_current_billing_period(self, obj: Subscription) -> dict[str, str] | None:
+        if (period := obj.current_billing_period) is None:
+            return None
+        starts_at, ends_at = period
+        return {"starts_at": starts_at.isoformat(), "ends_at": ends_at.isoformat()}
 
 
 class OrganisationSerializerFull(serializers.ModelSerializer):  # type: ignore[type-arg]

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -25,15 +25,9 @@ from .subscriptions.constants import CHARGEBEE
 logger = logging.getLogger(__name__)
 
 
-CURRENT_BILLING_PERIOD_SCHEMA = {
-    "type": "object",
-    "nullable": True,
-    "properties": {
-        "starts_at": {"type": "string", "format": "date-time"},
-        "ends_at": {"type": "string", "format": "date-time"},
-    },
-    "required": ["starts_at", "ends_at"],
-}
+class CurrentBillingPeriodSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    starts_at = serializers.DateTimeField(read_only=True)
+    ends_at = serializers.DateTimeField(read_only=True)
 
 
 class SubscriptionSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
@@ -48,12 +42,16 @@ class SubscriptionSerializer(serializers.ModelSerializer):  # type: ignore[type-
     def get_has_active_billing_periods(self, obj):  # type: ignore[no-untyped-def]
         return obj.has_active_billing_periods
 
-    @extend_schema_field(CURRENT_BILLING_PERIOD_SCHEMA)
-    def get_current_billing_period(self, obj: Subscription) -> dict[str, str] | None:
+    @extend_schema_field(CurrentBillingPeriodSerializer(allow_null=True))
+    def get_current_billing_period(
+        self, obj: Subscription
+    ) -> dict[str, typing.Any] | None:
         if (period := obj.current_billing_period) is None:
             return None
         starts_at, ends_at = period
-        return {"starts_at": starts_at.isoformat(), "ends_at": ends_at.isoformat()}
+        return CurrentBillingPeriodSerializer(
+            {"ends_at": ends_at, "starts_at": starts_at}
+        ).data
 
 
 class OrganisationSerializerFull(serializers.ModelSerializer):  # type: ignore[type-arg]

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -32,6 +32,7 @@ CURRENT_BILLING_PERIOD_SCHEMA = {
         "starts_at": {"type": "string", "format": "date-time"},
         "ends_at": {"type": "string", "format": "date-time"},
     },
+    "required": ["starts_at", "ends_at"],
 }
 
 

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -1084,6 +1084,33 @@ def test_current_billing_period__within_term__returns_monthly_window(
     )
 
 
+# February clamps a 31st term start to the 28th. Counting the end from that
+# clamped date rather than the term start would close the window on 28 March.
+@pytest.mark.freeze_time("2026-03-01T00:00:00+00:00")
+def test_current_billing_period__term_starts_on_the_31st__ends_on_the_anniversary(
+    organisation: Organisation,
+) -> None:
+    # Given
+    cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(
+            "2026-01-31T00:00:00+00:00"
+        ),
+        current_billing_term_ends_at=datetime.fromisoformat(
+            "2027-01-31T00:00:00+00:00"
+        ),
+    )
+
+    # When
+    period = cache.current_billing_period()
+
+    # Then
+    assert period == (
+        datetime.fromisoformat("2026-02-28T00:00:00+00:00"),
+        datetime.fromisoformat("2026-03-31T00:00:00+00:00"),
+    )
+
+
 @pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
 @pytest.mark.parametrize(
     "term_starts_at, term_ends_at",

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -1122,6 +1122,9 @@ def test_current_billing_period__term_starts_on_the_31st__ends_on_the_anniversar
         (None, "2026-10-01T00:00:00+00:00"),
         # Term ended, cache not caught up.
         ("2026-07-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00"),
+        # The term's final instant. has_active_billing_periods admits it, but
+        # a window opened here would run past the end of the term.
+        ("2026-08-10T12:00:00+00:00", "2026-09-10T12:00:00+00:00"),
         # Term not started.
         ("2026-10-01T00:00:00+00:00", "2026-11-01T00:00:00+00:00"),
     ],

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -1024,3 +1024,128 @@ def test_organisation_openfeature_evaluation_context__targeting_key_set__uses_it
 
     # Then
     assert context.targeting_key == "a" * 32
+
+
+@pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
+@pytest.mark.parametrize(
+    "term_starts_at, term_ends_at, expected_starts_at, expected_ends_at",
+    [
+        # Monthly term.
+        (
+            "2026-09-01T00:00:00+00:00",
+            "2026-10-01T00:00:00+00:00",
+            "2026-09-01T00:00:00+00:00",
+            "2026-10-01T00:00:00+00:00",
+        ),
+        # Annual term, first year.
+        (
+            "2026-01-05T00:00:00+00:00",
+            "2027-01-05T00:00:00+00:00",
+            "2026-09-05T00:00:00+00:00",
+            "2026-10-05T00:00:00+00:00",
+        ),
+        # Over a year old. Ignoring the year would land in 2025 (#6099).
+        (
+            "2024-09-03T00:00:00+00:00",
+            "2027-04-03T00:00:00+00:00",
+            "2026-09-03T00:00:00+00:00",
+            "2026-10-03T00:00:00+00:00",
+        ),
+        # Exactly on an anniversary.
+        (
+            "2025-09-10T12:00:00+00:00",
+            "2027-09-10T12:00:00+00:00",
+            "2026-09-10T12:00:00+00:00",
+            "2026-10-10T12:00:00+00:00",
+        ),
+    ],
+)
+def test_current_billing_period__within_term__returns_monthly_window(
+    organisation: Organisation,
+    term_starts_at: str,
+    term_ends_at: str,
+    expected_starts_at: str,
+    expected_ends_at: str,
+) -> None:
+    # Given
+    cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(term_starts_at),
+        current_billing_term_ends_at=datetime.fromisoformat(term_ends_at),
+    )
+
+    # When
+    period = cache.current_billing_period()
+
+    # Then
+    assert period == (
+        datetime.fromisoformat(expected_starts_at),
+        datetime.fromisoformat(expected_ends_at),
+    )
+
+
+@pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
+@pytest.mark.parametrize(
+    "term_starts_at, term_ends_at",
+    [
+        # No term, ie every free plan.
+        (None, None),
+        # Half a term.
+        ("2026-09-01T00:00:00+00:00", None),
+        (None, "2026-10-01T00:00:00+00:00"),
+        # Term ended, cache not caught up.
+        ("2026-07-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00"),
+        # Term not started.
+        ("2026-10-01T00:00:00+00:00", "2026-11-01T00:00:00+00:00"),
+    ],
+)
+def test_current_billing_period__no_active_term__returns_none(
+    organisation: Organisation,
+    term_starts_at: str | None,
+    term_ends_at: str | None,
+) -> None:
+    # Given
+    cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=(
+            datetime.fromisoformat(term_starts_at) if term_starts_at else None
+        ),
+        current_billing_term_ends_at=(
+            datetime.fromisoformat(term_ends_at) if term_ends_at else None
+        ),
+    )
+
+    # When / Then
+    assert cache.current_billing_period() is None
+
+
+@pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
+def test_subscription_current_billing_period__with_cache__reads_through(
+    organisation: Organisation,
+) -> None:
+    # Given
+    OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(
+            "2026-09-01T00:00:00+00:00"
+        ),
+        current_billing_term_ends_at=datetime.fromisoformat(
+            "2026-10-01T00:00:00+00:00"
+        ),
+    )
+
+    # When / Then
+    assert organisation.subscription.current_billing_period == (
+        datetime.fromisoformat("2026-09-01T00:00:00+00:00"),
+        datetime.fromisoformat("2026-10-01T00:00:00+00:00"),
+    )
+
+
+def test_subscription_current_billing_period__no_cache__returns_none(
+    organisation: Organisation,
+) -> None:
+    # Given
+    assert not organisation.has_subscription_information_cache()
+
+    # When / Then
+    assert organisation.subscription.current_billing_period is None

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -518,7 +518,7 @@ export type AuditLogDetail = AuditLogItem & {
 export type PaymentMethod = 'CHARGEBEE' | 'XERO' | 'AWS_MARKETPLACE'
 
 /** The monthly allowance window, null outside an active billing term. */
-export type BillingPeriod = {
+export type CurrentBillingPeriod = {
   starts_at: string
   ends_at: string
 }
@@ -536,7 +536,7 @@ export type Subscription = {
   payment_method: PaymentMethod | null
   notes: string | null
   has_active_billing_periods: boolean
-  current_billing_period: BillingPeriod | null
+  current_billing_period: CurrentBillingPeriod | null
 }
 
 export type OnboardingVariant = 'control' | 'single_page'

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -517,6 +517,12 @@ export type AuditLogDetail = AuditLogItem & {
 }
 export type PaymentMethod = 'CHARGEBEE' | 'XERO' | 'AWS_MARKETPLACE'
 
+/** The monthly allowance window, null outside an active billing term. */
+export type BillingPeriod = {
+  starts_at: string
+  ends_at: string
+}
+
 export type Subscription = {
   id: number
   uuid: string
@@ -530,6 +536,7 @@ export type Subscription = {
   payment_method: PaymentMethod | null
   notes: string | null
   has_active_billing_periods: boolean
+  current_billing_period: BillingPeriod | null
 }
 
 export type OnboardingVariant = 'control' | 'single_page'

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -7126,7 +7126,11 @@
                 "format": "date-time"
               }
             },
-            "readOnly": true
+            "readOnly": true,
+            "required": [
+              "starts_at",
+              "ends_at"
+            ]
           },
           "deleted_at": {
             "type": [

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -7111,6 +7111,23 @@
             "type": "boolean",
             "readOnly": true
           },
+          "current_billing_period": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "starts_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "ends_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "readOnly": true
+          },
           "deleted_at": {
             "type": [
               "string",

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -3759,6 +3759,21 @@
           "feature"
         ]
       },
+      "CurrentBillingPeriod": {
+        "type": "object",
+        "properties": {
+          "starts_at": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "ends_at": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
       "CustomCreateSegmentOverrideFeatureSegment": {
         "type": "object",
         "properties": {
@@ -7112,25 +7127,15 @@
             "readOnly": true
           },
           "current_billing_period": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "properties": {
-              "starts_at": {
-                "type": "string",
-                "format": "date-time"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CurrentBillingPeriod"
               },
-              "ends_at": {
-                "type": "string",
-                "format": "date-time"
+              {
+                "type": "null"
               }
-            },
-            "readOnly": true,
-            "required": [
-              "starts_at",
-              "ends_at"
-            ]
+            ],
+            "readOnly": true
           },
           "deleted_at": {
             "type": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27856,6 +27856,18 @@ components:
         has_active_billing_periods:
           type: boolean
           readOnly: true
+        current_billing_period:
+          type:
+            - object
+            - 'null'
+          properties:
+            starts_at:
+              type: string
+              format: date-time
+            ends_at:
+              type: string
+              format: date-time
+          readOnly: true
         deleted_at:
           type:
             - string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27868,6 +27868,9 @@ components:
               type: string
               format: date-time
           readOnly: true
+          required:
+            - starts_at
+            - ends_at
         deleted_at:
           type:
             - string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20129,6 +20129,17 @@ components:
           type: integer
       required:
         - user
+    CurrentBillingPeriod:
+      type: object
+      properties:
+        starts_at:
+          type: string
+          format: date-time
+          readOnly: true
+        ends_at:
+          type: string
+          format: date-time
+          readOnly: true
     CustomCreateSegmentOverrideFeatureSegment:
       type: object
       properties:
@@ -27857,20 +27868,10 @@ components:
           type: boolean
           readOnly: true
         current_billing_period:
-          type:
-            - object
-            - 'null'
-          properties:
-            starts_at:
-              type: string
-              format: date-time
-            ends_at:
-              type: string
-              format: date-time
+          oneOf:
+            - $ref: '#/components/schemas/CurrentBillingPeriod'
+            - type: 'null'
           readOnly: true
-          required:
-            - starts_at
-            - ends_at
         deleted_at:
           type:
             - string


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8257. Unblocks #8258 and #8188.

The usage page cannot show which billing period someone is in or when their allowance resets. The term dates sit on `OrganisationSubscriptionInformationCache` and reach no response.

Adds `current_billing_period` to the subscription:

```json
"current_billing_period": { "starts_at": "2026-09-03T00:00:00+00:00", "ends_at": "2026-10-03T00:00:00+00:00" }
```

`null` outside an active billing term, which covers free plans and a cache that has not caught up with a renewal. `ends_at` is the next monthly anniversary of the term start rather than the end of the term, because the allowance resets monthly.

This counts whole years, which `analytics_db_service` does not (#6099), so on an annual term older than a year the period will not match the usage figures beside it.

## How did you test this code?

Unit tests in `test_unit_organisations_models.py` cover a monthly term, an annual term in its first year, an annual term over a year old (the case in #6099), sitting exactly on an anniversary, and five cases that return null.


