### PR TITLE
feat(onboarding): create the demo flag as multivariate

### DIFF
--- a/frontend/web/components/pages/onboarding/hooks/__tests__/createOnboardingFlag.test.ts
+++ b/frontend/web/components/pages/onboarding/hooks/__tests__/createOnboardingFlag.test.ts
@@ -7,10 +7,13 @@ import { ProjectFlag } from 'common/types/responses'
 const initiate = jest.fn((args: unknown) => ({ args, type: 'createFlag' }))
 const createMultivariateOption = jest.fn()
 
+const removeProjectFlag = jest.fn()
+
 jest.mock('common/services/useProjectFlag', () => ({
   projectFlagService: {
     endpoints: { createProjectFlag: { initiate: (a: unknown) => initiate(a) } },
   },
+  removeProjectFlag: (...a: unknown[]) => removeProjectFlag(...a),
 }))
 jest.mock('common/services/useMultivariateOption', () => ({
   createMultivariateOption: (...a: unknown[]) => createMultivariateOption(...a),
@@ -43,6 +46,7 @@ const expectedOption = {
 
 beforeEach(() => {
   initiate.mockClear()
+  removeProjectFlag.mockReset().mockResolvedValue({ data: undefined })
   createMultivariateOption.mockReset().mockResolvedValue({ data: {} })
 })
 
@@ -71,17 +75,21 @@ describe('createOnboardingFlag', () => {
     })
     expect(createMultivariateOption).toHaveBeenCalledTimes(1)
     expect(createMultivariateOption).toHaveBeenCalledWith(store, expectedOption)
+    expect(removeProjectFlag).not.toHaveBeenCalled()
   })
 
-  it('throws when the variation request fails', async () => {
+  it('removes the new flag and throws when the variation request fails', async () => {
     createMultivariateOption.mockResolvedValue({ error: { status: 500 } })
+    const store = storeReturning(flag())
 
     await expect(
-      createOnboardingFlag(storeReturning(flag()), {
-        name: 'show_demo_button',
-        projectId: 3,
-      }),
+      createOnboardingFlag(store, { name: 'show_demo_button', projectId: 3 }),
     ).rejects.toEqual({ status: 500 })
+
+    expect(removeProjectFlag).toHaveBeenCalledWith(store, {
+      flag_id: 7,
+      project_id: 3,
+    })
   })
 })
 

--- a/frontend/web/components/pages/onboarding/hooks/__tests__/createOnboardingFlag.test.ts
+++ b/frontend/web/components/pages/onboarding/hooks/__tests__/createOnboardingFlag.test.ts
@@ -1,0 +1,102 @@
+import {
+  createOnboardingFlag,
+  ensureOnboardingVariation,
+} from 'components/pages/onboarding/hooks/createOnboardingFlag'
+import { ProjectFlag } from 'common/types/responses'
+
+const initiate = jest.fn((args: unknown) => ({ args, type: 'createFlag' }))
+const createMultivariateOption = jest.fn()
+
+jest.mock('common/services/useProjectFlag', () => ({
+  projectFlagService: {
+    endpoints: { createProjectFlag: { initiate: (a: unknown) => initiate(a) } },
+  },
+}))
+jest.mock('common/services/useMultivariateOption', () => ({
+  createMultivariateOption: (...a: unknown[]) => createMultivariateOption(...a),
+}))
+
+const flag = (multivariate_options: unknown[] = []) =>
+  ({
+    id: 7,
+    multivariate_options,
+    name: 'show_demo_button',
+    project: 3,
+  } as unknown as ProjectFlag)
+
+const storeReturning = (created: ProjectFlag) =>
+  ({
+    dispatch: jest.fn(() => ({ unwrap: () => Promise.resolve(created) })),
+  } as any)
+
+const expectedOption = {
+  body: {
+    default_percentage_allocation: 0,
+    feature: 7,
+    key: 'variant',
+    string_value: 'variant',
+    type: 'unicode',
+  },
+  feature_id: 7,
+  project_id: 3,
+}
+
+beforeEach(() => {
+  initiate.mockClear()
+  createMultivariateOption.mockReset().mockResolvedValue({ data: {} })
+})
+
+describe('createOnboardingFlag', () => {
+  it('creates a multivariate flag with a control value and one 0% variation', async () => {
+    const store = storeReturning(flag())
+
+    const created = await createOnboardingFlag(store, {
+      description: 'desc',
+      name: 'show_demo_button',
+      projectId: 3,
+      tags: [1],
+    })
+
+    expect(created).toEqual(flag())
+    expect(initiate).toHaveBeenCalledWith({
+      body: {
+        description: 'desc',
+        initial_value: 'control',
+        name: 'show_demo_button',
+        project: 3,
+        tags: [1],
+        type: 'MULTIVARIATE',
+      },
+      project_id: 3,
+    })
+    expect(createMultivariateOption).toHaveBeenCalledTimes(1)
+    expect(createMultivariateOption).toHaveBeenCalledWith(store, expectedOption)
+  })
+
+  it('throws when the variation request fails', async () => {
+    createMultivariateOption.mockResolvedValue({ error: { status: 500 } })
+
+    await expect(
+      createOnboardingFlag(storeReturning(flag()), {
+        name: 'show_demo_button',
+        projectId: 3,
+      }),
+    ).rejects.toEqual({ status: 500 })
+  })
+})
+
+describe('ensureOnboardingVariation', () => {
+  it.each`
+    options        | calls
+    ${[]}          | ${1}
+    ${[{ id: 1 }]} | ${0}
+    ${undefined}   | ${1}
+  `(
+    'creates the variation $calls time(s) when options are $options',
+    async ({ calls, options }) => {
+      await ensureOnboardingVariation(storeReturning(flag()), flag(options))
+
+      expect(createMultivariateOption).toHaveBeenCalledTimes(calls)
+    },
+  )
+})

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -17,7 +17,10 @@ import {
 } from 'common/types/responses'
 import { SmartDefaults } from './useSmartDefaults'
 import { createOrganisationViaAccountStore } from './createOrganisationViaAccountStore'
-import { createOnboardingFlag } from './createOnboardingFlag'
+import {
+  createOnboardingFlag,
+  ensureOnboardingVariation,
+} from './createOnboardingFlag'
 import API from 'project/api'
 import Constants from 'common/constants'
 
@@ -160,6 +163,7 @@ async function ensureFlag(
       flags?.results?.find((f) => f.tags?.includes(onboardingTag.id))) ||
     flags?.results?.find((f) => f.name === FLAG_NAME)
   if (existing) {
+    await ensureOnboardingVariation(store, existing)
     return existing
   }
   const isFirstFeature = !flags?.results?.length

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -163,7 +163,9 @@ async function ensureFlag(
       flags?.results?.find((f) => f.tags?.includes(onboardingTag.id))) ||
     flags?.results?.find((f) => f.name === FLAG_NAME)
   if (existing) {
-    await ensureOnboardingVariation(store, existing)
+    if (existing.name === FLAG_NAME) {
+      await ensureOnboardingVariation(store, existing)
+    }
     return existing
   }
   const isFirstFeature = !flags?.results?.length

--- a/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
+++ b/frontend/web/components/pages/onboarding/hooks/bootstrapOnboarding.ts
@@ -8,7 +8,6 @@ import {
 } from 'common/services/useEnvironment'
 import { projectFlagService } from 'common/services/useProjectFlag'
 import { tagService } from 'common/services/useTag'
-import { Req } from 'common/types/requests'
 import {
   Environment,
   PagedResponse,
@@ -18,6 +17,7 @@ import {
 } from 'common/types/responses'
 import { SmartDefaults } from './useSmartDefaults'
 import { createOrganisationViaAccountStore } from './createOrganisationViaAccountStore'
+import { createOnboardingFlag } from './createOnboardingFlag'
 import API from 'project/api'
 import Constants from 'common/constants'
 
@@ -163,18 +163,10 @@ async function ensureFlag(
     return existing
   }
   const isFirstFeature = !flags?.results?.length
-  const created = await store
-    .dispatch(
-      projectFlagService.endpoints.createProjectFlag.initiate({
-        body: {
-          name: FLAG_NAME,
-          project: project.id,
-          type: 'STANDARD',
-        } as Req['createProjectFlag']['body'],
-        project_id: project.id,
-      }),
-    )
-    .unwrap()
+  const created = await createOnboardingFlag(store, {
+    name: FLAG_NAME,
+    projectId: project.id,
+  })
   if (isFirstFeature) {
     API.trackEvent(Constants.events.CREATE_FIRST_FEATURE)
   }

--- a/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
@@ -1,5 +1,8 @@
 import { getStore } from 'common/store'
-import { projectFlagService } from 'common/services/useProjectFlag'
+import {
+  projectFlagService,
+  removeProjectFlag,
+} from 'common/services/useProjectFlag'
 import { createMultivariateOption } from 'common/services/useMultivariateOption'
 import { Req } from 'common/types/requests'
 import { ProjectFlag } from 'common/types/responses'
@@ -58,6 +61,11 @@ export async function createOnboardingFlag(
       }),
     )
     .unwrap()
-  await ensureOnboardingVariation(store, flag)
+  try {
+    await ensureOnboardingVariation(store, flag)
+  } catch (error) {
+    await removeProjectFlag(store, { flag_id: flag.id, project_id: projectId })
+    throw error
+  }
   return flag
 }

--- a/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
@@ -3,12 +3,11 @@ import { projectFlagService } from 'common/services/useProjectFlag'
 import { createMultivariateOption } from 'common/services/useMultivariateOption'
 import { Req } from 'common/types/requests'
 import { ProjectFlag } from 'common/types/responses'
-import Utils from 'common/utils/utils'
 
 type Store = ReturnType<typeof getStore>
 
 export const ONBOARDING_FLAG_CONTROL_VALUE = 'control'
-export const ONBOARDING_FLAG_VARIATIONS = ['variant']
+export const ONBOARDING_FLAG_VARIATION = 'variant'
 
 export type CreateOnboardingFlagInput = {
   projectId: number
@@ -17,8 +16,29 @@ export type CreateOnboardingFlagInput = {
   tags?: number[]
 }
 
-// The onboarding flag is multivariate (control + one 0% variation) so a
-// fresh user can start an experiment on it straight away.
+export async function ensureOnboardingVariation(
+  store: Store,
+  flag: ProjectFlag,
+): Promise<void> {
+  if (flag.multivariate_options?.length) {
+    return
+  }
+  const res = await createMultivariateOption(store, {
+    body: {
+      default_percentage_allocation: 0,
+      feature: flag.id,
+      key: ONBOARDING_FLAG_VARIATION,
+      string_value: ONBOARDING_FLAG_VARIATION,
+      type: 'unicode',
+    },
+    feature_id: flag.id,
+    project_id: flag.project,
+  })
+  if (res.error) {
+    throw res.error
+  }
+}
+
 export async function createOnboardingFlag(
   store: Store,
   { description, name, projectId, tags }: CreateOnboardingFlagInput,
@@ -38,18 +58,6 @@ export async function createOnboardingFlag(
       }),
     )
     .unwrap()
-  // Sequential so options get ascending ids in input order.
-  for (const value of ONBOARDING_FLAG_VARIATIONS) {
-    await createMultivariateOption(store, {
-      body: {
-        ...Utils.valueToFeatureState(value),
-        default_percentage_allocation: 0,
-        feature: flag.id,
-        key: value,
-      },
-      feature_id: flag.id,
-      project_id: projectId,
-    })
-  }
+  await ensureOnboardingVariation(store, flag)
   return flag
 }

--- a/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
@@ -12,8 +12,8 @@ export const ONBOARDING_FLAG_VARIATION = 'variant'
 export type CreateOnboardingFlagInput = {
   projectId: number
   name: string
-  description?: string | null
-  tags?: number[]
+  description?: ProjectFlag['description']
+  tags?: ProjectFlag['tags']
 }
 
 export async function ensureOnboardingVariation(

--- a/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
+++ b/frontend/web/components/pages/onboarding/hooks/createOnboardingFlag.ts
@@ -1,0 +1,55 @@
+import { getStore } from 'common/store'
+import { projectFlagService } from 'common/services/useProjectFlag'
+import { createMultivariateOption } from 'common/services/useMultivariateOption'
+import { Req } from 'common/types/requests'
+import { ProjectFlag } from 'common/types/responses'
+import Utils from 'common/utils/utils'
+
+type Store = ReturnType<typeof getStore>
+
+export const ONBOARDING_FLAG_CONTROL_VALUE = 'control'
+export const ONBOARDING_FLAG_VARIATIONS = ['variant']
+
+export type CreateOnboardingFlagInput = {
+  projectId: number
+  name: string
+  description?: string | null
+  tags?: number[]
+}
+
+// The onboarding flag is multivariate (control + one 0% variation) so a
+// fresh user can start an experiment on it straight away.
+export async function createOnboardingFlag(
+  store: Store,
+  { description, name, projectId, tags }: CreateOnboardingFlagInput,
+): Promise<ProjectFlag> {
+  const flag = await store
+    .dispatch(
+      projectFlagService.endpoints.createProjectFlag.initiate({
+        body: {
+          description,
+          initial_value: ONBOARDING_FLAG_CONTROL_VALUE,
+          name,
+          project: projectId,
+          tags,
+          type: 'MULTIVARIATE',
+        } as Req['createProjectFlag']['body'],
+        project_id: projectId,
+      }),
+    )
+    .unwrap()
+  // Sequential so options get ascending ids in input order.
+  for (const value of ONBOARDING_FLAG_VARIATIONS) {
+    await createMultivariateOption(store, {
+      body: {
+        ...Utils.valueToFeatureState(value),
+        default_percentage_allocation: 0,
+        feature: flag.id,
+        key: value,
+      },
+      feature_id: flag.id,
+      project_id: projectId,
+    })
+  }
+  return flag
+}

--- a/frontend/web/components/pages/onboarding/hooks/useOnboardingFlagRename.ts
+++ b/frontend/web/components/pages/onboarding/hooks/useOnboardingFlagRename.ts
@@ -1,10 +1,10 @@
 import {
-  useCreateProjectFlagMutation,
   useGetProjectFlagsQuery,
   useRemoveProjectFlagMutation,
 } from 'common/services/useProjectFlag'
+import { getStore } from 'common/store'
 import { Environment } from 'common/types/responses'
-import { Req } from 'common/types/requests'
+import { createOnboardingFlag } from './createOnboardingFlag'
 
 type UseOnboardingFlagRenameArgs = {
   projectId: number | null
@@ -14,8 +14,9 @@ type UseOnboardingFlagRenameArgs = {
 
 // "Rename" the flag. Feature names are immutable (the API marks `name`
 // read-only), so this is a delete + recreate: create first (no name conflict),
-// then drop the old one, carrying over its tags/type/description so the
-// Onboarding badge survives. Resolves true on success.
+// then drop the old one, carrying over its tags/description so the Onboarding
+// badge survives. Recreated via createOnboardingFlag so it stays multivariate.
+// Resolves true on success.
 export const useOnboardingFlagRename = ({
   environment,
   featureName,
@@ -28,7 +29,6 @@ export const useOnboardingFlagRename = ({
     },
     { skip: !projectId || !environment },
   )
-  const [createProjectFlag] = useCreateProjectFlagMutation()
   const [removeProjectFlag] = useRemoveProjectFlagMutation()
 
   const flag = projectFlags?.results?.find((f) => f.name === featureName)
@@ -38,16 +38,12 @@ export const useOnboardingFlagRename = ({
       return false
     }
     try {
-      await createProjectFlag({
-        body: {
-          description: flag.description,
-          name,
-          project: projectId,
-          tags: flag.tags,
-          type: flag.type,
-        } as Req['createProjectFlag']['body'],
-        project_id: projectId,
-      }).unwrap()
+      await createOnboardingFlag(getStore(), {
+        description: flag.description,
+        name,
+        projectId,
+        tags: flag.tags,
+      })
       await removeProjectFlag({
         flag_id: flag.id,
         project_id: projectId,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

The single-page onboarding now creates `show_demo_button` as a multivariate feature instead of a standard one, so users can start an experiment on it right after onboarding (experiments require a multivariate feature).

- New `createOnboardingFlag` helper creates the feature with `initial_value: 'control'` and `type: 'MULTIVARIATE'`, then adds one `variant` option at 0% allocation.
- `bootstrapOnboarding` uses the helper for first creation.
- `useOnboardingFlagRename` uses the same helper on delete + recreate, so a renamed flag keeps its variation.

No UI change: the onboarding flags table still shows a boolean toggle, and the variation at 0% means SDKs keep returning the control value. No docs change needed.

## How did you test this code?

Manually:
1. Sign up with a fresh account and land on the single-page onboarding.
2. Open the created project's features list: `show_demo_button` shows as multivariate with control value `control` and one `variant` option at 0%.
3. Rename the flag inline in the onboarding page and confirm the recreated flag is still multivariate with the same option.
4. Open Experiments, create a new experiment: the flag appears in the feature picker and its variation is selectable.
5. `npm run typecheck` clean for the onboarding files; ESLint passed via the pre-commit hook.