### PR TITLE
fix(usage): count whole years when resolving the billing period

### DIFF
--- a/api/app_analytics/analytics_db_service.py
+++ b/api/app_analytics/analytics_db_service.py
@@ -28,6 +28,7 @@ from app_analytics.models import (
 from app_analytics.types import Labels, PeriodType
 from environments.models import Environment
 from features.models import Feature
+from organisations.billing_periods import months_elapsed, period_start
 from organisations.models import Organisation, OrganisationSubscriptionInformationCache
 
 logger = structlog.get_logger("app_analytics")
@@ -341,9 +342,7 @@ def _get_start_date_and_stop_date_for_subscribed_organisation(
             else:
                 raise NotFound("No billing periods found for this organisation.")
 
-            month_delta = relativedelta(now, starts_at).months
-            date_start = relativedelta(months=month_delta) + starts_at
-            return date_start, now
+            return period_start(starts_at, now), now
 
         case constants.PREVIOUS_BILLING_PERIOD:
             if sub_cache and sub_cache.current_billing_term_starts_at:
@@ -351,11 +350,13 @@ def _get_start_date_and_stop_date_for_subscribed_organisation(
             else:
                 raise NotFound("No billing periods found for this organisation.")
 
-            month_delta = relativedelta(now, starts_at).months - 1
-            month_delta += relativedelta(now, starts_at).years * 12
-            date_start = relativedelta(months=month_delta) + starts_at
-            date_stop = relativedelta(months=month_delta + 1) + starts_at
-            return date_start, date_stop
+            # Both ends count from the term start, so a month too short
+            # for its day does not shift the window.
+            months = months_elapsed(starts_at, now)
+            return (
+                starts_at + relativedelta(months=months - 1),
+                starts_at + relativedelta(months=months),
+            )
 
         case constants.NINETY_DAY_PERIOD:
             date_start = now - relativedelta(days=90)

--- a/api/organisations/billing_periods.py
+++ b/api/organisations/billing_periods.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+
+
+def months_elapsed(since: datetime, now: datetime) -> int:
+    """Whole months between two datetimes, years included."""
+    elapsed = relativedelta(now, since)
+    return elapsed.years * 12 + elapsed.months
+
+
+def period_start(billing_term_starts_at: datetime, now: datetime) -> datetime:
+    """
+    Start of the monthly allowance window a term is currently in. A term can
+    run longer than a month, so this is the most recent monthly anniversary of
+    its start.
+    """
+    return billing_term_starts_at + relativedelta(
+        months=months_elapsed(billing_term_starts_at, now)
+    )

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -633,10 +633,13 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
             return None
 
         elapsed = relativedelta(timezone.now(), starts_at)
-        period_starts_at = starts_at + relativedelta(
-            months=elapsed.years * 12 + elapsed.months
+        months = elapsed.years * 12 + elapsed.months
+        # Both ends count from the term start. Counting the second from the
+        # first loses the original day when a month is too short for it.
+        return (
+            starts_at + relativedelta(months=months),
+            starts_at + relativedelta(months=months + 1),
         )
-        return period_starts_at, period_starts_at + relativedelta(months=1)
 
 
 class OrganisationAPIUsageNotification(models.Model):

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -25,6 +25,7 @@ from features.versioning.constants import DEFAULT_VERSION_LIMIT_DAYS
 from integrations.lead_tracking.hubspot.tasks import (
     track_hubspot_lead_v2,
 )
+from organisations.billing_periods import months_elapsed
 from organisations.chargebee import (  # type: ignore[attr-defined]
     get_customer_id_from_subscription_id,
     get_max_api_calls_for_plan,
@@ -632,8 +633,7 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
         if starts_at is None or not self.has_active_billing_periods():
             return None
 
-        elapsed = relativedelta(timezone.now(), starts_at)
-        months = elapsed.years * 12 + elapsed.months
+        months = months_elapsed(starts_at, timezone.now())
         # Both ends count from the term start. Counting the second from the
         # first loses the original day when a month is too short for it.
         return (

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -1,8 +1,9 @@
 import re
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from common.core.utils import is_enterprise, is_saas
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.cache import caches
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -322,6 +323,12 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         )
 
     @property
+    def current_billing_period(self) -> tuple[datetime, datetime] | None:
+        if not self.organisation.has_subscription_information_cache():
+            return None
+        return self.organisation.subscription_information_cache.current_billing_period()
+
+    @property
     def is_free_plan(self) -> bool:
         return self.subscription_plan_family == SubscriptionPlanFamily.FREE
 
@@ -614,6 +621,22 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
             return False
 
         return starts_at <= timezone.now() <= ends_at
+
+    def current_billing_period(self) -> tuple[datetime, datetime] | None:
+        """
+        Returns the monthly allowance window, or None outside a billing term.
+        A term can run longer than a month, so the window opens at the most
+        recent monthly anniversary of its start.
+        """
+        starts_at = self.current_billing_term_starts_at
+        if starts_at is None or not self.has_active_billing_periods():
+            return None
+
+        elapsed = relativedelta(timezone.now(), starts_at)
+        period_starts_at = starts_at + relativedelta(
+            months=elapsed.years * 12 + elapsed.months
+        )
+        return period_starts_at, period_starts_at + relativedelta(months=1)
 
 
 class OrganisationAPIUsageNotification(models.Model):

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -25,8 +25,19 @@ from .subscriptions.constants import CHARGEBEE
 logger = logging.getLogger(__name__)
 
 
+CURRENT_BILLING_PERIOD_SCHEMA = {
+    "type": "object",
+    "nullable": True,
+    "properties": {
+        "starts_at": {"type": "string", "format": "date-time"},
+        "ends_at": {"type": "string", "format": "date-time"},
+    },
+}
+
+
 class SubscriptionSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     has_active_billing_periods = serializers.SerializerMethodField()
+    current_billing_period = serializers.SerializerMethodField()
 
     class Meta:
         model = Subscription
@@ -35,6 +46,13 @@ class SubscriptionSerializer(serializers.ModelSerializer):  # type: ignore[type-
     @extend_schema_field({"type": "boolean"})
     def get_has_active_billing_periods(self, obj):  # type: ignore[no-untyped-def]
         return obj.has_active_billing_periods
+
+    @extend_schema_field(CURRENT_BILLING_PERIOD_SCHEMA)
+    def get_current_billing_period(self, obj: Subscription) -> dict[str, str] | None:
+        if (period := obj.current_billing_period) is None:
+            return None
+        starts_at, ends_at = period
+        return {"starts_at": starts_at.isoformat(), "ends_at": ends_at.isoformat()}
 
 
 class OrganisationSerializerFull(serializers.ModelSerializer):  # type: ignore[type-arg]

--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import structlog
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
@@ -11,6 +10,7 @@ from app_analytics.analytics_db_service import get_total_events_count
 from app_analytics.influxdb_wrapper import get_current_api_usage
 from core.helpers import get_current_site_url
 from integrations.flagsmith.client import get_openfeature_client
+from organisations.billing_periods import period_start
 from organisations.models import (
     Organisation,
     OrganisationAPIUsageNotification,
@@ -123,9 +123,7 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
             )
             return
 
-        # Truncate to the closest active month to get start of current period.
-        month_delta = _get_total_months(relativedelta(now, billing_starts_at))
-        period_starts_at = relativedelta(months=month_delta) + billing_starts_at
+        period_starts_at = period_start(billing_starts_at, now)
 
         allowed_api_calls = subscription_cache.allowed_30d_api_calls
 
@@ -182,7 +180,3 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
     )
 
     _send_api_usage_notification(organisation, matched_threshold)
-
-
-def _get_total_months(rd: relativedelta) -> int:
-    return rd.months + rd.years * 12

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import logging
 from datetime import timedelta
 
-from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
@@ -23,6 +22,7 @@ from app_analytics.influxdb_wrapper import (
 )
 from app_analytics.throttles import InfluxQueryThrottle
 from core.helpers import get_current_site_url
+from organisations.billing_periods import period_start
 from organisations.chargebee import webhook_event_types, webhook_handlers
 from organisations.exceptions import OrganisationHasNoPaidSubscription
 from organisations.models import (
@@ -393,8 +393,7 @@ class OrganisationAPIUsageNotificationView(ListAPIView):  # type: ignore[type-ar
         # by defaulting to something as a reasonable default.
         billing_starts_at = billing_starts_at or now - timedelta(days=30)
 
-        month_delta = relativedelta(now, billing_starts_at).months
-        period_starts_at = relativedelta(months=month_delta) + billing_starts_at
+        period_starts_at = period_start(billing_starts_at, now)
 
         queryset = OrganisationAPIUsageNotification.objects.filter(
             organisation_id=organisation.id,

--- a/api/tests/unit/app_analytics/test_analytics_db_service.py
+++ b/api/tests/unit/app_analytics/test_analytics_db_service.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 from rest_framework.exceptions import NotFound
 
 from app_analytics.analytics_db_service import (
+    _get_start_date_and_stop_date_for_subscribed_organisation,
     get_feature_evaluation_data,
     get_feature_evaluation_data_from_local_db,
     get_top_organisations_from_local_db,
@@ -966,3 +967,40 @@ def test_get_usage_data_for_window__no_analytics_configured__returns_empty(
 
     # Then
     assert result == []
+
+
+# A term over a year old resolved to the wrong year before #6099, so the current
+# period opened twelve months early and the usage shown was not the period's.
+@pytest.mark.freeze_time("2026-09-11T00:00:00+00:00")
+@pytest.mark.parametrize(
+    "period, expected_start",
+    [
+        (CURRENT_BILLING_PERIOD, "2026-09-07T00:00:00+00:00"),
+        (PREVIOUS_BILLING_PERIOD, "2026-08-07T00:00:00+00:00"),
+    ],
+)
+def test_get_start_date_and_stop_date__term_over_a_year_old__counts_the_years(
+    db: None,
+    organisation: Organisation,
+    period: PeriodType,
+    expected_start: str,
+) -> None:
+    # Given
+    sub_cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(
+            "2025-08-07T00:00:00+00:00"
+        ),
+        current_billing_term_ends_at=datetime.fromisoformat(
+            "2027-08-07T00:00:00+00:00"
+        ),
+    )
+
+    # When
+    date_start, _ = _get_start_date_and_stop_date_for_subscribed_organisation(
+        sub_cache=sub_cache,
+        period=period,
+    )
+
+    # Then
+    assert date_start == datetime.fromisoformat(expected_start)

--- a/api/tests/unit/organisations/test_unit_organisations_billing_periods.py
+++ b/api/tests/unit/organisations/test_unit_organisations_billing_periods.py
@@ -18,11 +18,11 @@ from organisations.billing_periods import months_elapsed, period_start
 def test_months_elapsed__spans_years__counts_them(
     since: str, now: str, expected: int
 ) -> None:
-    # Given / When / Then
-    assert (
-        months_elapsed(datetime.fromisoformat(since), datetime.fromisoformat(now))
-        == expected
-    )
+    # Given / When
+    elapsed = months_elapsed(datetime.fromisoformat(since), datetime.fromisoformat(now))
+
+    # Then
+    assert elapsed == expected
 
 
 @pytest.mark.parametrize(
@@ -45,7 +45,10 @@ def test_months_elapsed__spans_years__counts_them(
 def test_period_start__long_term__opens_on_the_latest_anniversary(
     term_starts_at: str, now: str, expected: str
 ) -> None:
-    # Given / When / Then
-    assert period_start(
+    # Given / When
+    start = period_start(
         datetime.fromisoformat(term_starts_at), datetime.fromisoformat(now)
-    ) == datetime.fromisoformat(expected)
+    )
+
+    # Then
+    assert start == datetime.fromisoformat(expected)

--- a/api/tests/unit/organisations/test_unit_organisations_billing_periods.py
+++ b/api/tests/unit/organisations/test_unit_organisations_billing_periods.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+import pytest
+
+from organisations.billing_periods import months_elapsed, period_start
+
+
+@pytest.mark.parametrize(
+    "since, now, expected",
+    [
+        ("2026-09-01T00:00:00+00:00", "2026-09-10T00:00:00+00:00", 0),
+        ("2026-01-05T00:00:00+00:00", "2026-09-10T00:00:00+00:00", 8),
+        # The year is the part #6099 dropped.
+        ("2024-09-03T00:00:00+00:00", "2026-09-10T00:00:00+00:00", 24),
+        ("2025-08-07T00:00:00+00:00", "2026-09-11T00:00:00+00:00", 13),
+    ],
+)
+def test_months_elapsed__spans_years__counts_them(
+    since: str, now: str, expected: int
+) -> None:
+    # Given / When / Then
+    assert (
+        months_elapsed(datetime.fromisoformat(since), datetime.fromisoformat(now))
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "term_starts_at, now, expected",
+    [
+        # Annual term over a year old. Dropping the year lands in 2025.
+        (
+            "2024-09-03T00:00:00+00:00",
+            "2026-09-10T00:00:00+00:00",
+            "2026-09-03T00:00:00+00:00",
+        ),
+        # February is too short for a 31st, so the window opens on the 28th.
+        (
+            "2026-01-31T00:00:00+00:00",
+            "2026-03-01T00:00:00+00:00",
+            "2026-02-28T00:00:00+00:00",
+        ),
+    ],
+)
+def test_period_start__long_term__opens_on_the_latest_anniversary(
+    term_starts_at: str, now: str, expected: str
+) -> None:
+    # Given / When / Then
+    assert period_start(
+        datetime.fromisoformat(term_starts_at), datetime.fromisoformat(now)
+    ) == datetime.fromisoformat(expected)

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -1084,6 +1084,33 @@ def test_current_billing_period__within_term__returns_monthly_window(
     )
 
 
+# February clamps a 31st term start to the 28th. Counting the end from that
+# clamped date rather than the term start would close the window on 28 March.
+@pytest.mark.freeze_time("2026-03-01T00:00:00+00:00")
+def test_current_billing_period__term_starts_on_the_31st__ends_on_the_anniversary(
+    organisation: Organisation,
+) -> None:
+    # Given
+    cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(
+            "2026-01-31T00:00:00+00:00"
+        ),
+        current_billing_term_ends_at=datetime.fromisoformat(
+            "2027-01-31T00:00:00+00:00"
+        ),
+    )
+
+    # When
+    period = cache.current_billing_period()
+
+    # Then
+    assert period == (
+        datetime.fromisoformat("2026-02-28T00:00:00+00:00"),
+        datetime.fromisoformat("2026-03-31T00:00:00+00:00"),
+    )
+
+
 @pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
 @pytest.mark.parametrize(
     "term_starts_at, term_ends_at",

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -1024,3 +1024,128 @@ def test_organisation_openfeature_evaluation_context__targeting_key_set__uses_it
 
     # Then
     assert context.targeting_key == "a" * 32
+
+
+@pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
+@pytest.mark.parametrize(
+    "term_starts_at, term_ends_at, expected_starts_at, expected_ends_at",
+    [
+        # Monthly term.
+        (
+            "2026-09-01T00:00:00+00:00",
+            "2026-10-01T00:00:00+00:00",
+            "2026-09-01T00:00:00+00:00",
+            "2026-10-01T00:00:00+00:00",
+        ),
+        # Annual term, first year.
+        (
+            "2026-01-05T00:00:00+00:00",
+            "2027-01-05T00:00:00+00:00",
+            "2026-09-05T00:00:00+00:00",
+            "2026-10-05T00:00:00+00:00",
+        ),
+        # Over a year old. Ignoring the year would land in 2025 (#6099).
+        (
+            "2024-09-03T00:00:00+00:00",
+            "2027-04-03T00:00:00+00:00",
+            "2026-09-03T00:00:00+00:00",
+            "2026-10-03T00:00:00+00:00",
+        ),
+        # Exactly on an anniversary.
+        (
+            "2025-09-10T12:00:00+00:00",
+            "2027-09-10T12:00:00+00:00",
+            "2026-09-10T12:00:00+00:00",
+            "2026-10-10T12:00:00+00:00",
+        ),
+    ],
+)
+def test_current_billing_period__within_term__returns_monthly_window(
+    organisation: Organisation,
+    term_starts_at: str,
+    term_ends_at: str,
+    expected_starts_at: str,
+    expected_ends_at: str,
+) -> None:
+    # Given
+    cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(term_starts_at),
+        current_billing_term_ends_at=datetime.fromisoformat(term_ends_at),
+    )
+
+    # When
+    period = cache.current_billing_period()
+
+    # Then
+    assert period == (
+        datetime.fromisoformat(expected_starts_at),
+        datetime.fromisoformat(expected_ends_at),
+    )
+
+
+@pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
+@pytest.mark.parametrize(
+    "term_starts_at, term_ends_at",
+    [
+        # No term, ie every free plan.
+        (None, None),
+        # Half a term.
+        ("2026-09-01T00:00:00+00:00", None),
+        (None, "2026-10-01T00:00:00+00:00"),
+        # Term ended, cache not caught up.
+        ("2026-07-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00"),
+        # Term not started.
+        ("2026-10-01T00:00:00+00:00", "2026-11-01T00:00:00+00:00"),
+    ],
+)
+def test_current_billing_period__no_active_term__returns_none(
+    organisation: Organisation,
+    term_starts_at: str | None,
+    term_ends_at: str | None,
+) -> None:
+    # Given
+    cache = OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=(
+            datetime.fromisoformat(term_starts_at) if term_starts_at else None
+        ),
+        current_billing_term_ends_at=(
+            datetime.fromisoformat(term_ends_at) if term_ends_at else None
+        ),
+    )
+
+    # When / Then
+    assert cache.current_billing_period() is None
+
+
+@pytest.mark.freeze_time("2026-09-10T12:00:00+00:00")
+def test_subscription_current_billing_period__with_cache__reads_through(
+    organisation: Organisation,
+) -> None:
+    # Given
+    OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(
+            "2026-09-01T00:00:00+00:00"
+        ),
+        current_billing_term_ends_at=datetime.fromisoformat(
+            "2026-10-01T00:00:00+00:00"
+        ),
+    )
+
+    # When / Then
+    assert organisation.subscription.current_billing_period == (
+        datetime.fromisoformat("2026-09-01T00:00:00+00:00"),
+        datetime.fromisoformat("2026-10-01T00:00:00+00:00"),
+    )
+
+
+def test_subscription_current_billing_period__no_cache__returns_none(
+    organisation: Organisation,
+) -> None:
+    # Given
+    assert not organisation.has_subscription_information_cache()
+
+    # When / Then
+    assert organisation.subscription.current_billing_period is None

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -2234,3 +2234,47 @@ def test_get_detailed_permissions__other_user_as_admin__returns_permissions(
             "derived_from": {"groups": [], "roles": []},
         }
     ]
+
+
+# A term over a year old resolved to the wrong year before #6099, so the window
+# opened twelve months early and swept up notifications from previous periods.
+@pytest.mark.freeze_time("2026-09-11T00:00:00+00:00")
+def test_get_api_usage_notifications__term_over_a_year_old__excludes_earlier_periods(
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    now = timezone.now()
+    OrganisationSubscriptionInformationCache.objects.create(
+        organisation=organisation,
+        current_billing_term_starts_at=datetime.fromisoformat(
+            "2025-08-07T00:00:00+00:00"
+        ),
+        current_billing_term_ends_at=datetime.fromisoformat(
+            "2027-08-07T00:00:00+00:00"
+        ),
+    )
+    # Inside the current window, which opens on 7 September 2026.
+    OrganisationAPIUsageNotification.objects.create(
+        organisation=organisation,
+        percent_usage=90,
+        notified_at=now,
+    )
+    # A year earlier, only reachable if the year is dropped.
+    OrganisationAPIUsageNotification.objects.create(
+        organisation=organisation,
+        percent_usage=100,
+        notified_at=datetime.fromisoformat("2025-09-20T00:00:00+00:00"),
+    )
+
+    url = reverse(
+        "api-v1:organisations:organisation-api-usage-notification",
+        args=[organisation.id],
+    )
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert [r["percent_usage"] for r in response.data["results"]] == [90]

--- a/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
+++ b/docs/docs/deployment-self-hosting/observability/_events-catalogue.md
@@ -2,7 +2,7 @@
 ### `api_usage.notification.evaluated`
 
 Logged at `info` from:
- - `api/organisations/task_helpers.py:155`
+ - `api/organisations/task_helpers.py:153`
 
 Attributes:
  - `allowed_api_calls`
@@ -24,7 +24,7 @@ Attributes:
 ### `api_usage.notification.sent`
 
 Logged at `info` from:
- - `api/organisations/task_helpers.py:178`
+ - `api/organisations/task_helpers.py:176`
 
 Attributes:
  - `matched_threshold`
@@ -33,9 +33,9 @@ Attributes:
 ### `app_analytics.no_analytics_database_configured`
 
 Logged at `warning` from:
- - `api/app_analytics/analytics_db_service.py:74`
- - `api/app_analytics/analytics_db_service.py:187`
- - `api/app_analytics/analytics_db_service.py:278`
+ - `api/app_analytics/analytics_db_service.py:75`
+ - `api/app_analytics/analytics_db_service.py:188`
+ - `api/app_analytics/analytics_db_service.py:279`
 
 Attributes:
  - `details`

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -517,6 +517,12 @@ export type AuditLogDetail = AuditLogItem & {
 }
 export type PaymentMethod = 'CHARGEBEE' | 'XERO' | 'AWS_MARKETPLACE'
 
+/** The monthly allowance window, null outside an active billing term. */
+export type BillingPeriod = {
+  starts_at: string
+  ends_at: string
+}
+
 export type Subscription = {
   id: number
   uuid: string
@@ -530,6 +536,7 @@ export type Subscription = {
   payment_method: PaymentMethod | null
   notes: string | null
   has_active_billing_periods: boolean
+  current_billing_period: BillingPeriod | null
 }
 
 export type OnboardingVariant = 'control' | 'single_page'

--- a/mcp/src/flagsmith_mcp/openapi.json
+++ b/mcp/src/flagsmith_mcp/openapi.json
@@ -7111,6 +7111,23 @@
             "type": "boolean",
             "readOnly": true
           },
+          "current_billing_period": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "starts_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "ends_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "readOnly": true
+          },
           "deleted_at": {
             "type": [
               "string",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27856,6 +27856,18 @@ components:
         has_active_billing_periods:
           type: boolean
           readOnly: true
+        current_billing_period:
+          type:
+            - object
+            - 'null'
+          properties:
+            starts_at:
+              type: string
+              format: date-time
+            ends_at:
+              type: string
+              format: date-time
+          readOnly: true
         deleted_at:
           type:
             - string


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #6099

`relativedelta(now, starts_at).months` returns the month component on its own, so a billing term that began over a year ago resolved to the same month a year early. A term starting September 2024, viewed today, opened the current period in September **2025** — the date range in the issue.

The arithmetic was repeated at four call sites and wrong at two:

| Site | Before |
|---|---|
| `analytics_db_service` current period | dropped the year |
| `organisations/views` notification window | dropped the year |
| `analytics_db_service` previous period | correct, by hand |
| `task_helpers._get_total_months` | correct, private copy |

All four now use `organisations/billing_periods.py`. `models.current_billing_period()` uses it too, so there is one definition rather than five.

The previous-period branch counts both ends from the term start rather than deriving the end from the start: `period_start - 1 month` would put a 31 January term on 28 January.

Stacked on #8501, which adds the model method this shares. Base it on `main` once that merges.

## How did you test this code?

`test_unit_organisations_billing_periods.py` covers the helper, including a two-year span and a 31 January term in February.

Regression tests at both fixed call sites, each using a term starting August 2025 viewed September 2026: the analytics period resolves to 2026, and the notification window no longer sweeps in a notification from twelve months earlier.