### PR TITLE
fix(usage): drop the app-wide quota banner on the usage dashboard

### DIFF
--- a/frontend/web/__tests__/routePaths.test.ts
+++ b/frontend/web/__tests__/routePaths.test.ts
@@ -1,4 +1,4 @@
-import { isAllowedWhileBlocked } from 'web/routePaths'
+import { isAllowedWhileBlocked, isOrganisationUsage } from 'web/routePaths'
 
 // App renders <Blocked /> wherever this is false, so a wrong answer either
 // locks a blocked organisation out, or lets it back in.
@@ -24,5 +24,18 @@ describe('isAllowedWhileBlocked', () => {
     expect(isAllowedWhileBlocked('/organisation/7528/usage/breakdown')).toBe(
       false,
     )
+  })
+})
+
+// App hides its app-wide quota banner here, where the page has its own.
+describe('isOrganisationUsage', () => {
+  it.each`
+    pathname                             | isUsage
+    ${'/organisation/7528/usage'}        | ${true}
+    ${'/organisation/7528/projects'}     | ${false}
+    ${'/organisation/7528/usage/charts'} | ${false}
+    ${'/organisations'}                  | ${false}
+  `('$pathname is the usage page: $isUsage', ({ isUsage, pathname }) => {
+    expect(isOrganisationUsage(pathname)).toBe(isUsage)
   })
 })

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -30,7 +30,7 @@ import Announcement from './Announcement'
 import { getBuildVersion } from 'common/services/useBuildVersion'
 import AccountProvider from 'common/providers/AccountProvider'
 import Nav from './navigation/Nav'
-import { isAllowedWhileBlocked } from 'web/routePaths'
+import { isAllowedWhileBlocked, isOrganisationUsage } from 'web/routePaths'
 import 'project/darkMode'
 
 const App = class extends Component {
@@ -269,6 +269,12 @@ const App = class extends Component {
       pathname === '/getting-started' &&
       getStoredOnboardingVariant() === 'single_page'
 
+    // The usage dashboard says the same thing in its own banner, with the
+    // detail this one cannot reach.
+    const hasOwnQuotaBanner =
+      isOrganisationUsage(pathname) &&
+      Utils.getFlagsmithHasFeature('usage_dashboard')
+
     const projectId = this.getProjectId(this.props)
     const environmentId = this.getEnvironmentId(this.props)
 
@@ -360,12 +366,14 @@ const App = class extends Component {
                     />
                     {user && (
                       <>
-                        <OrganisationLimit
-                          id={AccountStore.getOrganisation()?.id}
-                          organisationPlan={
-                            AccountStore.getOrganisation()?.subscription.plan
-                          }
-                        />
+                        {!hasOwnQuotaBanner && (
+                          <OrganisationLimit
+                            id={AccountStore.getOrganisation()?.id}
+                            organisationPlan={
+                              AccountStore.getOrganisation()?.subscription.plan
+                            }
+                          />
+                        )}
                         <div className='container announcement-container'>
                           <div>
                             <Announcement />

--- a/frontend/web/routePaths.ts
+++ b/frontend/web/routePaths.ts
@@ -9,7 +9,11 @@ export const ORGANISATION_USAGE = '/organisation/:organisationId/usage'
 // usage page, which explains the block.
 const ALLOWED_WHILE_BLOCKED = [ORGANISATIONS, ORGANISATION_USAGE]
 
+const matches = (pathname: string, path: string): boolean =>
+  !!matchPath(pathname, { exact: true, path, strict: false })
+
 export const isAllowedWhileBlocked = (pathname: string): boolean =>
-  ALLOWED_WHILE_BLOCKED.some((path) =>
-    matchPath(pathname, { exact: true, path, strict: false }),
-  )
+  ALLOWED_WHILE_BLOCKED.some((path) => matches(pathname, path))
+
+export const isOrganisationUsage = (pathname: string): boolean =>
+  matches(pathname, ORGANISATION_USAGE)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #8183

`OrganisationLimit` renders app-wide from `App`, so on the new usage dashboard it sat directly above the page's own over-limit banner, both saying the organisation is over its quota. The app-wide one cannot tell whether overage charges actually apply, so it hedges with "automated billing for the overages may apply"; the page can be specific. The page keeps its banner, the app-wide one is hidden there.

Only where the new dashboard renders, so the legacy usage page is untouched.

`isOrganisationUsage` joins `isAllowedWhileBlocked` in `web/routePaths`, which exists so a component can match a path without importing `web/routes`, which imports `App`.

This is what we would like to prevent:

<img width="1085" height="372" alt="image" src="https://github.com/user-attachments/assets/bceb3388-1fac-4eab-92be-e9b21e88eec7" />

## How did you test this code?

`web/__tests__/routePaths.test.ts` covers the new matcher, including that a path nested under the usage page does not match.

By hand against a local API: on the usage dashboard with the organisation over its limit, only the page's banner shows; off the usage route it still appears; with `usage_dashboard` off the legacy page still shows it.
