### PR TITLE
fix(OAuth): MCP tool calls return 401 after django-oauth-toolkit 3.4 upgrade

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -995,6 +995,10 @@ OAUTH2_PROVIDER = {
         "authorization_code",
         "refresh_token",
     ],
+    # MCP clients bind tokens to the MCP server URL (RFC 8707), which the API
+    # then receives as a forwarded bearer token. The API is the only resource
+    # server, so audience checks would reject every such token.
+    "RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR": None,
 }
 
 # Github OAuth credentials

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -995,9 +995,6 @@ OAUTH2_PROVIDER = {
         "authorization_code",
         "refresh_token",
     ],
-    # MCP clients bind tokens to the MCP server URL (RFC 8707), which the API
-    # then receives as a forwarded bearer token. The API is the only resource
-    # server, so audience checks would reject every such token.
     "RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR": None,
 }
 

--- a/api/tests/unit/oauth2_metadata/test_authentication.py
+++ b/api/tests/unit/oauth2_metadata/test_authentication.py
@@ -1,10 +1,14 @@
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from django.utils import timezone
+from oauth2_provider.models import AccessToken, Application
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from oauth2_metadata.authentication import OAuth2BearerTokenAuthentication
+from users.models import FFAdminUser
 
 
 @pytest.mark.parametrize(
@@ -50,3 +54,36 @@ def test_authenticate__bearer_header__delegates_to_dot(
 
     # Then
     assert result == (mock_user, "test-token")
+
+
+def test_authenticate__token_bound_to_mcp_resource__authenticates_user(
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    app = Application.objects.create(
+        name="MCP client",
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://example.com/callback",
+    )
+    AccessToken.objects.create(
+        user=admin_user,
+        application=app,
+        token="mcp-token",
+        scope="mcp",
+        expires=timezone.now() + timedelta(hours=1),
+        resource=["https://mcp.example.com/"],
+    )
+    request = Request(
+        APIRequestFactory().get(
+            "/api/v1/organisations/", HTTP_AUTHORIZATION="Bearer mcp-token"
+        )
+    )
+    auth = OAuth2BearerTokenAuthentication()
+
+    # When
+    result = auth.authenticate(request)
+
+    # Then
+    assert result is not None
+    assert result[0] == admin_user


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #8498

Sets `RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR` to `None` in `OAUTH2_PROVIDER`. Token validation is back to 2.270.0 behaviour; no config or migration changes for self-hosted installations.

**Root cause**
- #8469 bumped `django-oauth-toolkit` 3.1.0 → 3.4.1 (allowed by `<4.0.0`).
- 3.4 added RFC 8707 audience checks: `resource` on token requests is now stored and enforced.
- MCP clients send `resource=<MCP server URL>`; the MCP server forwards that token to the API, which rejects it as the wrong audience. Every MCP tool call has returned 401 since 2.271.0.

**Why `None`**
- The API is the only resource server, so audience binding protects nothing today.
- Tokens without `resource` (CLI, dashboard) are unrestricted either way.
- Pinning `<3.4` is not an option: 3.4.1 migrations are already applied on upgraded instances.

The refresh `invalid_target` error in #8498 is a separate MCP server URL issue, not addressed here.

## How did you test this code?

Added a test authenticating a token bound to an MCP resource URL against an API path. Fails on `main`, passes here.