### PR TITLE
fix(types): accept multivariate options in featureStateToValue

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -856,6 +856,9 @@ export type FeatureState = {
   feature_state_value: FlagsmithValue
   id: number
   identity?: number
+  // Edge only: edge-featurestates returns the identity on the feature state
+  // itself, where core's featurestates returns the numeric `identity` above.
+  identity_uuid?: string
   live_from?: string
   multivariate_feature_state_values: MultivariateFeatureStateValue[]
   updated_at: string

--- a/frontend/common/utils/featureStateToValue.ts
+++ b/frontend/common/utils/featureStateToValue.ts
@@ -1,6 +1,7 @@
 import type {
   FeatureStateValue,
   FlagsmithValue,
+  MultivariateOption,
   TraitValue,
 } from 'common/types/responses'
 
@@ -9,12 +10,20 @@ import type {
  *
  * Accepts either the nested `{ type, string_value, ... }` shape returned by the
  * featurestates endpoint or an already-flat value, and returns the flat value.
+ * Multivariate options carry that same nested shape, so they are accepted too.
  *
  * Kept in its own module, free of `common/utils` imports, so consumers (and
  * their unit tests) don't pull the Flux stores in through `utils.tsx`.
  */
+export type FeatureStateToValueInput =
+  | FlagsmithValue
+  | FeatureStateValue
+  | MultivariateOption
+  | TraitValue
+  | undefined
+
 export function featureStateToValue(
-  value: FlagsmithValue | FeatureStateValue | TraitValue | undefined,
+  value: FeatureStateToValueInput,
 ): FlagsmithValue {
   if (value === null || value === undefined) {
     return null
@@ -26,9 +35,11 @@ export function featureStateToValue(
   const type = 'value_type' in value ? value.value_type : value.type
   switch (type) {
     case 'bool':
-      return value.boolean_value
+      // Optional on multivariate options, so it can be absent.
+      return value.boolean_value ?? null
     case 'float':
-      return value.float_value ?? null
+      // Only traits carry a float. Feature state values and variations do not.
+      return 'float_value' in value ? value.float_value ?? null : null
     case 'int':
       return value.integer_value ?? null
     default:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Split out of #8500 so it can land on its own. Types only, no behaviour change.

`featureStateToValue` already flattened the multivariate option shape at runtime, and three call sites were already passing one, so those calls were failing type checks. This names `MultivariateOption` in the signature instead.

Two branches needed adjusting for it, and neither changes behaviour:

- **`bool`** now falls back to `null`. `boolean_value` is required (`boolean | null`) on `FeatureStateValue` and `TraitValue`, so `x ?? null` returns exactly `x` for every existing caller. It is optional only on `MultivariateOption`, which could not be passed before.
- **`float`** narrows before reading. `MultivariateOption` has no `float_value` at all, so TypeScript will not read it off the union. `in` is a runtime property check, so an object without the key takes the false branch and returns `null`, exactly as `undefined ?? null` did.

Also adds `identity_uuid` to `FeatureState`. `edge-featurestates` returns it and the type omitted it.

Worth noting while nearby, and not changed here: `FEATURE_STATE_VALUE_TYPES` is `(INTEGER, STRING, BOOLEAN)`, and `float_value` exists on traits only. So `FeatureStateValue` declaring `float_value` and `'float'` describes something the API cannot send. Pre-existing, and its own issue if we want the types to mirror the API.

## How did you test this code?

- **Unit tests** in `common/utils/__tests__/featureStateToValue.test.ts` pass unchanged, which is the point: no existing behaviour moved.
- **Typecheck** against `6b4c10ee1c`: **940 errors on main, 937 here.** The three fixed are `DiffVariations` once and `VariationOptions` twice. Three appear as changed only because a `FeatureState` field count in an unrelated error message moved from "12 more" to "13 more".

Nothing to exercise manually beyond a smoke test of any screen showing a flag value, a trait, or a variation, since the helper is shared.
